### PR TITLE
Enable setting coord type when creating mutable arrays

### DIFF
--- a/src/array/coord/mod.rs
+++ b/src/array/coord/mod.rs
@@ -12,8 +12,9 @@ pub use combined::{CoordBuffer, MutableCoordBuffer};
 pub use interleaved::{InterleavedCoordBuffer, MutableInterleavedCoordBuffer};
 pub use separated::{MutableSeparatedCoordBuffer, SeparatedCoordBuffer};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub enum CoordType {
+    #[default]
     Interleaved,
     Separated,
 }

--- a/src/array/linestring/mutable.rs
+++ b/src/array/linestring/mutable.rs
@@ -65,8 +65,7 @@ impl<O: OffsetSizeTrait> MutableLineStringArray<O> {
     pub fn with_capacities_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
     ) -> Self {
-        let (coord_capacity, geom_capacity) = count_from_iter(geoms);
-        Self::with_capacities(coord_capacity, geom_capacity)
+        Self::with_capacities_and_options_from_iter(geoms, Default::default())
     }
 
     pub fn with_capacities_and_options_from_iter<'a>(
@@ -221,8 +220,10 @@ impl<O: OffsetSizeTrait> MutableLineStringArray<O> {
         geoms: &[impl LineStringTrait<T = f64>],
         coord_type: Option<CoordType>,
     ) -> Self {
-        let mut array =
-            Self::with_capacities_and_options_from_iter(geoms.iter().map(Some), coord_type.unwrap_or_default());
+        let mut array = Self::with_capacities_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+        );
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }

--- a/src/array/linestring/mutable.rs
+++ b/src/array/linestring/mutable.rs
@@ -177,27 +177,27 @@ impl<O: OffsetSizeTrait> MutableLineStringArray<O> {
 
     pub fn from_line_strings(
         geoms: &[impl LineStringTrait<T = f64>],
-        coord_type: CoordType,
+        coord_type: Option<CoordType>,
     ) -> Self {
         let (coord_capacity, geom_capacity) = first_pass(geoms.iter().map(Some));
         second_pass(
             geoms.iter().map(Some),
             coord_capacity,
             geom_capacity,
-            coord_type,
+            coord_type.unwrap_or_default(),
         )
     }
 
     pub fn from_nullable_line_strings(
         geoms: &[Option<impl LineStringTrait<T = f64>>],
-        coord_type: CoordType,
+        coord_type: Option<CoordType>,
     ) -> Self {
         let (coord_capacity, geom_capacity) = first_pass(geoms.iter().map(|x| x.as_ref()));
         second_pass(
             geoms.iter().map(|x| x.as_ref()),
             coord_capacity,
             geom_capacity,
-            coord_type,
+            coord_type.unwrap_or_default(),
         )
     }
 }

--- a/src/array/multilinestring/mutable.rs
+++ b/src/array/multilinestring/mutable.rs
@@ -81,6 +81,20 @@ impl<O: OffsetSizeTrait> MutableMultiLineStringArray<O> {
         }
     }
 
+    pub fn with_capacities_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) -> Self {
+        Self::with_capacities_and_options_from_iter(geoms, Default::default())
+    }
+
+    pub fn with_capacities_and_options_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+        coord_type: CoordType,
+    ) -> Self {
+        let (coord_capacity, ring_capacity, geom_capacity) = count_from_iter(geoms);
+        Self::with_capacities_and_options(coord_capacity, ring_capacity, geom_capacity, coord_type)
+    }
+
     /// Reserves capacity for at least `additional` more LineStrings to be inserted
     /// in the given `Vec<T>`. The collection may reserve more space to
     /// speculatively avoid frequent reallocations. After calling `reserve`,
