### PR TITLE
Put rstar creation inside trait

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -9,3 +9,4 @@ pub mod geos;
 pub mod native;
 #[cfg(feature = "proj")]
 pub mod proj;
+pub mod rstar;

--- a/src/algorithm/rstar.rs
+++ b/src/algorithm/rstar.rs
@@ -1,0 +1,57 @@
+use crate::array::*;
+use arrow2::types::Offset;
+use rstar::primitives::CachedEnvelope;
+
+/// Construct an R-Tree from a geometry array.
+pub trait RTree<'a> {
+    /// The object type to store in the RTree.
+    type RTreeObject: rstar::RTreeObject;
+
+    /// Build an [`RTree`] spatial index containing this array's geometries.
+    fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject>;
+}
+
+impl<'a> RTree<'a> for PointArray {
+    type RTreeObject = crate::scalar::Point<'a>;
+
+    fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject> {
+        // Note: for points we don't memoize with CachedEnvelope
+        rstar::RTree::bulk_load(self.iter().flatten().collect())
+    }
+}
+
+impl<'a> RTree<'a> for RectArray {
+    type RTreeObject = crate::scalar::Rect<'a>;
+
+    fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject> {
+        // Note: for rects we don't memoize with CachedEnvelope
+        rstar::RTree::bulk_load(self.iter().flatten().collect())
+    }
+}
+
+macro_rules! iter_cached_impl {
+    ($type:ty, $scalar_type:ty) => {
+        impl<'a, O: Offset> RTree<'a> for $type {
+            type RTreeObject = CachedEnvelope<$scalar_type>;
+
+            fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject> {
+                rstar::RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
+            }
+        }
+    };
+}
+
+iter_cached_impl!(LineStringArray<O>, crate::scalar::LineString<'a, O>);
+iter_cached_impl!(PolygonArray<O>, crate::scalar::Polygon<'a, O>);
+iter_cached_impl!(MultiPointArray<O>, crate::scalar::MultiPoint<'a, O>);
+iter_cached_impl!(
+    MultiLineStringArray<O>,
+    crate::scalar::MultiLineString<'a, O>
+);
+iter_cached_impl!(MultiPolygonArray<O>, crate::scalar::MultiPolygon<'a, O>);
+iter_cached_impl!(WKBArray<O>, crate::scalar::WKB<'a, O>);
+iter_cached_impl!(MixedGeometryArray<O>, crate::scalar::Geometry<'a, O>);
+iter_cached_impl!(
+    GeometryCollectionArray<O>,
+    crate::scalar::GeometryCollection<'a, O>
+);

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -8,8 +8,6 @@ use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
 use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::DataType;
 use arrow2::types::Offset;
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 /// An immutable array of WKB geometries using GeoArrow's in-memory representation.
 ///
@@ -43,7 +41,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for WKBArray<O> {
     type Scalar = WKB<'a, O>;
     type ScalarGeo = geo::Geometry;
     type ArrowArray = BinaryArray<O>;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         WKB::new_borrowed(&self.0, i)
@@ -85,11 +82,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for WKBArray<O> {
 
     fn into_coord_type(self, _coord_type: CoordType) -> Self {
         self
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/coord/combined/array.rs
+++ b/src/array/coord/combined/array.rs
@@ -8,7 +8,6 @@ use crate::GeometryArrayTrait;
 use arrow2::array::{Array, FixedSizeListArray, StructArray};
 use arrow2::datatypes::DataType;
 use itertools::Itertools;
-use rstar::RTree;
 
 /// An Arrow representation of an array of coordinates.
 ///
@@ -44,7 +43,6 @@ impl<'a> GeometryArrayTrait<'a> for CoordBuffer {
     type ArrowArray = Box<dyn Array>;
     type Scalar = Coord<'a>;
     type ScalarGeo = geo::Coord;
-    type RTreeObject = Self::Scalar;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         match self {
@@ -107,10 +105,6 @@ impl<'a> GeometryArrayTrait<'a> for CoordBuffer {
                 CoordBuffer::Interleaved(new_buffer.into())
             }
         }
-    }
-
-    fn rstar_tree(&'a self) -> RTree<Self::Scalar> {
-        panic!("not implemented for coords");
     }
 
     fn len(&self) -> usize {

--- a/src/array/coord/interleaved/array.rs
+++ b/src/array/coord/interleaved/array.rs
@@ -5,7 +5,6 @@ use crate::GeometryArrayTrait;
 use arrow2::array::{Array, FixedSizeListArray, PrimitiveArray};
 use arrow2::buffer::Buffer;
 use arrow2::datatypes::{DataType, Field};
-use rstar::RTree;
 
 /// A an array of XY coordinates stored interleaved in a single buffer.
 #[derive(Debug, Clone, PartialEq)]
@@ -57,7 +56,6 @@ impl<'a> GeometryArrayTrait<'a> for InterleavedCoordBuffer {
     type ArrowArray = FixedSizeListArray;
     type Scalar = InterleavedCoord<'a>;
     type ScalarGeo = geo::Coord;
-    type RTreeObject = Self::Scalar;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         InterleavedCoord {
@@ -92,10 +90,6 @@ impl<'a> GeometryArrayTrait<'a> for InterleavedCoordBuffer {
 
     fn into_coord_type(self, _coord_type: CoordType) -> Self {
         panic!("into_coord_type only implemented on CoordBuffer");
-    }
-
-    fn rstar_tree(&'a self) -> RTree<Self::Scalar> {
-        panic!("not implemented for coords");
     }
 
     fn len(&self) -> usize {

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -1,7 +1,6 @@
 use arrow2::array::{Array, PrimitiveArray, StructArray};
 use arrow2::buffer::Buffer;
 use arrow2::datatypes::{DataType, Field};
-use rstar::RTree;
 
 use crate::array::CoordType;
 use crate::error::{GeoArrowError, Result};
@@ -64,7 +63,6 @@ impl<'a> GeometryArrayTrait<'a> for SeparatedCoordBuffer {
     type ArrowArray = StructArray;
     type Scalar = SeparatedCoord<'a>;
     type ScalarGeo = geo::Coord;
-    type RTreeObject = Self::Scalar;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         SeparatedCoord {
@@ -100,10 +98,6 @@ impl<'a> GeometryArrayTrait<'a> for SeparatedCoordBuffer {
 
     fn into_coord_type(self, _coord_type: CoordType) -> Self {
         panic!("into_coord_type only implemented on CoordBuffer");
-    }
-
-    fn rstar_tree(&'a self) -> RTree<Self::Scalar> {
-        panic!("not implemented for coords");
     }
 
     fn len(&self) -> usize {

--- a/src/array/geometry/array.rs
+++ b/src/array/geometry/array.rs
@@ -2,7 +2,6 @@ use arrow2::array::Array;
 use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::DataType;
 use arrow2::types::Offset;
-use rstar::RTree;
 
 use crate::algorithm::native::type_id::TypeIds;
 use crate::array::{
@@ -32,7 +31,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
     type Scalar = crate::scalar::Geometry<'a, O>;
     type ScalarGeo = geo::Geometry;
     type ArrowArray = Box<dyn Array>;
-    type RTreeObject = Self::Scalar;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         match self {
@@ -132,13 +130,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             }
             GeometryArray::Rect(arr) => GeometryArray::Rect(arr.into_coord_type(coord_type)),
         }
-    }
-
-    fn rstar_tree(&'a self) -> RTree<Self::Scalar> {
-        let elements: Vec<_> = (0..self.len())
-            .filter_map(|geom_idx| self.get(geom_idx))
-            .collect();
-        RTree::bulk_load(elements)
     }
 
     /// The length of the [`GeometryArray`]. Every array has a length corresponding to the number

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -4,8 +4,6 @@ use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::DataType;
 use arrow2::offset::OffsetsBuffer;
 use arrow2::types::Offset;
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 use crate::array::{CoordBuffer, CoordType, MixedGeometryArray};
 use crate::scalar::GeometryCollection;
@@ -50,7 +48,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryCollectionArray<O> {
     type Scalar = GeometryCollection<'a, O>;
     type ScalarGeo = geo::GeometryCollection;
     type ArrowArray = ListArray<O>;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         GeometryCollection {
@@ -93,11 +90,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryCollectionArray<O> {
 
     fn into_coord_type(self, _coord_type: CoordType) -> Self {
         todo!()
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -9,8 +9,6 @@ use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field};
 use arrow2::offset::OffsetsBuffer;
 use arrow2::types::Offset;
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 use super::MutableLineStringArray;
 
@@ -113,7 +111,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for LineStringArray<O> {
     type Scalar = LineString<'a, O>;
     type ScalarGeo = geo::LineString;
     type ArrowArray = ListArray<O>;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     /// Gets the value at slot `i`
     fn value(&'a self, i: usize) -> Self::Scalar {
@@ -158,11 +155,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for LineStringArray<O> {
             self.geom_offsets,
             self.validity,
         )
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -3,8 +3,6 @@ use arrow2::bitmap::Bitmap;
 use arrow2::buffer::Buffer;
 use arrow2::datatypes::{DataType, Field, UnionMode};
 use arrow2::types::Offset;
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 use crate::array::mixed::mutable::MutableMixedGeometryArray;
 use crate::array::{
@@ -170,7 +168,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MixedGeometryArray<O> {
     type Scalar = Geometry<'a, O>;
     type ScalarGeo = geo::Geometry;
     type ArrowArray = UnionArray;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     /// Gets the value at slot `i`
     fn value(&'a self, i: usize) -> Self::Scalar {
@@ -278,11 +275,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MixedGeometryArray<O> {
 
     fn into_coord_type(self, _coord_type: crate::array::CoordType) -> Self {
         todo!();
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -9,8 +9,6 @@ use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field};
 use arrow2::offset::{Offsets, OffsetsBuffer};
 use arrow2::types::Offset;
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 use super::MutableMultiLineStringArray;
 
@@ -148,7 +146,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MultiLineStringArray<O> {
     type Scalar = MultiLineString<'a, O>;
     type ScalarGeo = geo::MultiLineString;
     type ArrowArray = ListArray<O>;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         MultiLineString::new_borrowed(&self.coords, &self.geom_offsets, &self.ring_offsets, i)
@@ -196,11 +193,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MultiLineStringArray<O> {
             self.ring_offsets,
             self.validity,
         )
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -10,8 +10,6 @@ use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field};
 use arrow2::offset::{Offsets, OffsetsBuffer};
 use arrow2::types::Offset;
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 /// An immutable array of MultiPoint geometries using GeoArrow's in-memory representation.
 ///
@@ -112,7 +110,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MultiPointArray<O> {
     type Scalar = MultiPoint<'a, O>;
     type ScalarGeo = geo::MultiPoint;
     type ArrowArray = ListArray<O>;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         MultiPoint::new_borrowed(&self.coords, &self.geom_offsets, i)
@@ -156,10 +153,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MultiPointArray<O> {
             self.geom_offsets,
             self.validity,
         )
-    }
-
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -9,8 +9,6 @@ use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field};
 use arrow2::offset::{Offsets, OffsetsBuffer};
 use arrow2::types::Offset;
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 use super::MutableMultiPolygonArray;
 
@@ -173,7 +171,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MultiPolygonArray<O> {
     type Scalar = MultiPolygon<'a, O>;
     type ScalarGeo = geo::MultiPolygon;
     type ArrowArray = ListArray<O>;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         MultiPolygon::new_borrowed(
@@ -236,11 +233,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MultiPolygonArray<O> {
             self.ring_offsets,
             self.validity,
         )
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -11,7 +11,6 @@ use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
 use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::DataType;
 use arrow2::types::Offset;
-use rstar::RTree;
 
 /// An immutable array of Point geometries using GeoArrow's in-memory representation.
 ///
@@ -73,7 +72,6 @@ impl<'a> GeometryArrayTrait<'a> for PointArray {
     type Scalar = Point<'a>;
     type ScalarGeo = geo::Point;
     type ArrowArray = Box<dyn Array>;
-    type RTreeObject = Self::Scalar;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         Point::new_borrowed(&self.coords, i)
@@ -119,12 +117,6 @@ impl<'a> GeometryArrayTrait<'a> for PointArray {
 
     fn into_coord_type(self, coord_type: CoordType) -> Self {
         Self::new(self.coords.into_coord_type(coord_type), self.validity)
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        // Note: for points we don't memoize with CachedEnvelope
-        RTree::bulk_load(self.iter().flatten().collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -10,8 +10,6 @@ use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field};
 use arrow2::offset::OffsetsBuffer;
 use arrow2::types::Offset;
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 use super::MutablePolygonArray;
 
@@ -148,7 +146,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for PolygonArray<O> {
     type Scalar = Polygon<'a, O>;
     type ScalarGeo = geo::Polygon;
     type ArrowArray = ListArray<O>;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         Polygon::new_borrowed(&self.coords, &self.geom_offsets, &self.ring_offsets, i)
@@ -195,11 +192,6 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for PolygonArray<O> {
             self.ring_offsets,
             self.validity,
         )
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -2,8 +2,6 @@ use arrow2::array::{Array, FixedSizeListArray, PrimitiveArray};
 use arrow2::bitmap::Bitmap;
 use arrow2::buffer::Buffer;
 use arrow2::datatypes::{DataType, Field};
-use rstar::primitives::CachedEnvelope;
-use rstar::RTree;
 
 use crate::array::{CoordBuffer, CoordType};
 use crate::scalar::Rect;
@@ -38,7 +36,6 @@ impl<'a> GeometryArrayTrait<'a> for RectArray {
     type Scalar = Rect<'a>;
     type ScalarGeo = geo::Rect;
     type ArrowArray = FixedSizeListArray;
-    type RTreeObject = CachedEnvelope<Self::Scalar>;
 
     fn value(&'a self, i: usize) -> Self::Scalar {
         Rect::new_borrowed(&self.values, i)
@@ -78,11 +75,6 @@ impl<'a> GeometryArrayTrait<'a> for RectArray {
 
     fn into_coord_type(self, _coord_type: CoordType) -> Self {
         unimplemented!()
-    }
-
-    /// Build a spatial index containing this array's geometries
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -4,7 +4,6 @@ use crate::array::{CoordBuffer, CoordType};
 use arrow2::array::Array;
 use arrow2::bitmap::{Bitmap, MutableBitmap};
 use arrow2::datatypes::DataType;
-use rstar::{RTree, RTreeObject};
 use std::any::Any;
 
 /// A trait of common methods that all geometry arrays in this crate implement.
@@ -17,9 +16,6 @@ pub trait GeometryArrayTrait<'a> {
 
     /// The [`arrow2` array][arrow2::array] that corresponds to this geometry array.
     type ArrowArray;
-
-    /// An object type used for creating the rtree in [`GeometryArrayTrait::rstar_tree`].
-    type RTreeObject: RTreeObject;
 
     /// Access the value at slot `i` as an Arrow scalar, not considering validity.
     fn value(&'a self, i: usize) -> Self::Scalar;
@@ -73,9 +69,6 @@ pub trait GeometryArrayTrait<'a> {
     /// This is useful if you want to apply an operation to _every_ coordinate in unison, such as a
     /// reprojection or a scaling operation, with no regards to each individual geometry
     fn with_coords(self, coords: CoordBuffer) -> Self;
-
-    /// Build an [`RTree`] spatial index containing this array's geometries.
-    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject>;
 
     /// Get the coordinate type of this geometry array, either interleaved or separated.
     fn coord_type(&self) -> CoordType;
@@ -154,7 +147,7 @@ pub trait GeometryArrayTrait<'a> {
     fn to_boxed(&self) -> Box<Self>;
 }
 
-pub trait GeometryScalarTrait<'a>: RTreeObject {
+pub trait GeometryScalarTrait<'a> {
     /// The [`geo`] scalar object for this geometry array type.
     type ScalarGeo;
 


### PR DESCRIPTION
### Change list

- Create new `algorithm/rstar` mod
- Remove rstar from `GeometryArrayTrait`. This is nice because simplifying the trait will probably make other things easier in the future, like using `impl GeometryArrayTrait` in places or `Box<dyn GeometryArrayTrait>` like how arrow2 has `Box<dyn Array>` in places. Right now, that's not really doable for me because I have associated types that have to be defined


Closes https://github.com/geoarrow/geoarrow-rs/issues/175