### PR TITLE
Clean up and improve stability of MixedGeometryArray

### DIFF
--- a/src/array/coord/mod.rs
+++ b/src/array/coord/mod.rs
@@ -12,7 +12,7 @@ pub use combined::{CoordBuffer, CoordBufferBuilder};
 pub use interleaved::{InterleavedCoordBuffer, InterleavedCoordBufferBuilder};
 pub use separated::{SeparatedCoordBuffer, SeparatedCoordBufferBuilder};
 
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CoordType {
     #[default]
     Interleaved,

--- a/src/array/linestring/builder.rs
+++ b/src/array/linestring/builder.rs
@@ -8,7 +8,7 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::LineStringTrait;
 use crate::io::wkb::reader::linestring::WKBLineString;
 use crate::scalar::WKB;
-use crate::trait_::IntoArrow;
+use crate::trait_::{GeometryArrayBuilder, IntoArrow};
 use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::NullBufferBuilder;
 use std::convert::From;
@@ -251,6 +251,20 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
 
     pub fn finish(self) -> LineStringArray<O> {
         self.into()
+    }
+}
+
+impl<O: OffsetSizeTrait> GeometryArrayBuilder for LineStringBuilder<O> {
+    fn len(&self) -> usize {
+        self.geom_offsets.len_proxy()
+    }
+
+    fn validity(&self) -> &NullBufferBuilder {
+        &self.validity
+    }
+
+    fn into_array_ref(self) -> Arc<dyn Array> {
+        Arc::new(self.into_arrow())
     }
 }
 

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -707,7 +707,6 @@ mod test {
             geo::Geometry::MultiPolygon(multipolygon::mp0()),
         ];
         let arr: MixedGeometryArray<i32> = geoms.as_slice().try_into().unwrap();
-        dbg!(&arr);
 
         // Round trip to/from arrow-rs
         let arrow_array = arr.into_arrow();
@@ -716,5 +715,21 @@ mod test {
         assert_eq!(round_trip_arr.value_as_geo(0), geoms[0]);
         assert_eq!(round_trip_arr.value_as_geo(1), geoms[1]);
         assert_eq!(round_trip_arr.value_as_geo(2), geoms[2]);
+    }
+
+    #[test]
+    fn arrow_roundtrip_not_all_types2() {
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
+        let arr: MixedGeometryArray<i32> = geoms.as_slice().try_into().unwrap();
+
+        // Round trip to/from arrow-rs
+        let arrow_array = arr.into_arrow();
+        let round_trip_arr: MixedGeometryArray<i32> = (&arrow_array).try_into().unwrap();
+
+        assert_eq!(round_trip_arr.value_as_geo(0), geoms[0]);
+        assert_eq!(round_trip_arr.value_as_geo(1), geoms[1]);
     }
 }

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow_array::{Array, OffsetSizeTrait, UnionArray};
@@ -7,8 +7,8 @@ use arrow_schema::{DataType, Field, UnionFields, UnionMode};
 
 use crate::array::mixed::builder::MixedGeometryBuilder;
 use crate::array::{
-    CoordType, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray,
-    PointArray, PolygonArray,
+    LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray,
+    PolygonArray,
 };
 use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
