### PR TITLE
Start moving js methods to per-folder algs

### DIFF
--- a/js/src/algorithm/geo/area.rs
+++ b/js/src/algorithm/geo/area.rs
@@ -1,0 +1,31 @@
+use crate::array::*;
+use wasm_bindgen::prelude::*;
+
+macro_rules! impl_area {
+    ($struct_name:ident) => {
+        #[wasm_bindgen]
+        impl $struct_name {
+            /// Unsigned planar area of a geometry.
+            #[wasm_bindgen]
+            pub fn area(&self) -> FloatArray {
+                use geoarrow::algorithm::geo::Area;
+                FloatArray(Area::unsigned_area(&self.0))
+            }
+
+            /// Signed planar area of a geometry.
+            #[wasm_bindgen]
+            pub fn signed_area(&self) -> FloatArray {
+                use geoarrow::algorithm::geo::Area;
+                FloatArray(Area::signed_area(&self.0))
+            }
+        }
+    };
+}
+
+impl_area!(PointArray);
+impl_area!(LineStringArray);
+impl_area!(PolygonArray);
+impl_area!(MultiPointArray);
+impl_area!(MultiLineStringArray);
+impl_area!(MultiPolygonArray);
+impl_area!(GeometryArray);

--- a/js/src/algorithm/geo/center.rs
+++ b/js/src/algorithm/geo/center.rs
@@ -1,0 +1,27 @@
+use crate::array::*;
+use wasm_bindgen::prelude::*;
+
+macro_rules! impl_center {
+    ($struct_name:ident) => {
+        #[wasm_bindgen]
+        impl $struct_name {
+            /// Compute the center of geometries
+            ///
+            /// This first computes the axis-aligned bounding rectangle, then takes the center of
+            /// that box
+            #[wasm_bindgen]
+            pub fn center(&self) -> PointArray {
+                use geoarrow::algorithm::geo::Center;
+                PointArray(Center::center(&self.0))
+            }
+        }
+    };
+}
+
+impl_center!(PointArray);
+impl_center!(LineStringArray);
+impl_center!(PolygonArray);
+impl_center!(MultiPointArray);
+impl_center!(MultiLineStringArray);
+impl_center!(MultiPolygonArray);
+impl_center!(GeometryArray);

--- a/js/src/algorithm/geo/centroid.rs
+++ b/js/src/algorithm/geo/centroid.rs
@@ -1,0 +1,29 @@
+use crate::array::*;
+use wasm_bindgen::prelude::*;
+
+macro_rules! impl_centroid {
+    ($struct_name:ident) => {
+        #[wasm_bindgen]
+        impl $struct_name {
+            /// Calculation of the centroid.
+            /// The centroid is the arithmetic mean position of all points in the shape.
+            /// Informally, it is the point at which a cutout of the shape could be perfectly
+            /// balanced on the tip of a pin.
+            /// The geometric centroid of a convex object always lies in the object.
+            /// A non-convex object might have a centroid that _is outside the object itself_.
+            #[wasm_bindgen]
+            pub fn centroid(&self) -> PointArray {
+                use geoarrow::algorithm::geo::Centroid;
+                PointArray(Centroid::centroid(&self.0))
+            }
+        }
+    };
+}
+
+impl_centroid!(PointArray);
+impl_centroid!(LineStringArray);
+impl_centroid!(PolygonArray);
+impl_centroid!(MultiPointArray);
+impl_centroid!(MultiLineStringArray);
+impl_centroid!(MultiPolygonArray);
+impl_centroid!(GeometryArray);

--- a/js/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/js/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -1,0 +1,35 @@
+use crate::array::*;
+use wasm_bindgen::prelude::*;
+
+macro_rules! impl_alg {
+    ($struct_name:ident) => {
+        #[wasm_bindgen]
+        impl $struct_name {
+            /// Calculate the unsigned approximate geodesic area of a `Geometry`.
+            #[wasm_bindgen]
+            pub fn chamberlain_duquette_unsigned_area(&self) -> FloatArray {
+                use geoarrow::algorithm::geo::ChamberlainDuquetteArea;
+                FloatArray(ChamberlainDuquetteArea::chamberlain_duquette_unsigned_area(
+                    &self.0,
+                ))
+            }
+
+            /// Calculate the signed approximate geodesic area of a `Geometry`.
+            #[wasm_bindgen]
+            pub fn chamberlain_duquette_signed_area(&self) -> FloatArray {
+                use geoarrow::algorithm::geo::ChamberlainDuquetteArea;
+                FloatArray(ChamberlainDuquetteArea::chamberlain_duquette_signed_area(
+                    &self.0,
+                ))
+            }
+        }
+    };
+}
+
+impl_alg!(PointArray);
+impl_alg!(LineStringArray);
+impl_alg!(PolygonArray);
+impl_alg!(MultiPointArray);
+impl_alg!(MultiLineStringArray);
+impl_alg!(MultiPolygonArray);
+impl_alg!(GeometryArray);

