### PR TITLE
wip coord buffer trait

### DIFF
--- a/src/algorithm/geo/affine_ops.rs
+++ b/src/algorithm/geo/affine_ops.rs
@@ -65,7 +65,7 @@ impl AffineOps<AffineTransform> for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> AffineOps<AffineTransform> for $type {
+        impl<C: CoordBuffer, O: Offset> AffineOps<AffineTransform> for $type {
             fn affine_transform(&self, transform: &AffineTransform) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()
@@ -86,7 +86,7 @@ iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
 iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
 iter_geo_impl!(WKBArray<O>, geo::Geometry);
 
-impl<O: Offset> AffineOps<AffineTransform> for MultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> AffineOps<AffineTransform> for MultiPointArray<O> {
     fn affine_transform(&self, transform: &AffineTransform) -> Self {
         let output_geoms: Vec<Option<geo::MultiPoint>> = self
             .iter_geo()
@@ -97,7 +97,7 @@ impl<O: Offset> AffineOps<AffineTransform> for MultiPointArray<O> {
     }
 }
 
-impl<O: Offset> AffineOps<AffineTransform> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> AffineOps<AffineTransform> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn affine_transform(&self, transform: &AffineTransform) -> Self;
     }
@@ -125,7 +125,7 @@ impl AffineOps<Vec<AffineTransform>> for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> AffineOps<Vec<AffineTransform>> for $type {
+        impl<C: CoordBuffer, O: Offset> AffineOps<Vec<AffineTransform>> for $type {
             fn affine_transform(&self, transform: &Vec<AffineTransform>) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()
@@ -147,7 +147,7 @@ iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
 iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
 iter_geo_impl!(WKBArray<O>, geo::Geometry);
 
-impl<O: Offset> AffineOps<Vec<AffineTransform>> for MultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> AffineOps<Vec<AffineTransform>> for MultiPointArray<O> {
     fn affine_transform(&self, transform: &Vec<AffineTransform>) -> Self {
         let output_geoms: Vec<Option<geo::MultiPoint>> = self
             .iter_geo()
@@ -161,7 +161,7 @@ impl<O: Offset> AffineOps<Vec<AffineTransform>> for MultiPointArray<O> {
     }
 }
 
-impl<O: Offset> AffineOps<Vec<AffineTransform>> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> AffineOps<Vec<AffineTransform>> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn affine_transform(&self, transform: &Vec<AffineTransform>) -> Self;
     }

--- a/src/algorithm/geo/area.rs
+++ b/src/algorithm/geo/area.rs
@@ -54,7 +54,7 @@ impl Area for PointArray {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: Offset> Area for $type {
+        impl<C: CoordBuffer, O: Offset> Area for $type {
             fn signed_area(&self) -> PrimitiveArray<f64> {
                 zeroes(self.len(), self.validity())
             }
@@ -72,7 +72,7 @@ zero_impl!(MultiLineStringArray<O>);
 
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> Area for $type {
+        impl<C: CoordBuffer, O: Offset> Area for $type {
             fn signed_area(&self) -> PrimitiveArray<f64> {
                 let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(self.len());
                 self.iter_geo()
@@ -94,7 +94,7 @@ iter_geo_impl!(PolygonArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> Area for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Area for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn signed_area(&self) -> PrimitiveArray<f64>;
 

--- a/src/algorithm/geo/bounding_rect.rs
+++ b/src/algorithm/geo/bounding_rect.rs
@@ -32,7 +32,7 @@ pub trait BoundingRect<O: Offset> {
     fn bounding_rect(&self) -> PolygonArray<O>;
 }
 
-impl<O: Offset> BoundingRect<O> for PointArray {
+impl<C: CoordBuffer, O: Offset> BoundingRect<O> for PointArray {
     fn bounding_rect(&self) -> PolygonArray<O> {
         let output_geoms: Vec<Option<Polygon>> = self
             .iter_geo()
@@ -46,7 +46,7 @@ impl<O: Offset> BoundingRect<O> for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> BoundingRect<O> for $type {
+        impl<C: CoordBuffer, O: Offset> BoundingRect<O> for $type {
             fn bounding_rect(&self) -> PolygonArray<O> {
                 let output_geoms: Vec<Option<Polygon>> = self
                     .iter_geo()
@@ -68,7 +68,7 @@ iter_geo_impl!(MultiLineStringArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> BoundingRect<O> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> BoundingRect<O> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn bounding_rect(&self) -> PolygonArray<O>;
     }

--- a/src/algorithm/geo/center.rs
+++ b/src/algorithm/geo/center.rs
@@ -22,7 +22,7 @@ impl Center for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> Center for $type {
+        impl<C: CoordBuffer, O: Offset> Center for $type {
             fn center(&self) -> PointArray {
                 let mut output_array = MutablePointArray::with_capacity(self.len());
                 self.iter_geo().for_each(|maybe_g| {
@@ -43,7 +43,7 @@ iter_geo_impl!(MultiLineStringArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> Center for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Center for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn center(&self) -> PointArray;
     }

--- a/src/algorithm/geo/centroid.rs
+++ b/src/algorithm/geo/centroid.rs
@@ -64,7 +64,7 @@ impl Centroid for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> Centroid for $type {
+        impl<C: CoordBuffer, O: Offset> Centroid for $type {
             fn centroid(&self) -> PointArray {
                 let mut output_array = MutablePointArray::with_capacity(self.len());
                 self.iter_geo().for_each(|maybe_g| {
@@ -83,7 +83,7 @@ iter_geo_impl!(MultiLineStringArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> Centroid for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Centroid for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn centroid(&self) -> PointArray;
     }

--- a/src/algorithm/geo/chaikin_smoothing.rs
+++ b/src/algorithm/geo/chaikin_smoothing.rs
@@ -22,7 +22,7 @@ pub trait ChaikinSmoothing {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> ChaikinSmoothing for $type {
+        impl<C: CoordBuffer, O: Offset> ChaikinSmoothing for $type {
             fn chaikin_smoothing(&self, n_iterations: BroadcastablePrimitive<u32>) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()

--- a/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -71,7 +71,7 @@ impl ChamberlainDuquetteArea for PointArray {
 /// Generate a `ChamberlainDuquetteArea` implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: Offset> ChamberlainDuquetteArea for $type {
+        impl<C: CoordBuffer, O: Offset> ChamberlainDuquetteArea for $type {
             fn chamberlain_duquette_signed_area(&self) -> PrimitiveArray<f64> {
                 zeroes(self.len(), self.validity())
             }
@@ -90,7 +90,7 @@ zero_impl!(MultiLineStringArray<O>);
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> ChamberlainDuquetteArea for $type {
+        impl<C: CoordBuffer, O: Offset> ChamberlainDuquetteArea for $type {
             fn chamberlain_duquette_signed_area(&self) -> PrimitiveArray<f64> {
                 let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(self.len());
                 self.iter_geo().for_each(|maybe_g| {
@@ -114,7 +114,7 @@ iter_geo_impl!(PolygonArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> ChamberlainDuquetteArea for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> ChamberlainDuquetteArea for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn chamberlain_duquette_signed_area(&self) -> PrimitiveArray<f64>;
         fn chamberlain_duquette_unsigned_area(&self) -> PrimitiveArray<f64>;

--- a/src/algorithm/geo/convex_hull.rs
+++ b/src/algorithm/geo/convex_hull.rs
@@ -49,7 +49,7 @@ pub trait ConvexHull<O: Offset> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> ConvexHull<O> for $type {
+        impl<C: CoordBuffer, O: Offset> ConvexHull<O> for $type {
             fn convex_hull(&self) -> PolygonArray<O> {
                 let output_geoms: Vec<Option<Polygon>> = self
                     .iter_geo()
@@ -70,7 +70,7 @@ iter_geo_impl!(MultiLineStringArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> ConvexHull<O> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> ConvexHull<O> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn convex_hull(&self) -> PolygonArray<O>;
     }

--- a/src/algorithm/geo/densify.rs
+++ b/src/algorithm/geo/densify.rs
@@ -30,7 +30,7 @@ pub trait Densify {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> Densify for $type {
+        impl<C: CoordBuffer, O: Offset> Densify for $type {
             type Output = $type;
 
             fn densify(&self, max_distance: BroadcastablePrimitive<f64>) -> Self::Output {

--- a/src/algorithm/geo/dimensions.rs
+++ b/src/algorithm/geo/dimensions.rs
@@ -42,7 +42,7 @@ impl HasDimensions for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> HasDimensions for $type {
+        impl<C: CoordBuffer, O: Offset> HasDimensions for $type {
             fn is_empty(&self) -> BooleanArray {
                 let mut output_array = MutableBooleanArray::with_capacity(self.len());
                 self.iter_geo()
@@ -60,7 +60,7 @@ iter_geo_impl!(MultiLineStringArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> HasDimensions for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> HasDimensions for GeometryArray<O> {
     fn is_empty(&self) -> BooleanArray {
         match self {
             GeometryArray::WKB(arr) => HasDimensions::is_empty(arr),

--- a/src/algorithm/geo/euclidean_length.rs
+++ b/src/algorithm/geo/euclidean_length.rs
@@ -37,7 +37,7 @@ impl EuclideanLength for PointArray {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: Offset> EuclideanLength for $type {
+        impl<C: CoordBuffer, O: Offset> EuclideanLength for $type {
             fn euclidean_length(&self) -> PrimitiveArray<f64> {
                 zeroes(self.len(), self.validity())
             }
@@ -50,7 +50,7 @@ zero_impl!(MultiPointArray<O>);
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> EuclideanLength for $type {
+        impl<C: CoordBuffer, O: Offset> EuclideanLength for $type {
             fn euclidean_length(&self) -> PrimitiveArray<f64> {
                 let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(self.len());
                 self.iter_geo()

--- a/src/algorithm/geo/geodesic_area.rs
+++ b/src/algorithm/geo/geodesic_area.rs
@@ -197,7 +197,7 @@ impl GeodesicArea for PointArray {
 /// Generate a `GeodesicArea` implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: Offset> GeodesicArea for $type {
+        impl<C: CoordBuffer, O: Offset> GeodesicArea for $type {
             fn geodesic_perimeter(&self) -> PrimitiveArray<f64> {
                 zeroes(self.len(), self.validity())
             }
@@ -236,7 +236,7 @@ zero_impl!(MultiLineStringArray<O>);
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> GeodesicArea for $type {
+        impl<C: CoordBuffer, O: Offset> GeodesicArea for $type {
             fn geodesic_perimeter(&self) -> PrimitiveArray<f64> {
                 let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(self.len());
 
@@ -313,7 +313,7 @@ iter_geo_impl!(PolygonArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> GeodesicArea for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> GeodesicArea for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn geodesic_area_signed(&self) -> PrimitiveArray<f64>;
         fn geodesic_area_unsigned(&self) -> PrimitiveArray<f64>;

--- a/src/algorithm/geo/geodesic_length.rs
+++ b/src/algorithm/geo/geodesic_length.rs
@@ -59,7 +59,7 @@ impl GeodesicLength for PointArray {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: Offset> GeodesicLength for $type {
+        impl<C: CoordBuffer, O: Offset> GeodesicLength for $type {
             fn geodesic_length(&self) -> PrimitiveArray<f64> {
                 zeroes(self.len(), self.validity())
             }
@@ -72,7 +72,7 @@ zero_impl!(MultiPointArray<O>);
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> GeodesicLength for $type {
+        impl<C: CoordBuffer, O: Offset> GeodesicLength for $type {
             fn geodesic_length(&self) -> PrimitiveArray<f64> {
                 let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(self.len());
                 self.iter_geo()

--- a/src/algorithm/geo/haversine_length.rs
+++ b/src/algorithm/geo/haversine_length.rs
@@ -53,7 +53,7 @@ impl HaversineLength for PointArray {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: Offset> HaversineLength for $type {
+        impl<C: CoordBuffer, O: Offset> HaversineLength for $type {
             fn haversine_length(&self) -> PrimitiveArray<f64> {
                 zeroes(self.len(), self.validity())
             }
@@ -66,7 +66,7 @@ zero_impl!(MultiPointArray<O>);
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> HaversineLength for $type {
+        impl<C: CoordBuffer, O: Offset> HaversineLength for $type {
             fn haversine_length(&self) -> PrimitiveArray<f64> {
                 let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(self.len());
                 self.iter_geo()

--- a/src/algorithm/geo/line_interpolate_point.rs
+++ b/src/algorithm/geo/line_interpolate_point.rs
@@ -37,7 +37,7 @@ pub trait LineInterpolatePoint<Rhs> {
     fn line_interpolate_point(&self, fraction: &Rhs) -> PointArray;
 }
 
-impl<O: Offset> LineInterpolatePoint<PrimitiveArray<f64>> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> LineInterpolatePoint<PrimitiveArray<f64>> for LineStringArray<O> {
     fn line_interpolate_point(&self, p: &PrimitiveArray<f64>) -> PointArray {
         let mut output_array = MutablePointArray::with_capacity(self.len());
 
@@ -54,7 +54,7 @@ impl<O: Offset> LineInterpolatePoint<PrimitiveArray<f64>> for LineStringArray<O>
     }
 }
 
-impl<O: Offset> LineInterpolatePoint<f64> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> LineInterpolatePoint<f64> for LineStringArray<O> {
     fn line_interpolate_point(&self, p: &f64) -> PointArray {
         let mut output_array = MutablePointArray::with_capacity(self.len());
 

--- a/src/algorithm/geo/line_locate_point.rs
+++ b/src/algorithm/geo/line_locate_point.rs
@@ -37,7 +37,7 @@ pub trait LineLocatePoint<Rhs> {
     fn line_locate_point(&self, p: &Rhs) -> PrimitiveArray<f64>;
 }
 
-impl<O: Offset> LineLocatePoint<PointArray> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> LineLocatePoint<PointArray> for LineStringArray<O> {
     fn line_locate_point(&self, p: &PointArray) -> PrimitiveArray<f64> {
         let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(self.len());
 

--- a/src/algorithm/geo/minimum_rotated_rect.rs
+++ b/src/algorithm/geo/minimum_rotated_rect.rs
@@ -83,7 +83,7 @@ impl MinimumRotatedRect<i64> for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $offset_type:ty) => {
-        impl<O: Offset> MinimumRotatedRect<$offset_type> for $type {
+        impl<C: CoordBuffer, O: Offset> MinimumRotatedRect<$offset_type> for $type {
             fn minimum_rotated_rect(&self) -> PolygonArray<$offset_type> {
                 // The number of output geoms is the same as the input
                 let geom_capacity = self.len();

--- a/src/algorithm/geo/remove_repeated_points.rs
+++ b/src/algorithm/geo/remove_repeated_points.rs
@@ -27,7 +27,7 @@ impl RemoveRepeatedPoints for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> RemoveRepeatedPoints for $type {
+        impl<C: CoordBuffer, O: Offset> RemoveRepeatedPoints for $type {
             fn remove_repeated_points(&self) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()

--- a/src/algorithm/geo/rotate.rs
+++ b/src/algorithm/geo/rotate.rs
@@ -133,7 +133,7 @@ impl Rotate<PrimitiveArray<f64>> for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> Rotate<PrimitiveArray<f64>> for $type {
+        impl<C: CoordBuffer, O: Offset> Rotate<PrimitiveArray<f64>> for $type {
             fn rotate_around_centroid(&self, degrees: &PrimitiveArray<f64>) -> $type {
                 let centroids = self.centroid();
                 let transforms: Vec<AffineTransform> = centroids
@@ -176,7 +176,7 @@ iter_geo_impl!(MultiLineStringArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> Rotate<PrimitiveArray<f64>> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Rotate<PrimitiveArray<f64>> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn rotate_around_centroid(&self, degrees: &PrimitiveArray<f64>) -> Self;
         fn rotate_around_center(&self, degrees: &PrimitiveArray<f64>) -> Self;
@@ -223,7 +223,7 @@ impl Rotate<f64> for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl_scalar {
     ($type:ty) => {
-        impl<O: Offset> Rotate<f64> for $type {
+        impl<C: CoordBuffer, O: Offset> Rotate<f64> for $type {
             fn rotate_around_centroid(&self, degrees: &f64) -> $type {
                 let centroids = self.centroid();
                 let transforms: Vec<AffineTransform> = centroids
@@ -263,7 +263,7 @@ iter_geo_impl_scalar!(MultiLineStringArray<O>);
 iter_geo_impl_scalar!(MultiPolygonArray<O>);
 iter_geo_impl_scalar!(WKBArray<O>);
 
-impl<O: Offset> Rotate<f64> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Rotate<f64> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn rotate_around_centroid(&self, degrees: &f64) -> Self;
         fn rotate_around_center(&self, degrees: &f64) -> Self;

--- a/src/algorithm/geo/scale.rs
+++ b/src/algorithm/geo/scale.rs
@@ -149,7 +149,7 @@ impl Scale for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> Scale for $type {
+        impl<C: CoordBuffer, O: Offset> Scale for $type {
             fn scale(&self, scale_factor: BroadcastablePrimitive<f64>) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()
@@ -205,7 +205,7 @@ iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
 iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
 iter_geo_impl!(WKBArray<O>, geo::Geometry);
 
-impl<O: Offset> Scale for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Scale for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn scale(&self, scale_factor: BroadcastablePrimitive<f64>) -> Self;
 

--- a/src/algorithm/geo/simplify.rs
+++ b/src/algorithm/geo/simplify.rs
@@ -53,7 +53,7 @@ impl Simplify for PointArray {
 /// Implementation that returns the identity
 macro_rules! identity_impl {
     ($type:ty) => {
-        impl<O: Offset> Simplify for $type {
+        impl<C: CoordBuffer, O: Offset> Simplify for $type {
             fn simplify(&self, _epsilon: &f64) -> Self {
                 self.clone()
             }
@@ -66,7 +66,7 @@ identity_impl!(MultiPointArray<O>);
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> Simplify for $type {
+        impl<C: CoordBuffer, O: Offset> Simplify for $type {
             fn simplify(&self, epsilon: &f64) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()

--- a/src/algorithm/geo/simplify_vw.rs
+++ b/src/algorithm/geo/simplify_vw.rs
@@ -51,7 +51,7 @@ impl SimplifyVw for PointArray {
 /// Implementation that returns the identity
 macro_rules! identity_impl {
     ($type:ty) => {
-        impl<O: Offset> SimplifyVw for $type {
+        impl<C: CoordBuffer, O: Offset> SimplifyVw for $type {
             fn simplify_vw(&self, _epsilon: &f64) -> Self {
                 self.clone()
             }
@@ -64,7 +64,7 @@ identity_impl!(MultiPointArray<O>);
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> SimplifyVw for $type {
+        impl<C: CoordBuffer, O: Offset> SimplifyVw for $type {
             fn simplify_vw(&self, epsilon: &f64) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()

--- a/src/algorithm/geo/skew.rs
+++ b/src/algorithm/geo/skew.rs
@@ -184,7 +184,7 @@ impl Skew for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> Skew for $type {
+        impl<C: CoordBuffer, O: Offset> Skew for $type {
             fn skew(&self, scale_factor: BroadcastablePrimitive<f64>) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()
@@ -240,7 +240,7 @@ iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
 iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
 iter_geo_impl!(WKBArray<O>, geo::Geometry);
 
-impl<O: Offset> Skew for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Skew for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn skew(&self, scale_factor: BroadcastablePrimitive<f64>) -> Self;
 

--- a/src/algorithm/geo/translate.rs
+++ b/src/algorithm/geo/translate.rs
@@ -69,7 +69,7 @@ impl Translate for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> Translate for $type {
+        impl<C: CoordBuffer, O: Offset> Translate for $type {
             fn translate(
                 &self,
                 x_offset: BroadcastablePrimitive<f64>,
@@ -97,7 +97,7 @@ iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
 iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
 iter_geo_impl!(WKBArray<O>, geo::Geometry);
 
-impl<O: Offset> Translate for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Translate for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn translate(
             &self,

--- a/src/algorithm/geo/vincenty_length.rs
+++ b/src/algorithm/geo/vincenty_length.rs
@@ -53,7 +53,7 @@ impl VincentyLength for PointArray {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: Offset> VincentyLength for $type {
+        impl<C: CoordBuffer, O: Offset> VincentyLength for $type {
             fn vincenty_length(&self) -> Result<PrimitiveArray<f64>> {
                 Ok(zeroes(self.len(), self.validity()))
             }
@@ -66,7 +66,7 @@ zero_impl!(MultiPointArray<O>);
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> VincentyLength for $type {
+        impl<C: CoordBuffer, O: Offset> VincentyLength for $type {
             fn vincenty_length(&self) -> Result<PrimitiveArray<f64>> {
                 let mut output_array = MutablePrimitiveArray::<f64>::with_capacity(self.len());
                 // TODO: remove unwrap

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -23,7 +23,7 @@ use rstar::RTree;
 pub struct WKBArray<O: Offset>(BinaryArray<O>);
 
 // Implement geometry accessors
-impl<O: Offset> WKBArray<O> {
+impl<C: CoordBuffer, O: Offset> WKBArray<O> {
     /// Create a new WKBArray from a BinaryArray
     pub fn new(arr: BinaryArray<O>) -> Self {
         Self(arr)
@@ -166,7 +166,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for WKBArray<O> {
     }
 }
 
-impl<O: Offset> WKBArray<O> {
+impl<C: CoordBuffer, O: Offset> WKBArray<O> {
     /// Returns the value at slot `i` as a GEOS geometry.
     #[cfg(feature = "geos")]
     pub fn value_as_geos(&self, i: usize) -> geos::Geometry {
@@ -212,7 +212,7 @@ impl<O: Offset> WKBArray<O> {
     }
 }
 
-impl<O: Offset> From<BinaryArray<O>> for WKBArray<O> {
+impl<C: CoordBuffer, O: Offset> From<BinaryArray<O>> for WKBArray<O> {
     fn from(value: BinaryArray<O>) -> Self {
         Self::new(value)
     }
@@ -317,14 +317,14 @@ impl TryFrom<WKBArray<i64>> for WKBArray<i32> {
 //     }
 // }
 
-impl<O: Offset> From<Vec<Option<geo::Geometry>>> for WKBArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<geo::Geometry>>> for WKBArray<O> {
     fn from(other: Vec<Option<geo::Geometry>>) -> Self {
         let mut_arr: MutableWKBArray<O> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::Geometry>>> for WKBArray<O> {
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::Geometry>>> for WKBArray<O> {
     fn from(other: bumpalo::collections::Vec<'_, Option<geo::Geometry>>) -> Self {
         let mut_arr: MutableWKBArray<O> = other.into();
         mut_arr.into()

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -13,13 +13,13 @@ use super::array::WKBArray;
 #[derive(Debug, Clone)]
 pub struct MutableWKBArray<O: Offset>(MutableBinaryArray<O>);
 
-impl<O: Offset> Default for MutableWKBArray<O> {
+impl<C: CoordBuffer, O: Offset> Default for MutableWKBArray<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Offset> MutableWKBArray<O> {
+impl<C: CoordBuffer, O: Offset> MutableWKBArray<O> {
     /// Creates a new empty [`MutableWKBArray`].
     /// # Implementation
     /// This allocates a [`Vec`] of one element
@@ -40,7 +40,7 @@ impl<O: Offset> MutableWKBArray<O> {
     }
 }
 
-impl<O: Offset> MutableGeometryArray for MutableWKBArray<O> {
+impl<C: CoordBuffer, O: Offset> MutableGeometryArray for MutableWKBArray<O> {
     fn len(&self) -> usize {
         self.0.values().len()
     }
@@ -69,7 +69,7 @@ impl<O: Offset> MutableGeometryArray for MutableWKBArray<O> {
 }
 
 #[cfg(feature = "geozero")]
-impl<O: Offset> From<Vec<Option<Geometry>>> for MutableWKBArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<Geometry>>> for MutableWKBArray<O> {
     fn from(other: Vec<Option<Geometry>>) -> Self {
         let mut wkb_array = MutableBinaryArray::<O>::with_capacity(other.len());
 
@@ -83,14 +83,14 @@ impl<O: Offset> From<Vec<Option<Geometry>>> for MutableWKBArray<O> {
 }
 
 #[cfg(not(feature = "geozero"))]
-impl<O: Offset> From<Vec<Option<Geometry>>> for MutableWKBArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<Geometry>>> for MutableWKBArray<O> {
     fn from(_other: Vec<Option<Geometry>>) -> Self {
         panic!("Activate the 'geozero' feature to convert to WKB.")
     }
 }
 
 #[cfg(feature = "geozero")]
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<Geometry>>> for MutableWKBArray<O> {
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<Geometry>>> for MutableWKBArray<O> {
     fn from(other: bumpalo::collections::Vec<'_, Option<Geometry>>) -> Self {
         let mut wkb_array = MutableBinaryArray::<O>::with_capacity(other.len());
 
@@ -104,13 +104,13 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<Geometry>>> for Mutabl
 }
 
 #[cfg(not(feature = "geozero"))]
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<Geometry>>> for MutableWKBArray<O> {
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<Geometry>>> for MutableWKBArray<O> {
     fn from(_other: bumpalo::collections::Vec<'_, Option<Geometry>>) -> Self {
         panic!("Activate the 'geozero' feature to convert to WKB.")
     }
 }
 
-impl<O: Offset> From<MutableWKBArray<O>> for WKBArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableWKBArray<O>> for WKBArray<O> {
     fn from(other: MutableWKBArray<O>) -> Self {
         Self::new(other.0.into())
     }

--- a/src/array/coord/combined/array.rs
+++ b/src/array/coord/combined/array.rs
@@ -3,12 +3,34 @@ use crate::array::{
     SeparatedCoordBuffer,
 };
 use crate::error::GeoArrowError;
+use crate::geo_traits::CoordTrait;
 use crate::scalar::Coord;
 use crate::GeometryArrayTrait;
 use arrow2::array::{Array, FixedSizeListArray, StructArray};
 use arrow2::datatypes::DataType;
 use itertools::Itertools;
 use rstar::RTree;
+
+pub trait CoordBuffer {
+    type ArrowArray;
+    type Scalar: CoordTrait;
+
+    fn value(&self, i: usize) -> Self::Scalar;
+
+    fn logical_type(&self) -> DataType;
+
+    fn into_arrow(self) -> Self::ArrowArray;
+
+    fn into_boxed_arrow(self) -> Box<dyn Array>;
+
+    fn coord_type(&self) -> CoordType;
+
+    fn slice(&mut self, offset: usize, length: usize);
+
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize);
+
+    fn owned_slice(&self, offset: usize, length: usize) -> Self;
+}
 
 /// An Arrow representation of an array of coordinates.
 ///
@@ -22,11 +44,11 @@ use rstar::RTree;
 /// This is named `CoordBuffer` instead of `CoordArray` because the buffer does not store its own
 /// validity bitmask. Rather the geometry arrays that build on top of this maintain their own
 /// validity masks.
-#[derive(Debug, Clone)]
-pub enum CoordBuffer {
-    Interleaved(InterleavedCoordBuffer),
-    Separated(SeparatedCoordBuffer),
-}
+// #[derive(Debug, Clone)]
+// pub enum CoordBuffer {
+//     Interleaved(InterleavedCoordBuffer),
+//     Separated(SeparatedCoordBuffer),
+// }
 
 impl CoordBuffer {
     pub fn get_x(&self, i: usize) -> f64 {

--- a/src/array/coord/combined/mod.rs
+++ b/src/array/coord/combined/mod.rs
@@ -1,5 +1,5 @@
 mod array;
 mod mutable;
 
-pub use array::CoordBuffer;
+pub use array::{CoordBuffer, CoordBufferTrait};
 pub use mutable::MutableCoordBuffer;

--- a/src/array/coord/combined/mutable.rs
+++ b/src/array/coord/combined/mutable.rs
@@ -1,4 +1,12 @@
 use crate::array::{CoordBuffer, MutableInterleavedCoordBuffer, MutableSeparatedCoordBuffer};
+use crate::geo_traits::CoordTrait;
+
+pub trait MutableCoordBuffer:
+    Into<dyn CoordBuffer<ArrowArray = Self::ArrowArray, Scalar = Self::Scalar>> + Sized
+{
+    type ArrowArray;
+    type Scalar: CoordTrait;
+}
 
 #[derive(Debug, Clone)]
 pub enum MutableCoordBuffer {

--- a/src/array/geometry/array.rs
+++ b/src/array/geometry/array.rs
@@ -316,43 +316,43 @@ impl TryFrom<&dyn Array> for GeometryArray<i64> {
 }
 
 // TODO: write a macro to dedupe these `From`s
-impl<O: Offset> From<PointArray> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> From<PointArray> for GeometryArray<O> {
     fn from(value: PointArray) -> Self {
         GeometryArray::Point(value)
     }
 }
 
-impl<O: Offset> From<LineStringArray<O>> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> From<LineStringArray<O>> for GeometryArray<O> {
     fn from(value: LineStringArray<O>) -> Self {
         GeometryArray::LineString(value)
     }
 }
 
-impl<O: Offset> From<PolygonArray<O>> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> From<PolygonArray<O>> for GeometryArray<O> {
     fn from(value: PolygonArray<O>) -> Self {
         GeometryArray::Polygon(value)
     }
 }
 
-impl<O: Offset> From<MultiPointArray<O>> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MultiPointArray<O>> for GeometryArray<O> {
     fn from(value: MultiPointArray<O>) -> Self {
         GeometryArray::MultiPoint(value)
     }
 }
 
-impl<O: Offset> From<MultiLineStringArray<O>> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MultiLineStringArray<O>> for GeometryArray<O> {
     fn from(value: MultiLineStringArray<O>) -> Self {
         GeometryArray::MultiLineString(value)
     }
 }
 
-impl<O: Offset> From<MultiPolygonArray<O>> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MultiPolygonArray<O>> for GeometryArray<O> {
     fn from(value: MultiPolygonArray<O>) -> Self {
         GeometryArray::MultiPolygon(value)
     }
 }
 
-impl<O: Offset> From<WKBArray<O>> for GeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> From<WKBArray<O>> for GeometryArray<O> {
     fn from(value: WKBArray<O>) -> Self {
         GeometryArray::WKB(value)
     }

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -27,7 +27,7 @@ pub struct GeometryCollectionArray<O: Offset> {
     pub validity: Option<Bitmap>,
 }
 
-impl<O: Offset> GeometryCollectionArray<O> {
+impl<C: CoordBuffer, O: Offset> GeometryCollectionArray<O> {
     /// Create a new GeometryCollectionArray from parts
     ///
     /// # Implementation
@@ -159,7 +159,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryCollectionArray<O> {
 }
 
 // Implement geometry accessors
-impl<O: Offset> GeometryCollectionArray<O> {
+impl<C: CoordBuffer, O: Offset> GeometryCollectionArray<O> {
     /// Iterator over geo Geometry objects, not looking at validity
     pub fn iter_geo_values(&self) -> impl Iterator<Item = geo::GeometryCollection> + '_ {
         (0..self.len()).map(|i| self.value_as_geo(i))

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -49,7 +49,7 @@ pub(super) fn check<O: Offset>(
     Ok(())
 }
 
-impl<O: Offset> LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> LineStringArray<O> {
     /// Create a new LineStringArray from parts
     ///
     /// # Implementation
@@ -242,7 +242,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for LineStringArray<O> {
 }
 
 // Implement geometry accessors
-impl<O: Offset> LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> LineStringArray<O> {
     /// Iterator over geo Geometry objects, not looking at validity
     pub fn iter_geo_values(&self) -> impl Iterator<Item = geo::LineString> + '_ {
         (0..self.len()).map(|i| self.value_as_geo(i))
@@ -286,7 +286,7 @@ impl<O: Offset> LineStringArray<O> {
     }
 }
 
-impl<O: Offset> TryFrom<&ListArray<O>> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<&ListArray<O>> for LineStringArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: &ListArray<O>) -> Result<Self> {
@@ -342,21 +342,21 @@ impl TryFrom<&dyn Array> for LineStringArray<i64> {
     }
 }
 
-impl<O: Offset> From<Vec<Option<geo::LineString>>> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<geo::LineString>>> for LineStringArray<O> {
     fn from(other: Vec<Option<geo::LineString>>) -> Self {
         let mut_arr: MutableLineStringArray<O> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: Offset> From<Vec<geo::LineString>> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<geo::LineString>> for LineStringArray<O> {
     fn from(other: Vec<geo::LineString>) -> Self {
         let mut_arr: MutableLineStringArray<O> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::LineString>>>
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::LineString>>>
     for LineStringArray<O>
 {
     fn from(other: bumpalo::collections::Vec<'_, Option<geo::LineString>>) -> Self {
@@ -365,7 +365,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::LineString>>>
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::LineString>> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, geo::LineString>> for LineStringArray<O> {
     fn from(other: bumpalo::collections::Vec<'_, geo::LineString>) -> Self {
         let mut_arr: MutableLineStringArray<O> = other.into();
         mut_arr.into()
@@ -374,13 +374,13 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::LineString>> for LineStr
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<O: Offset> From<LineStringArray<O>> for MultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> From<LineStringArray<O>> for MultiPointArray<O> {
     fn from(value: LineStringArray<O>) -> Self {
         Self::new(value.coords, value.geom_offsets, value.validity)
     }
 }
 
-impl<O: Offset> TryFrom<WKBArray<O>> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<WKBArray<O>> for LineStringArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -408,7 +408,7 @@ impl TryFrom<LineStringArray<i64>> for LineStringArray<i32> {
 }
 
 /// Default to an empty array
-impl<O: Offset> Default for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> Default for LineStringArray<O> {
     fn default() -> Self {
         MutableLineStringArray::default().into()
     }

--- a/src/array/linestring/mutable.rs
+++ b/src/array/linestring/mutable.rs
@@ -195,13 +195,13 @@ impl<'a, O: Offset> MutableLineStringArray<O> {
     }
 }
 
-impl<O: Offset> Default for MutableLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> Default for MutableLineStringArray<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Offset> From<MutableLineStringArray<O>> for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableLineStringArray<O>> for LineStringArray<O> {
     fn from(other: MutableLineStringArray<O>) -> Self {
         let validity = other.validity.and_then(|x| {
             let bitmap: Bitmap = x.into();
@@ -216,7 +216,7 @@ impl<O: Offset> From<MutableLineStringArray<O>> for LineStringArray<O> {
     }
 }
 
-impl<O: Offset> From<MutableLineStringArray<O>> for ListArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableLineStringArray<O>> for ListArray<O> {
     fn from(arr: MutableLineStringArray<O>) -> Self {
         arr.into_arrow()
     }
@@ -251,14 +251,14 @@ fn second_pass<'a, O: Offset>(
     array
 }
 
-impl<O: Offset> From<Vec<geo::LineString>> for MutableLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<geo::LineString>> for MutableLineStringArray<O> {
     fn from(geoms: Vec<geo::LineString>) -> Self {
         let (coord_capacity, geom_capacity) = first_pass(geoms.iter().map(Some), geoms.len());
         second_pass(geoms.into_iter().map(Some), coord_capacity, geom_capacity)
     }
 }
 
-impl<O: Offset> From<Vec<Option<geo::LineString>>> for MutableLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<geo::LineString>>> for MutableLineStringArray<O> {
     fn from(geoms: Vec<Option<geo::LineString>>) -> Self {
         let (coord_capacity, geom_capacity) =
             first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
@@ -266,14 +266,14 @@ impl<O: Offset> From<Vec<Option<geo::LineString>>> for MutableLineStringArray<O>
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::LineString>> for MutableLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, geo::LineString>> for MutableLineStringArray<O> {
     fn from(geoms: bumpalo::collections::Vec<'_, geo::LineString>) -> Self {
         let (coord_capacity, geom_capacity) = first_pass(geoms.iter().map(Some), geoms.len());
         second_pass(geoms.into_iter().map(Some), coord_capacity, geom_capacity)
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::LineString>>>
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::LineString>>>
     for MutableLineStringArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<geo::LineString>>) -> Self {
@@ -283,7 +283,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::LineString>>>
     }
 }
 
-impl<O: Offset> TryFrom<WKBArray<O>> for MutableLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<WKBArray<O>> for MutableLineStringArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -307,7 +307,7 @@ impl<O: Offset> TryFrom<WKBArray<O>> for MutableLineStringArray<O> {
 }
 
 // #[cfg(feature = "geos")]
-// impl<O: Offset> TryFrom<Vec<Option<geos::Geometry<'_>>>> for MutableLineStringArray<O> {
+// impl<C: CoordBuffer, O: Offset> TryFrom<Vec<Option<geos::Geometry<'_>>>> for MutableLineStringArray<O> {
 //     type Error = GeoArrowError;
 //     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
 //         let length = value.len();
@@ -331,7 +331,7 @@ impl<O: Offset> TryFrom<WKBArray<O>> for MutableLineStringArray<O> {
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<O: Offset> From<MutableLineStringArray<O>> for MutableMultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableLineStringArray<O>> for MutableMultiPointArray<O> {
     fn from(value: MutableLineStringArray<O>) -> Self {
         Self::try_new(value.coords, value.geom_offsets, value.validity).unwrap()
     }

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -120,7 +120,7 @@ impl From<&String> for GeometryType {
     }
 }
 
-impl<O: Offset> MixedGeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> MixedGeometryArray<O> {
     /// Create a new MixedGeometryArray from parts
     ///
     /// # Implementation
@@ -344,7 +344,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MixedGeometryArray<O> {
 }
 
 // Implement geometry accessors
-impl<O: Offset> MixedGeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> MixedGeometryArray<O> {
     /// Iterator over geo Geometry objects, not looking at validity
     pub fn iter_geo_values(&self) -> impl Iterator<Item = geo::Geometry> + '_ {
         (0..self.len()).map(|i| self.value_as_geo(i))
@@ -558,7 +558,7 @@ impl TryFrom<&UnionArray> for MixedGeometryArray<i64> {
     }
 }
 
-impl<O: Offset> TryFrom<Vec<geo::Geometry>> for MixedGeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<Vec<geo::Geometry>> for MixedGeometryArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geo::Geometry>) -> std::result::Result<Self, Self::Error> {

--- a/src/array/mixed/mutable.rs
+++ b/src/array/mixed/mutable.rs
@@ -301,13 +301,13 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
     }
 }
 
-impl<O: Offset> Default for MutableMixedGeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> Default for MutableMixedGeometryArray<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Offset> From<MutableMixedGeometryArray<O>> for MixedGeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableMixedGeometryArray<O>> for MixedGeometryArray<O> {
     fn from(other: MutableMixedGeometryArray<O>) -> Self {
         Self::new(
             other.types.into(),
@@ -392,7 +392,7 @@ fn from_geo_iterator<'a, O: Offset>(
     Ok(array)
 }
 
-impl<O: Offset> TryFrom<Vec<geo::Geometry>> for MutableMixedGeometryArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<Vec<geo::Geometry>> for MutableMixedGeometryArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geo::Geometry>) -> std::result::Result<Self, Self::Error> {

--- a/src/array/multilinestring/mutable.rs
+++ b/src/array/multilinestring/mutable.rs
@@ -285,13 +285,13 @@ impl<'a, O: Offset> MutableMultiLineStringArray<O> {
     }
 }
 
-impl<O: Offset> Default for MutableMultiLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> Default for MutableMultiLineStringArray<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Offset> From<MutableMultiLineStringArray<O>> for MultiLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableMultiLineStringArray<O>> for MultiLineStringArray<O> {
     fn from(other: MutableMultiLineStringArray<O>) -> Self {
         let validity = other.validity.and_then(|x| {
             let bitmap: Bitmap = x.into();
@@ -352,7 +352,7 @@ fn second_pass<'a, O: Offset>(
     array
 }
 
-impl<O: Offset> From<Vec<geo::MultiLineString>> for MutableMultiLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<geo::MultiLineString>> for MutableMultiLineStringArray<O> {
     fn from(geoms: Vec<geo::MultiLineString>) -> Self {
         let (coord_capacity, ring_capacity, geom_capacity) =
             first_pass(geoms.iter().map(Some), geoms.len());
@@ -365,7 +365,7 @@ impl<O: Offset> From<Vec<geo::MultiLineString>> for MutableMultiLineStringArray<
     }
 }
 
-impl<O: Offset> From<Vec<Option<geo::MultiLineString>>> for MutableMultiLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<geo::MultiLineString>>> for MutableMultiLineStringArray<O> {
     fn from(geoms: Vec<Option<geo::MultiLineString>>) -> Self {
         let (coord_capacity, ring_capacity, geom_capacity) =
             first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
@@ -378,7 +378,7 @@ impl<O: Offset> From<Vec<Option<geo::MultiLineString>>> for MutableMultiLineStri
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiLineString>>
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiLineString>>
     for MutableMultiLineStringArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, geo::MultiLineString>) -> Self {
@@ -393,7 +393,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiLineString>>
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiLineString>>>
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiLineString>>>
     for MutableMultiLineStringArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<geo::MultiLineString>>) -> Self {
@@ -408,7 +408,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiLineString>>
     }
 }
 
-impl<O: Offset> TryFrom<WKBArray<O>> for MutableMultiLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<WKBArray<O>> for MutableMultiLineStringArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -434,7 +434,7 @@ impl<O: Offset> TryFrom<WKBArray<O>> for MutableMultiLineStringArray<O> {
 
 /// Polygon and MultiLineString have the same layout, so enable conversions between the two to
 /// change the semantic type
-impl<O: Offset> From<MutableMultiLineStringArray<O>> for MutablePolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableMultiLineStringArray<O>> for MutablePolygonArray<O> {
     fn from(value: MutableMultiLineStringArray<O>) -> Self {
         Self::try_new(
             value.coords,

--- a/src/array/multipoint/mutable.rs
+++ b/src/array/multipoint/mutable.rs
@@ -208,13 +208,13 @@ impl<'a, O: Offset> MutableMultiPointArray<O> {
     }
 }
 
-impl<O: Offset> Default for MutableMultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> Default for MutableMultiPointArray<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Offset> MutableGeometryArray for MutableMultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> MutableGeometryArray for MutableMultiPointArray<O> {
     fn len(&self) -> usize {
         self.coords.len()
     }
@@ -232,7 +232,7 @@ impl<O: Offset> MutableGeometryArray for MutableMultiPointArray<O> {
     }
 }
 
-impl<O: Offset> From<MutableMultiPointArray<O>> for MultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableMultiPointArray<O>> for MultiPointArray<O> {
     fn from(mut other: MutableMultiPointArray<O>) -> Self {
         let validity = other.validity.and_then(|x| {
             let bitmap: Bitmap = x.into();
@@ -251,7 +251,7 @@ impl<O: Offset> From<MutableMultiPointArray<O>> for MultiPointArray<O> {
     }
 }
 
-impl<O: Offset> From<MutableMultiPointArray<O>> for ListArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableMultiPointArray<O>> for ListArray<O> {
     fn from(arr: MutableMultiPointArray<O>) -> Self {
         arr.into_arrow()
     }
@@ -286,14 +286,14 @@ fn second_pass<'a, O: Offset>(
     array
 }
 
-impl<O: Offset> From<Vec<geo::MultiPoint>> for MutableMultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<geo::MultiPoint>> for MutableMultiPointArray<O> {
     fn from(geoms: Vec<geo::MultiPoint>) -> Self {
         let (coord_capacity, geom_capacity) = first_pass(geoms.iter().map(Some), geoms.len());
         second_pass(geoms.into_iter().map(Some), coord_capacity, geom_capacity)
     }
 }
 
-impl<O: Offset> From<Vec<Option<geo::MultiPoint>>> for MutableMultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<geo::MultiPoint>>> for MutableMultiPointArray<O> {
     fn from(geoms: Vec<Option<geo::MultiPoint>>) -> Self {
         let (coord_capacity, geom_capacity) =
             first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
@@ -301,14 +301,14 @@ impl<O: Offset> From<Vec<Option<geo::MultiPoint>>> for MutableMultiPointArray<O>
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiPoint>> for MutableMultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiPoint>> for MutableMultiPointArray<O> {
     fn from(geoms: bumpalo::collections::Vec<'_, geo::MultiPoint>) -> Self {
         let (coord_capacity, geom_capacity) = first_pass(geoms.iter().map(Some), geoms.len());
         second_pass(geoms.into_iter().map(Some), coord_capacity, geom_capacity)
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiPoint>>>
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiPoint>>>
     for MutableMultiPointArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<geo::MultiPoint>>) -> Self {
@@ -318,7 +318,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiPoint>>>
     }
 }
 
-impl<O: Offset> TryFrom<WKBArray<O>> for MutableMultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<WKBArray<O>> for MutableMultiPointArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -343,7 +343,7 @@ impl<O: Offset> TryFrom<WKBArray<O>> for MutableMultiPointArray<O> {
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<O: Offset> From<MutableMultiPointArray<O>> for MutableLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableMultiPointArray<O>> for MutableLineStringArray<O> {
     fn from(value: MutableMultiPointArray<O>) -> Self {
         Self::try_new(value.coords, value.geom_offsets, value.validity).unwrap()
     }

--- a/src/array/multipolygon/mutable.rs
+++ b/src/array/multipolygon/mutable.rs
@@ -345,13 +345,13 @@ impl<'a, O: Offset> MutableMultiPolygonArray<O> {
     }
 }
 
-impl<O: Offset> Default for MutableMultiPolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> Default for MutableMultiPolygonArray<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Offset> From<MutableMultiPolygonArray<O>> for MultiPolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutableMultiPolygonArray<O>> for MultiPolygonArray<O> {
     fn from(other: MutableMultiPolygonArray<O>) -> Self {
         let validity = other.validity.and_then(|x| {
             let bitmap: Bitmap = x.into();
@@ -438,7 +438,7 @@ fn second_pass<'a, O: Offset>(
     array
 }
 
-impl<O: Offset> From<Vec<geo::MultiPolygon>> for MutableMultiPolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<geo::MultiPolygon>> for MutableMultiPolygonArray<O> {
     fn from(geoms: Vec<geo::MultiPolygon>) -> Self {
         let (coord_capacity, ring_capacity, polygon_capacity, geom_capacity) =
             first_pass(geoms.iter().map(Some), geoms.len());
@@ -452,7 +452,7 @@ impl<O: Offset> From<Vec<geo::MultiPolygon>> for MutableMultiPolygonArray<O> {
     }
 }
 
-impl<O: Offset> From<Vec<Option<geo::MultiPolygon>>> for MutableMultiPolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<geo::MultiPolygon>>> for MutableMultiPolygonArray<O> {
     fn from(geoms: Vec<Option<geo::MultiPolygon>>) -> Self {
         let (coord_capacity, ring_capacity, polygon_capacity, geom_capacity) =
             first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
@@ -466,7 +466,7 @@ impl<O: Offset> From<Vec<Option<geo::MultiPolygon>>> for MutableMultiPolygonArra
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiPolygon>>
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiPolygon>>
     for MutableMultiPolygonArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, geo::MultiPolygon>) -> Self {
@@ -482,7 +482,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiPolygon>>
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiPolygon>>>
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiPolygon>>>
     for MutableMultiPolygonArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<geo::MultiPolygon>>) -> Self {
@@ -498,7 +498,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiPolygon>>>
     }
 }
 
-impl<O: Offset> TryFrom<WKBArray<O>> for MutableMultiPolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<WKBArray<O>> for MutableMultiPolygonArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {

--- a/src/array/point/iterator.rs
+++ b/src/array/point/iterator.rs
@@ -1,12 +1,12 @@
-use crate::array::PointArray;
+use crate::array::{PointArray, CoordBuffer};
 use crate::GeometryArrayTrait;
 use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
 use arrow2::trusted_len::TrustedLen;
 
 /// Iterator of values of a [`PointArray`]
 #[derive(Clone, Debug)]
-pub struct PointArrayValuesIter<'a> {
-    array: &'a PointArray,
+pub struct PointArrayValuesIter<'a, C: CoordBuffer> {
+    array: &'a PointArray<C>,
     index: usize,
     end: usize,
 }

--- a/src/array/point/mutable.rs
+++ b/src/array/point/mutable.rs
@@ -237,7 +237,7 @@ impl From<bumpalo::collections::Vec<'_, Option<Point>>> for MutablePointArray {
     }
 }
 
-impl<O: Offset> TryFrom<WKBArray<O>> for MutablePointArray {
+impl<C: CoordBuffer, O: Offset> TryFrom<WKBArray<O>> for MutablePointArray {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self, Self::Error> {

--- a/src/array/polygon/mutable.rs
+++ b/src/array/polygon/mutable.rs
@@ -266,13 +266,13 @@ impl<'a, O: Offset> MutablePolygonArray<O> {
     }
 }
 
-impl<O: Offset> Default for MutablePolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> Default for MutablePolygonArray<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Offset> From<MutablePolygonArray<O>> for PolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutablePolygonArray<O>> for PolygonArray<O> {
     fn from(other: MutablePolygonArray<O>) -> Self {
         let validity = other.validity.and_then(|x| {
             let bitmap: Bitmap = x.into();
@@ -336,7 +336,7 @@ fn second_pass<'a, O: Offset>(
     array
 }
 
-impl<O: Offset> From<Vec<geo::Polygon>> for MutablePolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<geo::Polygon>> for MutablePolygonArray<O> {
     fn from(geoms: Vec<geo::Polygon>) -> Self {
         let (coord_capacity, ring_capacity, geom_capacity) =
             first_pass(geoms.iter().map(Some), geoms.len());
@@ -349,7 +349,7 @@ impl<O: Offset> From<Vec<geo::Polygon>> for MutablePolygonArray<O> {
     }
 }
 
-impl<O: Offset> From<Vec<Option<geo::Polygon>>> for MutablePolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> From<Vec<Option<geo::Polygon>>> for MutablePolygonArray<O> {
     fn from(geoms: Vec<Option<geo::Polygon>>) -> Self {
         let (coord_capacity, ring_capacity, geom_capacity) =
             first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
@@ -362,7 +362,7 @@ impl<O: Offset> From<Vec<Option<geo::Polygon>>> for MutablePolygonArray<O> {
     }
 }
 
-impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::Polygon>> for MutablePolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, geo::Polygon>> for MutablePolygonArray<O> {
     fn from(geoms: bumpalo::collections::Vec<'_, geo::Polygon>) -> Self {
         let (coord_capacity, ring_capacity, geom_capacity) =
             first_pass(geoms.iter().map(Some), geoms.len());
@@ -374,7 +374,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::Polygon>> for MutablePol
         )
     }
 }
-impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::Polygon>>>
+impl<C: CoordBuffer, O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::Polygon>>>
     for MutablePolygonArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<geo::Polygon>>) -> Self {
@@ -389,7 +389,7 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::Polygon>>>
     }
 }
 
-impl<O: Offset> TryFrom<WKBArray<O>> for MutablePolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> TryFrom<WKBArray<O>> for MutablePolygonArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -415,7 +415,7 @@ impl<O: Offset> TryFrom<WKBArray<O>> for MutablePolygonArray<O> {
 
 /// Polygon and MultiLineString have the same layout, so enable conversions between the two to
 /// change the semantic type
-impl<O: Offset> From<MutablePolygonArray<O>> for MutableMultiLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> From<MutablePolygonArray<O>> for MutableMultiLineStringArray<O> {
     fn from(value: MutablePolygonArray<O>) -> Self {
         Self::try_new(
             value.coords,

--- a/src/io/geozero/array/linestring.rs
+++ b/src/io/geozero/array/linestring.rs
@@ -5,7 +5,7 @@ use crate::array::{LineStringArray, MutableLineStringArray};
 use crate::io::geozero::scalar::linestring::process_line_string;
 use crate::GeometryArrayTrait;
 
-impl<O: Offset> GeozeroGeometry for LineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for LineStringArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -44,7 +44,7 @@ impl<T: GeozeroGeometry, O: Offset> ToGeoArrowLineStringArray<O> for T {
 }
 
 #[allow(unused_variables)]
-impl<O: Offset> GeomProcessor for MutableLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> GeomProcessor for MutableLineStringArray<O> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         self.reserve(0, size);
         Ok(())

--- a/src/io/geozero/array/multilinestring.rs
+++ b/src/io/geozero/array/multilinestring.rs
@@ -5,7 +5,7 @@ use crate::array::{MultiLineStringArray, MutableMultiLineStringArray};
 use crate::io::geozero::scalar::multilinestring::process_multi_line_string;
 use crate::GeometryArrayTrait;
 
-impl<O: Offset> GeozeroGeometry for MultiLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for MultiLineStringArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -48,7 +48,7 @@ impl<T: GeozeroGeometry, O: Offset> ToGeoArrowMultiLineStringArray<O> for T {
 }
 
 #[allow(unused_variables)]
-impl<O: Offset> GeomProcessor for MutableMultiLineStringArray<O> {
+impl<C: CoordBuffer, O: Offset> GeomProcessor for MutableMultiLineStringArray<O> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         self.reserve(0, 0, size);

--- a/src/io/geozero/array/multipoint.rs
+++ b/src/io/geozero/array/multipoint.rs
@@ -4,7 +4,7 @@ use crate::GeometryArrayTrait;
 use arrow2::types::Offset;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<O: Offset> GeozeroGeometry for MultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for MultiPointArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -43,7 +43,7 @@ impl<T: GeozeroGeometry, O: Offset> ToGeoArrowMultiPointArray<O> for T {
 }
 
 #[allow(unused_variables)]
-impl<O: Offset> GeomProcessor for MutableMultiPointArray<O> {
+impl<C: CoordBuffer, O: Offset> GeomProcessor for MutableMultiPointArray<O> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         self.reserve(0, size);
         Ok(())

--- a/src/io/geozero/array/multipolygon.rs
+++ b/src/io/geozero/array/multipolygon.rs
@@ -5,7 +5,7 @@ use crate::array::{MultiPolygonArray, MutableMultiPolygonArray};
 use crate::io::geozero::scalar::multipolygon::process_multi_polygon;
 use crate::GeometryArrayTrait;
 
-impl<O: Offset> GeozeroGeometry for MultiPolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for MultiPolygonArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -44,7 +44,7 @@ impl<T: GeozeroGeometry, O: Offset> ToGeoArrowMultiPolygonArray<O> for T {
 }
 
 #[allow(unused_variables)]
-impl<O: Offset> GeomProcessor for MutableMultiPolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> GeomProcessor for MutableMultiPolygonArray<O> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         self.reserve(0, 0, 0, size);

--- a/src/io/geozero/array/polygon.rs
+++ b/src/io/geozero/array/polygon.rs
@@ -5,7 +5,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::{MutablePolygonArray, PolygonArray};
 
-impl<O: Offset> GeozeroGeometry for PolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for PolygonArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -44,7 +44,7 @@ impl<T: GeozeroGeometry, O: Offset> ToGeoArrowPolygonArray<O> for T {
 }
 
 #[allow(unused_variables)]
-impl<O: Offset> GeomProcessor for MutablePolygonArray<O> {
+impl<C: CoordBuffer, O: Offset> GeomProcessor for MutablePolygonArray<O> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         self.reserve(0, 0, size);

--- a/src/io/geozero/scalar/linestring.rs
+++ b/src/io/geozero/scalar/linestring.rs
@@ -19,7 +19,7 @@ pub(crate) fn process_line_string<'a, P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: Offset> GeozeroGeometry for LineString<'_, O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for LineString<'_, O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multilinestring.rs
+++ b/src/io/geozero/scalar/multilinestring.rs
@@ -27,7 +27,7 @@ pub(crate) fn process_multi_line_string<'a, P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: Offset> GeozeroGeometry for MultiLineString<'_, O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for MultiLineString<'_, O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multipoint.rs
+++ b/src/io/geozero/scalar/multipoint.rs
@@ -19,7 +19,7 @@ pub(crate) fn process_multi_point<'a, P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: Offset> GeozeroGeometry for MultiPoint<'_, O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for MultiPoint<'_, O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multipolygon.rs
+++ b/src/io/geozero/scalar/multipolygon.rs
@@ -21,7 +21,7 @@ pub(crate) fn process_multi_polygon<'a, P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: Offset> GeozeroGeometry for MultiPolygon<'_, O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for MultiPolygon<'_, O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/polygon.rs
+++ b/src/io/geozero/scalar/polygon.rs
@@ -44,7 +44,7 @@ pub(crate) fn process_polygon<'a, P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: Offset> GeozeroGeometry for Polygon<'_, O> {
+impl<C: CoordBuffer, O: Offset> GeozeroGeometry for Polygon<'_, O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/scalar/binary/scalar.rs
+++ b/src/scalar/binary/scalar.rs
@@ -43,14 +43,14 @@ impl<'a, O: Offset> GeometryScalarTrait<'a> for WKB<'a, O> {
 }
 
 #[cfg(feature = "geozero")]
-impl<O: Offset> From<WKB<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<WKB<'_, O>> for geo::Geometry {
     fn from(value: WKB<'_, O>) -> Self {
         (&value).into()
     }
 }
 
 #[cfg(feature = "geozero")]
-impl<O: Offset> From<&WKB<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<&WKB<'_, O>> for geo::Geometry {
     fn from(value: &WKB<'_, O>) -> Self {
         let buf = value.arr.value(value.geom_index);
         geozero::wkb::Wkb(buf.to_vec()).to_geo().unwrap()
@@ -58,20 +58,20 @@ impl<O: Offset> From<&WKB<'_, O>> for geo::Geometry {
 }
 
 #[cfg(not(feature = "geozero"))]
-impl<O: Offset> From<WKB<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<WKB<'_, O>> for geo::Geometry {
     fn from(_value: WKB<'_, O>) -> Self {
         (&_value).into()
     }
 }
 
 #[cfg(not(feature = "geozero"))]
-impl<O: Offset> From<&WKB<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<&WKB<'_, O>> for geo::Geometry {
     fn from(_value: &WKB<'_, O>) -> Self {
         panic!("Activate the 'geozero' feature to convert WKB items to geo::Geometry.")
     }
 }
 
-impl<O: Offset> RTreeObject for WKB<'_, O> {
+impl<C: CoordBuffer, O: Offset> RTreeObject for WKB<'_, O> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -83,7 +83,7 @@ impl<O: Offset> RTreeObject for WKB<'_, O> {
     }
 }
 
-impl<O: Offset> PartialEq for WKB<'_, O> {
+impl<C: CoordBuffer, O: Offset> PartialEq for WKB<'_, O> {
     fn eq(&self, other: &Self) -> bool {
         self.arr.value(self.geom_index) == other.arr.value(other.geom_index)
     }

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -73,7 +73,7 @@ impl<'a, O: Offset> GeometryTrait<'a> for Geometry<'a, O> {
     }
 }
 
-impl<O: Offset> RTreeObject for Geometry<'_, O> {
+impl<C: CoordBuffer, O: Offset> RTreeObject for Geometry<'_, O> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -90,7 +90,7 @@ impl<O: Offset> RTreeObject for Geometry<'_, O> {
     }
 }
 
-impl<O: Offset> From<Geometry<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<Geometry<'_, O>> for geo::Geometry {
     fn from(value: Geometry<'_, O>) -> Self {
         match value {
             Geometry::Point(geom) => geom.into(),

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -51,13 +51,13 @@ impl<'a, O: Offset> GeometryCollectionTrait<'a> for GeometryCollection<'a, O> {
     }
 }
 
-impl<O: Offset> From<GeometryCollection<'_, O>> for geo::GeometryCollection {
+impl<C: CoordBuffer, O: Offset> From<GeometryCollection<'_, O>> for geo::GeometryCollection {
     fn from(value: GeometryCollection<'_, O>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: Offset> From<&GeometryCollection<'_, O>> for geo::GeometryCollection {
+impl<C: CoordBuffer, O: Offset> From<&GeometryCollection<'_, O>> for geo::GeometryCollection {
     fn from(value: &GeometryCollection<'_, O>) -> Self {
         let num_geometries = value.num_geometries();
         let mut geoms: Vec<geo::Geometry> = Vec::with_capacity(num_geometries);
@@ -69,7 +69,7 @@ impl<O: Offset> From<&GeometryCollection<'_, O>> for geo::GeometryCollection {
     }
 }
 
-impl<O: Offset> RTreeObject for GeometryCollection<'_, O> {
+impl<C: CoordBuffer, O: Offset> RTreeObject for GeometryCollection<'_, O> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {

--- a/src/scalar/linestring/scalar.rs
+++ b/src/scalar/linestring/scalar.rs
@@ -116,13 +116,13 @@ impl<'a, O: Offset> LineStringTrait<'a> for &LineString<'a, O> {
     }
 }
 
-impl<O: Offset> From<LineString<'_, O>> for geo::LineString {
+impl<C: CoordBuffer, O: Offset> From<LineString<'_, O>> for geo::LineString {
     fn from(value: LineString<'_, O>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: Offset> From<&LineString<'_, O>> for geo::LineString {
+impl<C: CoordBuffer, O: Offset> From<&LineString<'_, O>> for geo::LineString {
     fn from(value: &LineString<'_, O>) -> Self {
         let num_coords = value.num_coords();
         let mut coords: Vec<geo::Coord> = Vec::with_capacity(num_coords);
@@ -135,13 +135,13 @@ impl<O: Offset> From<&LineString<'_, O>> for geo::LineString {
     }
 }
 
-impl<O: Offset> From<LineString<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<LineString<'_, O>> for geo::Geometry {
     fn from(value: LineString<'_, O>) -> Self {
         geo::Geometry::LineString(value.into())
     }
 }
 
-impl<O: Offset> RTreeObject for LineString<'_, O> {
+impl<C: CoordBuffer, O: Offset> RTreeObject for LineString<'_, O> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -150,7 +150,7 @@ impl<O: Offset> RTreeObject for LineString<'_, O> {
     }
 }
 
-impl<O: Offset> PartialEq for LineString<'_, O> {
+impl<C: CoordBuffer, O: Offset> PartialEq for LineString<'_, O> {
     fn eq(&self, other: &Self) -> bool {
         line_string_eq(self, other)
     }

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -133,13 +133,13 @@ impl<'a, O: Offset> MultiLineStringTrait<'a> for &MultiLineString<'a, O> {
     }
 }
 
-impl<O: Offset> From<MultiLineString<'_, O>> for geo::MultiLineString {
+impl<C: CoordBuffer, O: Offset> From<MultiLineString<'_, O>> for geo::MultiLineString {
     fn from(value: MultiLineString<'_, O>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: Offset> From<&MultiLineString<'_, O>> for geo::MultiLineString {
+impl<C: CoordBuffer, O: Offset> From<&MultiLineString<'_, O>> for geo::MultiLineString {
     fn from(value: &MultiLineString<'_, O>) -> Self {
         // Start and end indices into the ring_offsets buffer
         let (start_geom_idx, end_geom_idx) = value.geom_offsets.start_end(value.geom_index);
@@ -160,13 +160,13 @@ impl<O: Offset> From<&MultiLineString<'_, O>> for geo::MultiLineString {
     }
 }
 
-impl<O: Offset> From<MultiLineString<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<MultiLineString<'_, O>> for geo::Geometry {
     fn from(value: MultiLineString<'_, O>) -> Self {
         geo::Geometry::MultiLineString(value.into())
     }
 }
 
-impl<O: Offset> RTreeObject for MultiLineString<'_, O> {
+impl<C: CoordBuffer, O: Offset> RTreeObject for MultiLineString<'_, O> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -175,7 +175,7 @@ impl<O: Offset> RTreeObject for MultiLineString<'_, O> {
     }
 }
 
-impl<O: Offset> PartialEq for MultiLineString<'_, O> {
+impl<C: CoordBuffer, O: Offset> PartialEq for MultiLineString<'_, O> {
     fn eq(&self, other: &Self) -> bool {
         multi_line_string_eq(self, other)
     }

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -117,13 +117,13 @@ impl<'a, O: Offset> MultiPointTrait<'a> for &MultiPoint<'a, O> {
     }
 }
 
-impl<O: Offset> From<MultiPoint<'_, O>> for geo::MultiPoint {
+impl<C: CoordBuffer, O: Offset> From<MultiPoint<'_, O>> for geo::MultiPoint {
     fn from(value: MultiPoint<'_, O>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: Offset> From<&MultiPoint<'_, O>> for geo::MultiPoint {
+impl<C: CoordBuffer, O: Offset> From<&MultiPoint<'_, O>> for geo::MultiPoint {
     fn from(value: &MultiPoint<'_, O>) -> Self {
         let (start_idx, end_idx) = value.geom_offsets.start_end(value.geom_index);
         let mut coords: Vec<geo::Point> = Vec::with_capacity(end_idx - start_idx);
@@ -136,13 +136,13 @@ impl<O: Offset> From<&MultiPoint<'_, O>> for geo::MultiPoint {
     }
 }
 
-impl<O: Offset> From<MultiPoint<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<MultiPoint<'_, O>> for geo::Geometry {
     fn from(value: MultiPoint<'_, O>) -> Self {
         geo::Geometry::MultiPoint(value.into())
     }
 }
 
-impl<O: Offset> RTreeObject for MultiPoint<'_, O> {
+impl<C: CoordBuffer, O: Offset> RTreeObject for MultiPoint<'_, O> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -151,7 +151,7 @@ impl<O: Offset> RTreeObject for MultiPoint<'_, O> {
     }
 }
 
-impl<O: Offset> PartialEq for MultiPoint<'_, O> {
+impl<C: CoordBuffer, O: Offset> PartialEq for MultiPoint<'_, O> {
     fn eq(&self, other: &Self) -> bool {
         multi_point_eq(self, other)
     }

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -145,13 +145,13 @@ impl<'a, O: Offset> MultiPolygonTrait<'a> for &MultiPolygon<'a, O> {
     }
 }
 
-impl<O: Offset> From<MultiPolygon<'_, O>> for geo::MultiPolygon {
+impl<C: CoordBuffer, O: Offset> From<MultiPolygon<'_, O>> for geo::MultiPolygon {
     fn from(value: MultiPolygon<'_, O>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: Offset> From<&MultiPolygon<'_, O>> for geo::MultiPolygon {
+impl<C: CoordBuffer, O: Offset> From<&MultiPolygon<'_, O>> for geo::MultiPolygon {
     fn from(value: &MultiPolygon<'_, O>) -> Self {
         // Start and end indices into the polygon_offsets buffer
         let (start_geom_idx, end_geom_idx) = value.geom_offsets.start_end(value.geom_index);
@@ -172,13 +172,13 @@ impl<O: Offset> From<&MultiPolygon<'_, O>> for geo::MultiPolygon {
     }
 }
 
-impl<O: Offset> From<MultiPolygon<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<MultiPolygon<'_, O>> for geo::Geometry {
     fn from(value: MultiPolygon<'_, O>) -> Self {
         geo::Geometry::MultiPolygon(value.into())
     }
 }
 
-impl<O: Offset> RTreeObject for MultiPolygon<'_, O> {
+impl<C: CoordBuffer, O: Offset> RTreeObject for MultiPolygon<'_, O> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -187,7 +187,7 @@ impl<O: Offset> RTreeObject for MultiPolygon<'_, O> {
     }
 }
 
-impl<O: Offset> PartialEq for MultiPolygon<'_, O> {
+impl<C: CoordBuffer, O: Offset> PartialEq for MultiPolygon<'_, O> {
     fn eq(&self, other: &Self) -> bool {
         multi_polygon_eq(self, other)
     }

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -159,13 +159,13 @@ impl<'a, O: Offset> PolygonTrait<'a> for &Polygon<'a, O> {
     }
 }
 
-impl<O: Offset> From<Polygon<'_, O>> for geo::Polygon {
+impl<C: CoordBuffer, O: Offset> From<Polygon<'_, O>> for geo::Polygon {
     fn from(value: Polygon<'_, O>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: Offset> From<&Polygon<'_, O>> for geo::Polygon {
+impl<C: CoordBuffer, O: Offset> From<&Polygon<'_, O>> for geo::Polygon {
     fn from(value: &Polygon<'_, O>) -> Self {
         parse_polygon(
             value.coords.clone(),
@@ -176,13 +176,13 @@ impl<O: Offset> From<&Polygon<'_, O>> for geo::Polygon {
     }
 }
 
-impl<O: Offset> From<Polygon<'_, O>> for geo::Geometry {
+impl<C: CoordBuffer, O: Offset> From<Polygon<'_, O>> for geo::Geometry {
     fn from(value: Polygon<'_, O>) -> Self {
         geo::Geometry::Polygon(value.into())
     }
 }
 
-impl<O: Offset> RTreeObject for Polygon<'_, O> {
+impl<C: CoordBuffer, O: Offset> RTreeObject for Polygon<'_, O> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -191,7 +191,7 @@ impl<O: Offset> RTreeObject for Polygon<'_, O> {
     }
 }
 
-impl<O: Offset> PartialEq for Polygon<'_, O> {
+impl<C: CoordBuffer, O: Offset> PartialEq for Polygon<'_, O> {
     fn eq(&self, other: &Self) -> bool {
         polygon_eq(self, other)
     }

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -68,11 +68,11 @@ pub trait GeometryArrayTrait<'a> {
     /// This is `O(1)`.
     fn into_boxed_arrow(self) -> Box<dyn Array>;
 
-    /// Create a new array with replaced coordinates
-    ///
-    /// This is useful if you want to apply an operation to _every_ coordinate in unison, such as a
-    /// reprojection or a scaling operation, with no regards to each individual geometry
-    fn with_coords(self, coords: CoordBuffer) -> Self;
+    // /// Create a new array with replaced coordinates
+    // ///
+    // /// This is useful if you want to apply an operation to _every_ coordinate in unison, such as a
+    // /// reprojection or a scaling operation, with no regards to each individual geometry
+    // fn with_coords(self, coords: CoordBuffer) -> Self;
 
     /// Build an [`RTree`] spatial index containing this array's geometries.
     fn rstar_tree(&'a self) -> RTree<Self::RTreeObject>;


### PR DESCRIPTION
This is hard!

In particular I hit that there are multiple traits needed potentially:

- `Coord`: this would be similar to the `arrow2` `Offset` trait, and would be simple, describing whether it's XY, XYZ, etc. Maybe this would also have some knowledge of whether it's interleaved/separated, but that's uncertain.
- `CoordBuffer`: I started with this, until I realized that I'd also need a mutable version of this. And we'd need some interaction between `CoordBuffer` and some `MutableCoordBuffer` trait. Not sure exactly how that would work.

In contrast to `Offset`, which is used as a generic in both `OffsetsBuffer<O>` and the mutable `Offsets<O>`, there are _multiple ways to store the coords_ for the coord buffer. In particular, separated and interleaved coords aren't just generic over a single type, but their internal storage is different too. So you'd really need a generic for the coord buffer, and maybe another for the coord?

Closes https://github.com/kylebarron/geoarrow-rs/issues/127