### PR TITLE
Python: separate ffi mod; add primitive arrays

### DIFF
--- a/python/core/python/geoarrow/rust/core/__init__.py
+++ b/python/core/python/geoarrow/rust/core/__init__.py
@@ -1,8 +1,1 @@
-from .rust import (
-    LineStringArray,
-    MultiLineStringArray,
-    MultiPointArray,
-    MultiPolygonArray,
-    PointArray,
-    PolygonArray,
-)
+from .rust import *

--- a/python/core/src/array/binary.rs
+++ b/python/core/src/array/binary.rs
@@ -1,9 +1,43 @@
+use crate::array::*;
 use pyo3::prelude::*;
+use pyo3::types::PyType;
 
 /// An immutable array of WKB-formatted geometries in WebAssembly memory using GeoArrow's in-memory
 /// representation.
 #[pyclass]
 pub struct WKBArray(pub(crate) geoarrow::array::WKBArray<i32>);
+
+#[pymethods]
+impl WKBArray {
+    #[classmethod]
+    fn from_arrow(_cls: &PyType, py: Python<'_>, ob: PyObject) -> Result<WKBArray, PyErr> {
+        ob.extract(py)
+    }
+
+    fn to_point_array(&self) -> Result<PointArray, PyErr> {
+        Ok(PointArray(self.0.clone().try_into().unwrap()))
+    }
+
+    fn to_line_string_array(&self) -> Result<LineStringArray, PyErr> {
+        Ok(LineStringArray(self.0.clone().try_into().unwrap()))
+    }
+
+    fn to_polygon_array(&self) -> Result<PolygonArray, PyErr> {
+        Ok(PolygonArray(self.0.clone().try_into().unwrap()))
+    }
+
+    fn to_multi_point_array(&self) -> Result<MultiPointArray, PyErr> {
+        Ok(MultiPointArray(self.0.clone().try_into().unwrap()))
+    }
+
+    fn to_multi_line_string_array(&self) -> Result<MultiLineStringArray, PyErr> {
+        Ok(MultiLineStringArray(self.0.clone().try_into().unwrap()))
+    }
+
+    fn to_multi_polygon_array(&self) -> Result<MultiPolygonArray, PyErr> {
+        Ok(MultiPolygonArray(self.0.clone().try_into().unwrap()))
+    }
+}
 
 impl From<geoarrow::array::WKBArray<i32>> for WKBArray {
     fn from(value: geoarrow::array::WKBArray<i32>) -> Self {

--- a/python/core/src/array/mod.rs
+++ b/python/core/src/array/mod.rs
@@ -21,4 +21,7 @@ pub use multipoint::MultiPointArray;
 pub use multipolygon::MultiPolygonArray;
 pub use point::PointArray;
 pub use polygon::PolygonArray;
-pub use primitive::{BooleanArray, Float64Array};
+pub use primitive::{
+    BooleanArray, Float16Array, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+    Int8Array, LargeStringArray, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};

--- a/python/core/src/array/primitive.rs
+++ b/python/core/src/array/primitive.rs
@@ -1,31 +1,35 @@
 use pyo3::prelude::*;
 
-#[pyclass]
-pub struct Float64Array(pub(crate) arrow::array::Float64Array);
+macro_rules! impl_primitive_array {
+    ($struct_name:ident, $arrow_rs_array:ty) => {
+        #[pyclass]
+        pub struct $struct_name(pub(crate) $arrow_rs_array);
 
-impl From<arrow::array::Float64Array> for Float64Array {
-    fn from(value: arrow::array::Float64Array) -> Self {
-        Self(value)
-    }
+        impl From<$arrow_rs_array> for $struct_name {
+            fn from(value: $arrow_rs_array) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<$struct_name> for $arrow_rs_array {
+            fn from(value: $struct_name) -> Self {
+                value.0
+            }
+        }
+    };
 }
 
-impl From<Float64Array> for arrow::array::Float64Array {
-    fn from(value: Float64Array) -> Self {
-        value.0
-    }
-}
-
-#[pyclass]
-pub struct BooleanArray(pub(crate) arrow::array::BooleanArray);
-
-impl From<arrow::array::BooleanArray> for BooleanArray {
-    fn from(value: arrow::array::BooleanArray) -> Self {
-        Self(value)
-    }
-}
-
-impl From<BooleanArray> for arrow::array::BooleanArray {
-    fn from(value: BooleanArray) -> Self {
-        value.0
-    }
-}
+impl_primitive_array!(BooleanArray, arrow::array::BooleanArray);
+impl_primitive_array!(Float16Array, arrow::array::Float16Array);
+impl_primitive_array!(Float32Array, arrow::array::Float32Array);
+impl_primitive_array!(Float64Array, arrow::array::Float64Array);
+impl_primitive_array!(UInt8Array, arrow::array::UInt8Array);
+impl_primitive_array!(UInt16Array, arrow::array::UInt16Array);
+impl_primitive_array!(UInt32Array, arrow::array::UInt32Array);
+impl_primitive_array!(UInt64Array, arrow::array::UInt64Array);
+impl_primitive_array!(Int8Array, arrow::array::Int8Array);
+impl_primitive_array!(Int16Array, arrow::array::Int16Array);
+impl_primitive_array!(Int32Array, arrow::array::Int32Array);
+impl_primitive_array!(Int64Array, arrow::array::Int64Array);
+impl_primitive_array!(StringArray, arrow::array::StringArray);
+impl_primitive_array!(LargeStringArray, arrow::array::LargeStringArray);

--- a/python/core/src/ffi/mod.rs
+++ b/python/core/src/ffi/mod.rs
@@ -1,0 +1,2 @@
+pub mod from_python;
+pub mod to_python;

--- a/python/core/src/ffi/to_python.rs
+++ b/python/core/src/ffi/to_python.rs
@@ -1,0 +1,78 @@
+use crate::array::*;
+use arrow::array::Array;
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use geoarrow::GeometryArrayTrait;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyTuple};
+use pyo3::PyResult;
+use std::ffi::CString;
+
+/// Implement the __arrow_c_array__ method on a GeometryArray
+macro_rules! impl_arrow_c_array_geometry_array {
+    ($struct_name:ident) => {
+        #[pymethods]
+        impl $struct_name {
+            /// An implementation of the Arrow PyCapsule Interface
+            fn __arrow_c_array__(&self, _requested_schema: PyObject) -> PyResult<PyObject> {
+                let field = self.0.extension_field();
+                let ffi_schema = FFI_ArrowSchema::try_from(&*field).unwrap();
+                let ffi_array = FFI_ArrowArray::new(&self.0.clone().into_array_ref().to_data());
+
+                let schema_capsule_name = CString::new("arrow_schema").unwrap();
+                let array_capsule_name = CString::new("arrow_array").unwrap();
+
+                Python::with_gil(|py| {
+                    let schema_capsule = PyCapsule::new(py, ffi_schema, Some(schema_capsule_name))?;
+                    let array_capsule = PyCapsule::new(py, ffi_array, Some(array_capsule_name))?;
+                    let tuple = PyTuple::new(py, vec![schema_capsule, array_capsule]);
+                    Ok(tuple.to_object(py))
+                })
+            }
+        }
+    };
+}
+
+impl_arrow_c_array_geometry_array!(PointArray);
+impl_arrow_c_array_geometry_array!(LineStringArray);
+impl_arrow_c_array_geometry_array!(PolygonArray);
+impl_arrow_c_array_geometry_array!(MultiPointArray);
+impl_arrow_c_array_geometry_array!(MultiLineStringArray);
+impl_arrow_c_array_geometry_array!(MultiPolygonArray);
+
+macro_rules! impl_arrow_c_array_primitive {
+    ($struct_name:ident) => {
+        #[pymethods]
+        impl $struct_name {
+            /// An implementation of the Arrow PyCapsule Interface
+            fn __arrow_c_array__(&self, _requested_schema: PyObject) -> PyResult<PyObject> {
+                let ffi_schema = FFI_ArrowSchema::try_from(self.0.data_type()).unwrap();
+                let ffi_array = FFI_ArrowArray::new(&self.0.to_data());
+
+                let schema_capsule_name = CString::new("arrow_schema").unwrap();
+                let array_capsule_name = CString::new("arrow_array").unwrap();
+
+                Python::with_gil(|py| {
+                    let schema_capsule = PyCapsule::new(py, ffi_schema, Some(schema_capsule_name))?;
+                    let array_capsule = PyCapsule::new(py, ffi_array, Some(array_capsule_name))?;
+                    let tuple = PyTuple::new(py, vec![schema_capsule, array_capsule]);
+                    Ok(tuple.to_object(py))
+                })
+            }
+        }
+    };
+}
+
+impl_arrow_c_array_primitive!(BooleanArray);
+impl_arrow_c_array_primitive!(Float16Array);
+impl_arrow_c_array_primitive!(Float32Array);
+impl_arrow_c_array_primitive!(Float64Array);
+impl_arrow_c_array_primitive!(UInt8Array);
+impl_arrow_c_array_primitive!(UInt16Array);
+impl_arrow_c_array_primitive!(UInt32Array);
+impl_arrow_c_array_primitive!(UInt64Array);
+impl_arrow_c_array_primitive!(Int8Array);
+impl_arrow_c_array_primitive!(Int16Array);
+impl_arrow_c_array_primitive!(Int32Array);
+impl_arrow_c_array_primitive!(Int64Array);
+impl_arrow_c_array_primitive!(StringArray);
+impl_arrow_c_array_primitive!(LargeStringArray);

--- a/python/core/src/lib.rs
+++ b/python/core/src/lib.rs
@@ -3,13 +3,6 @@ pub mod algorithm;
 pub mod array;
 pub mod broadcasting;
 pub mod ffi;
-// pub mod ffi2;
-
-/// Formats the sum of two numbers as string.
-#[pyfunction]
-fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
-    Ok((a + b).to_string())
-}
 
 /// A Python module implemented in Rust.
 #[pymodule]
@@ -20,10 +13,23 @@ fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<array::MultiPointArray>()?;
     m.add_class::<array::MultiLineStringArray>()?;
     m.add_class::<array::MultiPolygonArray>()?;
+    m.add_class::<array::WKBArray>()?;
 
+    // Primitive arrays
     m.add_class::<array::BooleanArray>()?;
+    m.add_class::<array::Float16Array>()?;
+    m.add_class::<array::Float32Array>()?;
     m.add_class::<array::Float64Array>()?;
+    m.add_class::<array::Int16Array>()?;
+    m.add_class::<array::Int32Array>()?;
+    m.add_class::<array::Int64Array>()?;
+    m.add_class::<array::Int8Array>()?;
+    m.add_class::<array::LargeStringArray>()?;
+    m.add_class::<array::StringArray>()?;
+    m.add_class::<array::UInt16Array>()?;
+    m.add_class::<array::UInt32Array>()?;
+    m.add_class::<array::UInt64Array>()?;
+    m.add_class::<array::UInt8Array>()?;
 
-    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
It works round trip!

```py
import pyarrow as pa
import shapely
import pandas as pd
import geopandas as gpd
from geoarrow.rust.core import WKBArray

gdf = gpd.read_file(gpd.datasets.get_path('nybb'))
large_gdf = pd.concat([gdf] * 1000)
wkb = shapely.to_wkb(large_gdf['geometry'])

pa_wkb_arr = pa.array(wkb)
rust_wkb_arr = WKBArray.from_arrow(pa_wkb_arr)
rust_multi_polygon_arr = rust_wkb_arr.to_multi_polygon_array()
area = rust_multi_polygon_arr.area()

pa_area_array = pa.array(area)
```