### PR TITLE
Geom collection trait attempt 3

### DIFF
--- a/src/array/mixed/mutable.rs
+++ b/src/array/mixed/mutable.rs
@@ -303,13 +303,8 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
             .push(GeometryType::MultiPolygon.default_ordering());
         self.multi_polygons.push_multi_polygon(value)
     }
-}
 
-impl<'a: 'iter, 'iter, O: Offset> MutableMixedGeometryArray<O> {
-    pub fn push_geometry(
-        &mut self,
-        value: &'a impl GeometryTrait<'a, 'iter, T = f64>,
-    ) -> Result<()> {
+    pub fn push_geometry(&mut self, value: &'a impl GeometryTrait<'a, T = f64>) -> Result<()> {
         match value.as_type() {
             crate::geo_traits::GeometryType::Point(g) => self.push_point(Some(g)),
             crate::geo_traits::GeometryType::LineString(g) => self.push_line_string(Some(g))?,
@@ -319,9 +314,9 @@ impl<'a: 'iter, 'iter, O: Offset> MutableMixedGeometryArray<O> {
                 self.push_multi_line_string(Some(p))?
             }
             crate::geo_traits::GeometryType::MultiPolygon(p) => self.push_multi_polygon(Some(p))?,
-            crate::geo_traits::GeometryType::GeometryCollection(_) => {
-                panic!("nested geometry collections not supported")
-            }
+            // crate::geo_traits::GeometryType::GeometryCollection(_) => {
+            //     panic!("nested geometry collections not supported")
+            // }
             _ => todo!(),
         };
         Ok(())

--- a/src/array/mixed/mutable.rs
+++ b/src/array/mixed/mutable.rs
@@ -303,8 +303,13 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
             .push(GeometryType::MultiPolygon.default_ordering());
         self.multi_polygons.push_multi_polygon(value)
     }
+}
 