@@ -23,20 +23,20 @@ use crate::GeometryArrayTrait;
 #[derive(Debug, Clone)]
 // #[derive(Debug, Clone, PartialEq)]
 pub struct MixedGeometryArray<O: OffsetSizeTrait> {
-    // Always GeoDataType::Mixed or GeoDataType::LargeMixed
+    /// Always GeoDataType::Mixed or GeoDataType::LargeMixed
     data_type: GeoDataType,
 
-    // Invariant: every item in `types` is `> 0 && < fields.len()`
-    types: ScalarBuffer<i8>,
+    /// Invariant: every item in `type_ids` is `> 0 && < fields.len()` if `type_ids` are not provided. If `type_ids` exist in the GeoDataType, then every item in `type_ids` is `> 0 && `
+    type_ids: ScalarBuffer<i8>,
 
-    // Invariant: `offsets.len() == types.len()`
+    /// Invariant: `offsets.len() == type_ids.len()`
     offsets: ScalarBuffer<i32>,
 
     /// A lookup table for which child array is used
     ///
     /// To read a value:
     /// ``rs
-    /// let child_index = self.types[i];
+    /// let child_index = self.type_ids[i];
     /// let offset = self.offsets[i] as usize;
     /// let geometry_type = self.map[child_index as usize];
     /// ``
@@ -44,7 +44,7 @@ pub struct MixedGeometryArray<O: OffsetSizeTrait> {
     ///
     /// Note that we include an ordering so that exporting this array to Arrow is O(1). If we used
     /// another ordering like always Point, LineString, etc. then we'd either have to always export
-    /// all arrays (including some zero-length arrays) or have to reorder the `types` buffer when
+    /// all arrays (including some zero-length arrays) or have to reorder the `type_ids` buffer when
     /// exporting.
     ///
     /// The default ordering is:
@@ -60,12 +60,12 @@ pub struct MixedGeometryArray<O: OffsetSizeTrait> {
     // Then that wrapper type can also take a default ordering.
     map: [Option<GeometryType>; 6],
 
-    points: PointArray,
-    line_strings: LineStringArray<O>,
-    polygons: PolygonArray<O>,
-    multi_points: MultiPointArray<O>,
-    multi_line_strings: MultiLineStringArray<O>,
-    multi_polygons: MultiPolygonArray<O>,
+    points: Option<PointArray>,
+    line_strings: Option<LineStringArray<O>>,
+    polygons: Option<PolygonArray<O>>,
+    multi_points: Option<MultiPointArray<O>>,
+    multi_line_strings: Option<MultiLineStringArray<O>>,
+    multi_polygons: Option<MultiPolygonArray<O>>,
 
     /// An offset used for slicing into this array. The offset will be 0 if the array has not been
     /// sliced.
@@ -74,13 +74,13 @@ pub struct MixedGeometryArray<O: OffsetSizeTrait> {
     /// fields directly. If this were always a _sparse_ union array, we could! We could then always
     /// slice from offset to length of each underlying array. But we're under the assumption that
     /// most or all of the time we have a dense union array, where the `offsets` buffer is defined.
-    /// In that case, to know how to slice each underlying array, we'd have to walk the `types` and
-    /// `offsets` arrays (in O(N) time) to figure out how to slice the underlying arrays.
+    /// In that case, to know how to slice each underlying array, we'd have to walk the `type_ids`
+    /// and `offsets` arrays (in O(N) time) to figure out how to slice the underlying arrays.
     ///
     /// Instead, we store the slice offset.
     ///
     /// Note that this offset is only for slicing into the **fields**, i.e. the geometry arrays.
-    /// The `types` and `offsets` arrays are sliced as usual.
+    /// The `type_ids` and `offsets` arrays are sliced as usual.
     ///
     /// TODO: when exporting this array, export to arrow2 and then slice from scratch because we
     /// can't set the `offset` in a UnionArray constructor
@@ -137,14 +137,14 @@ impl<O: OffsetSizeTrait> MixedGeometryArray<O> {
     /// - if the largest geometry offset does not match the number of coordinates
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        types: ScalarBuffer<i8>,
+        type_ids: ScalarBuffer<i8>,
         offsets: ScalarBuffer<i32>,
-        points: PointArray,
-        line_strings: LineStringArray<O>,
-        polygons: PolygonArray<O>,
-        multi_points: MultiPointArray<O>,
-        multi_line_strings: MultiLineStringArray<O>,
-        multi_polygons: MultiPolygonArray<O>,
+        points: Option<PointArray>,
+        line_strings: Option<LineStringArray<O>>,
+        polygons: Option<PolygonArray<O>>,
+        multi_points: Option<MultiPointArray<O>>,
+        multi_line_strings: Option<MultiLineStringArray<O>>,
+        multi_polygons: Option<MultiPolygonArray<O>>,
     ) -> Self {
         let default_ordering = [
             Some(GeometryType::Point),
@@ -155,9 +155,27 @@ impl<O: OffsetSizeTrait> MixedGeometryArray<O> {
             Some(GeometryType::MultiPolygon),
         ];
 
-        // let coord_type = coords.coord_type();
-        // TODO: use correct coord type
-        let coord_type = CoordType::Interleaved;
+        let mut coord_types = HashSet::new();
+        if let Some(ref points) = points {
+            coord_types.insert(points.coord_type());
+        }
+        if let Some(ref line_strings) = line_strings {
+            coord_types.insert(line_strings.coord_type());
+        }
+        if let Some(ref polygons) = polygons {
+            coord_types.insert(polygons.coord_type());
+        }
+        if let Some(ref multi_points) = multi_points {
+            coord_types.insert(multi_points.coord_type());
+        }
+        if let Some(ref multi_line_strings) = multi_line_strings {
+            coord_types.insert(multi_line_strings.coord_type());
+        }
+        if let Some(ref multi_polygons) = multi_polygons {
+            coord_types.insert(multi_polygons.coord_type());
+        }
+        assert_eq!(coord_types.len(), 1);
+        let coord_type = coord_types.into_iter().next().unwrap();
         let data_type = match O::IS_LARGE {
             true => GeoDataType::LargeMixed(coord_type),
             false => GeoDataType::Mixed(coord_type),
@@ -165,7 +183,7 @@ impl<O: OffsetSizeTrait> MixedGeometryArray<O> {
 
         Self {
             data_type,
-            types,
+            type_ids,
             offsets,
             map: default_ordering,
             points,
@@ -192,28 +210,28 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MixedGeometryArray<O> {
         let mut fields: Vec<Arc<Field>> = vec![];
         let mut type_ids = vec![];
 
-        if self.points.len() > 0 {
-            fields.push(self.points.extension_field());
+        if let Some(ref points) = self.points {
+            fields.push(points.extension_field());
             type_ids.push(0);
         }
-        if self.line_strings.len() > 0 {
-            fields.push(self.line_strings.extension_field());
+        if let Some(ref line_strings) = self.line_strings {
+            fields.push(line_strings.extension_field());
             type_ids.push(1);
         }
-        if self.polygons.len() > 0 {
-            fields.push(self.polygons.extension_field());
+        if let Some(ref polygons) = self.polygons {
+            fields.push(polygons.extension_field());
             type_ids.push(2);
         }
-        if self.multi_points.len() > 0 {
-            fields.push(self.multi_points.extension_field());
+        if let Some(ref multi_points) = self.multi_points {
+            fields.push(multi_points.extension_field());
             type_ids.push(3);
         }
-        if self.multi_line_strings.len() > 0 {
-            fields.push(self.multi_line_strings.extension_field());
+        if let Some(ref multi_line_strings) = self.multi_line_strings {
+            fields.push(multi_line_strings.extension_field());
             type_ids.push(4);
         }
-        if self.multi_polygons.len() > 0 {
-            fields.push(self.multi_polygons.extension_field());
+        if let Some(ref multi_polygons) = self.multi_polygons {
+            fields.push(multi_polygons.extension_field());
             type_ids.push(5);
         }
 
@@ -245,8 +263,8 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MixedGeometryArray<O> {
     /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
-        // Note that `types` is sliced as usual, and thus always has the correct length.
-        self.types.len()
+        // Note that `type_ids` is sliced as usual, and thus always has the correct length.
+        self.type_ids.len()
     }
 
     /// Returns the optional validity.
@@ -282,7 +300,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O> {
         );
         Self {
             data_type: self.data_type.clone(),
-            types: self.types.slice(offset, length),
+            type_ids: self.type_ids.slice(offset, length),
             offsets: self.offsets.slice(offset, length),
             map: self.map,
             points: self.points.clone(),
@@ -305,23 +323,27 @@ impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MixedGeometryArray<O>
     type ItemGeo = geo::Geometry;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        dbg!(&self.types);
-        let child_index = self.types[index];
-        dbg!(child_index);
+        let child_index = self.type_ids[index];
         let offset = self.offsets[index] as usize;
-        dbg!(offset);
-        dbg!(&self.map);
         let geometry_type = self.map[child_index as usize].unwrap();
 
         match geometry_type {
-            GeometryType::Point => Geometry::Point(self.points.value(offset)),
-            GeometryType::LineString => Geometry::LineString(self.line_strings.value(offset)),
-            GeometryType::Polygon => Geometry::Polygon(self.polygons.value(offset)),
-            GeometryType::MultiPoint => Geometry::MultiPoint(self.multi_points.value(offset)),
-            GeometryType::MultiLineString => {
-                Geometry::MultiLineString(self.multi_line_strings.value(offset))
+            GeometryType::Point => Geometry::Point(self.points.as_ref().unwrap().value(offset)),
+            GeometryType::LineString => {
+                Geometry::LineString(self.line_strings.as_ref().unwrap().value(offset))
             }
-            GeometryType::MultiPolygon => Geometry::MultiPolygon(self.multi_polygons.value(offset)),
+            GeometryType::Polygon => {
+                Geometry::Polygon(self.polygons.as_ref().unwrap().value(offset))
+            }
+            GeometryType::MultiPoint => {
+                Geometry::MultiPoint(self.multi_points.as_ref().unwrap().value(offset))
+            }
+            GeometryType::MultiLineString => {
+                Geometry::MultiLineString(self.multi_line_strings.as_ref().unwrap().value(offset))
+            }
+            GeometryType::MultiPolygon => {
+                Geometry::MultiPolygon(self.multi_polygons.as_ref().unwrap().value(offset))
+            }
         }
     }
 }
@@ -330,7 +352,59 @@ impl<O: OffsetSizeTrait> IntoArrow for MixedGeometryArray<O> {
     type ArrowArray = UnionArray;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        todo!()
+        let mut field_type_ids = vec![];
+        let mut child_arrays = vec![];
+
+        if let Some(ref points) = self.points {
+            field_type_ids.push(0);
+            child_arrays.push((
+                points.extension_field().as_ref().clone(),
+                points.clone().into_array_ref(),
+            ));
+        }
+        if let Some(ref line_strings) = self.line_strings {
+            field_type_ids.push(1);
+            child_arrays.push((
+                line_strings.extension_field().as_ref().clone(),
+                line_strings.clone().into_array_ref(),
+            ));
+        }
+        if let Some(ref polygons) = self.polygons {
+            field_type_ids.push(2);
+            child_arrays.push((
+                polygons.extension_field().as_ref().clone(),
+                polygons.clone().into_array_ref(),
+            ));
+        }
+        if let Some(ref multi_points) = self.multi_points {
+            field_type_ids.push(3);
+            child_arrays.push((
+                multi_points.extension_field().as_ref().clone(),
+                multi_points.clone().into_array_ref(),
+            ));
+        }
+        if let Some(ref multi_line_strings) = self.multi_line_strings {
+            field_type_ids.push(4);
+            child_arrays.push((
+                multi_line_strings.extension_field().as_ref().clone(),
+                multi_line_strings.clone().into_array_ref(),
+            ));
+        }
+        if let Some(ref multi_polygons) = self.multi_polygons {
+            field_type_ids.push(5);
+            child_arrays.push((
+                multi_polygons.extension_field().as_ref().clone(),
+                multi_polygons.clone().into_array_ref(),
+            ));
+        }
+
+        UnionArray::try_new(
+            &field_type_ids,
+            self.type_ids.into_inner(),
+            Some(self.offsets.into_inner()),
+            child_arrays,
+        )
+        .unwrap()
     }
 }
 
@@ -374,180 +448,142 @@ impl<O: OffsetSizeTrait> MixedGeometryArray<O> {
 impl TryFrom<&UnionArray> for MixedGeometryArray<i32> {
     type Error = GeoArrowError;
 
-    fn try_from(_value: &UnionArray) -> std::result::Result<Self, Self::Error> {
-        todo!()
-        // let types = value.types().clone();
-        // let offsets = value.offsets().unwrap().clone();
-        // let child_arrays = value.fields();
+    fn try_from(value: &UnionArray) -> std::result::Result<Self, Self::Error> {
+        let mut points: Option<PointArray> = None;
+        let mut line_strings: Option<LineStringArray<i32>> = None;
+        let mut polygons: Option<PolygonArray<i32>> = None;
+        let mut multi_points: Option<MultiPointArray<i32>> = None;
+        let mut multi_line_strings: Option<MultiLineStringArray<i32>> = None;
+        let mut multi_polygons: Option<MultiPolygonArray<i32>> = None;
+        match value.data_type() {
+            DataType::Union(fields, mode) => {
+                if !matches!(mode, UnionMode::Dense) {
+                    return Err(GeoArrowError::General("Expected dense union".to_string()));
+                }
 
-        // // Need to construct the mapping from the logical ordering to the physical ordering
-        // let map = match value.data_type() {
-        //     DataType::Union(fields, _mode) => {
-        //         let mut map: [Option<GeometryType>; 6] = [None, None, None, None, None, None];
-        //         assert!(ids.len() < 6);
-        //         for (pos, &id) in ids.iter().enumerate() {
-        //             let geom_type: GeometryType = match fields[pos].data_type() {
-        //                 DataType::Extension(ext_name, _, _) => (ext_name).into(),
-        //                 _ => panic!(),
-        //             };
+                for (type_id, field) in fields.iter() {
+                    if let Some(extension_name) = field.metadata().get("ARROW:extension:name") {
+                        match extension_name.as_str() {
+                            "geoarrow.point" => {
+                                points = Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.linestring" => {
+                                line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.polygon" => {
+                                polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.multipoint" => {
+                                multi_points =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.multilinestring" => {
+                                multi_line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.multipolygon" => {
+                                multi_polygons =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            _ => {
+                                return Err(GeoArrowError::General(format!(
+                                    "Unexpected geoarrow type {}",
+                                    extension_name
+                                )))
+                            }
+                        }
+                    };
+                }
+            }
+            _ => panic!("expected union type"),
+        };
 
-        //             // Set this geometry type in the lookup table
-        //             // So when you see `type: 3`, then you look up index `map[3]`, which gives you
-        //             // a geometry type. Then that geometry type is looked up in the primitive
-        //             // arrays.
-        //             map[id as usize] = Some(geom_type);
-        //         }
+        let type_ids = value.type_ids().clone();
+        // This is after checking for dense union
+        let offsets = value.offsets().unwrap().clone();
 
-        //         map
-        //     }
-        //     DataType::Union(_, None, _) => {
-        //         // return default ordering
-        //         [
-        //             Some(GeometryType::Point),
-        //             Some(GeometryType::LineString),
-        //             Some(GeometryType::Polygon),
-        //             Some(GeometryType::MultiPoint),
-        //             Some(GeometryType::MultiLineString),
-        //             Some(GeometryType::MultiPolygon),
-        //         ]
-        //     }
-        //     _ => panic!(),
-        // };
-
-        // let mut points: Option<PointArray> = None;
-        // let mut line_strings: Option<LineStringArray<i32>> = None;
-        // let mut polygons: Option<PolygonArray<i32>> = None;
-        // let mut multi_points: Option<MultiPointArray<i32>> = None;
-        // let mut multi_line_strings: Option<MultiLineStringArray<i32>> = None;
-        // let mut multi_polygons: Option<MultiPolygonArray<i32>> = None;
-
-        // for field in child_arrays {
-        //     let geometry_array: GeometryArray<i32> = field.as_ref().try_into().unwrap();
-        //     match geometry_array {
-        //         GeometryArray::Point(arr) => {
-        //             points = Some(arr);
-        //         }
-        //         GeometryArray::LineString(arr) => {
-        //             line_strings = Some(arr);
-        //         }
-        //         GeometryArray::Polygon(arr) => {
-        //             polygons = Some(arr);
-        //         }
-        //         GeometryArray::MultiPoint(arr) => {
-        //             multi_points = Some(arr);
-        //         }
-        //         GeometryArray::MultiLineString(arr) => {
-        //             multi_line_strings = Some(arr);
-        //         }
-        //         GeometryArray::MultiPolygon(arr) => {
-        //             multi_polygons = Some(arr);
-        //         }
-        //         _ => todo!(),
-        //     }
-        // }
-
-        // Ok(Self {
-        //     types,
-        //     offsets,
-        //     map,
-        //     points: points.unwrap_or_default(),
-        //     line_strings: line_strings.unwrap_or_default(),
-        //     polygons: polygons.unwrap_or_default(),
-        //     multi_points: multi_points.unwrap_or_default(),
-        //     multi_line_strings: multi_line_strings.unwrap_or_default(),
-        //     multi_polygons: multi_polygons.unwrap_or_default(),
-        //     slice_offset: 0,
-        // })
+        Ok(Self::new(
+            type_ids,
+            offsets,
+            points,
+            line_strings,
+            polygons,
+            multi_points,
+            multi_line_strings,
+            multi_polygons,
+        ))
     }
 }
 
 impl TryFrom<&UnionArray> for MixedGeometryArray<i64> {
     type Error = GeoArrowError;
 
-    fn try_from(_value: &UnionArray) -> std::result::Result<Self, Self::Error> {
-        todo!()
-        // let types = value.types().clone();
-        // let offsets = value.offsets().unwrap().clone();
-        // let child_arrays = value.fields();
+    fn try_from(value: &UnionArray) -> std::result::Result<Self, Self::Error> {
+        let mut points: Option<PointArray> = None;
+        let mut line_strings: Option<LineStringArray<i64>> = None;
+        let mut polygons: Option<PolygonArray<i64>> = None;
+        let mut multi_points: Option<MultiPointArray<i64>> = None;
+        let mut multi_line_strings: Option<MultiLineStringArray<i64>> = None;
+        let mut multi_polygons: Option<MultiPolygonArray<i64>> = None;
+        match value.data_type() {
+            DataType::Union(fields, mode) => {
+                if !matches!(mode, UnionMode::Dense) {
+                    return Err(GeoArrowError::General("Expected dense union".to_string()));
+                }
 
-        // // Need to construct the mapping from the logical ordering to the physical ordering
-        // let map = match value.data_type() {
-        //     DataType::Union(fields, Some(ids), _mode) => {
-        //         let mut map: [Option<GeometryType>; 6] = [None, None, None, None, None, None];
-        //         assert!(ids.len() < 6);
-        //         for (pos, &id) in ids.iter().enumerate() {
-        //             let geom_type: GeometryType = match fields[pos].data_type() {
-        //                 DataType::Extension(ext_name, _, _) => (ext_name).into(),
-        //                 _ => panic!(),
-        //             };
+                for (type_id, field) in fields.iter() {
+                    if let Some(extension_name) = field.metadata().get("ARROW:extension:name") {
+                        match extension_name.as_str() {
+                            "geoarrow.point" => {
+                                points = Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.linestring" => {
+                                line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.polygon" => {
+                                polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.multipoint" => {
+                                multi_points =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.multilinestring" => {
+                                multi_line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            "geoarrow.multipolygon" => {
+                                multi_polygons =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            _ => {
+                                return Err(GeoArrowError::General(format!(
+                                    "Unexpected geoarrow type {}",
+                                    extension_name
+                                )))
+                            }
+                        }
+                    };
+                }
+            }
+            _ => panic!("expected union type"),
+        };
 
-        //             // Set this geometry type in the lookup table
-        //             // So when you see `type: 3`, then you look up index `map[3]`, which gives you
-        //             // a geometry type. Then that geometry type is looked up in the primitive
-        //             // arrays.
-        //             map[id as usize] = Some(geom_type);
-        //         }
+        let type_ids = value.type_ids().clone();
+        // This is after checking for dense union
+        let offsets = value.offsets().unwrap().clone();
 
-        //         map
-        //     }
-        //     DataType::Union(_, None, _) => {
-        //         // return default ordering
-        //         [
-        //             Some(GeometryType::Point),
-        //             Some(GeometryType::LineString),
-        //             Some(GeometryType::Polygon),
-        //             Some(GeometryType::MultiPoint),
-        //             Some(GeometryType::MultiLineString),
-        //             Some(GeometryType::MultiPolygon),
-        //         ]
-        //     }
-        //     _ => panic!(),
-        // };
-
-        // let mut points: Option<PointArray> = None;
-        // let mut line_strings: Option<LineStringArray<i64>> = None;
-        // let mut polygons: Option<PolygonArray<i64>> = None;
-        // let mut multi_points: Option<MultiPointArray<i64>> = None;
-        // let mut multi_line_strings: Option<MultiLineStringArray<i64>> = None;
-        // let mut multi_polygons: Option<MultiPolygonArray<i64>> = None;
-
-        // for field in child_arrays {
-        //     let geometry_array: GeometryArray<i64> = field.as_ref().try_into().unwrap();
-        //     match geometry_array {
-        //         GeometryArray::Point(arr) => {
-        //             points = Some(arr);
-        //         }
-        //         GeometryArray::LineString(arr) => {
-        //             line_strings = Some(arr);
-        //         }
-        //         GeometryArray::Polygon(arr) => {
-        //             polygons = Some(arr);
-        //         }
-        //         GeometryArray::MultiPoint(arr) => {
-        //             multi_points = Some(arr);
-        //         }
-        //         GeometryArray::MultiLineString(arr) => {
-        //             multi_line_strings = Some(arr);
-        //         }
-        //         GeometryArray::MultiPolygon(arr) => {
-        //             multi_polygons = Some(arr);
-        //         }
-        //         _ => todo!(),
-        //     }
-        // }
-
-        // Ok(Self {
-        //     types,
-        //     offsets,
-        //     map,
-        //     points: points.unwrap_or_default(),
-        //     line_strings: line_strings.unwrap_or_default(),
-        //     polygons: polygons.unwrap_or_default(),
-        //     multi_points: multi_points.unwrap_or_default(),
-        //     multi_line_strings: multi_line_strings.unwrap_or_default(),
-        //     multi_polygons: multi_polygons.unwrap_or_default(),
-        //     slice_offset: 0,
-        // })
+        Ok(Self::new(
+            type_ids,
+            offsets,
+            points,
+            line_strings,
+            polygons,
+            multi_points,
+            multi_line_strings,
+            multi_polygons,
+        ))
     }
 }
 
@@ -618,9 +654,8 @@ mod test {
         assert_eq!(arr.value_as_geo(5), geoms[5]);
     }
 
-    #[ignore = "Something wrong in arrow-rs transition"]
     #[test]
-    fn arrow2_roundtrip() {
+    fn arrow_roundtrip() {
         let geoms: Vec<geo::Geometry> = vec![
             geo::Geometry::Point(point::p0()),
             geo::Geometry::LineString(linestring::ls0()),
@@ -631,7 +666,7 @@ mod test {
         ];
         let arr: MixedGeometryArray<i32> = geoms.clone().try_into().unwrap();
 
-        // Round trip to/from arrow2
+        // Round trip to/from arrow-rs
         let arrow_array = arr.into_arrow();
         let round_trip_arr: MixedGeometryArray<i32> = (&arrow_array).try_into().unwrap();
 

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -452,31 +452,6 @@ impl<O: OffsetSizeTrait> From<MixedGeometryBuilder<O>> for MixedGeometryArray<O>
     }
 }
 
-// TODO: figure out these trait impl errors
-// fn from_geometry_trait_iterator<'a, O: OffsetSizeTrait>(
-//     geoms: impl Iterator<Item = impl GeometryTrait<T = f64> + 'a>,
-//     prefer_multi: bool
-// ) -> MixedGeometryBuilder<O> {
-//     let mut array = MixedGeometryBuilder::new();
-
-//     for geom in geoms.into_iter() {
-//         match geom.as_type() {
-//             GeometryType::Point(point) => {
-//                 array.push_valid_point(point);
-//                 // if prefer_multi {
-//                 //     array.push_point_as_multi_point(Some(point));
-//                 // } else {
-//                 //     array.push_point(Some(point));
-//                 // }
-//             }
-//             _ => todo!(),
-//         };
-//         // maybe_geom.
-//     }
-
-//     array
-// }
-
 #[derive(Debug, Clone, Copy)]
 pub struct MixedCapacity {
     /// Simple: just the total number of points, nulls included
@@ -613,6 +588,7 @@ impl MixedCapacity {
 
     pub fn add_geometry<'a>(&mut self, geom: Option<&'a (impl GeometryTrait + 'a)>) {
         // TODO: what to do about null geometries? We don't know which type they have
+        assert!(geom.is_some());
         if let Some(geom) = geom {
             match geom.as_type() {
                 crate::geo_traits::GeometryType::Point(_) => self.add_point(),

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -418,12 +418,36 @@ impl<O: OffsetSizeTrait> From<MixedGeometryBuilder<O>> for MixedGeometryArray<O>
         Self::new(
             other.types.into(),
             other.offsets.into(),
-            other.points.into(),
-            other.line_strings.into(),
-            other.polygons.into(),
-            other.multi_points.into(),
-            other.multi_line_strings.into(),
-            other.multi_polygons.into(),
+            if other.points.len() > 0 {
+                Some(other.points.into())
+            } else {
+                None
+            },
+            if other.line_strings.len() > 0 {
+                Some(other.line_strings.into())
+            } else {
+                None
+            },
+            if other.polygons.len() > 0 {
+                Some(other.polygons.into())
+            } else {
+                None
+            },
+            if other.multi_points.len() > 0 {
+                Some(other.multi_points.into())
+            } else {
+                None
+            },
+            if other.multi_line_strings.len() > 0 {
+                Some(other.multi_line_strings.into())
+            } else {
+                None
+            },
+            if other.multi_polygons.len() > 0 {
+                Some(other.multi_polygons.into())
+            } else {
+                None
+            },
         )
     }
 }

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -11,7 +11,7 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{LineStringTrait, MultiLineStringTrait};
 use crate::io::wkb::reader::maybe_multi_line_string::WKBMaybeMultiLineString;
 use crate::scalar::WKB;
-use crate::trait_::IntoArrow;
+use crate::trait_::{GeometryArrayBuilder, IntoArrow};
 use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 
@@ -346,6 +346,20 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
 
     pub fn finish(self) -> MultiLineStringArray<O> {
         self.into()
+    }
+}
+
+impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiLineStringBuilder<O> {
+    fn len(&self) -> usize {
+        self.geom_offsets.len_proxy()
+    }
+
+    fn validity(&self) -> &NullBufferBuilder {
+        &self.validity
+    }
+
+    fn into_array_ref(self) -> Arc<dyn Array> {
+        Arc::new(self.into_arrow())
     }
 }
 

--- a/src/array/multipoint/builder.rs
+++ b/src/array/multipoint/builder.rs
@@ -302,14 +302,6 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiPointBuilder<O> {
         &self.validity
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
     fn into_array_ref(self) -> Arc<dyn Array> {
         self.into_array_ref()
     }

--- a/src/array/multipolygon/builder.rs
+++ b/src/array/multipolygon/builder.rs
@@ -11,7 +11,7 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{LineStringTrait, MultiPolygonTrait, PolygonTrait};
 use crate::io::wkb::reader::maybe_multipolygon::WKBMaybeMultiPolygon;
 use crate::scalar::WKB;
-use crate::trait_::IntoArrow;
+use crate::trait_::{GeometryArrayBuilder, IntoArrow};
 use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 
@@ -416,6 +416,20 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
 impl<O: OffsetSizeTrait> Default for MultiPolygonBuilder<O> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiPolygonBuilder<O> {
+    fn len(&self) -> usize {
+        self.geom_offsets.len_proxy()
+    }
+
+    fn validity(&self) -> &NullBufferBuilder {
+        &self.validity
+    }
+
+    fn into_array_ref(self) -> Arc<dyn Array> {
+        Arc::new(self.into_arrow())
     }
 }
 

--- a/src/array/point/builder.rs
+++ b/src/array/point/builder.rs
@@ -189,14 +189,6 @@ impl GeometryArrayBuilder for PointBuilder {
         &self.validity
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
     fn into_array_ref(self) -> Arc<dyn Array> {
         self.into_arrow()
     }

--- a/src/array/polygon/builder.rs
+++ b/src/array/polygon/builder.rs
@@ -10,7 +10,7 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{CoordTrait, LineStringTrait, PolygonTrait, RectTrait};
 use crate::io::wkb::reader::polygon::WKBPolygon;
 use crate::scalar::WKB;
-use crate::trait_::IntoArrow;
+use crate::trait_::{GeometryArrayBuilder, IntoArrow};
 use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 
@@ -351,6 +351,20 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
 impl<O: OffsetSizeTrait> Default for PolygonBuilder<O> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<O: OffsetSizeTrait> GeometryArrayBuilder for PolygonBuilder<O> {
+    fn len(&self) -> usize {
+        self.geom_offsets.len_proxy()
+    }
+
+    fn validity(&self) -> &NullBufferBuilder {
+        &self.validity
+    }
+
+    fn into_array_ref(self) -> Arc<dyn Array> {
+        Arc::new(self.into_arrow())
     }
 }
 

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -180,12 +180,12 @@ pub fn from_wkb<O: OffsetSizeTrait>(
         if large_type {
             let mut builder =
                 MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, coord_type);
-            builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()));
+            builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()), true);
             Ok(Arc::new(builder.finish()))
         } else {
             let mut builder =
                 MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, coord_type);
-            builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()));
+            builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()), true);
             Ok(Arc::new(builder.finish()))
         }
     }

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -249,12 +249,6 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync {
     //     self.as_box().into()
     // }
 
-    /// Convert to `Any`, to enable dynamic casting.
-    fn as_any(&self) -> &dyn Any;
-
-    /// Convert to mutable `Any`, to enable dynamic casting.
-    fn as_mut_any(&mut self) -> &mut dyn Any;
-
     // /// Adds a new null element to the array.
     // fn push_null(&mut self);
 


### PR DESCRIPTION
### Change list

- Implement conversion of `MixedGeometryArray` to and from `UnionArray`.
- Allow the children of the `MixedGeometryArray` to be `None`
- Remove `point_counter` et al, in favor of `self.points.len()`
- Re-enable previously-failing test, which tested round trip from MixedArray to arrow-rs UnionArray and back.
- Add builder option to prefer adding to multi geometry arrays.