@@ -118,6 +132,22 @@ impl<O: OffsetSizeTrait> MutableMultiLineStringArray<O> {
         self.coords.reserve_exact(coord_additional);
         self.ring_offsets.reserve(ring_additional);
         self.geom_offsets.reserve(geom_additional);
+    }
+
+    pub fn reserve_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) {
+        let (coord_capacity, ring_capacity, geom_capacity) = count_from_iter(geoms);
+        self.reserve(coord_capacity, ring_capacity, geom_capacity)
+    }
+
+    pub fn reserve_exact_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) {
+        let (coord_capacity, ring_capacity, geom_capacity) = count_from_iter(geoms);
+        self.reserve_exact(coord_capacity, ring_capacity, geom_capacity)
     }
 
     /// The canonical method to create a [`MutableMultiLineStringArray`] out of its internal
@@ -240,6 +270,16 @@ impl<O: OffsetSizeTrait> MutableMultiLineStringArray<O> {
         Ok(())
     }
 
+    pub fn extend_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait<T = f64> + 'a)>>,
+    ) {
+        geoms
+            .into_iter()
+            .try_for_each(|maybe_multi_point| self.push_multi_line_string(maybe_multi_point))
+            .unwrap();
+    }
+
     /// Push a raw offset to the underlying geometry offsets buffer.
     ///
     /// # Safety
@@ -281,6 +321,30 @@ impl<O: OffsetSizeTrait> MutableMultiLineStringArray<O> {
         self.geom_offsets.extend_constant(1);
         self.validity.append(false);
     }
+
+    pub fn from_multi_line_strings(
+        geoms: &[impl MultiLineStringTrait<T = f64>],
+        coord_type: Option<CoordType>,
+    ) -> Self {
+        let mut array = Self::with_capacities_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+        );
+        array.extend_from_iter(geoms.iter().map(Some));
+        array
+    }
+
+    pub fn from_nullable_multi_line_strings(
+        geoms: &[Option<impl MultiLineStringTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+    ) -> Self {
+        let mut array = Self::with_capacities_and_options_from_iter(
+            geoms.iter().map(|x| x.as_ref()),
+            coord_type.unwrap_or_default(),
+        );
+        array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
+        array
+    }
 }
 
 impl<O: OffsetSizeTrait> IntoArrow for MutableMultiLineStringArray<O> {
@@ -309,23 +373,25 @@ impl<O: OffsetSizeTrait> From<MutableMultiLineStringArray<O>> for MultiLineStrin
     }
 }
 
-fn first_pass<'a>(
+fn count_from_iter<'a>(
     geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
-    geoms_length: usize,
 ) -> (usize, usize, usize) {
     // Total number of coordinates
     let mut coord_capacity = 0;
     let mut ring_capacity = 0;
-    let geom_capacity = geoms_length;
+    let mut geom_capacity = 0;
 
-    for multi_line_string in geoms.into_iter().flatten() {
-        // Total number of rings in this polygon
-        let num_line_strings = multi_line_string.num_lines();
-        ring_capacity += num_line_strings;
+    for maybe_multi_line_string in geoms.into_iter() {
+        geom_capacity += 1;
+        if let Some(multi_line_string) = maybe_multi_line_string {
+            // Total number of rings in this polygon
+            let num_line_strings = multi_line_string.num_lines();
+            ring_capacity += num_line_strings;
 
-        for line_string_idx in 0..num_line_strings {
-            let line_string = multi_line_string.line(line_string_idx).unwrap();
-            coord_capacity += line_string.num_coords();
+            for line_string_idx in 0..num_line_strings {
+                let line_string = multi_line_string.line(line_string_idx).unwrap();
+                coord_capacity += line_string.num_coords();
+            }
         }
     }
 
@@ -333,37 +399,11 @@ fn first_pass<'a>(
     (coord_capacity, ring_capacity, geom_capacity)
 }
 
-fn second_pass<'a, O: OffsetSizeTrait>(
-    geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait<T = f64> + 'a)>>,
-    coord_capacity: usize,
-    ring_capacity: usize,
-    geom_capacity: usize,
-) -> MutableMultiLineStringArray<O> {
-    let mut array =
-        MutableMultiLineStringArray::with_capacities(coord_capacity, ring_capacity, geom_capacity);
-
-    geoms
-        .into_iter()
-        .try_for_each(|maybe_multi_line_string| {
-            array.push_multi_line_string(maybe_multi_line_string)
-        })
-        .unwrap();
-
-    array
-}
-
 impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<Vec<G>>
     for MutableMultiLineStringArray<O>
 {
     fn from(geoms: Vec<G>) -> Self {
-        let (coord_capacity, ring_capacity, geom_capacity) =
-            first_pass(geoms.iter().map(Some), geoms.len());
-        second_pass(
-            geoms.iter().map(Some),
-            coord_capacity,
-            ring_capacity,
-            geom_capacity,
-        )
+        Self::from_multi_line_strings(&geoms, Default::default())
     }
 }
 
@@ -371,14 +411,7 @@ impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<Vec<Option<G>>>
     for MutableMultiLineStringArray<O>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
-        let (coord_capacity, ring_capacity, geom_capacity) =
-            first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
-        second_pass(
-            geoms.iter().map(|x| x.as_ref()),
-            coord_capacity,
-            ring_capacity,
-            geom_capacity,
-        )
+        Self::from_nullable_multi_line_strings(&geoms, Default::default())
     }
 }
 
