### PR TITLE
Rename GeoArrayAccessor to GeometryArrayAccessor

### DIFF
--- a/benches/nybb.rs
+++ b/benches/nybb.rs
@@ -4,7 +4,7 @@ use arrow_ipc::reader::FileReader;
 use criterion::{criterion_group, criterion_main, Criterion};
 use geoarrow::algorithm::geo::EuclideanDistance;
 use geoarrow::array::{MultiPolygonArray, PointArray};
-use geoarrow::trait_::GeoArrayAccessor;
+use geoarrow::trait_::GeometryArrayAccessor;
 
 fn load_nybb() -> MultiPolygonArray<i32> {
     let file = File::open("fixtures/nybb.arrow").unwrap();

--- a/src/algorithm/geo/centroid.rs
+++ b/src/algorithm/geo/centroid.rs
@@ -18,7 +18,7 @@ use geo::algorithm::centroid::Centroid as GeoCentroid;
 /// ```
 /// use geoarrow::algorithm::geo::Centroid;
 /// use geoarrow::array::PolygonArray;
-/// use geoarrow::trait_::GeoArrayAccessor;
+/// use geoarrow::trait_::GeometryArrayAccessor;
 /// use geo::{point, polygon};
 ///
 /// // rhombus shaped polygon
@@ -44,7 +44,7 @@ pub trait Centroid {
     /// ```
     /// use geoarrow::algorithm::geo::Centroid;
     /// use geoarrow::array::LineStringArray;
-    /// use geoarrow::trait_::GeoArrayAccessor;
+    /// use geoarrow::trait_::GeometryArrayAccessor;
     /// use geo::{line_string, point};
     ///
     /// let line_string = line_string![

--- a/src/algorithm/geo/convex_hull.rs
+++ b/src/algorithm/geo/convex_hull.rs
@@ -80,7 +80,7 @@ impl<O: OffsetSizeTrait> ConvexHull<O> for GeometryArray<O> {
 mod tests {
     use super::ConvexHull;
     use crate::array::{LineStringArray, MultiPointArray};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geo::{line_string, polygon, MultiPoint, Point};
 
     #[test]

--- a/src/algorithm/geo/simplify.rs
+++ b/src/algorithm/geo/simplify.rs
@@ -20,7 +20,7 @@ pub trait Simplify {
     /// ```
     /// use geoarrow::algorithm::geo::Simplify;
     /// use geoarrow::array::LineStringArray;
-    /// use geoarrow::trait_::GeoArrayAccessor;
+    /// use geoarrow::trait_::GeometryArrayAccessor;
     /// use geo::line_string;
     ///
     /// let line_string = line_string![
@@ -107,7 +107,7 @@ impl<O: OffsetSizeTrait> Simplify for GeometryArray<O> {
 mod tests {
     use super::*;
     use crate::array::{LineStringArray, PolygonArray};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geo::{line_string, polygon};
 
     #[test]

--- a/src/algorithm/geo/simplify_vw.rs
+++ b/src/algorithm/geo/simplify_vw.rs
@@ -19,7 +19,7 @@ pub trait SimplifyVw {
     /// ```
     /// use geoarrow::algorithm::geo::SimplifyVw;
     /// use geoarrow::array::LineStringArray;
-    /// use geoarrow::trait_::GeoArrayAccessor;
+    /// use geoarrow::trait_::GeometryArrayAccessor;
     /// use geo::line_string;
     ///
     /// let line_string = line_string![

--- a/src/algorithm/proj.rs
+++ b/src/algorithm/proj.rs
@@ -29,7 +29,7 @@ impl Reproject for PointArray {
 
 #[cfg(test)]
 mod test {
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use approx::assert_relative_eq;
 
     use super::*;

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -8,7 +8,7 @@ use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
 use crate::scalar::WKB;
 // use crate::util::{owned_slice_offsets, owned_slice_validity};
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_array::{Array, BinaryArray, GenericBinaryArray, LargeBinaryArray};
@@ -144,7 +144,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for WKBArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for WKBArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for WKBArray<O> {
     type Item = WKB<'a, O>;
     type ItemGeo = geo::Geometry;
 

--- a/src/array/binary/iterator.rs
+++ b/src/array/binary/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::WKBArray;
 use crate::scalar::WKB;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;

--- a/src/array/coord/combined/array.rs
+++ b/src/array/coord/combined/array.rs
@@ -6,7 +6,7 @@ use crate::array::{
 };
 use crate::error::GeoArrowError;
 use crate::scalar::Coord;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::GeometryArrayTrait;
 use arrow_array::{Array, FixedSizeListArray, StructArray};
 use arrow_buffer::NullBuffer;
@@ -135,7 +135,7 @@ impl GeometryArraySelfMethods for CoordBuffer {
     }
 }
 
-impl<'a> GeoArrayAccessor<'a> for CoordBuffer {
+impl<'a> GeometryArrayAccessor<'a> for CoordBuffer {
     type Item = Coord<'a>;
     type ItemGeo = geo::Coord;
 

--- a/src/array/coord/interleaved/array.rs
+++ b/src/array/coord/interleaved/array.rs
@@ -4,7 +4,7 @@ use crate::array::{CoordType, InterleavedCoordBufferBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::CoordTrait;
 use crate::scalar::InterleavedCoord;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::GeometryArrayTrait;
 use arrow_array::{Array, FixedSizeListArray, Float64Array};
 use arrow_buffer::{NullBuffer, ScalarBuffer};
@@ -119,7 +119,7 @@ impl GeometryArraySelfMethods for InterleavedCoordBuffer {
     }
 }
 
-impl<'a> GeoArrayAccessor<'a> for InterleavedCoordBuffer {
+impl<'a> GeometryArrayAccessor<'a> for InterleavedCoordBuffer {
     type Item = InterleavedCoord<'a>;
     type ItemGeo = geo::Coord;
 

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -9,7 +9,7 @@ use crate::array::{CoordType, SeparatedCoordBufferBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::CoordTrait;
 use crate::scalar::SeparatedCoord;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::GeometryArrayTrait;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -128,7 +128,7 @@ impl GeometryArraySelfMethods for SeparatedCoordBuffer {
     }
 }
 
-impl<'a> GeoArrayAccessor<'a> for SeparatedCoordBuffer {
+impl<'a> GeometryArrayAccessor<'a> for SeparatedCoordBuffer {
     type Item = SeparatedCoord<'a>;
     type ItemGeo = geo::Coord;
 

--- a/src/array/geometry/array.rs
+++ b/src/array/geometry/array.rs
@@ -13,7 +13,7 @@ use crate::array::{
 use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
 use crate::scalar::Geometry;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::GeometryArrayTrait;
 
 /// A GeometryArray is an enum over the various underlying _zero copy_ GeoArrow array types.
@@ -234,7 +234,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for GeometryArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for GeometryArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for GeometryArray<O> {
     type Item = Geometry<'a, O>;
     type ItemGeo = geo::Geometry;
 

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -10,7 +10,7 @@ use crate::array::zip_validity::ZipValidity;
 use crate::array::{CoordBuffer, CoordType, MixedGeometryArray};
 use crate::datatypes::GeoDataType;
 use crate::scalar::GeometryCollection;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::GeometryArrayTrait;
 
 /// An immutable array of GeometryCollection geometries using GeoArrow's in-memory representation.
@@ -164,7 +164,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for GeometryCollectionArray<O>
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for GeometryCollectionArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for GeometryCollectionArray<O> {
     type Item = GeometryCollection<'a, O>;
     type ItemGeo = geo::GeometryCollection;
 

--- a/src/array/geometrycollection/iterator.rs
+++ b/src/array/geometrycollection/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::GeometryCollectionArray;
 use crate::scalar::GeometryCollection;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -9,7 +9,7 @@ use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::LineStringTrait;
 use crate::scalar::LineString;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::util::{owned_slice_offsets, owned_slice_validity};
 use crate::GeometryArrayTrait;
 use arrow_array::{Array, ArrayRef, GenericListArray, LargeListArray, ListArray, OffsetSizeTrait};
@@ -237,7 +237,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for LineStringArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for LineStringArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for LineStringArray<O> {
     type Item = LineString<'a, O>;
     type ItemGeo = geo::LineString;
 

--- a/src/array/linestring/iterator.rs
+++ b/src/array/linestring/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::LineStringArray;
 use crate::scalar::LineString;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -13,7 +13,7 @@ use crate::array::{
 use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
 use crate::scalar::Geometry;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::GeometryArrayTrait;
 
 /// # Invariants
@@ -300,7 +300,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for MixedGeometryArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MixedGeometryArray<O> {
     type Item = Geometry<'a, O>;
     type ItemGeo = geo::Geometry;
 

--- a/src/array/mixed/iterator.rs
+++ b/src/array/mixed/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::MixedGeometryArray;
 use crate::scalar::Geometry;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -10,7 +10,7 @@ use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
 use crate::geo_traits::MultiLineStringTrait;
 use crate::scalar::MultiLineString;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::util::{owned_slice_offsets, owned_slice_validity};
 use crate::GeometryArrayTrait;
 use arrow_array::{Array, GenericListArray, LargeListArray, ListArray, OffsetSizeTrait};
@@ -264,7 +264,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiLineStringArray<O> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for MultiLineStringArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiLineStringArray<O> {
     type Item = MultiLineString<'a, O>;
     type ItemGeo = geo::MultiLineString;
 

--- a/src/array/multilinestring/iterator.rs
+++ b/src/array/multilinestring/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::MultiLineStringArray;
 use crate::scalar::MultiLineString;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -11,7 +11,7 @@ use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiPointTrait;
 use crate::scalar::MultiPoint;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::util::{owned_slice_offsets, owned_slice_validity};
 use crate::GeometryArrayTrait;
 use arrow_array::{Array, GenericListArray, LargeListArray, ListArray, OffsetSizeTrait};
@@ -237,7 +237,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPointArray<O> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for MultiPointArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiPointArray<O> {
     type Item = MultiPoint<'a, O>;
     type ItemGeo = geo::MultiPoint;
 

--- a/src/array/multipoint/iterator.rs
+++ b/src/array/multipoint/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::MultiPointArray;
 use crate::scalar::MultiPoint;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -10,7 +10,7 @@ use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
 use crate::geo_traits::MultiPolygonTrait;
 use crate::scalar::MultiPolygon;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::util::{owned_slice_offsets, owned_slice_validity};
 use crate::GeometryArrayTrait;
 use arrow_array::{Array, GenericListArray, LargeListArray, ListArray, OffsetSizeTrait};
@@ -318,7 +318,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPolygonArray<O> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for MultiPolygonArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiPolygonArray<O> {
     type Item = MultiPolygon<'a, O>;
     type ItemGeo = geo::MultiPolygon;
 

--- a/src/array/multipolygon/iterator.rs
+++ b/src/array/multipolygon/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::MultiPolygonArray;
 use crate::scalar::MultiPolygon;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -10,7 +10,7 @@ use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
 use crate::geo_traits::PointTrait;
 use crate::scalar::Point;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::util::owned_slice_validity;
 use crate::GeometryArrayTrait;
 use arrow_array::{Array, ArrayRef, FixedSizeListArray, OffsetSizeTrait, StructArray};
@@ -172,7 +172,7 @@ impl GeometryArraySelfMethods for PointArray {
 }
 
 // Implement geometry accessors
-impl<'a> GeoArrayAccessor<'a> for PointArray {
+impl<'a> GeometryArrayAccessor<'a> for PointArray {
     type Item = Point<'a>;
     type ItemGeo = geo::Point;
 

--- a/src/array/point/iterator.rs
+++ b/src/array/point/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::PointArray;
 use crate::scalar::Point;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_buffer::NullBuffer;
 

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -9,7 +9,7 @@ use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
 use crate::geo_traits::PolygonTrait;
 use crate::scalar::Polygon;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::util::{owned_slice_offsets, owned_slice_validity};
 use crate::GeometryArrayTrait;
 use arrow_array::{Array, OffsetSizeTrait};
@@ -264,7 +264,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for PolygonArray<O> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeoArrayAccessor<'a> for PolygonArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for PolygonArray<O> {
     type Item = Polygon<'a, O>;
     type ItemGeo = geo::Polygon;
 

--- a/src/array/polygon/iterator.rs
+++ b/src/array/polygon/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::PolygonArray;
 use crate::scalar::Polygon;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;

--- a/src/array/polygon/util.rs
+++ b/src/array/polygon/util.rs
@@ -5,7 +5,7 @@ use arrow_buffer::OffsetBuffer;
 
 use crate::array::util::OffsetBufferUtils;
 use crate::array::CoordBuffer;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 
 pub(crate) fn parse_polygon<O: OffsetSizeTrait>(
     coords: Cow<'_, CoordBuffer>,

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -12,7 +12,7 @@ use crate::array::{CoordBuffer, CoordType};
 use crate::datatypes::GeoDataType;
 use crate::geo_traits::RectTrait;
 use crate::scalar::Rect;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods, IntoArrow};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::util::owned_slice_validity;
 use crate::GeometryArrayTrait;
 
@@ -145,7 +145,7 @@ impl GeometryArraySelfMethods for RectArray {
     }
 }
 
-impl<'a> GeoArrayAccessor<'a> for RectArray {
+impl<'a> GeometryArrayAccessor<'a> for RectArray {
     type Item = Rect<'a>;
     type ItemGeo = geo::Rect;
 

--- a/src/array/rect/iterator.rs
+++ b/src/array/rect/iterator.rs
@@ -2,7 +2,7 @@ use arrow_buffer::NullBuffer;
 
 use crate::array::RectArray;
 use crate::scalar::Rect;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 
 /// Iterator of values of a [`RectArray`]

--- a/src/io/geozero/array/linestring.rs
+++ b/src/io/geozero/array/linestring.rs
@@ -3,7 +3,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::{LineStringArray, LineStringBuilder};
 use crate::io::geozero::scalar::linestring::process_line_string;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 
 impl<O: OffsetSizeTrait> GeozeroGeometry for LineStringArray<O> {
@@ -84,7 +84,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for LineStringBuilder<O> {
 mod test {
     use super::*;
     use crate::test::linestring::{ls0, ls1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geo::Geometry;
     use geozero::error::Result;
     use geozero::ToWkt;

--- a/src/io/geozero/array/multilinestring.rs
+++ b/src/io/geozero/array/multilinestring.rs
@@ -3,7 +3,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
 use crate::io::geozero::scalar::multilinestring::process_multi_line_string;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 
 impl<O: OffsetSizeTrait> GeozeroGeometry for MultiLineStringArray<O> {
@@ -110,7 +110,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for MultiLineStringBuilder<O> {
 mod test {
     use super::*;
     use crate::test::multilinestring::{ml0, ml1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geo::Geometry;
     use geozero::error::Result;
     use geozero::ToWkt;

--- a/src/io/geozero/array/multipoint.rs
+++ b/src/io/geozero/array/multipoint.rs
@@ -1,6 +1,6 @@
 use crate::array::{MultiPointArray, MultiPointBuilder};
 use crate::io::geozero::scalar::multipoint::process_multi_point;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
@@ -83,7 +83,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for MultiPointBuilder<O> {
 mod test {
     use super::*;
     use crate::test::multipoint::{mp0, mp1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geo::Geometry;
     use geozero::error::Result;
     use geozero::ToWkt;

--- a/src/io/geozero/array/multipolygon.rs
+++ b/src/io/geozero/array/multipolygon.rs
@@ -3,7 +3,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::{MultiPolygonArray, MultiPolygonBuilder};
 use crate::io::geozero::scalar::multipolygon::process_multi_polygon;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 
 impl<O: OffsetSizeTrait> GeozeroGeometry for MultiPolygonArray<O> {
@@ -126,7 +126,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for MultiPolygonBuilder<O> {
 mod test {
     use super::*;
     use crate::test::multipolygon::{mp0, mp1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geo::Geometry;
     use geozero::error::Result;
     use geozero::ToWkt;

--- a/src/io/geozero/array/point.rs
+++ b/src/io/geozero/array/point.rs
@@ -1,6 +1,6 @@
 use crate::array::{PointArray, PointBuilder};
 use crate::io::geozero::scalar::point::process_point;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
@@ -162,7 +162,7 @@ impl GeomProcessor for PointBuilder {
 #[cfg(test)]
 mod test {
     use super::ToGeoArrowPointArray;
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geo::{line_string, point, Geometry, GeometryCollection, LineString, Point};
 
     fn p0() -> Point {

--- a/src/io/geozero/array/polygon.rs
+++ b/src/io/geozero/array/polygon.rs
@@ -1,6 +1,6 @@
 use crate::array::{PolygonArray, PolygonBuilder};
 use crate::io::geozero::scalar::polygon::process_polygon;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
@@ -102,7 +102,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for PolygonBuilder<O> {
 mod test {
     use super::*;
     use crate::test::polygon::{p0, p1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geo::Geometry;
     use geozero::error::Result;
     use geozero::ToWkt;

--- a/src/io/geozero/table/data_source.rs
+++ b/src/io/geozero/table/data_source.rs
@@ -1,7 +1,7 @@
 use crate::array::GeometryArray;
 use crate::io::geozero::scalar::geometry::process_geometry;
 use crate::table::GeoTable;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use arrow_array::{
     BinaryArray, Float16Array, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
     Int8Array, LargeBinaryArray, LargeStringArray, RecordBatch, StringArray, UInt16Array,

--- a/src/io/wkb/writer/polygon.rs
+++ b/src/io/wkb/writer/polygon.rs
@@ -103,7 +103,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&PolygonArray<A>> for WKBArray
 mod test {
     use super::*;
     use crate::test::polygon::{p0, p1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
     use geozero::{CoordDimensions, ToWkb};
 
     #[test]

--- a/src/scalar/coord/interleaved/scalar.rs
+++ b/src/scalar/coord/interleaved/scalar.rs
@@ -95,7 +95,7 @@ impl CoordTrait for &InterleavedCoord<'_> {
 #[cfg(test)]
 mod test {
     use crate::array::{InterleavedCoordBuffer, SeparatedCoordBuffer};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/src/scalar/coord/separated/scalar.rs
+++ b/src/scalar/coord/separated/scalar.rs
@@ -94,7 +94,7 @@ impl CoordTrait for &SeparatedCoord<'_> {
 #[cfg(test)]
 mod test {
     use crate::array::{InterleavedCoordBuffer, SeparatedCoordBuffer};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -3,7 +3,7 @@ use crate::array::MixedGeometryArray;
 use crate::geo_traits::GeometryCollectionTrait;
 use crate::scalar::geometrycollection::GeometryCollectionIterator;
 use crate::scalar::Geometry;
-use crate::trait_::GeoArrayAccessor;
+use crate::trait_::GeometryArrayAccessor;
 use crate::trait_::GeometryScalarTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;

--- a/src/scalar/linestring/scalar.rs
+++ b/src/scalar/linestring/scalar.rs
@@ -184,7 +184,7 @@ impl<O: OffsetSizeTrait> PartialEq for LineString<'_, O> {
 mod test {
     use crate::array::LineStringArray;
     use crate::test::linestring::{ls0, ls1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -6,7 +6,7 @@ use crate::geo_traits::MultiLineStringTrait;
 use crate::scalar::multilinestring::MultiLineStringIterator;
 use crate::scalar::LineString;
 use crate::trait_::GeometryScalarTrait;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods};
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
@@ -216,7 +216,7 @@ impl<O: OffsetSizeTrait> PartialEq for MultiLineString<'_, O> {
 mod test {
     use crate::array::MultiLineStringArray;
     use crate::test::multilinestring::{ml0, ml1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -6,7 +6,7 @@ use crate::geo_traits::MultiPointTrait;
 use crate::scalar::multipoint::MultiPointIterator;
 use crate::scalar::Point;
 use crate::trait_::GeometryScalarTrait;
-use crate::trait_::{GeoArrayAccessor, GeometryArraySelfMethods};
+use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods};
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
@@ -185,7 +185,7 @@ impl<O: OffsetSizeTrait> PartialEq for MultiPoint<'_, O> {
 mod test {
     use crate::array::MultiPointArray;
     use crate::test::multipoint::{mp0, mp1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -239,7 +239,7 @@ impl<O: OffsetSizeTrait> PartialEq for MultiPolygon<'_, O> {
 mod test {
     use crate::array::MultiPolygonArray;
     use crate::test::multipolygon::{mp0, mp1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/src/scalar/point/scalar.rs
+++ b/src/scalar/point/scalar.rs
@@ -164,7 +164,7 @@ impl PartialEq for Point<'_> {
 #[cfg(test)]
 mod test {
     use crate::array::{CoordBuffer, PointArray};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -232,7 +232,7 @@ impl<O: OffsetSizeTrait> PartialEq for Polygon<'_, O> {
 mod test {
     use crate::array::PolygonArray;
     use crate::test::polygon::{p0, p1};
-    use crate::trait_::GeoArrayAccessor;
+    use crate::trait_::GeometryArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -141,7 +141,7 @@ pub trait GeometryArrayTrait: std::fmt::Debug + Send + Sync {
 ///
 /// The value at null indexes is unspecified, and implementations must not rely on a specific
 /// value such as [`Default::default`] being returned, however, it must not be undefined
-pub trait GeoArrayAccessor<'a>: GeometryArrayTrait {
+pub trait GeometryArrayAccessor<'a>: GeometryArrayTrait {
     /// The [geoarrow scalar object][crate::scalar] for this geometry array type.
     type Item: Send + Sync + GeometryScalarTrait;
 


### PR DESCRIPTION
Be consistent with `GeometryArrayTrait`, `GeometryArraySelfMethods`, `GeometryArrayBuilder`.