### PR TITLE
Adds `new_with_capacity()` for all other geometry types 

### DIFF
--- a/src/array/multipoint/mutable.rs
+++ b/src/array/multipoint/mutable.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 // use super::array::check;
 use crate::array::mutable_offset::OffsetsBuilder;
 use crate::array::{
-    MultiPointArray, MutableCoordBuffer, MutableInterleavedCoordBuffer, MutableLineStringArray,
+    CoordType, 
+    MultiPointArray, 
+    MutableCoordBuffer, 
+    MutableInterleavedCoordBuffer, MutableSeparatedCoordBuffer,
+    MutableLineStringArray,
     WKBArray,
 };
 use crate::error::{GeoArrowError, Result};
@@ -29,14 +33,38 @@ pub struct MutableMultiPointArray<O: OffsetSizeTrait> {
 impl<O: OffsetSizeTrait> MutableMultiPointArray<O> {
     /// Creates a new empty [`MutableMultiPointArray`].
     pub fn new() -> Self {
-        Self::with_capacities(0, 0)
+        Self::new_with_options(Default::default())
     }
 
+    /// Creates a new [`MutableMultiPointArray`] with a specified [`CoordType`]
+    pub fn new_with_options(coord_type: CoordType) -> Self {
+        Self::with_capacities_and_options(0, 0, coord_type)
+    }
     /// Creates a new [`MutableMultiPointArray`] with a capacity.
     pub fn with_capacities(coord_capacity: usize, geom_capacity: usize) -> Self {
-        let coords = MutableInterleavedCoordBuffer::with_capacity(coord_capacity);
+        Self::with_capacities_and_options(
+            coord_capacity, 
+            geom_capacity, 
+            Default::default()
+        )
+    }
+
+    // with capacities and options enables us to write with_capacities based on this method
+    pub fn with_capacities_and_options(
+        coord_capacity: usize,
+        geom_capacity: usize,
+        coord_type: CoordType,
+    ) -> Self {
+        let coords = match coord_type {
+            CoordType::Interleaved => MutableCoordBuffer::Interleaved(
+                MutableInterleavedCoordBuffer::with_capacity(coord_capacity),
+            ),
+            CoordType::Separated => MutableCoordBuffer::Separated(
+                MutableSeparatedCoordBuffer::with_capacity(coord_capacity),
+            ),
+        };
         Self {
-            coords: MutableCoordBuffer::Interleaved(coords),
+            coords,
             geom_offsets: OffsetsBuilder::with_capacity(geom_capacity),
             validity: NullBufferBuilder::new(geom_capacity),
         }

--- a/src/array/multipolygon/mutable.rs
+++ b/src/array/multipolygon/mutable.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 // use super::array::check;
 use crate::array::mutable_offset::OffsetsBuilder;
 use crate::array::{
-    MultiPolygonArray, MutableCoordBuffer, MutableInterleavedCoordBuffer, WKBArray,
+    CoordType, MutableSeparatedCoordBuffer,
+    MutableCoordBuffer, MutableInterleavedCoordBuffer, 
+    MultiPolygonArray, WKBArray,
 };
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{LineStringTrait, MultiPolygonTrait, PolygonTrait};
@@ -61,6 +63,31 @@ impl<O: OffsetSizeTrait> MutableMultiPolygonArray<O> {
             polygon_offsets: OffsetsBuilder::with_capacity(polygon_capacity),
             ring_offsets: OffsetsBuilder::with_capacity(ring_capacity),
             validity: NullBufferBuilder::new(geom_capacity),
+        }
+    }
+
+    pub fn with_capacities_and_options(
+        coord_capacity: usize,
+        ring_capacity: usize,
+        polygon_capacity: usize,
+        geom_capacity: usize,
+        coord_type: CoordType
+    ) -> Self {
+        let coords = match coord_type {
+            CoordType::Interleaved => MutableCoordBuffer::Interleaved(
+                MutableInterleavedCoordBuffer::with_capacity(coord_capacity),
+            ),
+            CoordType::Separated => MutableCoordBuffer::Separated(
+                MutableSeparatedCoordBuffer::with_capacity(coord_capacity),
+            ),
+        };
+
+        Self { 
+            coords, 
+            geom_offsets: OffsetsBuilder::with_capacity(geom_capacity), 
+            polygon_offsets: OffsetsBuilder::with_capacity(polygon_capacity), 
+            ring_offsets: OffsetsBuilder::with_capacity(ring_capacity), 
+            validity: NullBufferBuilder::new(geom_capacity) 
         }
     }
 

--- a/src/array/polygon/mutable.rs
+++ b/src/array/polygon/mutable.rs
@@ -3,9 +3,11 @@ use std::sync::Arc;
 // use super::array::check;
 use crate::array::mutable_offset::OffsetsBuilder;
 use crate::array::{
-    MutableCoordBuffer, MutableInterleavedCoordBuffer, MutableMultiLineStringArray, PolygonArray,
+    CoordType, MutableCoordBuffer, 
+    MutableInterleavedCoordBuffer, MutableSeparatedCoordBuffer,
+    MutableMultiLineStringArray, PolygonArray,
     WKBArray,
-};
+}; 
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{LineStringTrait, PolygonTrait};
 use crate::io::wkb::reader::polygon::WKBPolygon;
@@ -43,15 +45,35 @@ impl<O: OffsetSizeTrait> MutablePolygonArray<O> {
         Self::with_capacities(0, 0, 0)
     }
 
+    pub fn new_with_options(coord_type: CoordType) -> Self {
+        Self::with_capacities_and_options(0, 0, 0, coord_type)
+    }
+
     /// Creates a new [`MutablePolygonArray`] with given capacities and no validity.
     pub fn with_capacities(
         coord_capacity: usize,
         ring_capacity: usize,
         geom_capacity: usize,
     ) -> Self {
-        let coords = MutableInterleavedCoordBuffer::with_capacity(coord_capacity);
+        Self::with_capacities_and_options(coord_capacity, ring_capacity, geom_capacity, Default::default())
+    }
+
+    pub fn with_capacities_and_options(
+        coord_capacity: usize,
+        ring_capacity: usize,
+        geom_capacity: usize,
+        coord_type: CoordType,
+    ) -> Self {
+        let coords = match coord_type {
+            CoordType::Interleaved => MutableCoordBuffer::Interleaved(
+                MutableInterleavedCoordBuffer::with_capacity(coord_capacity),
+            ),
+            CoordType::Separated => MutableCoordBuffer::Separated(
+                MutableSeparatedCoordBuffer::with_capacity(coord_capacity),
+            ),
+        };
         Self {
-            coords: MutableCoordBuffer::Interleaved(coords),
+            coords,
             geom_offsets: OffsetsBuilder::with_capacity(geom_capacity),
             ring_offsets: OffsetsBuilder::with_capacity(ring_capacity),
             validity: NullBufferBuilder::new(geom_capacity),


### PR DESCRIPTION
This PR adds `new_with_options()` and their required methods for the remaining geometry types (excluding Rect). 

Per https://github.com/geoarrow/geoarrow-rs/discussions/276#discussioncomment-7676936