@@ -386,14 +419,7 @@ impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<bumpalo::collect
     for MutableMultiLineStringArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        let (coord_capacity, ring_capacity, geom_capacity) =
-            first_pass(geoms.iter().map(Some), geoms.len());
-        second_pass(
-            geoms.iter().map(Some),
-            coord_capacity,
-            ring_capacity,
-            geom_capacity,
-        )
+        Self::from_multi_line_strings(&geoms, Default::default())
     }
 }
 
@@ -401,14 +427,7 @@ impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>>
     From<bumpalo::collections::Vec<'_, Option<G>>> for MutableMultiLineStringArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        let (coord_capacity, ring_capacity, geom_capacity) =
-            first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
-        second_pass(
-            geoms.iter().map(|x| x.as_ref()),
-            coord_capacity,
-            ring_capacity,
-            geom_capacity,
-        )
+        Self::from_nullable_multi_line_strings(&geoms, Default::default())
     }
 }
 

--- a/src/array/multilinestring/mutable.rs
+++ b/src/array/multilinestring/mutable.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 // use super::array::check;
 use crate::array::mutable_offset::OffsetsBuilder;
 use crate::array::{
-    MultiLineStringArray, MutableCoordBuffer, MutableInterleavedCoordBuffer, MutablePolygonArray,
-    WKBArray,
+    CoordType, MultiLineStringArray, MutableCoordBuffer, MutableInterleavedCoordBuffer,
+    MutablePolygonArray, MutableSeparatedCoordBuffer, WKBArray,
 };
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{LineStringTrait, MultiLineStringTrait};
@@ -41,15 +41,40 @@ impl<O: OffsetSizeTrait> MutableMultiLineStringArray<O> {
         MutablePolygonArray::new().into()
     }
 