-    pub fn push_geometry(&mut self, value: &'a impl GeometryTrait<'a, T = f64>) -> Result<()> {
+impl<'a: 'iter, 'iter, O: Offset> MutableMixedGeometryArray<O> {
+    pub fn push_geometry(
+        &mut self,
+        value: &'a impl GeometryTrait<'a, 'iter, T = f64>,
+    ) -> Result<()> {
         match value.as_type() {
             crate::geo_traits::GeometryType::Point(g) => self.push_point(Some(g)),
             crate::geo_traits::GeometryType::LineString(g) => self.push_line_string(Some(g))?,

--- a/src/geo_traits/geometry.rs
+++ b/src/geo_traits/geometry.rs
@@ -1,15 +1,14 @@
 use geo::{
-    CoordNum, Geometry, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon,
-    Point, Polygon, Rect,
+    CoordNum, Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect,
 };
 
 use super::{
-    GeometryCollectionTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
-    MultiPolygonTrait, PointTrait, PolygonTrait, RectTrait,
+    LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait,
+    PolygonTrait, RectTrait,
 };
 
 #[allow(clippy::type_complexity)]
-pub trait GeometryTrait<'a: 'iter, 'iter> {
+pub trait GeometryTrait<'a> {
     type T: CoordNum + 'a;
     type Point: 'a + PointTrait<T = Self::T>;
     type LineString: 'a + LineStringTrait<'a, T = Self::T>;
@@ -17,27 +16,26 @@ pub trait GeometryTrait<'a: 'iter, 'iter> {
     type MultiPoint: 'a + MultiPointTrait<'a, T = Self::T>;
     type MultiLineString: 'a + MultiLineStringTrait<'a, T = Self::T>;
     type MultiPolygon: 'a + MultiPolygonTrait<'a, T = Self::T>;
-    type GeometryCollection: 'a + GeometryCollectionTrait<'a, 'iter, T = Self::T>;
+    // type GeometryCollection: 'a + GeometryCollectionTrait<'a, 'iter, T = Self::T>;
     type Rect: 'a + RectTrait<'a, T = Self::T>;
 
     fn as_type(
         &'a self,
     ) -> GeometryType<
         'a,
-        'iter,
         Self::Point,
         Self::LineString,
         Self::Polygon,
         Self::MultiPoint,
         Self::MultiLineString,
         Self::MultiPolygon,
-        Self::GeometryCollection,
+        // Self::GeometryCollection,
         Self::Rect,
     >;
 }
 
 #[derive(Debug)]
-pub enum GeometryType<'a: 'iter, 'iter, P, L, Y, MP, ML, MY, GC, R>
+pub enum GeometryType<'a, P, L, Y, MP, ML, MY, R>
 where
     P: PointTrait,
     L: LineStringTrait<'a>,
@@ -45,7 +43,7 @@ where
     MP: MultiPointTrait<'a>,
     ML: MultiLineStringTrait<'a>,
     MY: MultiPolygonTrait<'a>,
-    GC: GeometryCollectionTrait<'a, 'iter>,
+    // GC: GeometryCollectionTrait<'a, 'iter>,
     R: RectTrait<'a>,
 {
     Point(&'a P),
@@ -54,11 +52,11 @@ where
     MultiPoint(&'a MP),
     MultiLineString(&'a ML),
     MultiPolygon(&'a MY),
-    GeometryCollection(&'iter GC),
+    // GeometryCollection(&'iter GC),
     Rect(&'a R),
 }
 
-impl<'a: 'iter, 'iter, T: CoordNum + 'a> GeometryTrait<'a, 'iter> for Geometry<T> {
+impl<'a: 'iter, 'iter, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
     type T = T;
     type Point = Point<Self::T>;
     type LineString = LineString<Self::T>;
@@ -66,21 +64,20 @@ impl<'a: 'iter, 'iter, T: CoordNum + 'a> GeometryTrait<'a, 'iter> for Geometry<T
     type MultiPoint = MultiPoint<Self::T>;
     type MultiLineString = MultiLineString<Self::T>;
     type MultiPolygon = MultiPolygon<Self::T>;
-    type GeometryCollection = GeometryCollection<Self::T>;
+    // type GeometryCollection = GeometryCollection<Self::T>;
     type Rect = Rect<Self::T>;
 
     fn as_type(
         &'a self,
     ) -> GeometryType<
         'a,
-        'iter,
         Point<T>,
         LineString<T>,
         Polygon<T>,
         MultiPoint<T>,
         MultiLineString<T>,
         MultiPolygon<T>,
-        GeometryCollection<T>,
+        // GeometryCollection<T>,
         Rect<T>,
     > {
         match self {
@@ -90,7 +87,7 @@ impl<'a: 'iter, 'iter, T: CoordNum + 'a> GeometryTrait<'a, 'iter> for Geometry<T
             Geometry::MultiPoint(p) => GeometryType::MultiPoint(p),
             Geometry::MultiLineString(p) => GeometryType::MultiLineString(p),
             Geometry::MultiPolygon(p) => GeometryType::MultiPolygon(p),
-            Geometry::GeometryCollection(p) => GeometryType::GeometryCollection(p),
+            // Geometry::GeometryCollection(p) => GeometryType::GeometryCollection(p),
             Geometry::Rect(p) => GeometryType::Rect(p),
             _ => todo!(),
         }

--- a/src/geo_traits/geometry.rs
+++ b/src/geo_traits/geometry.rs
@@ -9,21 +9,22 @@ use super::{
 };
 
 #[allow(clippy::type_complexity)]
-pub trait GeometryTrait<'a> {
-    type T: CoordNum;
+pub trait GeometryTrait<'a: 'iter, 'iter> {
+    type T: CoordNum + 'a;
     type Point: 'a + PointTrait<T = Self::T>;
     type LineString: 'a + LineStringTrait<'a, T = Self::T>;
     type Polygon: 'a + PolygonTrait<'a, T = Self::T>;
     type MultiPoint: 'a + MultiPointTrait<'a, T = Self::T>;
     type MultiLineString: 'a + MultiLineStringTrait<'a, T = Self::T>;
     type MultiPolygon: 'a + MultiPolygonTrait<'a, T = Self::T>;
-    type GeometryCollection: 'a + GeometryCollectionTrait<'a, T = Self::T>;
+    type GeometryCollection: 'a + GeometryCollectionTrait<'a, 'iter, T = Self::T>;
     type Rect: 'a + RectTrait<'a, T = Self::T>;
 
     fn as_type(
         &'a self,
     ) -> GeometryType<
         'a,
+        'iter,
         Self::Point,
         Self::LineString,
         Self::Polygon,
@@ -36,7 +37,7 @@ pub trait GeometryTrait<'a> {
 }
 
 #[derive(Debug)]
-pub enum GeometryType<'a, P, L, Y, MP, ML, MY, GC, R>
+pub enum GeometryType<'a: 'iter, 'iter, P, L, Y, MP, ML, MY, GC, R>
 where
     P: PointTrait,
     L: LineStringTrait<'a>,
@@ -44,7 +45,7 @@ where
     MP: MultiPointTrait<'a>,
     ML: MultiLineStringTrait<'a>,
     MY: MultiPolygonTrait<'a>,
-    GC: GeometryCollectionTrait<'a>,
+    GC: GeometryCollectionTrait<'a, 'iter>,
     R: RectTrait<'a>,
 {
     Point(&'a P),
@@ -53,11 +54,11 @@ where
     MultiPoint(&'a MP),
     MultiLineString(&'a ML),
     MultiPolygon(&'a MY),
-    GeometryCollection(&'a GC),
+    GeometryCollection(&'iter GC),
     Rect(&'a R),
 }
 
-impl<'a, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
+impl<'a: 'iter, 'iter, T: CoordNum + 'a> GeometryTrait<'a, 'iter> for Geometry<T> {
     type T = T;
     type Point = Point<Self::T>;
     type LineString = LineString<Self::T>;
@@ -72,6 +73,7 @@ impl<'a, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
         &'a self,
     ) -> GeometryType<
         'a,
+        'iter,
         Point<T>,
         LineString<T>,
         Polygon<T>,

--- a/src/geo_traits/geometry_collection.rs
+++ b/src/geo_traits/geometry_collection.rs
@@ -3,9 +3,9 @@ use geo::{CoordNum, Geometry, GeometryCollection};
 use std::iter::Cloned;
 use std::slice::Iter;
 
-pub trait GeometryCollectionTrait<'a> {
-    type T: CoordNum;
-    type ItemType: 'a + GeometryTrait<'a, T = Self::T>;
+pub trait GeometryCollectionTrait<'a: 'iter, 'iter> {
+    type T: CoordNum + 'a;
+    type ItemType: 'a + GeometryTrait<'a, 'iter, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// An iterator over the geometries in this GeometryCollection
@@ -19,10 +19,12 @@ pub trait GeometryCollectionTrait<'a> {
     fn geometry(&self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T> {
+impl<'a: 'iter, 'iter, T: CoordNum + 'a> GeometryCollectionTrait<'a, 'iter>
+    for GeometryCollection<T>
+{
     type T = T;
     type ItemType = Geometry<Self::T>;
-    type Iter = Cloned<Iter<'a, Self::ItemType>>;
+    type Iter = Cloned<Iter<'iter, Self::ItemType>>;
 
     fn geometries(&'a self) -> Self::Iter {
         self.0.iter().cloned()
@@ -37,7 +39,9 @@ impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T>
     }
 }
 
-impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for &GeometryCollection<T> {
+impl<'a: 'iter, 'iter, T: CoordNum + 'a> GeometryCollectionTrait<'a, 'iter>
+    for &GeometryCollection<T>
+{
     type T = T;
     type ItemType = Geometry<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;

--- a/src/geo_traits/geometry_collection.rs
+++ b/src/geo_traits/geometry_collection.rs
@@ -5,7 +5,7 @@ use std::slice::Iter;
 
 pub trait GeometryCollectionTrait<'a: 'iter, 'iter> {
     type T: CoordNum + 'a;
-    type ItemType: 'a + GeometryTrait<'a, 'iter, T = Self::T>;
+    type ItemType: 'iter + GeometryTrait<'iter, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// An iterator over the geometries in this GeometryCollection

--- a/src/io/wkb/reader/geometry.rs
+++ b/src/io/wkb/reader/geometry.rs
@@ -170,7 +170,7 @@ impl<'a> From<WKBGeometry<'a>> for WKBLineString<'a> {
     }
 }
 
-impl<'a> GeometryTrait<'a> for WKBGeometry<'a> {
+impl<'a: 'iter, 'iter> GeometryTrait<'a, 'iter> for WKBGeometry<'a> {
     type T = f64;
     type Point = WKBPoint<'a>;
     type LineString = WKBLineString<'a>;
@@ -185,6 +185,7 @@ impl<'a> GeometryTrait<'a> for WKBGeometry<'a> {
         &'a self,
     ) -> crate::geo_traits::GeometryType<
         'a,
+        'iter,
         WKBPoint,
         WKBLineString,
         WKBPolygon,

--- a/src/io/wkb/reader/geometry.rs
+++ b/src/io/wkb/reader/geometry.rs
@@ -170,7 +170,7 @@ impl<'a> From<WKBGeometry<'a>> for WKBLineString<'a> {
     }
 }
 
-impl<'a: 'iter, 'iter> GeometryTrait<'a, 'iter> for WKBGeometry<'a> {
+impl<'a> GeometryTrait<'a> for WKBGeometry<'a> {
     type T = f64;
     type Point = WKBPoint<'a>;
     type LineString = WKBLineString<'a>;
@@ -178,21 +178,20 @@ impl<'a: 'iter, 'iter> GeometryTrait<'a, 'iter> for WKBGeometry<'a> {
     type MultiPoint = WKBMultiPoint<'a>;
     type MultiLineString = WKBMultiLineString<'a>;
     type MultiPolygon = WKBMultiPolygon<'a>;
-    type GeometryCollection = WKBGeometryCollection<'a>;
+    // type GeometryCollection = WKBGeometryCollection<'a>;
     type Rect = WKBRect<'a>;
 
     fn as_type(
         &'a self,
     ) -> crate::geo_traits::GeometryType<
         'a,
-        'iter,
         WKBPoint,
         WKBLineString,
         WKBPolygon,
         WKBMultiPoint,
         WKBMultiLineString,
         WKBMultiPolygon,
-        WKBGeometryCollection,
+        // WKBGeometryCollection,
         WKBRect,
     > {
         use crate::geo_traits::GeometryType as B;
@@ -204,7 +203,8 @@ impl<'a: 'iter, 'iter> GeometryTrait<'a, 'iter> for WKBGeometry<'a> {
             A::MultiPoint(ls) => B::MultiPoint(ls),
             A::MultiLineString(ls) => B::MultiLineString(ls),
             A::MultiPolygon(ls) => B::MultiPolygon(ls),
-            A::GeometryCollection(gc) => B::GeometryCollection(gc),
+            // A::GeometryCollection(gc) => B::GeometryCollection(gc),
+            _ => todo!(),
         }
     }
 }

--- a/src/io/wkb/reader/geometry_collection.rs
+++ b/src/io/wkb/reader/geometry_collection.rs
@@ -19,8 +19,8 @@ impl<'a> WKBGeometryCollection<'a> {
 
 impl<'a: 'iter, 'iter> GeometryCollectionTrait<'a, 'iter> for WKBGeometryCollection<'a> {
     type T = f64;
-    type ItemType = WKBGeometry<'a>;
-    type Iter = Cloned<Iter<'a, Self::ItemType>>;
+    type ItemType = WKBGeometry<'iter>;
+    type Iter = Cloned<Iter<'iter, Self::ItemType>>;
 
     fn num_geometries(&self) -> usize {
         todo!()

--- a/src/io/wkb/reader/geometry_collection.rs
+++ b/src/io/wkb/reader/geometry_collection.rs
@@ -17,7 +17,7 @@ impl<'a> WKBGeometryCollection<'a> {
     }
 }
 
-impl<'a> GeometryCollectionTrait<'a> for WKBGeometryCollection<'a> {
+impl<'a: 'iter, 'iter> GeometryCollectionTrait<'a, 'iter> for WKBGeometryCollection<'a> {
     type T = f64;
     type ItemType = WKBGeometry<'a>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;

--- a/src/io/wkb/writer/geometry.rs
+++ b/src/io/wkb/writer/geometry.rs
@@ -11,7 +11,7 @@ use crate::io::wkb::writer::polygon::{polygon_wkb_size, write_polygon_as_wkb};
 use std::io::Write;
 
 /// The byte length of a Geometry
-pub fn geometry_wkb_size<'a>(geom: &'a impl GeometryTrait<'a>) -> usize {
+pub fn geometry_wkb_size<'a: 'iter, 'iter>(geom: &'a impl GeometryTrait<'a, 'iter>) -> usize {
     use GeometryType::*;
     match geom.as_type() {
         Point(_) => POINT_WKB_SIZE,
@@ -25,9 +25,9 @@ pub fn geometry_wkb_size<'a>(geom: &'a impl GeometryTrait<'a>) -> usize {
 }
 
 /// Write a Geometry to a Writer encoded as WKB
-pub fn write_geometry_as_wkb<'a, W: Write>(
+pub fn write_geometry_as_wkb<'a: 'iter, 'iter, W: Write>(
     writer: W,
-    geom: &'a impl GeometryTrait<'a, T = f64>,
+    geom: &'a impl GeometryTrait<'a, 'iter, T = f64>,
 ) -> Result<()> {
     use GeometryType::*;
     match geom.as_type() {

--- a/src/io/wkb/writer/geometry.rs
+++ b/src/io/wkb/writer/geometry.rs
@@ -11,7 +11,7 @@ use crate::io::wkb::writer::polygon::{polygon_wkb_size, write_polygon_as_wkb};
 use std::io::Write;
 
 /// The byte length of a Geometry
-pub fn geometry_wkb_size<'a: 'iter, 'iter>(geom: &'a impl GeometryTrait<'a, 'iter>) -> usize {
+pub fn geometry_wkb_size<'a>(geom: &'a impl GeometryTrait<'a>) -> usize {
     use GeometryType::*;
     match geom.as_type() {
         Point(_) => POINT_WKB_SIZE,
@@ -27,7 +27,7 @@ pub fn geometry_wkb_size<'a: 'iter, 'iter>(geom: &'a impl GeometryTrait<'a, 'ite
 /// Write a Geometry to a Writer encoded as WKB
 pub fn write_geometry_as_wkb<'a: 'iter, 'iter, W: Write>(
     writer: W,
-    geom: &'a impl GeometryTrait<'a, 'iter, T = f64>,
+    geom: &'a impl GeometryTrait<'a, T = f64>,
 ) -> Result<()> {
     use GeometryType::*;
     match geom.as_type() {

--- a/src/io/wkb/writer/geometrycollection.rs
+++ b/src/io/wkb/writer/geometrycollection.rs
@@ -13,11 +13,12 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Cursor, Write};
 
 /// The byte length of a WKBGeometryCollection
-pub fn geometry_collection_wkb_size<'a, O: Offset>(geom: &'a GeometryCollection<'a, O>) -> usize {
+pub fn geometry_collection_wkb_size<'a: 'iter, 'iter>(
+    geom: &'a impl GeometryCollectionTrait<'a, 'iter>,
+) -> usize {
     let mut sum = 1 + 4 + 4;
 
-    for geom_idx in 0..geom.num_geometries() {
-        let inner_geom = geom.geometry(geom_idx).unwrap();
+    for inner_geom in geom.geometries() {
         sum += geometry_wkb_size(&inner_geom);
     }
 

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -34,7 +34,7 @@ impl<'a, O: Offset> GeometryScalarTrait<'a> for Geometry<'a, O> {
     }
 }
 
-impl<'a, O: Offset> GeometryTrait<'a> for Geometry<'a, O> {
+impl<'a: 'iter, 'iter, O: Offset> GeometryTrait<'a, 'iter> for Geometry<'a, O> {
     type T = f64;
     type Point = Point<'a>;
     type LineString = LineString<'a, O>;
@@ -51,6 +51,7 @@ impl<'a, O: Offset> GeometryTrait<'a> for Geometry<'a, O> {
         &'a self,
     ) -> crate::geo_traits::GeometryType<
         'a,
+        'iter,
         Point,
         LineString<O>,
         Polygon<O>,

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -34,7 +34,7 @@ impl<'a, O: Offset> GeometryScalarTrait<'a> for Geometry<'a, O> {
     }
 }
 
-impl<'a: 'iter, 'iter, O: Offset> GeometryTrait<'a, 'iter> for Geometry<'a, O> {
+impl<'a: 'iter, 'iter, O: Offset> GeometryTrait<'a> for Geometry<'a, O> {
     type T = f64;
     type Point = Point<'a>;
     type LineString = LineString<'a, O>;
@@ -42,7 +42,7 @@ impl<'a: 'iter, 'iter, O: Offset> GeometryTrait<'a, 'iter> for Geometry<'a, O> {
     type MultiPoint = MultiPoint<'a, O>;
     type MultiLineString = MultiLineString<'a, O>;
     type MultiPolygon = MultiPolygon<'a, O>;
-    type GeometryCollection = GeometryCollection<'a, O>;
+    // type GeometryCollection = GeometryCollection<'a, O>;
     type Rect = Rect<'a>;
 
     // TODO: not 100% sure what this is
@@ -51,14 +51,13 @@ impl<'a: 'iter, 'iter, O: Offset> GeometryTrait<'a, 'iter> for Geometry<'a, O> {
         &'a self,
     ) -> crate::geo_traits::GeometryType<
         'a,
-        'iter,
         Point,
         LineString<O>,
         Polygon<O>,
         MultiPoint<O>,
         MultiLineString<O>,
         MultiPolygon<O>,
-        GeometryCollection<O>,
+        // GeometryCollection<O>,
         Rect,
     > {
         match self {

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -27,7 +27,7 @@ impl<'a, O: Offset> GeometryScalarTrait<'a> for GeometryCollection<'a, O> {
     }
 }
 
-impl<'a, O: Offset> GeometryCollectionTrait<'a> for GeometryCollection<'a, O> {
+impl<'a: 'iter, 'iter, O: Offset> GeometryCollectionTrait<'a, 'iter> for GeometryCollection<'a, O> {
     type T = f64;
     type ItemType = Geometry<'a, O>;
     type Iter = GeometryCollectionIterator<'a, O>;

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -29,8 +29,8 @@ impl<'a, O: Offset> GeometryScalarTrait<'a> for GeometryCollection<'a, O> {
 
 impl<'a: 'iter, 'iter, O: Offset> GeometryCollectionTrait<'a, 'iter> for GeometryCollection<'a, O> {
     type T = f64;
-    type ItemType = Geometry<'a, O>;
-    type Iter = GeometryCollectionIterator<'a, O>;
+    type ItemType = Geometry<'iter, O>;
+    type Iter = GeometryCollectionIterator<'iter, O>;
 
     fn geometries(&'a self) -> Self::Iter {
         GeometryCollectionIterator::new(self)


### PR DESCRIPTION
- disallow nested geometry collections (i.e. Geometry cannot hold GeometryCollections)
- try to add in multiple lifetimes as suggested in https://github.com/kylebarron/geoarrow-rs/issues/172#issuecomment-1692441676

Still getting

```
error[E0597]: `inner_geom` does not live long enough
  --> src/io/wkb/writer/geometrycollection.rs:22:34
   |
16 | pub fn geometry_collection_wkb_size<'a: 'iter, 'iter>(
   |                                     -- lifetime `'a` defined here
...
21 |     for inner_geom in geom.geometries() {
   |         ---------- binding `inner_geom` declared here
22 |         sum += geometry_wkb_size(&inner_geom);
   |                ------------------^^^^^^^^^^^-
   |                |                 |
   |                |                 borrowed value does not live long enough
   |                argument requires that `inner_geom` is borrowed for `'a`
23 |     }
   |     - `inner_geom` dropped here while still borrowed
```