### PR TITLE
implement arrow2 `Array` trait for geometry arrays

### DIFF
--- a/src/array/geometry/array.rs
+++ b/src/array/geometry/array.rs
@@ -149,7 +149,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
     /// of geometries it contains.
     fn len(&self) -> usize {
         match self {
-            GeometryArray::Point(arr) => arr.len(),
+            GeometryArray::Point(arr) => GeometryArrayTrait::len(arr),
             GeometryArray::LineString(arr) => arr.len(),
             GeometryArray::Polygon(arr) => arr.len(),
             GeometryArray::MultiPoint(arr) => arr.len(),
@@ -165,7 +165,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
     /// validity is [`None`], all slots are valid.
     fn validity(&self) -> Option<&Bitmap> {
         match self {
-            GeometryArray::Point(arr) => arr.validity(),
+            GeometryArray::Point(arr) => GeometryArrayTrait::validity(arr),
             GeometryArray::LineString(arr) => arr.validity(),
             GeometryArray::Polygon(arr) => arr.validity(),
             GeometryArray::MultiPoint(arr) => arr.validity(),
@@ -184,7 +184,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
     /// This function panics iff `offset + length > self.len()`.
     fn slice(&mut self, offset: usize, length: usize) {
         match self {
-            GeometryArray::Point(arr) => arr.slice(offset, length),
+            GeometryArray::Point(arr) => GeometryArrayTrait::slice(arr, offset, length),
             GeometryArray::LineString(arr) => arr.slice(offset, length),
             GeometryArray::Polygon(arr) => arr.slice(offset, length),
             GeometryArray::MultiPoint(arr) => arr.slice(offset, length),
@@ -203,7 +203,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
     /// The caller must ensure that `offset + length <= self.len()`
     unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
         match self {
-            GeometryArray::Point(arr) => arr.slice_unchecked(offset, length),
+            GeometryArray::Point(arr) => GeometryArrayTrait::slice_unchecked(arr, offset, length),
             GeometryArray::LineString(arr) => arr.slice_unchecked(offset, length),
             GeometryArray::Polygon(arr) => arr.slice_unchecked(offset, length),
             GeometryArray::MultiPoint(arr) => arr.slice_unchecked(offset, length),

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -369,7 +369,7 @@ impl<O: Offset> TryFrom<PointArray> for MultiPointArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: PointArray) -> Result<Self> {
-        let geom_length = value.len();
+        let geom_length = GeometryArrayTrait::len(&value);
 
         let coords = value.coords;
         let validity = value.validity;


### PR DESCRIPTION
Unsure whether this is wise or not. The arrow2 `Array` trait can be implemented by external structs. But we don't store a _literal_ arrow2 array object so that we can avoid downcasting overhead. But this means that e.g. debug fails
https://github.com/jorgecarleitao/arrow2/blob/d5c78e7ba45fcebfbafd55a82ba2601ee3ea9617/src/array/mod.rs#L305-L332

Because it's not a builtin arrow2 array.

So I'm thinking it'll probably be better to keep them separate