### PR TITLE
scalars directly referencing geometry arrays

### DIFF
--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -1,5 +1,5 @@
 use crate::algorithm::native::bounding_rect::bounding_rect_multipoint;
-use crate::array::CoordBuffer;
+use crate::array::{CoordBuffer, MultiPointArray};
 use crate::geo_traits::MultiPointTrait;
 use crate::scalar::multipoint::MultiPointIterator;
 use crate::scalar::Point;
@@ -13,48 +13,26 @@ use std::borrow::Cow;
 /// An Arrow equivalent of a MultiPoint
 #[derive(Debug, Clone)]
 pub struct MultiPoint<'a, O: Offset> {
-    /// Buffer of coordinates
-    pub coords: Cow<'a, CoordBuffer>,
-
-    /// Offsets into the coordinate array where each geometry starts
-    pub geom_offsets: Cow<'a, OffsetsBuffer<O>>,
+    pub arr: Cow<'a, MultiPointArray<O>>,
 
     pub geom_index: usize,
 }
 
 impl<'a, O: Offset> MultiPoint<'a, O> {
-    pub fn new(
-        coords: Cow<'a, CoordBuffer>,
-        geom_offsets: Cow<'a, OffsetsBuffer<O>>,
-        geom_index: usize,
-    ) -> Self {
+    pub fn new(arr: Cow<'a, MultiPointArray<O>>, geom_index: usize) -> Self {
+        Self { arr, geom_index }
+    }
+
+    pub fn new_borrowed(arr: &'a MultiPointArray<O>, geom_index: usize) -> Self {
         Self {
-            coords,
-            geom_offsets,
+            arr: Cow::Borrowed(arr),
             geom_index,
         }
     }
 
-    pub fn new_borrowed(
-        coords: &'a CoordBuffer,
-        geom_offsets: &'a OffsetsBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
+    pub fn new_owned(arr: MultiPointArray<O>, geom_index: usize) -> Self {
         Self {
-            coords: Cow::Borrowed(coords),
-            geom_offsets: Cow::Borrowed(geom_offsets),
-            geom_index,
-        }
-    }
-
-    pub fn new_owned(
-        coords: CoordBuffer,
-        geom_offsets: OffsetsBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self {
-            coords: Cow::Owned(coords),
-            geom_offsets: Cow::Owned(geom_offsets),
+            arr: Cow::Owned(arr),
             geom_index,
         }
     }

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -1,5 +1,5 @@
 use crate::algorithm::native::bounding_rect::bounding_rect_multipolygon;
-use crate::array::CoordBuffer;
+use crate::array::{CoordBuffer, MultiPolygonArray};
 use crate::geo_traits::MultiPolygonTrait;
 use crate::scalar::multipolygon::MultiPolygonIterator;
 use crate::scalar::Polygon;
@@ -12,65 +12,26 @@ use std::borrow::Cow;
 /// An Arrow equivalent of a MultiPolygon
 #[derive(Debug, Clone)]
 pub struct MultiPolygon<'a, O: Offset> {
-    pub coords: Cow<'a, CoordBuffer>,
-
-    /// Offsets into the polygon array where each geometry starts
-    pub geom_offsets: Cow<'a, OffsetsBuffer<O>>,
-
-    /// Offsets into the ring array where each polygon starts
-    pub polygon_offsets: Cow<'a, OffsetsBuffer<O>>,
-
-    /// Offsets into the coordinate array where each ring starts
-    pub ring_offsets: Cow<'a, OffsetsBuffer<O>>,
+    pub arr: Cow<'a, MultiPolygonArray<O>>,
 
     pub geom_index: usize,
 }
 
 impl<'a, O: Offset> MultiPolygon<'a, O> {
-    pub fn new(
-        coords: Cow<'a, CoordBuffer>,
-        geom_offsets: Cow<'a, OffsetsBuffer<O>>,
-        polygon_offsets: Cow<'a, OffsetsBuffer<O>>,
-        ring_offsets: Cow<'a, OffsetsBuffer<O>>,
-        geom_index: usize,
-    ) -> Self {
+    pub fn new(arr: Cow<'a, MultiPolygonArray<O>>, geom_index: usize) -> Self {
+        Self { arr, geom_index }
+    }
+
+    pub fn new_borrowed(arr: &'a MultiPolygonArray<O>, geom_index: usize) -> Self {
         Self {
-            coords,
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
+            arr: Cow::Borrowed(arr),
             geom_index,
         }
     }
 
-    pub fn new_borrowed(
-        coords: &'a CoordBuffer,
-        geom_offsets: &'a OffsetsBuffer<O>,
-        polygon_offsets: &'a OffsetsBuffer<O>,
-        ring_offsets: &'a OffsetsBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
+    pub fn new_owned(arr: MultiPolygonArray<O>, geom_index: usize) -> Self {
         Self {
-            coords: Cow::Borrowed(coords),
-            geom_offsets: Cow::Borrowed(geom_offsets),
-            polygon_offsets: Cow::Borrowed(polygon_offsets),
-            ring_offsets: Cow::Borrowed(ring_offsets),
-            geom_index,
-        }
-    }
-
-    pub fn new_owned(
-        coords: CoordBuffer,
-        geom_offsets: OffsetsBuffer<O>,
-        polygon_offsets: OffsetsBuffer<O>,
-        ring_offsets: OffsetsBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self {
-            coords: Cow::Owned(coords),
-            geom_offsets: Cow::Owned(geom_offsets),
-            polygon_offsets: Cow::Owned(polygon_offsets),
-            ring_offsets: Cow::Owned(ring_offsets),
+            arr: Cow::Owned(arr),
             geom_index,
         }
     }
@@ -94,12 +55,12 @@ impl<'a, O: Offset> MultiPolygonTrait<'a> for MultiPolygon<'a, O> {
     }
 
     fn num_polygons(&self) -> usize {
-        let (start, end) = self.geom_offsets.start_end(self.geom_index);
+        let (start, end) = self.arr.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
     fn polygon(&self, i: usize) -> Option<Self::ItemType> {
-        let (start, end) = self.geom_offsets.start_end(self.geom_index);
+        let (start, end) = self.arr.geom_offsets.start_end(self.geom_index);
         if i > (end - start) {
             return None;
         }
@@ -124,12 +85,12 @@ impl<'a, O: Offset> MultiPolygonTrait<'a> for &MultiPolygon<'a, O> {
     }
 
     fn num_polygons(&self) -> usize {
-        let (start, end) = self.geom_offsets.start_end(self.geom_index);
+        let (start, end) = self.arr.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
     fn polygon(&self, i: usize) -> Option<Self::ItemType> {
-        let (start, end) = self.geom_offsets.start_end(self.geom_index);
+        let (start, end) = self.arr.geom_offsets.start_end(self.geom_index);
         if i > (end - start) {
             return None;
         }
@@ -153,15 +114,15 @@ impl<O: Offset> From<MultiPolygon<'_, O>> for geo::MultiPolygon {
 impl<O: Offset> From<&MultiPolygon<'_, O>> for geo::MultiPolygon {
     fn from(value: &MultiPolygon<'_, O>) -> Self {
         // Start and end indices into the polygon_offsets buffer
-        let (start_geom_idx, end_geom_idx) = value.geom_offsets.start_end(value.geom_index);
+        let (start_geom_idx, end_geom_idx) = value.arr.geom_offsets.start_end(value.geom_index);
 
         let mut polygons: Vec<geo::Polygon> = Vec::with_capacity(end_geom_idx - start_geom_idx);
 
         for geom_idx in start_geom_idx..end_geom_idx {
             let poly = crate::array::polygon::util::parse_polygon(
-                value.coords.clone(),
-                value.polygon_offsets.clone(),
-                value.ring_offsets.clone(),
+                value.arr.coords.clone(),
+                value.arr.polygon_offsets.clone(),
+                value.arr.ring_offsets.clone(),
                 geom_idx,
             );
             polygons.push(poly);

--- a/src/scalar/point/scalar.rs
+++ b/src/scalar/point/scalar.rs
@@ -1,5 +1,5 @@
 use crate::algorithm::native::bounding_rect::bounding_rect_point;
-use crate::array::CoordBuffer;
+use crate::array::PointArray;
 use crate::geo_traits::{CoordTrait, PointTrait};
 use crate::trait_::GeometryScalarTrait;
 use rstar::{RTreeObject, AABB};
@@ -8,40 +8,40 @@ use std::borrow::Cow;
 /// An Arrow equivalent of a Point
 #[derive(Debug)]
 pub struct Point<'a> {
-    coords: Cow<'a, CoordBuffer>,
+    arr: Cow<'a, PointArray>,
     geom_index: usize,
 }
 
-impl<'a> ToOwned for Point<'a> {
-    type Owned = Point<'a>;
+// impl<'a> ToOwned for Point<'a> {
+//     type Owned = Point<'a>;
 
-    fn to_owned(&self) -> Self::Owned {
-        let (cb, geom_index) = match &self.coords {
-            Cow::Owned(cb) => (cb, self.geom_index),
-            // TODO: create new arrays that aren't linked to the existing array
-            // TODO: this geom_index will become 0
-            Cow::Borrowed(cb) => (cb.to_owned(), self.geom_index),
-        };
+//     fn to_owned(&self) -> Self::Owned {
+//         let (cb, geom_index) = match &self.coords {
+//             Cow::Owned(cb) => (cb, self.geom_index),
+//             // TODO: create new arrays that aren't linked to the existing array
+//             // TODO: this geom_index will become 0
+//             Cow::Borrowed(cb) => (cb.to_owned(), self.geom_index),
+//         };
 
-        Point::new_owned(cb.clone(), geom_index)
-    }
-}
+//         Point::new_owned(cb.clone(), geom_index)
+//     }
+// }
 
 impl<'a> Point<'a> {
-    pub fn new(coords: Cow<'a, CoordBuffer>, geom_index: usize) -> Self {
-        Point { coords, geom_index }
+    pub fn new(arr: Cow<'a, PointArray>, geom_index: usize) -> Self {
+        Point { arr, geom_index }
     }
 
-    pub fn new_borrowed(coords: &'a CoordBuffer, geom_index: usize) -> Self {
+    pub fn new_borrowed(arr: &'a PointArray, geom_index: usize) -> Self {
         Point {
-            coords: Cow::Borrowed(coords),
+            arr: Cow::Borrowed(arr),
             geom_index,
         }
     }
 
-    pub fn new_owned(coords: CoordBuffer, geom_index: usize) -> Self {
+    pub fn new_owned(arr: PointArray, geom_index: usize) -> Self {
         Point {
-            coords: Cow::Owned(coords),
+            arr: Cow::Owned(arr),
             geom_index,
         }
     }
@@ -59,11 +59,11 @@ impl PointTrait for Point<'_> {
     type T = f64;
 
     fn x(&self) -> f64 {
-        self.coords.get_x(self.geom_index)
+        self.arr.coords.get_x(self.geom_index)
     }
 
     fn y(&self) -> f64 {
-        self.coords.get_y(self.geom_index)
+        self.arr.coords.get_y(self.geom_index)
     }
 }
 
@@ -71,11 +71,11 @@ impl PointTrait for &Point<'_> {
     type T = f64;
 
     fn x(&self) -> f64 {
-        self.coords.get_x(self.geom_index)
+        self.arr.coords.get_x(self.geom_index)
     }
 
     fn y(&self) -> f64 {
-        self.coords.get_y(self.geom_index)
+        self.arr.coords.get_y(self.geom_index)
     }
 }
 
@@ -83,11 +83,11 @@ impl CoordTrait for Point<'_> {
     type T = f64;
 
     fn x(&self) -> Self::T {
-        self.coords.get_x(self.geom_index)
+        self.arr.coords.get_x(self.geom_index)
     }
 
     fn y(&self) -> Self::T {
-        self.coords.get_y(self.geom_index)
+        self.arr.coords.get_y(self.geom_index)
     }
 }
 


### PR DESCRIPTION
I'm not sure this will end up being simpler; in particular the existing approach makes it really easy for e.g. a `MultiLineString` to yield `LineString` scalars from `MultiLineStringTrait::line` without forming new objects, while with this new approach you'd have to create a new `LineStringArray` object and pass that with a new index in the return object from `MultiLineStringTrait::line`