### PR TITLE
Implement top-level from/to wkb

### DIFF
--- a/python/core/src/ffi/to_python.rs
+++ b/python/core/src/ffi/to_python.rs
@@ -38,6 +38,7 @@ impl_arrow_c_array_geometry_array!(PolygonArray);
 impl_arrow_c_array_geometry_array!(MultiPointArray);
 impl_arrow_c_array_geometry_array!(MultiLineStringArray);
 impl_arrow_c_array_geometry_array!(MultiPolygonArray);
+impl_arrow_c_array_geometry_array!(WKBArray);
 
 macro_rules! impl_arrow_c_array_primitive {
     ($struct_name:ident) => {

--- a/python/core/src/io/mod.rs
+++ b/python/core/src/io/mod.rs
@@ -1,0 +1,1 @@
+pub mod wkb;

--- a/python/core/src/io/wkb.rs
+++ b/python/core/src/io/wkb.rs
@@ -1,0 +1,112 @@
+use geoarrow::array::CoordType;
+use geoarrow::datatypes::GeoDataType;
+use geoarrow::io::wkb::{from_wkb as _from_wkb, to_wkb as _to_wkb};
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+
+use crate::array::*;
+use crate::ffi::from_python::{convert_to_geometry_array, import_arrow_c_array};
+
+/// Convert an Arrow BinaryArray from WKB to its GeoArrow-native counterpart.
+#[pyfunction]
+pub fn from_wkb(ob: &PyAny) -> PyResult<PyObject> {
+    let (array, field) = import_arrow_c_array(ob)?;
+    // TODO: need to improve crate's error handling
+    let array = convert_to_geometry_array(&array, &field).unwrap();
+
+    let geo_array = match array.data_type() {
+        GeoDataType::WKB => _from_wkb(
+            array
+                .as_any()
+                .downcast_ref::<geoarrow::array::WKBArray<i32>>()
+                .unwrap(),
+            false,
+            CoordType::Interleaved,
+        )
+        .unwrap(),
+        GeoDataType::LargeWKB => _from_wkb(
+            array
+                .as_any()
+                .downcast_ref::<geoarrow::array::WKBArray<i64>>()
+                .unwrap(),
+            false,
+            CoordType::Interleaved,
+        )
+        .unwrap(),
+        other => {
+            return Err(PyTypeError::new_err(format!(
+                "Unexpected array type {:?}",
+                other
+            )))
+        }
+    };
+    Python::with_gil(|py| {
+        let downcasted = match geo_array.data_type() {
+            GeoDataType::Point(_) => PointArray(
+                geo_array
+                    .as_any()
+                    .downcast_ref::<geoarrow::array::PointArray>()
+                    .unwrap()
+                    .clone(),
+            )
+            .into_py(py),
+            GeoDataType::LineString(_) => LineStringArray(
+                geo_array
+                    .as_any()
+                    .downcast_ref::<geoarrow::array::LineStringArray<i32>>()
+                    .unwrap()
+                    .clone(),
+            )
+            .into_py(py),
+            GeoDataType::Polygon(_) => PolygonArray(
+                geo_array
+                    .as_any()
+                    .downcast_ref::<geoarrow::array::PolygonArray<i32>>()
+                    .unwrap()
+                    .clone(),
+            )
+            .into_py(py),
+            GeoDataType::MultiPoint(_) => MultiPointArray(
+                geo_array
+                    .as_any()
+                    .downcast_ref::<geoarrow::array::MultiPointArray<i32>>()
+                    .unwrap()
+                    .clone(),
+            )
+            .into_py(py),
+            GeoDataType::MultiLineString(_) => MultiLineStringArray(
+                geo_array
+                    .as_any()
+                    .downcast_ref::<geoarrow::array::MultiLineStringArray<i32>>()
+                    .unwrap()
+                    .clone(),
+            )
+            .into_py(py),
+            GeoDataType::MultiPolygon(_) => MultiPolygonArray(
+                geo_array
+                    .as_any()
+                    .downcast_ref::<geoarrow::array::MultiPolygonArray<i32>>()
+                    .unwrap()
+                    .clone(),
+            )
+            .into_py(py),
+            other => {
+                return Err(PyTypeError::new_err(format!(
+                    "Unexpected parsed geometry array type {:?}",
+                    other
+                )))
+            }
+        };
+
+        Ok(downcasted)
+    })
+}
+
+/// Convert a GeoArrow-native geometry array to a WKBArray.
+#[pyfunction]
+pub fn to_wkb(ob: &PyAny) -> PyResult<WKBArray> {
+    let (array, field) = import_arrow_c_array(ob)?;
+    // TODO: need to improve crate's error handling
+    let array = convert_to_geometry_array(&array, &field).unwrap();
+    Ok(WKBArray(_to_wkb(array.as_ref())))
+}

--- a/python/core/src/lib.rs
+++ b/python/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod algorithm;
 pub mod array;
 pub mod broadcasting;
 pub mod ffi;
+pub mod io;
 
 /// A Python module implemented in Rust.
 #[pymodule]
@@ -33,6 +34,10 @@ fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
 
     // Top-level functions
     m.add_function(wrap_pyfunction!(crate::algorithm::geo::area::area, m)?)?;
+
+    // IO
+    m.add_function(wrap_pyfunction!(crate::io::wkb::to_wkb, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::io::wkb::from_wkb, m)?)?;
 
     Ok(())
 }

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -1,16 +1,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::array::mixed::MixedCapacity;
 use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 use crate::array::zip_validity::ZipValidity;
-use crate::array::{
-    CoordType, LineStringBuilder, MixedGeometryBuilder, MultiLineStringBuilder, MultiPointBuilder,
-    MultiPolygonBuilder, PointBuilder, PolygonBuilder, WKBBuilder,
-};
+use crate::array::{CoordType, WKBBuilder};
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
-use crate::io::wkb::reader::geometry::WKBGeometry;
+use crate::io::wkb::from_wkb;
 use crate::io::wkb::reader::r#type::infer_geometry_type;
 use crate::scalar::WKB;
 // use crate::util::{owned_slice_offsets, owned_slice_validity};
@@ -73,180 +69,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
         large_type: bool,
         coord_type: CoordType,
     ) -> Result<Arc<dyn GeometryArrayTrait>> {
-        let wkb_objects: Vec<Option<WKB<'_, O>>> = self.iter().collect();
-        let wkb_objects2: Vec<Option<WKBGeometry>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
-            .collect();
-
-        let capacity = MixedCapacity::from_owned_geometries(wkb_objects2.into_iter());
-        if capacity.point_compatible() {
-            let mut builder =
-                PointBuilder::with_capacity_and_options(capacity.point_capacity(), coord_type);
-            let wkb_points: Vec<Option<_>> = wkb_objects
-                .iter()
-                .map(|maybe_wkb| {
-                    maybe_wkb
-                        .as_ref()
-                        .map(|wkb| wkb.to_wkb_object().into_point())
-                })
-                .collect();
-            builder.extend_from_iter(wkb_points.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        } else if capacity.line_string_compatible() {
-            let wkb_line_strings: Vec<Option<_>> = wkb_objects
-                .iter()
-                .map(|maybe_wkb| {
-                    maybe_wkb
-                        .as_ref()
-                        .map(|wkb| wkb.to_wkb_object().into_line_string())
-                })
-                .collect();
-            if large_type {
-                let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
-                    capacity.line_string_capacity(),
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_line_strings.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            } else {
-                let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
-                    capacity.line_string_capacity(),
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_line_strings.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            }
-        } else if capacity.polygon_compatible() {
-            let wkb_polygons: Vec<Option<_>> = wkb_objects
-                .iter()
-                .map(|maybe_wkb| {
-                    maybe_wkb
-                        .as_ref()
-                        .map(|wkb| wkb.to_wkb_object().into_polygon())
-                })
-                .collect();
-            if large_type {
-                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
-                    capacity.polygon_capacity(),
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_polygons.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            } else {
-                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
-                    capacity.polygon_capacity(),
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_polygons.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            }
-        } else if capacity.multi_point_compatible() {
-            let wkb_multi_points: Vec<Option<_>> = wkb_objects
-                .iter()
-                .map(|maybe_wkb| {
-                    maybe_wkb
-                        .as_ref()
-                        .map(|wkb| wkb.to_wkb_object().into_maybe_multi_point())
-                })
-                .collect();
-
-            // Have to add point and multi point capacity together
-            let mut multi_point_capacity = capacity.multi_point_capacity();
-            multi_point_capacity.add_point_capacity(capacity.point_capacity());
-
-            if large_type {
-                let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
-                    multi_point_capacity,
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_multi_points.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            } else {
-                let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
-                    multi_point_capacity,
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_multi_points.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            }
-        } else if capacity.multi_line_string_compatible() {
-            let wkb_multi_line_strings: Vec<Option<_>> = wkb_objects
-                .iter()
-                .map(|maybe_wkb| {
-                    maybe_wkb
-                        .as_ref()
-                        .map(|wkb| wkb.to_wkb_object().into_maybe_multi_line_string())
-                })
-                .collect();
-
-            // Have to add line string and multi line string capacity together
-            let mut multi_line_string_capacity = capacity.multi_line_string_capacity();
-            multi_line_string_capacity.add_line_string_capacity(capacity.line_string_capacity());
-
-            if large_type {
-                let mut builder = MultiLineStringBuilder::<i32>::with_capacity_and_options(
-                    multi_line_string_capacity,
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_multi_line_strings.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            } else {
-                let mut builder = MultiLineStringBuilder::<i64>::with_capacity_and_options(
-                    multi_line_string_capacity,
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_multi_line_strings.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            }
-        } else if capacity.multi_polygon_compatible() {
-            let wkb_multi_polygons: Vec<Option<_>> = wkb_objects
-                .iter()
-                .map(|maybe_wkb| {
-                    maybe_wkb
-                        .as_ref()
-                        .map(|wkb| wkb.to_wkb_object().into_maybe_multi_polygon())
-                })
-                .collect();
-
-            // Have to add line string and multi line string capacity together
-            let mut multi_polygon_capacity = capacity.multi_polygon_capacity();
-            multi_polygon_capacity.add_polygon_capacity(capacity.polygon_capacity());
-
-            if large_type {
-                let mut builder = MultiPolygonBuilder::<i32>::with_capacity_and_options(
-                    multi_polygon_capacity,
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_multi_polygons.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            } else {
-                let mut builder = MultiPolygonBuilder::<i64>::with_capacity_and_options(
-                    multi_polygon_capacity,
-                    coord_type,
-                );
-                builder.extend_from_iter(wkb_multi_polygons.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            }
-        } else {
-            let wkb_geometry: Vec<Option<_>> = wkb_objects
-                .iter()
-                .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
-                .collect();
-
-            #[allow(clippy::collapsible_else_if)]
-            if large_type {
-                let mut builder =
-                    MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, coord_type);
-                builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            } else {
-                let mut builder =
-                    MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, coord_type);
-                builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()));
-                Ok(Arc::new(builder.finish()))
-            }
-        }
+        from_wkb(self, large_type, coord_type)
     }
 
     // pub fn with_validity(&self, validity: Option<NullBuffer>) -> Self {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -7,7 +7,7 @@ pub mod geojson;
 #[cfg(feature = "geos")]
 pub(crate) mod geos;
 #[cfg(feature = "geozero")]
-pub(crate) mod geozero;
+pub mod geozero;
 #[cfg(feature = "parquet")]
 pub mod parquet;
 pub mod wkb;

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -1,0 +1,264 @@
+use std::sync::Arc;
+
+use crate::array::mixed::MixedCapacity;
+use crate::array::*;
+use crate::datatypes::GeoDataType;
+use crate::error::Result;
+use crate::io::wkb::reader::geometry::WKBGeometry;
+use crate::scalar::WKB;
+use crate::GeometryArrayTrait;
+use arrow_array::OffsetSizeTrait;
+
+/// Parse a [WKBArray] to a GeometryArray with GeoArrow native encoding.
+pub fn from_wkb<O: OffsetSizeTrait>(
+    arr: &WKBArray<O>,
+    large_type: bool,
+    coord_type: CoordType,
+) -> Result<Arc<dyn GeometryArrayTrait>> {
+    let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
+    let wkb_objects2: Vec<Option<WKBGeometry>> = wkb_objects
+        .iter()
+        .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
+        .collect();
+
+    let capacity = MixedCapacity::from_owned_geometries(wkb_objects2.into_iter());
+    if capacity.point_compatible() {
+        let mut builder =
+            PointBuilder::with_capacity_and_options(capacity.point_capacity(), coord_type);
+        let wkb_points: Vec<Option<_>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_point())
+            })
+            .collect();
+        builder.extend_from_iter(wkb_points.iter().map(|x| x.as_ref()));
+        Ok(Arc::new(builder.finish()))
+    } else if capacity.line_string_compatible() {
+        let wkb_line_strings: Vec<Option<_>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_line_string())
+            })
+            .collect();
+        if large_type {
+            let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
+                capacity.line_string_capacity(),
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_line_strings.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        } else {
+            let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
+                capacity.line_string_capacity(),
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_line_strings.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        }
+    } else if capacity.polygon_compatible() {
+        let wkb_polygons: Vec<Option<_>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_polygon())
+            })
+            .collect();
+        if large_type {
+            let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
+                capacity.polygon_capacity(),
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_polygons.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        } else {
+            let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
+                capacity.polygon_capacity(),
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_polygons.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        }
+    } else if capacity.multi_point_compatible() {
+        let wkb_multi_points: Vec<Option<_>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_point())
+            })
+            .collect();
+
+        // Have to add point and multi point capacity together
+        let mut multi_point_capacity = capacity.multi_point_capacity();
+        multi_point_capacity.add_point_capacity(capacity.point_capacity());
+
+        if large_type {
+            let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
+                multi_point_capacity,
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_multi_points.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        } else {
+            let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
+                multi_point_capacity,
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_multi_points.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        }
+    } else if capacity.multi_line_string_compatible() {
+        let wkb_multi_line_strings: Vec<Option<_>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_line_string())
+            })
+            .collect();
+
+        // Have to add line string and multi line string capacity together
+        let mut multi_line_string_capacity = capacity.multi_line_string_capacity();
+        multi_line_string_capacity.add_line_string_capacity(capacity.line_string_capacity());
+
+        if large_type {
+            let mut builder = MultiLineStringBuilder::<i64>::with_capacity_and_options(
+                multi_line_string_capacity,
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_multi_line_strings.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        } else {
+            let mut builder = MultiLineStringBuilder::<i32>::with_capacity_and_options(
+                multi_line_string_capacity,
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_multi_line_strings.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        }
+    } else if capacity.multi_polygon_compatible() {
+        let wkb_multi_polygons: Vec<Option<_>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_polygon())
+            })
+            .collect();
+
+        // Have to add line string and multi line string capacity together
+        let mut multi_polygon_capacity = capacity.multi_polygon_capacity();
+        multi_polygon_capacity.add_polygon_capacity(capacity.polygon_capacity());
+
+        if large_type {
+            let mut builder = MultiPolygonBuilder::<i64>::with_capacity_and_options(
+                multi_polygon_capacity,
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_multi_polygons.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        } else {
+            let mut builder = MultiPolygonBuilder::<i32>::with_capacity_and_options(
+                multi_polygon_capacity,
+                coord_type,
+            );
+            builder.extend_from_iter(wkb_multi_polygons.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        }
+    } else {
+        let wkb_geometry: Vec<Option<_>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
+            .collect();
+
+        #[allow(clippy::collapsible_else_if)]
+        if large_type {
+            let mut builder =
+                MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, coord_type);
+            builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        } else {
+            let mut builder =
+                MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, coord_type);
+            builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()));
+            Ok(Arc::new(builder.finish()))
+        }
+    }
+}
+
+/// Convert a geometry array to a [WKBArray].
+pub fn to_wkb<O: OffsetSizeTrait>(arr: &dyn GeometryArrayTrait) -> WKBArray<O> {
+    match arr.data_type() {
+        GeoDataType::Point(_) => arr.as_any().downcast_ref::<PointArray>().unwrap().into(),
+        GeoDataType::LineString(_) => arr
+            .as_any()
+            .downcast_ref::<LineStringArray<i32>>()
+            .unwrap()
+            .into(),
+        GeoDataType::LargeLineString(_) => arr
+            .as_any()
+            .downcast_ref::<LineStringArray<i64>>()
+            .unwrap()
+            .into(),
+        GeoDataType::Polygon(_) => arr
+            .as_any()
+            .downcast_ref::<PolygonArray<i32>>()
+            .unwrap()
+            .into(),
+        GeoDataType::LargePolygon(_) => arr
+            .as_any()
+            .downcast_ref::<PolygonArray<i64>>()
+            .unwrap()
+            .into(),
+        GeoDataType::MultiPoint(_) => arr
+            .as_any()
+            .downcast_ref::<MultiPointArray<i32>>()
+            .unwrap()
+            .into(),
+        GeoDataType::LargeMultiPoint(_) => arr
+            .as_any()
+            .downcast_ref::<MultiPointArray<i64>>()
+            .unwrap()
+            .into(),
+        GeoDataType::MultiLineString(_) => arr
+            .as_any()
+            .downcast_ref::<MultiLineStringArray<i32>>()
+            .unwrap()
+            .into(),
+        GeoDataType::LargeMultiLineString(_) => arr
+            .as_any()
+            .downcast_ref::<MultiLineStringArray<i64>>()
+            .unwrap()
+            .into(),
+        GeoDataType::MultiPolygon(_) => arr
+            .as_any()
+            .downcast_ref::<MultiPolygonArray<i32>>()
+            .unwrap()
+            .into(),
+        GeoDataType::LargeMultiPolygon(_) => arr
+            .as_any()
+            .downcast_ref::<MultiPolygonArray<i64>>()
+            .unwrap()
+            .into(),
+        GeoDataType::Mixed(_) => arr
+            .as_any()
+            .downcast_ref::<MixedGeometryArray<i32>>()
+            .unwrap()
+            .into(),
+        GeoDataType::LargeMixed(_) => arr
+            .as_any()
+            .downcast_ref::<MixedGeometryArray<i64>>()
+            .unwrap()
+            .into(),
+        GeoDataType::GeometryCollection(_) => todo!(),
+        GeoDataType::LargeGeometryCollection(_) => todo!(),
+        GeoDataType::WKB => todo!(),
+        GeoDataType::LargeWKB => todo!(),
+        GeoDataType::Rect => todo!(),
+    }
+}