+    pub fn new_with_options(coord_type: CoordType) -> Self {
+        Self::with_capacities_and_options(0, 0, 0, coord_type)
+    }
+
     /// Creates a new [`MutableMultiLineStringArray`] with a capacity.
     pub fn with_capacities(
         coord_capacity: usize,
         ring_capacity: usize,
         geom_capacity: usize,
     ) -> Self {
-        let coords = MutableInterleavedCoordBuffer::with_capacity(coord_capacity);
+        Self::with_capacities_and_options(
+            coord_capacity,
+            ring_capacity,
+            geom_capacity,
+            Default::default(),
+        )
+    }
+
+    pub fn with_capacities_and_options(
+        coord_capacity: usize,
+        ring_capacity: usize,
+        geom_capacity: usize,
+        coord_type: CoordType,
+    ) -> Self {
+        let coords = match coord_type {
+            CoordType::Interleaved => MutableCoordBuffer::Interleaved(
+                MutableInterleavedCoordBuffer::with_capacity(coord_capacity),
+            ),
+            CoordType::Separated => MutableCoordBuffer::Separated(
+                MutableSeparatedCoordBuffer::with_capacity(coord_capacity),
+            ),
+        };
         Self {
-            coords: MutableCoordBuffer::Interleaved(coords),
+            coords,
             geom_offsets: OffsetsBuilder::with_capacity(geom_capacity),
             ring_offsets: OffsetsBuilder::with_capacity(ring_capacity),
             validity: NullBufferBuilder::new(geom_capacity),

--- a/src/array/point/mutable.rs
+++ b/src/array/point/mutable.rs
@@ -129,9 +129,10 @@ impl MutablePointArray {
 
     pub fn from_points<'a>(
         geoms: impl ExactSizeIterator + Iterator<Item = &'a (impl PointTrait<T = f64> + 'a)>,
-        coord_type: CoordType,
+        coord_type: Option<CoordType>,
     ) -> Self {
-        let mut mutable_array = Self::with_capacity_and_options(geoms.len(), coord_type);
+        let mut mutable_array =
+            Self::with_capacity_and_options(geoms.len(), coord_type.unwrap_or_default());
         geoms
             .into_iter()
             .for_each(|maybe_point| mutable_array.push_point(Some(maybe_point)));
@@ -140,9 +141,10 @@ impl MutablePointArray {
 
     pub fn from_nullable_points<'a>(
         geoms: impl ExactSizeIterator + Iterator<Item = Option<&'a (impl PointTrait<T = f64> + 'a)>>,
-        coord_type: CoordType,
+        coord_type: Option<CoordType>,
     ) -> MutablePointArray {
-        let mut mutable_array = Self::with_capacity_and_options(geoms.len(), coord_type);
+        let mut mutable_array =
+            Self::with_capacity_and_options(geoms.len(), coord_type.unwrap_or_default());
         geoms
             .into_iter()
             .for_each(|maybe_point| mutable_array.push_point(maybe_point));

--- a/src/array/point/mutable.rs
+++ b/src/array/point/mutable.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 // use super::array::check;
-use crate::array::{MutableCoordBuffer, MutableInterleavedCoordBuffer, PointArray, WKBArray};
+use crate::array::{
+    CoordType, MutableCoordBuffer, MutableInterleavedCoordBuffer, MutableSeparatedCoordBuffer,
+    PointArray, WKBArray,
+};
 use crate::error::GeoArrowError;
 use crate::geo_traits::PointTrait;
 use crate::io::wkb::reader::point::WKBPoint;
@@ -21,14 +24,30 @@ pub struct MutablePointArray {
 impl MutablePointArray {
     /// Creates a new empty [`MutablePointArray`].
     pub fn new() -> Self {
-        Self::with_capacity(0)
+        Self::new_with_options(Default::default())
+    }
+
+    pub fn new_with_options(coord_type: CoordType) -> Self {
+        Self::with_capacity_and_options(0, coord_type)
     }
 
     /// Creates a new [`MutablePointArray`] with a capacity.
     pub fn with_capacity(capacity: usize) -> Self {
-        let coords = MutableInterleavedCoordBuffer::with_capacity(capacity);
+        Self::with_capacity_and_options(capacity, Default::default())
+    }
+
+    /// Creates a new [`MutablePointArray`] with a capacity.
+    pub fn with_capacity_and_options(capacity: usize, coord_type: CoordType) -> Self {
+        let coords = match coord_type {
+            CoordType::Interleaved => MutableCoordBuffer::Interleaved(
+                MutableInterleavedCoordBuffer::with_capacity(capacity),
+            ),
+            CoordType::Separated => {
+                MutableCoordBuffer::Separated(MutableSeparatedCoordBuffer::with_capacity(capacity))
+            }
+        };
         Self {
-            coords: MutableCoordBuffer::Interleaved(coords),
+            coords,
             validity: NullBufferBuilder::new(capacity),
         }
     }
@@ -107,6 +126,28 @@ impl MutablePointArray {
         self.coords.push_xy(0., 0.);
         self.validity.append(false);
     }
+
+    pub fn from_points<'a>(
+        geoms: impl ExactSizeIterator + Iterator<Item = &'a (impl PointTrait<T = f64> + 'a)>,
+        coord_type: CoordType,
+    ) -> Self {
+        let mut mutable_array = Self::with_capacity_and_options(geoms.len(), coord_type);
+        geoms
+            .into_iter()
+            .for_each(|maybe_point| mutable_array.push_point(Some(maybe_point)));
+        mutable_array
+    }
+
+    pub fn from_nullable_points<'a>(
+        geoms: impl ExactSizeIterator + Iterator<Item = Option<&'a (impl PointTrait<T = f64> + 'a)>>,
+        coord_type: CoordType,
+    ) -> MutablePointArray {
+        let mut mutable_array = Self::with_capacity_and_options(geoms.len(), coord_type);
+        geoms
+            .into_iter()
+            .for_each(|maybe_point| mutable_array.push_point(maybe_point));
+        mutable_array
+    }
 }
 
 impl MutableGeometryArray for MutablePointArray {
@@ -159,53 +200,33 @@ impl From<MutablePointArray> for Arc<dyn Array> {
     }
 }
 