--- a/js/src/algorithm/geo/convex_hull.rs
+++ b/js/src/algorithm/geo/convex_hull.rs
@@ -1,0 +1,30 @@
+use crate::array::*;
+use wasm_bindgen::prelude::*;
+
+macro_rules! impl_alg {
+    ($struct_name:ident) => {
+        #[wasm_bindgen]
+        impl $struct_name {
+            /// Returns the convex hull of a Polygon. The hull is always oriented
+            /// counter-clockwise.
+            ///
+            /// This implementation uses the QuickHull algorithm, based on [Barber, C. Bradford;
+            /// Dobkin, David P.; Huhdanpaa, Hannu (1 December
+            /// 1996)](https://dx.doi.org/10.1145%2F235815.235821) Original paper here:
+            /// <http://www.cs.princeton.edu/~dpd/Papers/BarberDobkinHuhdanpaa.pdf>
+            #[wasm_bindgen]
+            pub fn convex_hull(&self) -> PolygonArray {
+                use geoarrow::algorithm::geo::ConvexHull;
+                PolygonArray(ConvexHull::convex_hull(&self.0))
+            }
+        }
+    };
+}
+
+impl_alg!(PointArray);
+impl_alg!(LineStringArray);
+impl_alg!(PolygonArray);
+impl_alg!(MultiPointArray);
+impl_alg!(MultiLineStringArray);
+impl_alg!(MultiPolygonArray);
+impl_alg!(GeometryArray);

--- a/js/src/algorithm/geo/dimensions.rs
+++ b/js/src/algorithm/geo/dimensions.rs
@@ -1,0 +1,28 @@
+use crate::array::*;
+use wasm_bindgen::prelude::*;
+
+macro_rules! impl_alg {
+    ($struct_name:ident) => {
+        #[wasm_bindgen]
+        impl $struct_name {
+            /// Some geometries, like a `MultiPoint`, can have zero coordinates - we call these
+            /// `empty`.
+            ///
+            /// Types like `Point`, which have at least one coordinate by construction, can never
+            /// be considered empty.
+            #[wasm_bindgen]
+            pub fn is_empty(&self) -> BooleanArray {
+                use geoarrow::algorithm::geo::HasDimensions;
+                BooleanArray(HasDimensions::is_empty(&self.0))
+            }
+        }
+    };
+}
+
+impl_alg!(PointArray);
+impl_alg!(LineStringArray);
+impl_alg!(PolygonArray);
+impl_alg!(MultiPointArray);
+impl_alg!(MultiLineStringArray);
+impl_alg!(MultiPolygonArray);
+impl_alg!(GeometryArray);

--- a/js/src/algorithm/geo/mod.rs
+++ b/js/src/algorithm/geo/mod.rs
@@ -1,3 +1,9 @@
+pub mod area;
+pub mod center;
+pub mod centroid;
+pub mod chamberlain_duquette_area;
+pub mod convex_hull;
+pub mod dimensions;
 pub mod euclidean_length;
 pub mod geodesic_length;
 pub mod haversine_length;

--- a/js/src/array/geometry.rs
+++ b/js/src/array/geometry.rs
@@ -1,6 +1,5 @@
 use crate::array::ffi::FFIArrowArray;
 use crate::array::polygon::PolygonArray;
