### PR TITLE
fix iter_geo a null value cause panic.

### DIFF
--- a/src/array/zip_validity.rs
+++ b/src/array/zip_validity.rs
@@ -40,7 +40,7 @@ where
             if is_valid {
                 Some(self.values.next().unwrap())
             } else {
-                self.values.advance_by(1);
+                let _ = self.values.advance_by(1);
                 None
             }
         })

--- a/src/array/zip_validity.rs
+++ b/src/array/zip_validity.rs
@@ -34,11 +34,16 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let value = self.values.next();
         let is_valid = self.validity.next();
-        is_valid
-            .zip(value)
-            .map(|(is_valid, value)| is_valid.then_some(value))
+
+        is_valid.map(|is_valid| {
+            if is_valid {
+                Some(self.values.next().unwrap())
+            } else {
+                self.values.advance_by(1);
+                None
+            }
+        })
     }
 
     #[inline]

--- a/src/array/zip_validity.rs
+++ b/src/array/zip_validity.rs
@@ -21,7 +21,6 @@ where
     /// # Panics
     /// This function panics if the size_hints of the iterators are different
     pub fn new(values: I, validity: V) -> Self {
-        assert_eq!(values.size_hint(), validity.size_hint());
         Self { values, validity }
     }
 }
@@ -197,5 +196,19 @@ where
             ZipValidity::Optional(i) => i,
             _ => panic!("Could not 'unwrap_optional'. 'ZipValidity' iterator has no nulls."),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::array::WKBArray;
+    use arrow_array::BinaryArray;
+    // This is a regression test for issue243
+    // see https://github.com/geoarrow/geoarrow-rs/issues/243
+    #[test]
+    fn issue243() {
+        let b = BinaryArray::from_opt_vec(vec![None]);
+        let arr = WKBArray::try_from(b).unwrap();
+        arr.iter_geo().for_each(|_x| {});
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A Rust implementation of the [GeoArrow](https://github.com/geoarrow/geoarrow) specification,
 //! plus algorithms implemented on and returning these GeoArrow arrays.
-
+#![feature(iter_advance_by)]
 pub use trait_::GeometryArrayTrait;
 
 pub mod algorithm;


### PR DESCRIPTION
trying to fix issue #243 

I have remove this line  https://github.com/geoarrow/geoarrow-rs/blob/main/src/array/zip_validity.rs#L24
But I am getting this panic.

~~~
  Finished test [unoptimized + debuginfo] target(s) in 0.15s
     Running unittests src/lib.rs (target/debug/deps/geoarrow2-698b5402eed14455)

running 1 test
thread 'array::zip_validity::tests::issue243' panicked at src/scalar/binary/scalar.rs:61:50:
called `Result::unwrap()` on an `Err` value: IoError(Error { kind: UnexpectedEof, message: "failed to fill whole buffer" })
stack backtrace:
   0: rust_begin_unwind
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/std/src/panicking.rs:597:5
   1: core::panicking::panic_fmt
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/panicking.rs:72:14
   2: core::result::unwrap_failed
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/result.rs:1653:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/result.rs:1077:23
   4: geoarrow2::scalar::binary::scalar::<impl core::convert::From<&geoarrow2::scalar::binary::scalar::WKB<O>> for geo_types::geometry::Geometry>::from
             at ./src/scalar/binary/scalar.rs:61:9
   5: <T as core::convert::Into<U>>::into
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/convert/mod.rs:757:9
   6: geoarrow2::scalar::binary::scalar::<impl core::convert::From<geoarrow2::scalar::binary::scalar::WKB<O>> for geo_types::geometry::Geometry>::from
             at ./src/scalar/binary/scalar.rs:53:9
   7: <T as core::convert::Into<U>>::into
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/convert/mod.rs:757:9
   8: geoarrow2::trait_::GeoArrayAccessor::value_as_geo
             at ./src/trait_.rs:195:9
   9: geoarrow2::array::binary::array::WKBArray<O>::iter_geo_values::{{closure}}
             at ./src/array/binary/array.rs:187:33
  10: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/ops/function.rs:305:13
  11: core::option::Option<T>::map
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/option.rs:1065:29
  12: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/iter/adapters/map.rs:103:26
  13: <geoarrow2::array::zip_validity::ZipValidityIter<T,I,V> as core::iter::traits::iterator::Iterator>::next
             at ./src/array/zip_validity.rs:37:21
  14: <geoarrow2::array::zip_validity::ZipValidity<T,I,V> as core::iter::traits::iterator::Iterator>::next
             at ./src/array/zip_validity.rs:138:39
  15: core::iter::traits::iterator::Iterator::fold
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/iter/traits/iterator.rs:2638:29
  16: core::iter::traits::iterator::Iterator::for_each
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/iter/traits/iterator.rs:857:9
  17: geoarrow2::array::zip_validity::tests::issue243
             at ./src/array/zip_validity.rs:212:9
  18: geoarrow2::array::zip_validity::tests::issue243::{{closure}}
             at ./src/array/zip_validity.rs:209:18
  19: core::ops::function::FnOnce::call_once
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/ops/function.rs:250:5
  20: core::ops::function::FnOnce::call_once
             at /rustc/09df6108c84fdec400043d99d9ee232336fd5a9f/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test array::zip_validity::tests::issue243 ... FAILED

failures:

failures:
    array::zip_validity::tests::issue243

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 109 filtered out; finished in 0.27s

error: test failed, to rerun pass `-p geoarrow2 --lib`

 *  The terminal process "cargo 'test', '--package', 'geoarrow2', '--lib', '--all-features', '--', 'array::zip_validity::tests', '--nocapture'" terminated with exit code: 101. 
 *  Terminal will be reused by tasks, press any key to close it. 

~~~