-fn from_coords<'a>(
-    geoms: impl Iterator<Item = &'a (impl PointTrait<T = f64> + 'a)>,
-    geoms_length: usize,
-) -> MutablePointArray {
-    let mut mutable_array = MutablePointArray::with_capacity(geoms_length);
-    geoms
-        .into_iter()
-        .for_each(|maybe_point| mutable_array.push_point(Some(maybe_point)));
-    mutable_array
-}
-
-pub(crate) fn from_nullable_coords<'a>(
-    geoms: impl Iterator<Item = Option<&'a (impl PointTrait<T = f64> + 'a)>>,
-    geoms_length: usize,
-) -> MutablePointArray {
-    let mut mutable_array = MutablePointArray::with_capacity(geoms_length);
-    geoms
-        .into_iter()
-        .for_each(|maybe_point| mutable_array.push_point(maybe_point));
-    mutable_array
-}
-
 impl<G: PointTrait<T = f64>> From<Vec<G>> for MutablePointArray {
     fn from(value: Vec<G>) -> Self {
-        let geoms_length = value.len();
-        from_coords(value.iter(), geoms_length)
+        MutablePointArray::from_points(value.iter(), Default::default())
     }
 }
 
 impl<G: PointTrait<T = f64>> From<Vec<Option<G>>> for MutablePointArray {
     fn from(geoms: Vec<Option<G>>) -> Self {
-        let geoms_length = geoms.len();
-        from_nullable_coords(geoms.iter().map(|x| x.as_ref()), geoms_length)
+        MutablePointArray::from_nullable_points(
+            geoms.iter().map(|x| x.as_ref()),
+            Default::default(),
+        )
     }
 }
 
 impl<G: PointTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>> for MutablePointArray {
     fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        let geoms_length = geoms.len();
-        from_coords(geoms.iter(), geoms_length)
+        MutablePointArray::from_points(geoms.iter(), Default::default())
     }
 }
 
 impl<G: PointTrait<T = f64>> From<bumpalo::collections::Vec<'_, Option<G>>> for MutablePointArray {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        let geoms_length = geoms.len();
-        from_nullable_coords(geoms.iter().map(|x| x.as_ref()), geoms_length)
+        MutablePointArray::from_nullable_points(
+            geoms.iter().map(|x| x.as_ref()),
+            Default::default(),
+        )
     }
 }
 