-use crate::array::primitive::BooleanArray;
 use crate::array::primitive::FloatArray;
 use crate::array::{
     LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray,

--- a/js/src/array/linestring.rs
+++ b/js/src/array/linestring.rs
@@ -1,6 +1,4 @@
 use crate::array::ffi::FFIArrowArray;
-use crate::array::point::PointArray;
-use crate::array::polygon::PolygonArray;
 use crate::array::primitive::BooleanArray;
 use crate::array::primitive::FloatArray;
 use crate::array::CoordBuffer;

--- a/js/src/array/macro.rs
+++ b/js/src/array/macro.rs
@@ -15,30 +15,6 @@ macro_rules! impl_geometry_array {
             }
 
             #[wasm_bindgen]
-            pub fn area(&self) -> FloatArray {
-                use geoarrow::algorithm::geo::Area;
-                FloatArray(Area::unsigned_area(&self.0))
-            }
-
-            #[wasm_bindgen]
-            pub fn center(&self) -> PointArray {
-                use geoarrow::algorithm::geo::Center;
-                PointArray(Center::center(&self.0))
-            }
-
-            #[wasm_bindgen]
-            pub fn centroid(&self) -> PointArray {
-                use geoarrow::algorithm::geo::Centroid;
-                PointArray(Centroid::centroid(&self.0))
-            }
-
-            #[wasm_bindgen]
-            pub fn convex_hull(&self) -> PolygonArray {
-                use geoarrow::algorithm::geo::ConvexHull;
-                PolygonArray(ConvexHull::convex_hull(&self.0))
-            }
-
-            #[wasm_bindgen]
             pub fn geodesic_area(&self) -> WasmResult<FloatArray> {
                 use geoarrow::algorithm::geo::geodesic_area_unsigned;
                 Ok(FloatArray(geodesic_area_unsigned(&self.into())?))
@@ -48,12 +24,6 @@ macro_rules! impl_geometry_array {
             pub fn geodesic_area_signed(&self) -> WasmResult<FloatArray> {
                 use geoarrow::algorithm::geo::geodesic_area_signed;
                 Ok(FloatArray(geodesic_area_signed(&self.into())?))
-            }
-
-            #[wasm_bindgen]
-            pub fn is_empty(&self) -> BooleanArray {
-                use geoarrow::algorithm::geo::HasDimensions;
-                BooleanArray(HasDimensions::is_empty(&self.0))
             }
 
             #[cfg(feature = "geodesy")]
@@ -95,12 +65,6 @@ macro_rules! impl_geometry_array {
                     yfact.0,
                     origin.0,
                 )?))
-            }
-
-            #[wasm_bindgen]
-            pub fn signed_area(&self) -> FloatArray {
-                use geoarrow::algorithm::geo::Area;
-                FloatArray(Area::signed_area(&self.0))
             }
 
             #[wasm_bindgen]

--- a/js/src/array/multilinestring.rs
+++ b/js/src/array/multilinestring.rs
@@ -1,6 +1,4 @@
 use crate::array::ffi::FFIArrowArray;
-use crate::array::point::PointArray;
-use crate::array::polygon::PolygonArray;
 use crate::array::primitive::BooleanArray;
 use crate::array::primitive::FloatArray;
 use crate::array::CoordBuffer;

--- a/js/src/array/multipoint.rs
+++ b/js/src/array/multipoint.rs
@@ -1,6 +1,4 @@
 use crate::array::ffi::FFIArrowArray;
-use crate::array::point::PointArray;
-use crate::array::polygon::PolygonArray;
 use crate::array::primitive::BooleanArray;
 use crate::array::primitive::FloatArray;
 use crate::array::CoordBuffer;

--- a/js/src/array/multipolygon.rs
+++ b/js/src/array/multipolygon.rs
@@ -1,6 +1,4 @@
 use crate::array::ffi::FFIArrowArray;
-use crate::array::point::PointArray;
-use crate::array::polygon::PolygonArray;
 use crate::array::primitive::BooleanArray;
 use crate::array::primitive::FloatArray;
 use crate::array::CoordBuffer;

--- a/js/src/array/point.rs
+++ b/js/src/array/point.rs
@@ -1,5 +1,4 @@
 use crate::array::ffi::FFIArrowArray;
-use crate::array::polygon::PolygonArray;
 use crate::array::primitive::BooleanArray;
 use crate::array::primitive::FloatArray;
 use crate::array::CoordBuffer;

--- a/js/src/array/polygon.rs
+++ b/js/src/array/polygon.rs
@@ -1,5 +1,4 @@
 use crate::array::ffi::FFIArrowArray;
-use crate::array::point::PointArray;
 use crate::array::primitive::BooleanArray;
 use crate::array::primitive::FloatArray;
 use crate::array::CoordBuffer;


### PR DESCRIPTION
Pros of this approach:

- execution of the macro is in the same file as its implementation. This means that you never have to add an import in a separate file.
- Enables you to execute the macro only on specific array types, for operations like length that aren't defined (in geo at least) on polygons
- The macro deduplicates the docstring. Write the docstring only once and it gets copied to every array type.