### PR TITLE
Publish `geoarrow2` 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,8 @@ dependencies = [
 [[package]]
 name = "arrow"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc25126d18a012146a888a0298f2c22e1150327bd2765fc76d710a556b2d614"
 dependencies = [
  "ahash",
  "arrow-arith",
@@ -153,7 +154,8 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ccd45e217ffa6e53bbb0080990e77113bdd4e91ddb84e97b77649810bcf1a7"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -167,7 +169,8 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bda9acea48b25123c08340f3a8ac361aa0f74469bb36f5ee9acf923fce23e9d"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -182,7 +185,8 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a0fc21915b00fc6c2667b069c1b64bdd920982f426079bc4a7cab86822886c"
 dependencies = [
  "bytes",
  "half 2.3.1",
@@ -192,7 +196,8 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc0368ed618d509636c1e3cc20db1281148190a78f43519487b2daf07b63b4a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -209,7 +214,8 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09aa6246a1d6459b3f14baeaa49606cfdbca34435c46320e14054d244987ca"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -227,7 +233,8 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907fafe280a3874474678c1858b9ca4cb7fd83fb8034ff5b6d6376205a08c634"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -238,7 +245,8 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79a43d6808411886b8c7d4f6f7dd477029c1e77ffffffb7923555cc6579639cd"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -251,7 +259,8 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82565c91fd627922ebfe2810ee4e8346841b6f9361b87505a9acea38b614fee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -270,7 +279,8 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b23b0e53c0db57c6749997fd343d4c0354c994be7eca67152dd2bdb9a3e1bb4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -284,7 +294,8 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361249898d2d6d4a6eeb7484be6ac74977e48da12a4dd81a708d620cc558117a"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -298,7 +309,8 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e28a5e781bf1b0f981333684ad13f5901f4cd2f20589eab7cf1797da8fc167"
 dependencies = [
  "bitflags 2.4.0",
 ]
@@ -306,7 +318,8 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6208466590960efc1d2a7172bc4ff18a67d6e25c529381d7f96ddaf0dc4036"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -319,7 +332,8 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a48149c63c11c9ff571e50ab8f017d2a7cb71037a882b42f6354ed2da9acc7"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1504,7 +1518,8 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "49.0.0"
-source = "git+https://github.com/apache/arrow-rs?rev=fbbb61d94282165f9bb9f73fb4d00a3af16d4aee#fbbb61d94282165f9bb9f73fb4d00a3af16d4aee"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af88740a842787da39b3d69ce5fbf6fce97d20211d3b299fee0a0da6430c74d4"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1519,7 +1534,6 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
- "half 2.3.1",
  "hashbrown",
  "lz4_flex",
  "num",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow2"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ proj = ["dep:proj"]
 
 [dependencies]
 anyhow = "1"
-arrow = { git = "https://github.com/apache/arrow-rs", rev="fbbb61d94282165f9bb9f73fb4d00a3af16d4aee", features = ["ffi"] }
-arrow-array = { git = "https://github.com/apache/arrow-rs", rev="fbbb61d94282165f9bb9f73fb4d00a3af16d4aee" }
-arrow-buffer = { git = "https://github.com/apache/arrow-rs", rev="fbbb61d94282165f9bb9f73fb4d00a3af16d4aee" }
-arrow-cast = { git = "https://github.com/apache/arrow-rs", rev="fbbb61d94282165f9bb9f73fb4d00a3af16d4aee" }
-arrow-data = { git = "https://github.com/apache/arrow-rs", rev="fbbb61d94282165f9bb9f73fb4d00a3af16d4aee" }
-arrow-ipc = { git = "https://github.com/apache/arrow-rs", rev="fbbb61d94282165f9bb9f73fb4d00a3af16d4aee" }
-arrow-schema = { git = "https://github.com/apache/arrow-rs", rev="fbbb61d94282165f9bb9f73fb4d00a3af16d4aee" }
+arrow = { version = "49", features = ["ffi"] }
+arrow-array = { version = "49" }
+arrow-buffer = { version = "49" }
+arrow-cast = { version = "49" }
+arrow-data = { version = "49" }
+arrow-ipc = { version = "49" }
+arrow-schema = { version = "49" }
 bumpalo = { version = "3", features = ["collections"] }
 byteorder = "1"
 # Set default-features = false because async not working in wasm right now
@@ -53,7 +53,7 @@ thiserror = "1"
 approx = "0.5.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 geozero = { version = "0.11", features = ["with-wkb"] }
-parquet = { git = "https://github.com/apache/arrow-rs", rev="fbbb61d94282165f9bb9f73fb4d00a3af16d4aee" }
+parquet = { version = "49" }
 
 [lib]
 doctest = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geoarrow2"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# **NAME CHANGE**:
+
+This crate was originally published under the name `geoarrow2` because someone
+else had [reserved the crate name
+`geoarrow`](https://crates.io/crates/geoarrow/0.0.0). That person did not plan
+to work on `geoarrow` and transferred ownership of that name to me, so future
+releases will be under the `geoarrow` crate name.
+
 # `geoarrow-rs`
 
 A Rust implementation of the [GeoArrow](https://github.com/geoarrow/geoarrow) specification and bindings to [GeoRust algorithms](https://github.com/georust/geo) for efficient spatial operations on GeoArrow memory.


### PR DESCRIPTION
For https://github.com/geoarrow/geoarrow-rs/issues/269, this adds a [warning at the top of the `crates.io` page for 0.0.2](https://crates.io/crates/geoarrow2) pointing users to install future versions from the `geoarrow` crate instead.

This PR is just for visibility, and not for merge. I already published geoarrow2 v0.0.2 from this branch