--- a/src/io/wkb/mod.rs
+++ b/src/io/wkb/mod.rs
@@ -1,2 +1,5 @@
-pub mod reader;
-pub mod writer;
+mod api;
+pub(crate) mod reader;
+pub(crate) mod writer;
+
+pub use api::{from_wkb, to_wkb};


### PR DESCRIPTION
Closes https://github.com/geoarrow/geoarrow-rs/issues/267

This appears to be 2x faster than shapely both at reading and writing WKB

```py
import pyarrow as pa
import shapely
import pandas as pd
import geopandas as gpd
import geoarrow.rust.core

gdf = gpd.read_file(gpd.datasets.get_path("nybb"))
large_gdf = pd.concat([gdf] * 1000)
wkb = shapely.to_wkb(large_gdf["geometry"])

pa_wkb_arr = pa.array(wkb)

%timeit geoarrow.rust.core.from_wkb(pa_wkb_arr)
# 457 ms ± 3.54 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit shapely.from_wkb(wkb)
# 1.06 s ± 16.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

geoarrow_arr = geoarrow.rust.core.from_wkb(pa_wkb_arr)

%timeit geoarrow.rust.core.to_wkb(geoarrow_arr)
# 923 ms ± 19.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit shapely.to_wkb(large_gdf["geometry"])
# 1.86 s ± 17.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```