### PR TITLE
WIP try to support ewkb parsing

### DIFF
--- a/src/io/wkb/reader/polygon.rs
+++ b/src/io/wkb/reader/polygon.rs
@@ -8,6 +8,7 @@ use crate::algorithm::native::eq::polygon_eq;
 use crate::geo_traits::{MultiPolygonTrait, PolygonTrait};
 use crate::io::wkb::reader::geometry::Endianness;
 use crate::io::wkb::reader::linearring::WKBLinearRing;
+use crate::io::wkb::reader::r#type::WKBOptions;
 
 const WKB_POLYGON_TYPE: u32 = 3;
 
@@ -17,9 +18,18 @@ pub struct WKBPolygon<'a> {
 }
 
 impl<'a> WKBPolygon<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64) -> Self {
+    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, options: WKBOptions) -> Self {
+        let mut offset = offset;
+        // Skip endianness
+        offset += 1;
+
+        if options.has_srid {
+            offset += 4;
+        }
+
         let mut reader = Cursor::new(buf);
-        reader.set_position(1 + offset);
+        // Skip endianness
+        reader.set_position(offset);
 
         // Assert that this is indeed a 2D Polygon
         assert_eq!(

--- a/src/io/wkb/reader/type.rs
+++ b/src/io/wkb/reader/type.rs
@@ -13,3 +13,23 @@ pub enum WKBGeometryType {
     MultiPolygon = 6,
     GeometryCollection = 7,
 }
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub struct WKBOptions {
+    pub is_ewkb: bool,
+    pub has_srid: bool,
+}
+
+impl WKBOptions {
+    // Taken from wkx under the MIT license
+    // https://github.com/cschwarz/wkx/blob/b85b7b93af101a87a7a0fffa2a6d68c551b3f8d3/lib/geometry.js#L73
+    pub fn from_geometry_type(geometry_type_int: u32) -> Self {
+        let has_srid = geometry_type_int & 0x20000000 == 0x20000000;
+        let is_ewkb = (geometry_type_int & 0x20000000)
+            | (geometry_type_int & 0x40000000)
+            | (geometry_type_int & 0x80000000)
+            != 0;
+
+        Self { is_ewkb, has_srid }
+    }
+}


### PR DESCRIPTION
@lewiszlw I took a look into how EWKB is implemented. It's a good amount more work left. If you'd like, you can finish up this PR; I'm happy to give pointers but it's not a high priority for me, since I'm not using postgis. 

I followed [this JS implementation](https://github.com/cschwarz/wkx/blob/b85b7b93af101a87a7a0fffa2a6d68c551b3f8d3/lib/geometry.js#L73-L142) and EWKB is minimally documented in the [GEOS docs](https://libgeos.org/specifications/wkb/#extended-wkb). I didn't see an official spec in light searching.

Necessary updates:

- Every wkb struct has a `size()` method that has the size in bytes of the current object. This is necessary because a `WKBPoint` can be included inside of a `WKBMultiPoint`, and latter needs to know where each `WKBPoint` starts and ends. With EWKB, the size of the value changes depending on whether it has an SRID included, and you have to read the geometry type `u32` to check that.
- Every wkb struct needs to maintain information on whether it is an EWKB or ISO-flavored WKB value, because that changes where the coord offsets are.
- Update the `match` in `to_wkb_object` [here](https://github.com/geoarrow/geoarrow-rs/blob/b9e7e1e2374b87017f5d75c74d5cda4f9ce93689/src/io/wkb/reader/geometry.rs#L27) to handle EWKB geometry codes
- Error/panic on 3d/4d coords
- tests, ideally with more tests on the current parsing as well (e.g. porting wkx tests to rust)


Unknowns:

- Does an EWKB Multi geometry always store its sub-geometry-parts as EWKB or non-EWKB? If a Point is part of a MultiPoint, does only the MultiPoint have an SRID set?