### PR TITLE
WIP (perf): WKB refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ required-features = ["gdal"]
 [[bench]]
 name = "nybb"
 harness = false
+
+[[bench]]
+name = "wkb"
+harness = false

--- a/benches/wkb.rs
+++ b/benches/wkb.rs
@@ -1,0 +1,56 @@
+use std::fs::File;
+
+use arrow2::error::Result;
+use arrow2::io::parquet::read;
+use criterion::{criterion_group, criterion_main, Criterion};
+use geoarrow2::array::{MultiPolygonArray, WKBArray};
+use geoarrow2::trait_::GeometryScalarTrait;
+
+fn load_parquet() -> Result<WKBArray<i32>> {
+    let mut file = File::open("fixtures/geoparquet/nz-building-outlines-geometry.parquet")?;
+
+    let metadata = read::read_metadata(&mut file)?;
+
+    let schema = read::infer_schema(&metadata)?;
+
+    let schema = schema.filter(|_index, field| field.name == "geometry");
+
+    let chunks = read::FileReader::new(file, metadata.row_groups, schema, None, None, None);
+
+    let mut wkb_arrays = vec![];
+    for maybe_chunk in chunks {
+        let chunk = maybe_chunk?;
+        assert_eq!(chunk.columns().len(), 1);
+        let column = &chunk.columns()[0];
+        let wkb_arr: WKBArray<i32> = column.as_ref().try_into().unwrap();
+        wkb_arrays.push(wkb_arr);
+    }
+
+    assert_eq!(wkb_arrays.len(), 1);
+
+    Ok(wkb_arrays.get(0).unwrap().clone())
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let array = load_parquet().unwrap();
+
+    c.bench_function("parse WKBArray to geoarrow MultiPolygonArray", |b| {
+        b.iter(|| {
+            let _values: MultiPolygonArray<i32> = array.clone().try_into().unwrap();
+        })
+    });
+    c.bench_function("parse WKBArray to Vec<geo::Geometry>", |b| {
+        b.iter(|| {
+            // Note: As of Sept 2023, `to_geo` uses geozero. This could change in the future, in
+            // which case, this bench would no longer be benching geozero.
+            let _values: Vec<geo::Geometry> = array
+                .clone()
+                .values_iter()
+                .map(|wkb| wkb.to_geo())
+                .collect();
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -8,3 +8,12 @@ wget https://www.nyc.gov/assets/planning/download/zip/data-maps/open-data/nybb_1
 extract nybb_16a.zip
 ogr2ogr nybb.arrow nybb_16a -lco GEOMETRY_ENCODING=GEOARROW -nlt PROMOTE_TO_MULTI
 ```
+
+### `nz-building-outlines` (WKB, MultiPolygon)
+
+This file is used for benchmarks. It's 400MB so it's not checked in to git.
+
+```
+wget https://storage.googleapis.com/open-geodata/linz-examples/nz-building-outlines.parquet -P geoparquet/
+ogr2ogr -select geometry -limit 100000 -lco ROW_GROUP_SIZE=100000 nz-building-outlines-geometry.parquet nz-building-outlines.parquet
+```

--- a/src/io/wkb/reader/coord.rs
+++ b/src/io/wkb/reader/coord.rs
@@ -16,9 +16,9 @@ const F64_WIDTH: u64 = 8;
 ///
 /// See page 65 of <https://portal.ogc.org/files/?artifact_id=25355>.
 #[derive(Debug, Clone, Copy)]
-pub struct WKBCoord<'a> {
+pub struct WKBCoord<'a, B: AsRef<[u8]> + 'a> {
     /// The underlying WKB buffer
-    buf: &'a [u8],
+    buf: B,
 
     /// The byte order of this WKB buffer
     byte_order: Endianness,
@@ -32,8 +32,8 @@ pub struct WKBCoord<'a> {
     offset: u64,
 }
 
-impl<'a> WKBCoord<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64) -> Self {
+impl<'a, B: AsRef<[u8]> + 'a> WKBCoord<'a, B> {
+    pub fn new(buf: B, byte_order: Endianness, offset: u64) -> Self {
         Self {
             buf,
             byte_order,
@@ -69,7 +69,7 @@ impl<'a> WKBCoord<'a> {
     }
 }
 
-impl<'a> CoordTrait for WKBCoord<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> CoordTrait for WKBCoord<'a, B> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -81,7 +81,7 @@ impl<'a> CoordTrait for WKBCoord<'a> {
     }
 }
 
-impl<'a> PointTrait for WKBCoord<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> PointTrait for WKBCoord<'a, B> {
     type T = f64;
 
     fn x(&self) -> Self::T {

--- a/src/io/wkb/reader/geometry.rs
+++ b/src/io/wkb/reader/geometry.rs
@@ -13,7 +13,7 @@ use crate::io::wkb::reader::{
 use crate::scalar::WKB;
 
 impl<'a, O: Offset> WKB<'a, O> {
-    pub fn to_wkb_object(&'a self) -> WKBGeometry<'a> {
+    pub fn to_wkb_object(&'a self) -> WKBGeometry<'a, WKB<'a, O>> {
         let buf = self.arr.value(self.geom_index);
         let mut reader = Cursor::new(buf);
         let byte_order = reader.read_u8().unwrap();
@@ -25,6 +25,30 @@ impl<'a, O: Offset> WKB<'a, O> {
 
         match geometry_type {
             1 => WKBGeometry::Point(WKBPoint::new(buf, byte_order.into(), 0)),
+            2 => WKBGeometry::LineString(WKBLineString::new(buf, byte_order.into(), 0)),
+            3 => WKBGeometry::Polygon(WKBPolygon::new(buf, byte_order.into(), 0)),
+            4 => WKBGeometry::MultiPoint(WKBMultiPoint::new(buf, byte_order.into())),
+            5 => WKBGeometry::MultiLineString(WKBMultiLineString::new(buf, byte_order.into())),
+            6 => WKBGeometry::MultiPolygon(WKBMultiPolygon::new(buf, byte_order.into())),
+            7 => {
+                WKBGeometry::GeometryCollection(WKBGeometryCollection::new(buf, byte_order.into()))
+            }
+            _ => panic!("Unexpected geometry type"),
+        }
+    }
+
+    pub fn into_wkb_object(self) -> WKBGeometry<'a, WKB<'a, O>> {
+        let buf = self.arr.value(self.geom_index);
+        let mut reader = Cursor::new(buf);
+        let byte_order = reader.read_u8().unwrap();
+        let geometry_type = match byte_order {
+            0 => reader.read_u32::<BigEndian>().unwrap(),
+            1 => reader.read_u32::<LittleEndian>().unwrap(),
+            _ => panic!("Unexpected byte order."),
+        };
+
+        match geometry_type {
+            1 => WKBGeometry::Point(WKBPoint::new(self, byte_order.into(), 0)),
             2 => WKBGeometry::LineString(WKBLineString::new(buf, byte_order.into(), 0)),
             3 => WKBGeometry::Polygon(WKBPolygon::new(buf, byte_order.into(), 0)),
             4 => WKBGeometry::MultiPoint(WKBMultiPoint::new(buf, byte_order.into())),
@@ -49,12 +73,21 @@ impl<'a, O: Offset> WKB<'a, O> {
         geometry_type.try_into().unwrap()
     }
 
-    pub fn to_wkb_line_string(&'a self) -> WKBLineString<'a> {
-        match self.to_wkb_object() {
-            WKBGeometry::LineString(geom) => geom,
-            _ => panic!(),
-        }
-    }
+    // pub fn to_wkb_line_string(&'a self) -> WKBLineString<'a> {
+    //     match self.to_wkb_object() {
+    //         WKBGeometry::LineString(geom) => geom,
+    //         _ => panic!(),
+    //     }
+    // }
+
+    // // pub fn to_wkb_maybe_multi_polygon(&'a self) ->
+    // pub fn to_wkb_maybe_multi_polygon(&'a self) -> WKBMaybeMultiPolygon<'a> {
+    //     match self.to_wkb_object() {
+    //         WKBGeometry::Polygon(geom) => WKBMaybeMultiPolygon::Polygon(geom),
+    //         WKBGeometry::MultiPolygon(geom) => WKBMaybeMultiPolygon::MultiPolygon(geom),
+    //         _ => panic!(),
+    //     }
+    // }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -84,60 +117,60 @@ impl From<Endianness> for u8 {
 }
 
 #[derive(Debug, Clone)]
-pub enum WKBGeometry<'a> {
-    Point(WKBPoint<'a>),
-    LineString(WKBLineString<'a>),
-    Polygon(WKBPolygon<'a>),
-    MultiPoint(WKBMultiPoint<'a>),
-    MultiLineString(WKBMultiLineString<'a>),
-    MultiPolygon(WKBMultiPolygon<'a>),
-    GeometryCollection(WKBGeometryCollection<'a>),
+pub enum WKBGeometry<'a, B: AsRef<[u8]> + 'a> {
+    Point(WKBPoint<'a, B>),
+    LineString(WKBLineString<'a, B>),
+    Polygon(WKBPolygon<'a, B>),
+    MultiPoint(WKBMultiPoint<'a, B>),
+    MultiLineString(WKBMultiLineString<'a, B>),
+    MultiPolygon(WKBMultiPolygon<'a, B>),
+    GeometryCollection(WKBGeometryCollection<'a, B>),
 }
 
-impl<'a> WKBGeometry<'a> {
-    pub fn into_point(self) -> WKBPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> WKBGeometry<'a, B> {
+    pub fn into_point(self) -> WKBPoint<'a, B> {
         match self {
             WKBGeometry::Point(geom) => geom,
             _ => panic!(),
         }
     }
 
-    pub fn into_line_string(self) -> WKBLineString<'a> {
+    pub fn into_line_string(self) -> WKBLineString<'a, B> {
         match self {
             WKBGeometry::LineString(geom) => geom,
             _ => panic!(),
         }
     }
 
-    pub fn into_polygon(self) -> WKBPolygon<'a> {
+    pub fn into_polygon(self) -> WKBPolygon<'a, B> {
         match self {
             WKBGeometry::Polygon(geom) => geom,
             _ => panic!(),
         }
     }
 
-    pub fn into_multi_point(self) -> WKBMultiPoint<'a> {
+    pub fn into_multi_point(self) -> WKBMultiPoint<'a, B> {
         match self {
             WKBGeometry::MultiPoint(geom) => geom,
             _ => panic!(),
         }
     }
 
-    pub fn into_multi_line_string(self) -> WKBMultiLineString<'a> {
+    pub fn into_multi_line_string(self) -> WKBMultiLineString<'a, B> {
         match self {
             WKBGeometry::MultiLineString(geom) => geom,
             _ => panic!(),
         }
     }
 
-    pub fn into_multi_polygon(self) -> WKBMultiPolygon<'a> {
+    pub fn into_multi_polygon(self) -> WKBMultiPolygon<'a, B> {
         match self {
             WKBGeometry::MultiPolygon(geom) => geom,
             _ => panic!(),
         }
     }
 
-    pub fn into_maybe_multi_point(self) -> WKBMaybeMultiPoint<'a> {
+    pub fn into_maybe_multi_point(self) -> WKBMaybeMultiPoint<'a, B> {
         match self {
             WKBGeometry::Point(geom) => WKBMaybeMultiPoint::Point(geom),
             WKBGeometry::MultiPoint(geom) => WKBMaybeMultiPoint::MultiPoint(geom),
@@ -145,14 +178,14 @@ impl<'a> WKBGeometry<'a> {
         }
     }
 
-    pub fn into_maybe_multi_line_string(self) -> WKBMaybeMultiLineString<'a> {
+    pub fn into_maybe_multi_line_string(self) -> WKBMaybeMultiLineString<'a, B> {
         match self {
             WKBGeometry::LineString(geom) => WKBMaybeMultiLineString::LineString(geom),
             WKBGeometry::MultiLineString(geom) => WKBMaybeMultiLineString::MultiLineString(geom),
             _ => panic!(),
         }
     }
-    pub fn into_maybe_multi_polygon(self) -> WKBMaybeMultiPolygon<'a> {
+    pub fn into_maybe_multi_polygon(self) -> WKBMaybeMultiPolygon<'a, B> {
         match self {
             WKBGeometry::Polygon(geom) => WKBMaybeMultiPolygon::Polygon(geom),
             WKBGeometry::MultiPolygon(geom) => WKBMaybeMultiPolygon::MultiPolygon(geom),
@@ -161,38 +194,29 @@ impl<'a> WKBGeometry<'a> {
     }
 }
 
-impl<'a> From<WKBGeometry<'a>> for WKBLineString<'a> {
-    fn from(value: WKBGeometry<'a>) -> Self {
-        match value {
-            WKBGeometry::LineString(geom) => geom,
-            _ => panic!(),
-        }
-    }
-}
-
-impl<'a> GeometryTrait<'a> for WKBGeometry<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> GeometryTrait<'a> for WKBGeometry<'a, B> {
     type T = f64;
-    type Point = WKBPoint<'a>;
-    type LineString = WKBLineString<'a>;
-    type Polygon = WKBPolygon<'a>;
-    type MultiPoint = WKBMultiPoint<'a>;
-    type MultiLineString = WKBMultiLineString<'a>;
-    type MultiPolygon = WKBMultiPolygon<'a>;
-    type GeometryCollection = WKBGeometryCollection<'a>;
-    type Rect = WKBRect<'a>;
+    type Point = WKBPoint<'a, B>;
+    type LineString = WKBLineString<'a, B>;
+    type Polygon = WKBPolygon<'a, B>;
+    type MultiPoint = WKBMultiPoint<'a, B>;
+    type MultiLineString = WKBMultiLineString<'a, B>;
+    type MultiPolygon = WKBMultiPolygon<'a, B>;
+    type GeometryCollection = WKBGeometryCollection<'a, B>;
+    type Rect = WKBRect<'a, B>;
 
     fn as_type(
         &'a self,
     ) -> crate::geo_traits::GeometryType<
         'a,
-        WKBPoint,
-        WKBLineString,
-        WKBPolygon,
-        WKBMultiPoint,
-        WKBMultiLineString,
-        WKBMultiPolygon,
-        WKBGeometryCollection,
-        WKBRect,
+        WKBPoint<'a, B>,
+        WKBLineString<'a, B>,
+        WKBPolygon<'a, B>,
+        WKBMultiPoint<'a, B>,
+        WKBMultiLineString<'a, B>,
+        WKBMultiPolygon<'a, B>,
+        WKBGeometryCollection<'a, B>,
+        WKBRect<'a, B>,
     > {
         use crate::geo_traits::GeometryType as B;
         use WKBGeometry as A;

--- a/src/io/wkb/reader/geometry_collection.rs
+++ b/src/io/wkb/reader/geometry_collection.rs
@@ -6,20 +6,20 @@ use std::slice::Iter;
 /// Not yet implemented but required for WKBGeometry
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
-pub struct WKBGeometryCollection<'a> {
-    buf: &'a [u8],
+pub struct WKBGeometryCollection<'a, B: AsRef<[u8]> + 'a> {
+    buf: B,
     byte_order: Endianness,
 }
 
-impl<'a> WKBGeometryCollection<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness) -> Self {
+impl<'a, B: AsRef<[u8]> + 'a> WKBGeometryCollection<'a, B> {
+    pub fn new(buf: B, byte_order: Endianness) -> Self {
         Self { buf, byte_order }
     }
 }
 
-impl<'a> GeometryCollectionTrait<'a> for WKBGeometryCollection<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> GeometryCollectionTrait<'a> for WKBGeometryCollection<'a, B> {
     type T = f64;
-    type ItemType = WKBGeometry<'a>;
+    type ItemType = WKBGeometry<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_geometries(&self) -> usize {

--- a/src/io/wkb/reader/linearring.rs
+++ b/src/io/wkb/reader/linearring.rs
@@ -12,9 +12,9 @@ use crate::io::wkb::reader::geometry::Endianness;
 ///
 /// See page 65 of <https://portal.ogc.org/files/?artifact_id=25355>.
 #[derive(Debug, Clone, Copy)]
-pub struct WKBLinearRing<'a> {
+pub struct WKBLinearRing<'a, B: AsRef<[u8]> + 'a> {
     /// The underlying WKB buffer
-    buf: &'a [u8],
+    buf: B,
 
     /// The byte order of this WKB buffer
     byte_order: Endianness,
@@ -31,8 +31,8 @@ pub struct WKBLinearRing<'a> {
     num_points: usize,
 }
 
-impl<'a> WKBLinearRing<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64) -> Self {
+impl<'a, B: AsRef<[u8]> + 'a> WKBLinearRing<'a, B> {
+    pub fn new(buf: B, byte_order: Endianness, offset: u64) -> Self {
         let mut reader = Cursor::new(buf);
         reader.set_position(offset);
         let num_points = match byte_order {
@@ -67,9 +67,9 @@ impl<'a> WKBLinearRing<'a> {
     }
 }
 
-impl<'a> LineStringTrait<'a> for WKBLinearRing<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> LineStringTrait<'a> for WKBLinearRing<'a, B> {
     type T = f64;
-    type ItemType = WKBCoord<'a>;
+    type ItemType = WKBCoord<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_coords(&self) -> usize {

--- a/src/io/wkb/reader/linestring.rs
+++ b/src/io/wkb/reader/linestring.rs
@@ -12,8 +12,8 @@ use crate::io::wkb::reader::geometry::Endianness;
 const HEADER_BYTES: u64 = 5;
 
 #[derive(Debug, Clone, Copy)]
-pub struct WKBLineString<'a> {
-    buf: &'a [u8],
+pub struct WKBLineString<'a, B: AsRef<[u8]> + 'a> {
+    buf: B,
     byte_order: Endianness,
 
     /// The number of points in this LineString WKB
@@ -24,8 +24,8 @@ pub struct WKBLineString<'a> {
     offset: u64,
 }
 
-impl<'a> WKBLineString<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64) -> Self {
+impl<'a, B: AsRef<[u8]> + 'a> WKBLineString<'a, B> {
+    pub fn new(buf: B, byte_order: Endianness, offset: u64) -> Self {
         let mut reader = Cursor::new(buf);
         reader.set_position(HEADER_BYTES + offset);
         let num_points = match byte_order {
@@ -72,9 +72,9 @@ impl<'a> WKBLineString<'a> {
     }
 }
 
-impl<'a> LineStringTrait<'a> for WKBLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> LineStringTrait<'a> for WKBLineString<'a, B> {
     type T = f64;
-    type ItemType = WKBCoord<'a>;
+    type ItemType = WKBCoord<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_coords(&self) -> usize {
@@ -99,9 +99,9 @@ impl<'a> LineStringTrait<'a> for WKBLineString<'a> {
     }
 }
 
-impl<'a> LineStringTrait<'a> for &WKBLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> LineStringTrait<'a> for &WKBLineString<'a, B> {
     type T = f64;
-    type ItemType = WKBCoord<'a>;
+    type ItemType = WKBCoord<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_coords(&self) -> usize {
@@ -123,9 +123,9 @@ impl<'a> LineStringTrait<'a> for &WKBLineString<'a> {
     }
 }
 
-impl<'a> MultiLineStringTrait<'a> for WKBLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiLineStringTrait<'a> for WKBLineString<'a, B> {
     type T = f64;
-    type ItemType = WKBLineString<'a>;
+    type ItemType = WKBLineString<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_lines(&self) -> usize {
@@ -145,9 +145,9 @@ impl<'a> MultiLineStringTrait<'a> for WKBLineString<'a> {
     }
 }
 
-impl<'a> MultiLineStringTrait<'a> for &WKBLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiLineStringTrait<'a> for &WKBLineString<'a, B> {
     type T = f64;
-    type ItemType = WKBLineString<'a>;
+    type ItemType = WKBLineString<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_lines(&self) -> usize {

--- a/src/io/wkb/reader/maybe_multi_line_string.rs
+++ b/src/io/wkb/reader/maybe_multi_line_string.rs
@@ -9,21 +9,21 @@ use std::slice::Iter;
 ///
 /// This is used for casting a mix of linestrings and multi linestrings to an array of multi linestrings
 #[derive(Debug, Clone)]
-pub enum WKBMaybeMultiLineString<'a> {
-    LineString(WKBLineString<'a>),
-    MultiLineString(WKBMultiLineString<'a>),
+pub enum WKBMaybeMultiLineString<'a, B: AsRef<[u8]> + 'a> {
+    LineString(WKBLineString<'a, B>),
+    MultiLineString(WKBMultiLineString<'a, B>),
 }
 
-impl<'a> WKBMaybeMultiLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> WKBMaybeMultiLineString<'a, B> {
     /// Check if this has equal coordinates as some other MultiLineString object
     pub fn equals_multi_line_string(&self, other: impl MultiLineStringTrait<'a, T = f64>) -> bool {
         multi_line_string_eq(self, other)
     }
 }
 
-impl<'a> MultiLineStringTrait<'a> for WKBMaybeMultiLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiLineStringTrait<'a> for WKBMaybeMultiLineString<'a, B> {
     type T = f64;
-    type ItemType = WKBLineString<'a>;
+    type ItemType = WKBLineString<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_lines(&self) -> usize {
@@ -48,9 +48,9 @@ impl<'a> MultiLineStringTrait<'a> for WKBMaybeMultiLineString<'a> {
     }
 }
 
-impl<'a> MultiLineStringTrait<'a> for &WKBMaybeMultiLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiLineStringTrait<'a> for &WKBMaybeMultiLineString<'a, B> {
     type T = f64;
-    type ItemType = WKBLineString<'a>;
+    type ItemType = WKBLineString<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_lines(&self) -> usize {

--- a/src/io/wkb/reader/maybe_multi_point.rs
+++ b/src/io/wkb/reader/maybe_multi_point.rs
@@ -11,21 +11,21 @@ use std::slice::Iter;
 ///
 /// This is used for casting a mix of Points and multi Points to an array of multi Points
 #[derive(Debug, Clone, Copy)]
-pub enum WKBMaybeMultiPoint<'a> {
-    Point(WKBPoint<'a>),
-    MultiPoint(WKBMultiPoint<'a>),
+pub enum WKBMaybeMultiPoint<'a, B: AsRef<[u8]> + 'a> {
+    Point(WKBPoint<'a, B>),
+    MultiPoint(WKBMultiPoint<'a, B>),
 }
 
-impl<'a> WKBMaybeMultiPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> WKBMaybeMultiPoint<'a, B> {
     /// Check if this has equal coordinates as some other MultiPoint object
     pub fn equals_multi_point(&self, other: impl MultiPointTrait<'a, T = f64>) -> bool {
         multi_point_eq(self, other)
     }
 }
 
-impl<'a> MultiPointTrait<'a> for WKBMaybeMultiPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPointTrait<'a> for WKBMaybeMultiPoint<'a, B> {
     type T = f64;
-    type ItemType = WKBPoint<'a>;
+    type ItemType = WKBPoint<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_points(&self) -> usize {
@@ -50,9 +50,9 @@ impl<'a> MultiPointTrait<'a> for WKBMaybeMultiPoint<'a> {
     }
 }
 
-impl<'a> MultiPointTrait<'a> for &WKBMaybeMultiPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPointTrait<'a> for &WKBMaybeMultiPoint<'a, B> {
     type T = f64;
-    type ItemType = WKBPoint<'a>;
+    type ItemType = WKBPoint<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_points(&self) -> usize {

--- a/src/io/wkb/reader/maybe_multipolygon.rs
+++ b/src/io/wkb/reader/maybe_multipolygon.rs
@@ -9,21 +9,21 @@ use std::slice::Iter;
 ///
 /// This is used for casting a mix of polygons and multi polygons to an array of multi polygons
 #[derive(Debug, Clone)]
-pub enum WKBMaybeMultiPolygon<'a> {
-    Polygon(WKBPolygon<'a>),
-    MultiPolygon(WKBMultiPolygon<'a>),
+pub enum WKBMaybeMultiPolygon<'a, B: AsRef<[u8]> + 'a> {
+    Polygon(WKBPolygon<'a, B>),
+    MultiPolygon(WKBMultiPolygon<'a, B>),
 }
 
-impl<'a> WKBMaybeMultiPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> WKBMaybeMultiPolygon<'a, B> {
     /// Check if this has equal coordinates as some other MultiPolygon object
     pub fn equals_multi_polygon(&self, other: impl MultiPolygonTrait<'a, T = f64>) -> bool {
         multi_polygon_eq(self, other)
     }
 }
 
-impl<'a> MultiPolygonTrait<'a> for WKBMaybeMultiPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPolygonTrait<'a> for WKBMaybeMultiPolygon<'a, B> {
     type T = f64;
-    type ItemType = WKBPolygon<'a>;
+    type ItemType = WKBPolygon<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_polygons(&self) -> usize {
@@ -48,9 +48,9 @@ impl<'a> MultiPolygonTrait<'a> for WKBMaybeMultiPolygon<'a> {
     }
 }
 
-impl<'a> MultiPolygonTrait<'a> for &WKBMaybeMultiPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPolygonTrait<'a> for &WKBMaybeMultiPolygon<'a, B> {
     type T = f64;
-    type ItemType = WKBPolygon<'a>;
+    type ItemType = WKBPolygon<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_polygons(&self) -> usize {

--- a/src/io/wkb/reader/multilinestring.rs
+++ b/src/io/wkb/reader/multilinestring.rs
@@ -12,12 +12,12 @@ use crate::io::wkb::reader::linestring::WKBLineString;
 const HEADER_BYTES: u64 = 5;
 
 #[derive(Debug, Clone)]
-pub struct WKBMultiLineString<'a> {
+pub struct WKBMultiLineString<'a, B: AsRef<[u8]> + 'a> {
     /// A WKBLineString object for each of the internal line strings
-    wkb_line_strings: Vec<WKBLineString<'a>>,
+    wkb_line_strings: Vec<WKBLineString<'a, B>>,
 }
 
-impl<'a> WKBMultiLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> WKBMultiLineString<'a, B> {
     pub fn new(buf: &'a [u8], byte_order: Endianness) -> Self {
         let mut reader = Cursor::new(buf);
         reader.set_position(HEADER_BYTES);
@@ -63,9 +63,9 @@ impl<'a> WKBMultiLineString<'a> {
     }
 }
 
-impl<'a> MultiLineStringTrait<'a> for WKBMultiLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiLineStringTrait<'a> for WKBMultiLineString<'a, B> {
     type T = f64;
-    type ItemType = WKBLineString<'a>;
+    type ItemType = WKBLineString<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_lines(&self) -> usize {
@@ -85,9 +85,9 @@ impl<'a> MultiLineStringTrait<'a> for WKBMultiLineString<'a> {
     }
 }
 
-impl<'a> MultiLineStringTrait<'a> for &WKBMultiLineString<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiLineStringTrait<'a> for &WKBMultiLineString<'a, B> {
     type T = f64;
-    type ItemType = WKBLineString<'a>;
+    type ItemType = WKBLineString<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_lines(&self) -> usize {

--- a/src/io/wkb/reader/multipoint.rs
+++ b/src/io/wkb/reader/multipoint.rs
@@ -10,16 +10,16 @@ use crate::io::wkb::reader::geometry::Endianness;
 use crate::io::wkb::reader::point::WKBPoint;
 
 #[derive(Debug, Clone, Copy)]
-pub struct WKBMultiPoint<'a> {
-    buf: &'a [u8],
+pub struct WKBMultiPoint<'a, B: AsRef<[u8]> + 'a> {
+    buf: B,
     byte_order: Endianness,
 
     /// The number of points in this multi point
     num_points: usize,
 }
 
-impl<'a> WKBMultiPoint<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness) -> Self {
+impl<'a, B: AsRef<[u8]> + 'a> WKBMultiPoint<'a, B> {
+    pub fn new(buf: B, byte_order: Endianness) -> Self {
         // TODO: assert WKB type?
         let mut reader = Cursor::new(buf);
         // Set reader to after 1-byte byteOrder and 4-byte wkbType
@@ -62,9 +62,9 @@ impl<'a> WKBMultiPoint<'a> {
     }
 }
 
-impl<'a> MultiPointTrait<'a> for WKBMultiPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPointTrait<'a> for WKBMultiPoint<'a, B> {
     type T = f64;
-    type ItemType = WKBPoint<'a>;
+    type ItemType = WKBPoint<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_points(&self) -> usize {
@@ -88,9 +88,9 @@ impl<'a> MultiPointTrait<'a> for WKBMultiPoint<'a> {
     }
 }
 
-impl<'a> MultiPointTrait<'a> for &WKBMultiPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPointTrait<'a> for &WKBMultiPoint<'a, B> {
     type T = f64;
-    type ItemType = WKBPoint<'a>;
+    type ItemType = WKBPoint<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_points(&self) -> usize {

--- a/src/io/wkb/reader/multipolygon.rs
+++ b/src/io/wkb/reader/multipolygon.rs
@@ -12,7 +12,7 @@ use crate::io::wkb::reader::polygon::WKBPolygon;
 const HEADER_BYTES: u64 = 5;
 
 #[derive(Debug, Clone)]
-pub struct WKBMultiPolygon<'a> {
+pub struct WKBMultiPolygon<'a, B: AsRef<[u8]> + 'a> {
     // buf: &'a [u8],
     // byte_order: Endianness,
 
@@ -24,10 +24,10 @@ pub struct WKBMultiPolygon<'a> {
     // /// The length of this vec must match the number of polygons
     // // polygon_offsets: Vec<usize>,
     /// A WKBPolygon object for each of the internal line strings
-    wkb_polygons: Vec<WKBPolygon<'a>>,
+    wkb_polygons: Vec<WKBPolygon<'a, B>>,
 }
 
-impl<'a> WKBMultiPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> WKBMultiPolygon<'a, B> {
     pub fn new(buf: &'a [u8], byte_order: Endianness) -> Self {
         let mut reader = Cursor::new(buf);
         reader.set_position(HEADER_BYTES);
@@ -60,9 +60,9 @@ impl<'a> WKBMultiPolygon<'a> {
     }
 }
 
-impl<'a> MultiPolygonTrait<'a> for WKBMultiPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPolygonTrait<'a> for WKBMultiPolygon<'a, B> {
     type T = f64;
-    type ItemType = WKBPolygon<'a>;
+    type ItemType = WKBPolygon<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_polygons(&self) -> usize {
@@ -82,9 +82,9 @@ impl<'a> MultiPolygonTrait<'a> for WKBMultiPolygon<'a> {
     }
 }
 
-impl<'a> MultiPolygonTrait<'a> for &WKBMultiPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPolygonTrait<'a> for &WKBMultiPolygon<'a, B> {
     type T = f64;
-    type ItemType = WKBPolygon<'a>;
+    type ItemType = WKBPolygon<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_polygons(&self) -> usize {

--- a/src/io/wkb/reader/point.rs
+++ b/src/io/wkb/reader/point.rs
@@ -9,13 +9,13 @@ use std::slice::Iter;
 ///
 /// See page 66 of <https://portal.ogc.org/files/?artifact_id=25355>.
 #[derive(Debug, Clone, Copy)]
-pub struct WKBPoint<'a> {
+pub struct WKBPoint<'a, B: AsRef<[u8]> + 'a> {
     /// The coordinate inside this WKBPoint
-    coord: WKBCoord<'a>,
+    coord: WKBCoord<'a, B>,
 }
 
-impl<'a> WKBPoint<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64) -> Self {
+impl<'a, B: AsRef<[u8]> + 'a> WKBPoint<'a, B> {
+    pub fn new(buf: B, byte_order: Endianness, offset: u64) -> Self {
         // The space of the byte order + geometry type
         let offset = offset + 5;
         let coord = WKBCoord::new(buf, byte_order, offset);
@@ -40,7 +40,7 @@ impl<'a> WKBPoint<'a> {
     }
 }
 
-impl<'a> PointTrait for WKBPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> PointTrait for WKBPoint<'a, B> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -52,7 +52,7 @@ impl<'a> PointTrait for WKBPoint<'a> {
     }
 }
 
-impl<'a> PointTrait for &WKBPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> PointTrait for &WKBPoint<'a, B> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -64,9 +64,9 @@ impl<'a> PointTrait for &WKBPoint<'a> {
     }
 }
 
-impl<'a> MultiPointTrait<'a> for WKBPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPointTrait<'a> for WKBPoint<'a, B> {
     type T = f64;
-    type ItemType = WKBPoint<'a>;
+    type ItemType = WKBPoint<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_points(&self) -> usize {
@@ -86,9 +86,9 @@ impl<'a> MultiPointTrait<'a> for WKBPoint<'a> {
     }
 }
 
-impl<'a> MultiPointTrait<'a> for &WKBPoint<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPointTrait<'a> for &WKBPoint<'a, B> {
     type T = f64;
-    type ItemType = WKBPoint<'a>;
+    type ItemType = WKBPoint<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_points(&self) -> usize {

--- a/src/io/wkb/reader/polygon.rs
+++ b/src/io/wkb/reader/polygon.rs
@@ -12,12 +12,12 @@ use crate::io::wkb::reader::linearring::WKBLinearRing;
 const WKB_POLYGON_TYPE: u32 = 3;
 
 #[derive(Debug, Clone)]
-pub struct WKBPolygon<'a> {
-    wkb_linear_rings: Vec<WKBLinearRing<'a>>,
+pub struct WKBPolygon<'a, B: AsRef<[u8]> + 'a> {
+    wkb_linear_rings: Vec<WKBLinearRing<'a, B>>,
 }
 
-impl<'a> WKBPolygon<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64) -> Self {
+impl<'a, B: AsRef<[u8]> + 'a> WKBPolygon<'a, B> {
+    pub fn new(buf: B, byte_order: Endianness, offset: u64) -> Self {
         let mut reader = Cursor::new(buf);
         reader.set_position(1 + offset);
 
@@ -77,9 +77,9 @@ impl<'a> WKBPolygon<'a> {
     }
 }
 
-impl<'a> PolygonTrait<'a> for WKBPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> PolygonTrait<'a> for WKBPolygon<'a, B> {
     type T = f64;
-    type ItemType = WKBLinearRing<'a>;
+    type ItemType = WKBLinearRing<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_interiors(&self) -> usize {
@@ -112,9 +112,9 @@ impl<'a> PolygonTrait<'a> for WKBPolygon<'a> {
     }
 }
 
-impl<'a> PolygonTrait<'a> for &WKBPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> PolygonTrait<'a> for &WKBPolygon<'a, B> {
     type T = f64;
-    type ItemType = WKBLinearRing<'a>;
+    type ItemType = WKBLinearRing<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_interiors(&self) -> usize {
@@ -147,9 +147,9 @@ impl<'a> PolygonTrait<'a> for &WKBPolygon<'a> {
     }
 }
 
-impl<'a> MultiPolygonTrait<'a> for WKBPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPolygonTrait<'a> for WKBPolygon<'a, B> {
     type T = f64;
-    type ItemType = WKBPolygon<'a>;
+    type ItemType = WKBPolygon<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_polygons(&self) -> usize {
@@ -169,9 +169,9 @@ impl<'a> MultiPolygonTrait<'a> for WKBPolygon<'a> {
     }
 }
 
-impl<'a> MultiPolygonTrait<'a> for &WKBPolygon<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> MultiPolygonTrait<'a> for &WKBPolygon<'a, B> {
     type T = f64;
-    type ItemType = WKBPolygon<'a>;
+    type ItemType = WKBPolygon<'a, B>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn num_polygons(&self) -> usize {

--- a/src/io/wkb/reader/rect.rs
+++ b/src/io/wkb/reader/rect.rs
@@ -3,13 +3,13 @@ use crate::io::wkb::reader::coord::WKBCoord;
 
 /// This does not exist in the WKB specification, but is defined in order to conform WKBGeometry to
 /// the GeometryTrait definition
-pub struct WKBRect<'a> {
-    _buf: &'a [u8],
+pub struct WKBRect<'a, B: AsRef<[u8]> + 'a> {
+    _buf: B,
 }
 
-impl<'a> RectTrait<'a> for WKBRect<'a> {
+impl<'a, B: AsRef<[u8]> + 'a> RectTrait<'a> for WKBRect<'a, B> {
     type T = f64;
-    type ItemType = WKBCoord<'a>;
+    type ItemType = WKBCoord<'a, B>;
 
     fn lower(&self) -> Self::ItemType {
         todo!()


### PR DESCRIPTION
While writing up https://github.com/kylebarron/geoarrow-rs/pull/183 I was looking at 

https://github.com/kylebarron/geoarrow-rs/blob/ae98fe2e1f8c7b2798322e87a4d6116ebf9a6679/src/array/multipoint/mutable.rs#L333-L341

and seeing that I'm making two extra passes over the entire array before the `first_pass` and `second_pass` functions to count array sizes and instantiate & fill the arrays. I think one pass is necessary if I want `first_pass` to be totally generic, but I shouldn't need both. Using a quick `std::time` timer around the first line, I see that that's taking ~1ms out of the 18.5ms total for my 100,000 multi polygon example.

So with a better architecture, we could probably take out that 5% perf penalty. I tried it here but I'm getting lots of lifetime issues