### PR TITLE
Implement "downcasting" on arrays to convert to simpler array type

### DIFF
--- a/python/core/src/io/wkb.rs
+++ b/python/core/src/io/wkb.rs
@@ -23,6 +23,7 @@ pub fn from_wkb(ob: &PyAny) -> PyResult<PyObject> {
                 .unwrap(),
             false,
             CoordType::Interleaved,
+            None,
         )
         .unwrap(),
         GeoDataType::LargeWKB => _from_wkb(
@@ -32,6 +33,7 @@ pub fn from_wkb(ob: &PyAny) -> PyResult<PyObject> {
                 .unwrap(),
             false,
             CoordType::Interleaved,
+            None,
         )
         .unwrap(),
         other => {

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::array::binary::WKBCapacity;
+use crate::array::mixed::array::GeometryType;
 use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 use crate::array::zip_validity::ZipValidity;
 use crate::array::{CoordType, WKBBuilder};
@@ -70,8 +71,9 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
         &self,
         large_type: bool,
         coord_type: CoordType,
+        geom_type: Option<GeometryType>,
     ) -> Result<Arc<dyn GeometryArrayTrait>> {
-        from_wkb(self, large_type, coord_type)
+        from_wkb(self, large_type, coord_type, geom_type)
     }
 
     // pub fn with_validity(&self, validity: Option<NullBuffer>) -> Self {

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -133,7 +133,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
         } else {
             self.geoms.push_point(value);
         }
-        self.geom_offsets.extend_constant(1);
+        self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
         Ok(())
     }
@@ -149,7 +149,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
         } else {
             self.geoms.push_line_string(value)?;
         }
-        self.geom_offsets.extend_constant(1);
+        self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
         Ok(())
     }
@@ -165,7 +165,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
         } else {
             self.geoms.push_polygon(value)?;
         }
-        self.geom_offsets.extend_constant(1);
+        self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
         Ok(())
     }
@@ -176,7 +176,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
         value: Option<&impl MultiPointTrait<T = f64>>,
     ) -> Result<()> {
         self.geoms.push_multi_point(value)?;
-        self.geom_offsets.extend_constant(1);
+        self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
         Ok(())
     }
@@ -187,7 +187,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
         value: Option<&impl MultiLineStringTrait<T = f64>>,
     ) -> Result<()> {
         self.geoms.push_multi_line_string(value)?;
-        self.geom_offsets.extend_constant(1);
+        self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
         Ok(())
     }
@@ -198,7 +198,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
         value: Option<&impl MultiPolygonTrait<T = f64>>,
     ) -> Result<()> {
         self.geoms.push_multi_polygon(value)?;
-        self.geom_offsets.extend_constant(1);
+        self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
         Ok(())
     }

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -352,7 +352,30 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MixedGeometryArray<O> {
     }
 
     fn coord_type(&self) -> crate::array::CoordType {
-        todo!();
+        let mut coord_types = HashSet::new();
+
+        if let Some(ref points) = self.points {
+            coord_types.insert(points.coord_type());
+        }
+        if let Some(ref line_strings) = self.line_strings {
+            coord_types.insert(line_strings.coord_type());
+        }
+        if let Some(ref polygons) = self.polygons {
+            coord_types.insert(polygons.coord_type());
+        }
+        if let Some(ref multi_points) = self.multi_points {
+            coord_types.insert(multi_points.coord_type());
+        }
+        if let Some(ref multi_line_strings) = self.multi_line_strings {
+            coord_types.insert(multi_line_strings.coord_type());
+        }
+        if let Some(ref multi_polygons) = self.multi_polygons {
+            coord_types.insert(multi_polygons.coord_type());
+        }
+
+        assert_eq!(coord_types.len(), 1);
+        let coord_type = coord_types.drain().next().unwrap();
+        coord_type
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -225,6 +225,71 @@ impl<O: OffsetSizeTrait> MixedGeometryArray<O> {
                 .unwrap_or_default(),
         )
     }
