### PR TITLE
minimize allocations when output geometry arrays are the same size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,5 +76,9 @@ name = "nybb"
 harness = false
 
 [[bench]]
+name = "translate"
+harness = false
+
+[[bench]]
 name = "wkb"
 harness = false

--- a/benches/translate.rs
+++ b/benches/translate.rs
@@ -1,0 +1,34 @@
+use geo::polygon;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use geoarrow::algorithm::geo::Translate;
+use geoarrow::array::PolygonArray;
+
+fn create_data() -> PolygonArray<i32> {
+    // An L shape
+    // https://github.com/georust/geo/blob/7cb7d0ffa6bf1544c5ca9922bd06100c36f815d7/README.md?plain=1#L40
+    let poly = polygon![
+        (x: 0.0, y: 0.0),
+        (x: 4.0, y: 0.0),
+        (x: 4.0, y: 1.0),
+        (x: 1.0, y: 1.0),
+        (x: 1.0, y: 4.0),
+        (x: 0.0, y: 4.0),
+        (x: 0.0, y: 0.0),
+    ];
+    let v = vec![poly; 1000];
+    v.as_slice().into()
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let data = create_data();
+
+    c.bench_function("translate PolygonArray", |b| {
+        b.iter(|| {
+            let _ = data.translate(10.0.into(), 20.0.into());
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/algorithm/geo/skew.rs
+++ b/src/algorithm/geo/skew.rs
@@ -137,13 +137,19 @@ pub trait Skew {
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
 impl Skew for PointArray {
     fn skew(&self, scale_factor: BroadcastablePrimitive<Float64Type>) -> Self {
-        let output_geoms: Vec<Option<geo::Point>> = self
-            .iter_geo()
-            .zip(&scale_factor)
-            .map(|(maybe_g, scale_factor)| maybe_g.map(|geom| geom.skew(scale_factor.unwrap())))
-            .collect();
+        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        output_geoms.into()
+        self.iter_geo()
+            .zip(&scale_factor)
+            .for_each(|(maybe_g, scale_factor)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| geom.skew(scale_factor.unwrap()))
+                        .as_ref(),
+                )
+            });
+
+        output_array.finish()
     }
 
     fn skew_xy(
@@ -151,16 +157,19 @@ impl Skew for PointArray {
         x_factor: BroadcastablePrimitive<Float64Type>,
         y_factor: BroadcastablePrimitive<Float64Type>,
     ) -> Self {
-        let output_geoms: Vec<Option<geo::Point>> = self
-            .iter_geo()
-            .zip(&x_factor)
-            .zip(&y_factor)
-            .map(|((maybe_g, x_factor), y_factor)| {
-                maybe_g.map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap()))
-            })
-            .collect();
+        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        output_geoms.into()
+        self.iter_geo().zip(&x_factor).zip(&y_factor).for_each(
+            |((maybe_g, x_factor), y_factor)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap()))
+                        .as_ref(),
+                )
+            },
+        );
+
+        output_array.finish()
     }
 
     fn skew_around_point(
@@ -169,35 +178,44 @@ impl Skew for PointArray {
         y_factor: BroadcastablePrimitive<Float64Type>,
         origin: geo::Point,
     ) -> Self {
-        let output_geoms: Vec<Option<geo::Point>> = self
-            .iter_geo()
-            .zip(&x_factor)
-            .zip(&y_factor)
-            .map(|((maybe_g, x_factor), y_factor)| {
-                maybe_g.map(|geom| {
-                    geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)
-                })
-            })
-            .collect();
+        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        output_geoms.into()
+        self.iter_geo().zip(&x_factor).zip(&y_factor).for_each(
+            |((maybe_g, x_factor), y_factor)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| {
+                            geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)
+                        })
+                        .as_ref(),
+                )
+            },
+        );
+
+        output_array.finish()
     }
 }
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
-    ($type:ty, $geo_type:ty) => {
+    ($type:ty, $builder_type:ty, $push_func:ident) => {
         impl<O: OffsetSizeTrait> Skew for $type {
             fn skew(&self, scale_factor: BroadcastablePrimitive<Float64Type>) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self
-                    .iter_geo()
-                    .zip(scale_factor.into_iter())
-                    .map(|(maybe_g, scale_factor)| {
-                        maybe_g.map(|geom| geom.skew(scale_factor.unwrap()))
-                    })
-                    .collect();
+                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                output_geoms.into()
+                self.iter_geo()
+                    .zip(&scale_factor)
+                    .for_each(|(maybe_g, scale_factor)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| geom.skew(scale_factor.unwrap()))
+                                    .as_ref(),
+                            )
+                            .unwrap();
+                    });
+
+                output_array.finish()
             }
 
             fn skew_xy(
@@ -205,16 +223,21 @@ macro_rules! iter_geo_impl {
                 x_factor: BroadcastablePrimitive<Float64Type>,
                 y_factor: BroadcastablePrimitive<Float64Type>,
             ) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self
-                    .iter_geo()
-                    .zip(x_factor.into_iter())
-                    .zip(y_factor.into_iter())
-                    .map(|((maybe_g, x_factor), y_factor)| {
-                        maybe_g.map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap()))
-                    })
-                    .collect();
+                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                output_geoms.into()
+                self.iter_geo().zip(&x_factor).zip(&y_factor).for_each(
+                    |((maybe_g, x_factor), y_factor)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap()))
+                                    .as_ref(),
+                            )
+                            .unwrap()
+                    },
+                );
+
+                output_array.finish()
             }
 
             fn skew_around_point(
@@ -223,29 +246,45 @@ macro_rules! iter_geo_impl {
                 y_factor: BroadcastablePrimitive<Float64Type>,
                 origin: geo::Point,
             ) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self
-                    .iter_geo()
-                    .zip(x_factor.into_iter())
-                    .zip(y_factor.into_iter())
-                    .map(|((maybe_g, x_factor), y_factor)| {
-                        maybe_g.map(|geom| {
-                            geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)
-                        })
-                    })
-                    .collect();
+                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                output_geoms.into()
+                self.iter_geo().zip(&x_factor).zip(&y_factor).for_each(
+                    |((maybe_g, x_factor), y_factor)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| {
+                                        geom.skew_around_point(
+                                            x_factor.unwrap(),
+                                            y_factor.unwrap(),
+                                            origin,
+                                        )
+                                    })
+                                    .as_ref(),
+                            )
+                            .unwrap()
+                    },
+                );
+
+                output_array.finish()
             }
         }
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, geo::LineString);
-iter_geo_impl!(PolygonArray<O>, geo::Polygon);
-iter_geo_impl!(MultiPointArray<O>, geo::MultiPoint);
-iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
-
+iter_geo_impl!(LineStringArray<O>, LineStringBuilder<O>, push_line_string);
+iter_geo_impl!(PolygonArray<O>, PolygonBuilder<O>, push_polygon);
+iter_geo_impl!(MultiPointArray<O>, MultiPointBuilder<O>, push_multi_point);
+iter_geo_impl!(
+    MultiLineStringArray<O>,
+    MultiLineStringBuilder<O>,
+    push_multi_line_string
+);
+iter_geo_impl!(
+    MultiPolygonArray<O>,
+    MultiPolygonBuilder<O>,
+    push_multi_polygon
+);
 impl<O: OffsetSizeTrait> Skew for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn skew(&self, scale_factor: BroadcastablePrimitive<Float64Type>) -> Self;

--- a/src/algorithm/proj.rs
+++ b/src/algorithm/proj.rs
@@ -32,7 +32,7 @@ macro_rules! iter_geo_impl {
     ($type:ty, $builder_type:ty, $push_func:ident) => {
         impl<O: OffsetSizeTrait> Reproject for $type {
             fn reproject(&self, proj: &Proj) -> Result<Self> {
-                let mut output_array = <$builder_type>::new();
+                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
                 for maybe_geom in self.iter_geo() {
                     if let Some(mut geom) = maybe_geom {


### PR DESCRIPTION
Follow up on https://github.com/geoarrow/geoarrow-rs/pull/310#discussion_r1427462729

It's about 20% faster for `translate` when output arrays are pre-allocated:
```
translate PolygonArray  time:   [96.935 µs 97.334 µs 97.805 µs]
                        change: [-19.186% -18.846% -18.539%] (p = 0.00 < 0.05)
                        Performance has improved.
```