### PR TITLE
Restore commented tests

### DIFF
--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -492,7 +492,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_interleaved_example() {
         let linestring_arr = example_linestring_interleaved();
 
@@ -503,7 +502,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_separated_example() {
         let linestring_arr = example_linestring_separated().into_coord_type(CoordType::Interleaved);
 

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -573,7 +573,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_interleaved_example() {
         let geom_arr = example_multilinestring_interleaved();
 
@@ -584,9 +583,7 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_separated_example() {
-        // TODO: support checking equality of interleaved vs separated coords
         let geom_arr = example_multilinestring_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_multilinestring_wkb();

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -492,7 +492,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_interleaved_example() {
         let geom_arr = example_multipoint_interleaved();
 
@@ -503,7 +502,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_separated_example() {
         // TODO: support checking equality of interleaved vs separated coords
         let geom_arr = example_multipoint_separated().into_coord_type(CoordType::Interleaved);

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -634,7 +634,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_interleaved_example() {
         let geom_arr = example_multipolygon_interleaved();
 
@@ -645,7 +644,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_separated_example() {
         // TODO: support checking equality of interleaved vs separated coords
         let geom_arr = example_multipolygon_separated().into_coord_type(CoordType::Interleaved);

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -545,7 +545,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_interleaved_example() {
         let geom_arr = example_polygon_interleaved();
 
@@ -556,7 +555,6 @@ mod test {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn parse_wkb_geoarrow_separated_example() {
         // TODO: support checking equality of interleaved vs separated coords
         let geom_arr = example_polygon_separated().into_coord_type(CoordType::Interleaved);

--- a/src/io/geos/array/linestring.rs
+++ b/src/io/geos/array/linestring.rs
@@ -44,11 +44,10 @@ mod test {
     use crate::test::linestring::ls_array;
 
     #[test]
-    #[allow(unused_variables)]
     fn geos_round_trip() {
         let arr = ls_array();
         let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter_geos().collect();
         let round_trip: LineStringArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/multilinestring.rs
+++ b/src/io/geos/array/multilinestring.rs
@@ -160,11 +160,10 @@ mod test {
     use crate::test::multilinestring::ml_array;
 
     #[test]
-    #[allow(unused_variables)]
     fn geos_round_trip() {
         let arr = ml_array();
         let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter_geos().collect();
         let round_trip: MultiLineStringArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/multipoint.rs
+++ b/src/io/geos/array/multipoint.rs
@@ -92,11 +92,10 @@ mod test {
     use crate::test::multipoint::mp_array;
 
     #[test]
-    #[allow(unused_variables)]
     fn geos_round_trip() {
         let arr = mp_array();
         let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter_geos().collect();
         let round_trip: MultiPointArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/multipolygon.rs
+++ b/src/io/geos/array/multipolygon.rs
@@ -221,11 +221,10 @@ mod test {
     use crate::test::multipolygon::mp_array;
 
     #[test]
-    #[allow(unused_variables)]
     fn geos_round_trip() {
         let arr = mp_array();
         let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter_geos().collect();
         let round_trip: MultiPolygonArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/polygon.rs
+++ b/src/io/geos/array/polygon.rs
@@ -184,11 +184,10 @@ mod test {
     use crate::test::polygon::p_array;
 
     #[test]
-    #[allow(unused_variables)]
     fn geos_round_trip() {
         let arr = p_array();
         let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter_geos().collect();
         let round_trip: PolygonArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -74,13 +74,12 @@ mod test {
     use crate::test::linestring::{ls0, ls1};
 
     #[test]
-    #[allow(unused_variables)]
     fn round_trip() {
         let orig_arr: LineStringArray<i32> = vec![Some(ls0()), Some(ls1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
         let new_arr: LineStringArray<i32> = wkb_arr.try_into().unwrap();
 
-        // assert_eq!(orig_arr, new_arr);
+        assert_eq!(orig_arr, new_arr);
     }
 
     // // TODO: parsing WKBArray<i64> into LineStringArray<i32> not yet implemented

--- a/src/io/wkb/writer/multilinestring.rs
+++ b/src/io/wkb/writer/multilinestring.rs
@@ -82,12 +82,11 @@ mod test {
     use crate::test::multilinestring::{ml0, ml1};
 
     #[test]
-    #[allow(unused_variables)]
     fn round_trip() {
         let orig_arr: MultiLineStringArray<i32> = vec![Some(ml0()), Some(ml1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
         let new_arr: MultiLineStringArray<i32> = wkb_arr.try_into().unwrap();
 
-        // assert_eq!(orig_arr, new_arr);
+        assert_eq!(orig_arr, new_arr);
     }
 }

--- a/src/io/wkb/writer/multipoint.rs
+++ b/src/io/wkb/writer/multipoint.rs
@@ -74,12 +74,11 @@ mod test {
     use crate::test::multipoint::{mp0, mp1};
 
     #[test]
-    #[allow(unused_variables)]
     fn round_trip() {
         let orig_arr: MultiPointArray<i32> = vec![Some(mp0()), Some(mp1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
         let new_arr: MultiPointArray<i32> = wkb_arr.try_into().unwrap();
 
-        // assert_eq!(orig_arr, new_arr);
+        assert_eq!(orig_arr, new_arr);
     }
 }

--- a/src/io/wkb/writer/multipolygon.rs
+++ b/src/io/wkb/writer/multipolygon.rs
@@ -82,12 +82,11 @@ mod test {
     use crate::test::multipolygon::{mp0, mp1};
 
     #[test]
-    #[allow(unused_variables)]
     fn round_trip() {
         let orig_arr: MultiPolygonArray<i32> = vec![Some(mp0()), Some(mp1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
         let new_arr: MultiPolygonArray<i32> = wkb_arr.try_into().unwrap();
 
-        // assert_eq!(orig_arr, new_arr);
+        assert_eq!(orig_arr, new_arr);
     }
 }

--- a/src/io/wkb/writer/polygon.rs
+++ b/src/io/wkb/writer/polygon.rs
@@ -106,7 +106,6 @@ mod test {
     use geozero::{CoordDimensions, ToWkb};
 
     #[test]
-    #[allow(unused_variables)]
     fn round_trip() {
         let orig_arr: PolygonArray<i32> = vec![Some(p0()), Some(p1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
@@ -122,7 +121,7 @@ mod test {
         assert_eq!(wkb_arr.value(0).as_ref(), &wkb0);
         assert_eq!(wkb_arr.value(1).as_ref(), &wkb1);
 
-        // assert_eq!(orig_arr, new_arr);
+        assert_eq!(orig_arr, new_arr);
     }
 
     // // TODO: parsing WKBArray<i64> into LineStringArray<i32> not yet implemented


### PR DESCRIPTION
### Change list

- Restore some commented tests
- Remove `#[allow(unused_variables)]`