+
+    pub fn downcast(&self) -> Arc<dyn GeometryArrayTrait> {
+        // TODO: do I need to handle the slice offset?
+        if self.points.is_some()
+            && self.line_strings.is_none()
+            && self.polygons.is_none()
+            && self.multi_points.is_none()
+            && self.multi_line_strings.is_none()
+            && self.multi_polygons.is_none()
+        {
+            return Arc::new(self.points.as_ref().unwrap().clone());
+        }
+
+        if self.points.is_none()
+            && self.line_strings.is_some()
+            && self.polygons.is_none()
+            && self.multi_points.is_none()
+            && self.multi_line_strings.is_none()
+            && self.multi_polygons.is_none()
+        {
+            return Arc::new(self.line_strings.as_ref().unwrap().clone());
+        }
+
+        if self.points.is_none()
+            && self.line_strings.is_none()
+            && self.polygons.is_some()
+            && self.multi_points.is_none()
+            && self.multi_line_strings.is_none()
+            && self.multi_polygons.is_none()
+        {
+            return Arc::new(self.polygons.as_ref().unwrap().clone());
+        }
+
+        if self.points.is_none()
+            && self.line_strings.is_none()
+            && self.polygons.is_none()
+            && self.multi_points.is_some()
+            && self.multi_line_strings.is_none()
+            && self.multi_polygons.is_none()
+        {
+            return self.multi_points.as_ref().unwrap().downcast();
+        }
+
+        if self.points.is_none()
+            && self.line_strings.is_none()
+            && self.polygons.is_none()
+            && self.multi_points.is_none()
+            && self.multi_line_strings.is_some()
+            && self.multi_polygons.is_none()
+        {
+            return self.multi_line_strings.as_ref().unwrap().downcast();
+        }
+
+        if self.points.is_none()
+            && self.line_strings.is_none()
+            && self.polygons.is_none()
+            && self.multi_points.is_none()
+            && self.multi_line_strings.is_none()
+            && self.multi_polygons.is_some()
+        {
+            return self.multi_polygons.as_ref().unwrap().downcast();
+        }
+
+        Arc::new(self.clone())
+    }
 }
 
 impl<O: OffsetSizeTrait> GeometryArrayTrait for MixedGeometryArray<O> {

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -155,6 +155,18 @@ impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
             self.len(),
         )
     }