--- a/src/array/polygon/mutable.rs
+++ b/src/array/polygon/mutable.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 // use super::array::check;
 use crate::array::mutable_offset::OffsetsBuilder;
 use crate::array::{
-    MutableCoordBuffer, MutableInterleavedCoordBuffer, MutableMultiLineStringArray, PolygonArray,
-    WKBArray,
+    CoordType, MutableCoordBuffer, MutableInterleavedCoordBuffer, MutableMultiLineStringArray,
+    MutableSeparatedCoordBuffer, PolygonArray, WKBArray,
 };
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{LineStringTrait, PolygonTrait};
@@ -43,15 +43,40 @@ impl<O: OffsetSizeTrait> MutablePolygonArray<O> {
         Self::with_capacities(0, 0, 0)
     }
 
+    pub fn new_with_options(coord_type: CoordType) -> Self {
+        Self::with_capacities_and_options(0, 0, 0, coord_type)
+    }
+
     /// Creates a new [`MutablePolygonArray`] with given capacities and no validity.
     pub fn with_capacities(
         coord_capacity: usize,
         ring_capacity: usize,
         geom_capacity: usize,
     ) -> Self {
-        let coords = MutableInterleavedCoordBuffer::with_capacity(coord_capacity);
+        Self::with_capacities_and_options(
+            coord_capacity,
+            ring_capacity,
+            geom_capacity,
+            Default::default(),
+        )
+    }
+
+    pub fn with_capacities_and_options(
+        coord_capacity: usize,
+        ring_capacity: usize,
+        geom_capacity: usize,
+        coord_type: CoordType,
+    ) -> Self {
+        let coords = match coord_type {
+            CoordType::Interleaved => MutableCoordBuffer::Interleaved(
+                MutableInterleavedCoordBuffer::with_capacity(coord_capacity),
+            ),
+            CoordType::Separated => MutableCoordBuffer::Separated(
+                MutableSeparatedCoordBuffer::with_capacity(coord_capacity),
+            ),
+        };
         Self {
-            coords: MutableCoordBuffer::Interleaved(coords),
+            coords,
             geom_offsets: OffsetsBuilder::with_capacity(geom_capacity),
             ring_offsets: OffsetsBuilder::with_capacity(ring_capacity),
             validity: NullBufferBuilder::new(geom_capacity),

--- a/src/io/geos/array/point.rs
+++ b/src/io/geos/array/point.rs
@@ -1,4 +1,3 @@
-use crate::array::point::mutable::from_nullable_coords;
 use crate::array::{MutablePointArray, PointArray};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSPoint;
@@ -7,15 +6,14 @@ impl<'a> TryFrom<Vec<Option<geos::Geometry<'a>>>> for MutablePointArray {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry<'a>>>) -> std::result::Result<Self, Self::Error> {
-        let length = value.len();
         // TODO: don't use new_unchecked
         let geos_linestring_objects: Vec<Option<GEOSPoint>> = value
             .into_iter()
             .map(|geom| geom.map(GEOSPoint::new_unchecked))
             .collect();
-        Ok(from_nullable_coords(
+        Ok(MutablePointArray::from_nullable_points(
             geos_linestring_objects.iter().map(|item| item.as_ref()),
-            length,
+            Default::default(),
         ))
     }
 }


### PR DESCRIPTION
### Change list

- Add `new_with_options`, `with_capacities_and_options`, etc that allow defining the coord type of the generated arrays (either interleaved or separated)
- Convert the existing `first_pass` and `second_pass` functions for each mutable array into a private `count_from_iter` that takes in an iterable of geometries (implemented from traits) and an `extend_from_iter` that fills geometries into the array, whether or not they've been pre-allocated.

    So this is exposed to the end user as e.g. `from_line_strings` which takes in a slice of `impl LineStringTrait` and creates a `MutableLineStringArray` with the exact allocations. This makes the `From` impls super simple
- Add `Default` for `CoordType`, setting it to `Interleaved`