### PR TITLE
Add vscode workspace colors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,23 @@
 {
-  "rust-analyzer.cargo.features": "all"
+  "rust-analyzer.cargo.features": "all",
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#e9c2ac",
+    "activityBar.background": "#e9c2ac",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#289750",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#e9c2ac",
+    "statusBar.background": "#dea584",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#d3885c",
+    "statusBarItem.remoteBackground": "#dea584",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#dea584",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#dea58499",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#dea584"
 }

--- a/js/.vscode/settings.json
+++ b/js/.vscode/settings.json
@@ -1,3 +1,23 @@
 {
-    "rust-analyzer.cargo.features": "all"
+    "rust-analyzer.cargo.features": "all",
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#5592d5",
+        "activityBar.background": "#5592d5",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#f2ccde",
+        "activityBarBadge.foreground": "#15202b",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#5592d5",
+        "statusBar.background": "#3178c6",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#5592d5",
+        "statusBarItem.remoteBackground": "#3178c6",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#3178c6",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#3178c699",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#3178c6"
 }

--- a/python/.vscode/settings.json
+++ b/python/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+  "rust-analyzer.linkedProjects": [
+    "./geoarrow-rust/Cargo.toml"
+  ],
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#498cc4",
+    "activityBar.background": "#498cc4",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#e8b7d1",
+    "activityBarBadge.foreground": "#15202b",
+    "commandCenter.border": "#e7e7e799",
+    "sash.hoverBorder": "#498cc4",
+    "statusBar.background": "#3572a5",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#498cc4",
+    "statusBarItem.remoteBackground": "#3572a5",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#3572a5",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#3572a599",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.color": "#3572A5"
+}


### PR DESCRIPTION
If you have the [`peacock` extension](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock) installed, this will open up a different window color for the python, js, and rust workspaces