+
+    pub fn downcast(&self) -> Arc<dyn GeometryArrayTrait> {
+        if self.geom_offsets.last().to_usize().unwrap() == self.len() {
+            return Arc::new(LineStringArray::new(
+                self.coords.clone(),
+                self.ring_offsets.clone(),
+                self.validity.clone(),
+            ));
+        }
+
+        Arc::new(self.clone())
+    }
 }
 
 impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiLineStringArray<O> {

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -122,6 +122,15 @@ impl<O: OffsetSizeTrait> MultiPointArray<O> {
     pub fn buffer_lengths(&self) -> MultiPointCapacity {
         MultiPointCapacity::new(self.geom_offsets.last().to_usize().unwrap(), self.len())
     }
+
+    pub fn downcast(&self) -> Arc<dyn GeometryArrayTrait> {
+        // Note: this won't allow a downcast for empty MultiPoints
+        if self.geom_offsets.last().to_usize().unwrap() == self.len() {
+            return Arc::new(PointArray::new(self.coords.clone(), self.validity.clone()));
+        }
+
+        Arc::new(self.clone())
+    }
 }
 
 impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiPointArray<O> {

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -187,6 +187,19 @@ impl<O: OffsetSizeTrait> MultiPolygonArray<O> {
             self.len(),
         )
     }
+
+    pub fn downcast(&self) -> Arc<dyn GeometryArrayTrait> {
+        if self.geom_offsets.last().to_usize().unwrap() == self.len() {
+            return Arc::new(PolygonArray::new(
+                self.coords.clone(),
+                self.polygon_offsets.clone(),
+                self.ring_offsets.clone(),
+                self.validity.clone(),
+            ));
+        }
+
+        Arc::new(self.clone())
+    }
 }
 
 impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiPolygonArray<O> {

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -178,7 +178,7 @@ mod test {
     use crate::test::point;
 
     #[test]
-    fn point_round_trip() {
+    fn point_round_trip_explicit_casting() {
         let arr = point::point_array();
         let wkb_arr: WKBArray<i32> = to_wkb(&arr);
         let roundtrip = from_wkb(
@@ -188,6 +188,16 @@ mod test {
             Some(GeometryType::Point),
         )
         .unwrap();
+        let rt_point_arr = roundtrip.as_any().downcast_ref::<PointArray>().unwrap();
+        assert_eq!(&arr, rt_point_arr);
+    }
+
+    #[test]
+    fn point_round_trip() {
+        let points = vec![point::p0(), point::p1(), point::p2()];
+        let arr = PointArray::from(points.as_slice());
+        let wkb_arr: WKBArray<i32> = to_wkb(&arr);
+        let roundtrip = from_wkb(&wkb_arr, false, CoordType::Interleaved, None).unwrap();
         let rt_point_arr = roundtrip.as_any().downcast_ref::<PointArray>().unwrap();
         assert_eq!(&arr, rt_point_arr);
     }

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use crate::array::mixed::MixedCapacity;
+use crate::array::geometrycollection::GeometryCollectionBuilder;
 use crate::array::*;
 use crate::datatypes::GeoDataType;
 use crate::error::Result;
-use crate::io::wkb::reader::geometry::WKBGeometry;
 use crate::scalar::WKB;
 use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
@@ -16,178 +15,14 @@ pub fn from_wkb<O: OffsetSizeTrait>(
     coord_type: CoordType,
 ) -> Result<Arc<dyn GeometryArrayTrait>> {
     let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-    let wkb_objects2: Vec<Option<WKBGeometry>> = wkb_objects
-        .iter()
-        .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
-        .collect();
-
-    let capacity = MixedCapacity::from_owned_geometries(wkb_objects2.into_iter())?;
-    if capacity.point_compatible() {
-        let mut builder =
-            PointBuilder::with_capacity_and_options(capacity.point_capacity(), coord_type);
-        let wkb_points: Vec<Option<_>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| {
-                maybe_wkb
-                    .as_ref()
-                    .map(|wkb| wkb.to_wkb_object().into_point())
-            })
-            .collect();
-        builder.extend_from_iter(wkb_points.iter().map(|x| x.as_ref()));
-        Ok(Arc::new(builder.finish()))
-    } else if capacity.line_string_compatible() {
-        let wkb_line_strings: Vec<Option<_>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| {
-                maybe_wkb
-                    .as_ref()
-                    .map(|wkb| wkb.to_wkb_object().into_line_string())
-            })
-            .collect();
-        if large_type {
-            let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
-                capacity.line_string_capacity(),
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_line_strings.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        } else {
-            let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
-                capacity.line_string_capacity(),
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_line_strings.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        }
-    } else if capacity.polygon_compatible() {
-        let wkb_polygons: Vec<Option<_>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| {
-                maybe_wkb
-                    .as_ref()
-                    .map(|wkb| wkb.to_wkb_object().into_polygon())
-            })
-            .collect();
-        if large_type {
-            let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
-                capacity.polygon_capacity(),
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_polygons.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        } else {
-            let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
-                capacity.polygon_capacity(),
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_polygons.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        }
-    } else if capacity.multi_point_compatible() {
-        let wkb_multi_points: Vec<Option<_>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| {
-                maybe_wkb
-                    .as_ref()
-                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_point())
-            })
-            .collect();
-
-        // Have to add point and multi point capacity together
-        let mut multi_point_capacity = capacity.multi_point_capacity();
-        multi_point_capacity.add_point_capacity(capacity.point_capacity());
-
-        if large_type {
-            let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
-                multi_point_capacity,
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_multi_points.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        } else {
-            let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
-                multi_point_capacity,
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_multi_points.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        }
-    } else if capacity.multi_line_string_compatible() {
-        let wkb_multi_line_strings: Vec<Option<_>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| {
-                maybe_wkb
-                    .as_ref()
-                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_line_string())
-            })
-            .collect();
-
-        // Have to add line string and multi line string capacity together
-        let mut multi_line_string_capacity = capacity.multi_line_string_capacity();
-        multi_line_string_capacity.add_line_string_capacity(capacity.line_string_capacity());
-
-        if large_type {
-            let mut builder = MultiLineStringBuilder::<i64>::with_capacity_and_options(
-                multi_line_string_capacity,
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_multi_line_strings.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        } else {
-            let mut builder = MultiLineStringBuilder::<i32>::with_capacity_and_options(
-                multi_line_string_capacity,
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_multi_line_strings.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        }
-    } else if capacity.multi_polygon_compatible() {
-        let wkb_multi_polygons: Vec<Option<_>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| {
-                maybe_wkb
-                    .as_ref()
-                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_polygon())
-            })
-            .collect();
-
-        // Have to add line string and multi line string capacity together
-        let mut multi_polygon_capacity = capacity.multi_polygon_capacity();
-        multi_polygon_capacity.add_polygon_capacity(capacity.polygon_capacity());
-
-        if large_type {
-            let mut builder = MultiPolygonBuilder::<i64>::with_capacity_and_options(
-                multi_polygon_capacity,
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_multi_polygons.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        } else {
-            let mut builder = MultiPolygonBuilder::<i32>::with_capacity_and_options(
-                multi_polygon_capacity,
-                coord_type,
-            );
-            builder.extend_from_iter(wkb_multi_polygons.iter().map(|x| x.as_ref()));
-            Ok(Arc::new(builder.finish()))
-        }
+    if large_type {
+        let builder =
+            GeometryCollectionBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type), true)?;
+        Ok(builder.finish().downcast())
     } else {
-        let wkb_geometry: Vec<Option<_>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
-            .collect();
-
-        #[allow(clippy::collapsible_else_if)]
-        if large_type {
-            let mut builder =
-                MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, coord_type);
-            builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()), true);
-            Ok(Arc::new(builder.finish()))
-        } else {
-            let mut builder =
-                MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, coord_type);
-            builder.extend_from_iter(wkb_geometry.iter().map(|x| x.as_ref()), true);
-            Ok(Arc::new(builder.finish()))
-        }
+        let builder =
+            GeometryCollectionBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type), true)?;
+        Ok(builder.finish().downcast())
     }
 }
 


### PR DESCRIPTION
### Change list

- Add `downcast` method to convert to a simpler type. This is relevant for the `Multi*` types, as well as `MixedGeometryArray` and `GeometryCollectionArray` (this should probably go on `GeometryArrayTrait`?)
- Simplify `from_wkb` by parsing to a `GeometryCollectionArray` and then downcasting


### TODO:

- [x] Add tests for `from_wkb` to assert that e.g. a point array does indeed get read as a point array. (note that downcasting isn't implemented for null entries yet)