### PR TITLE
geozero-based wkt and ewkb parsing

### DIFF
--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -86,6 +86,10 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
             self.len(),
         )
     }
+
+    pub fn into_inner(self) -> GenericBinaryArray<O> {
+        self.0
+    }
 }
 
 impl<O: OffsetSizeTrait> GeometryArrayTrait for WKBArray<O> {

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -44,16 +44,11 @@ pub struct MixedGeometryBuilder<O: OffsetSizeTrait> {
 impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O> {
     /// Creates a new empty [`MixedGeometryBuilder`].
     pub fn new() -> Self {
-        Self {
-            types: vec![],
-            points: PointBuilder::new(),
-            line_strings: LineStringBuilder::new(),
-            polygons: PolygonBuilder::new(),
-            multi_points: MultiPointBuilder::new(),
-            multi_line_strings: MultiLineStringBuilder::new(),
-            multi_polygons: MultiPolygonBuilder::new(),
-            offsets: vec![],
-        }
+        Self::new_with_options(Default::default())
+    }
+
+    pub fn new_with_options(coord_type: CoordType) -> Self {
+        Self::with_capacity_and_options(Default::default(), coord_type)
     }
 
     /// Creates a new [`MixedGeometryBuilder`] with given capacity and no validity.

--- a/src/array/mixed/capacity.rs
+++ b/src/array/mixed/capacity.rs
@@ -8,7 +8,7 @@ use crate::array::polygon::PolygonCapacity;
 use crate::error::Result;
 use crate::geo_traits::*;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct MixedCapacity {
     /// Simple: just the total number of points, nulls included
     pub(crate) point: usize,

--- a/src/io/geozero/api/ewkb.rs
+++ b/src/io/geozero/api/ewkb.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use crate::array::geometrycollection::GeometryCollectionBuilder;
 use crate::array::*;
 use crate::error::Result;
-use crate::GeometryArrayTrait;
 use crate::io::geozero::array::mixed::MixedGeometryStreamBuilder;
+use crate::GeometryArrayTrait;
 use arrow_array::{Array, GenericBinaryArray, OffsetSizeTrait};
-use geozero::{ToGeo, GeozeroGeometry};
+use geozero::{GeozeroGeometry, ToGeo};
 
 pub trait FromEWKB: Sized {
     type Input<O: OffsetSizeTrait>;

--- a/src/io/geozero/api/ewkb.rs
+++ b/src/io/geozero/api/ewkb.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use crate::array::geometrycollection::GeometryCollectionBuilder;
+use crate::array::*;
+use crate::error::Result;
+use crate::GeometryArrayTrait;
+use arrow_array::{Array, GenericBinaryArray, OffsetSizeTrait};
+use geozero::ToGeo;
+
+pub trait FromEWKB: Sized {
+    type Input<O: OffsetSizeTrait>;
+
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self>;
+}
+
+impl<OOutput: OffsetSizeTrait> FromEWKB for MixedGeometryArray<OOutput> {
+    type Input<O: OffsetSizeTrait> = GenericBinaryArray<O>;
+
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self> {
+        let mut builder = MixedGeometryBuilder::new_with_options(coord_type);
+        for i in 0..arr.len() {
+            if arr.is_valid(i) {
+                let geo_geom = geozero::wkb::Ewkb(arr.value(i).to_vec()).to_geo()?;
+                builder.push_geometry(Some(&geo_geom))?;
+            } else {
+                builder.push_null();
+            }
+        }
+
+        Ok(builder.finish())
+    }
+}
+
+impl<OOutput: OffsetSizeTrait> FromEWKB for GeometryCollectionArray<OOutput> {
+    type Input<O: OffsetSizeTrait> = GenericBinaryArray<O>;
+
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self> {
+        let mut builder = GeometryCollectionBuilder::new_with_options(coord_type);
+        for i in 0..arr.len() {
+            if arr.is_valid(i) {
+                let geo_geom = geozero::wkb::Ewkb(arr.value(i).to_vec()).to_geo()?;
+                builder.push_geometry(Some(&geo_geom), true)?;
+            } else {
+                builder.push_null();
+            }
+        }
+
+        Ok(builder.finish())
+    }
+}
+
+impl FromEWKB for Arc<dyn GeometryArrayTrait> {
+    type Input<O: OffsetSizeTrait> = GenericBinaryArray<O>;
+
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self> {
+        let geom_arr = GeometryCollectionArray::<i64>::from_ewkb(arr, coord_type)?;
+        Ok(geom_arr.downcast())
+    }
+}

--- a/src/io/geozero/api/mod.rs
+++ b/src/io/geozero/api/mod.rs
@@ -1,0 +1,5 @@
+pub mod ewkb;
+pub mod wkt;
+
+pub use ewkb::FromEWKB;
+pub use wkt::FromWKT;

--- a/src/io/geozero/api/wkt.rs
+++ b/src/io/geozero/api/wkt.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use crate::array::geometrycollection::GeometryCollectionBuilder;
+use crate::array::*;
+use crate::error::Result;
+use crate::GeometryArrayTrait;
+use arrow_array::{Array, GenericStringArray, OffsetSizeTrait};
+use geozero::ToGeo;
+
+pub trait FromWKT: Sized {
+    type Input<O: OffsetSizeTrait>;
+
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self>;
+}
+
+impl<OOutput: OffsetSizeTrait> FromWKT for MixedGeometryArray<OOutput> {
+    type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
+
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self> {
+        let mut builder = MixedGeometryBuilder::new_with_options(coord_type);
+        for i in 0..arr.len() {
+            if arr.is_valid(i) {
+                let wkt_str = geozero::wkt::WktStr(arr.value(i));
+                let geo_geom = wkt_str.to_geo()?;
+                builder.push_geometry(Some(&geo_geom))?;
+            } else {
+                builder.push_null();
+            }
+        }
+
+        Ok(builder.finish())
+    }
+}
+
+impl<OOutput: OffsetSizeTrait> FromWKT for GeometryCollectionArray<OOutput> {
+    type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
+
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self> {
+        let mut builder = GeometryCollectionBuilder::new_with_options(coord_type);
+        for i in 0..arr.len() {
+            if arr.is_valid(i) {
+                let wkt_str = geozero::wkt::WktStr(arr.value(i));
+                let geo_geom = wkt_str.to_geo()?;
+                builder.push_geometry(Some(&geo_geom), true)?;
+            } else {
+                builder.push_null();
+            }
+        }
+
+        Ok(builder.finish())
+    }
+}
+
+impl FromWKT for Arc<dyn GeometryArrayTrait> {
+    type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
+
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self> {
+        let geom_arr = GeometryCollectionArray::<i64>::from_wkt(arr, coord_type)?;
+        Ok(geom_arr.downcast())
+    }
+}

--- a/src/io/geozero/array/geometrycollection.rs
+++ b/src/io/geozero/array/geometrycollection.rs
@@ -1,0 +1,23 @@
+use crate::array::GeometryCollectionArray;
+use crate::io::geozero::scalar::geometry_collection::process_geometry_collection;
+use crate::trait_::GeometryArrayAccessor;
+use crate::GeometryArrayTrait;
+use arrow_array::OffsetSizeTrait;
+use geozero::{GeomProcessor, GeozeroGeometry};
+
+impl<O: OffsetSizeTrait> GeozeroGeometry for GeometryCollectionArray<O> {
+    fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
+    where
+        Self: Sized,
+    {
+        let num_geometries = self.len();
+        processor.geometrycollection_begin(num_geometries, 0)?;
+
+        for geom_idx in 0..num_geometries {
+            process_geometry_collection(&self.value(geom_idx), geom_idx, processor)?;
+        }
+
+        processor.geometrycollection_end(num_geometries - 1)?;
+        Ok(())
+    }
+}

--- a/src/io/geozero/array/linestring.rs
+++ b/src/io/geozero/array/linestring.rs
@@ -30,15 +30,15 @@ pub trait ToLineStringArray<O: OffsetSizeTrait> {
     fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<O>>;
 
     /// Convert to a GeoArrow LineStringBuilder
-    fn to_mutable_line_string_array(&self) -> geozero::error::Result<LineStringBuilder<O>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<O>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToLineStringArray<O> for T {
     fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<O>> {
-        Ok(self.to_mutable_line_string_array()?.into())
+        Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_mutable_line_string_array(&self) -> geozero::error::Result<LineStringBuilder<O>> {
+    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<O>> {
         let mut mutable_array = LineStringBuilder::<O>::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)

--- a/src/io/geozero/array/mixed.rs
+++ b/src/io/geozero/array/mixed.rs
@@ -30,15 +30,15 @@ pub trait ToMixedArray<O: OffsetSizeTrait> {
     fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<O>>;
 
     /// Convert to a GeoArrow MixedArrayBuilder
-    fn to_mutable_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryBuilder<O>>;
+    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<O>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToMixedArray<O> for T {
     fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<O>> {
-        Ok(self.to_mutable_mixed_geometry_array()?.into())
+        Ok(self.to_mixed_geometry_builder()?.into())
     }
 
-    fn to_mutable_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryBuilder<O>> {
+    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<O>> {
         let mut stream_builder = MixedGeometryStreamBuilder::new();
         self.process_geom(&mut stream_builder)?;
         Ok(stream_builder.builder)

--- a/src/io/geozero/array/mixed.rs
+++ b/src/io/geozero/array/mixed.rs
@@ -1,5 +1,5 @@
 use crate::array::mixed::array::GeometryType;
-use crate::array::{MixedGeometryArray, MixedGeometryBuilder};
+use crate::array::{MixedGeometryArray, MixedGeometryBuilder, CoordType};
 use crate::io::geozero::scalar::geometry::process_geometry;
 use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
@@ -60,6 +60,17 @@ impl<O: OffsetSizeTrait> MixedGeometryStreamBuilder<O> {
             builder: MixedGeometryBuilder::<O>::new(),
             current_geom_type: GeometryType::Point,
         }
+    }
+
+    pub fn new_with_options(coord_type: CoordType) -> Self {
+        Self {
+            builder: MixedGeometryBuilder::<O>::new_with_options(coord_type),
+            current_geom_type: GeometryType::Point,
+        }
+    }
+
+    pub fn push_null(&mut self) {
+        self.builder.push_null()
     }
 
     pub fn finish(self) -> MixedGeometryArray<O> {

--- a/src/io/geozero/array/mixed.rs
+++ b/src/io/geozero/array/mixed.rs
@@ -1,5 +1,5 @@
 use crate::array::mixed::array::GeometryType;
-use crate::array::{MixedGeometryArray, MixedGeometryBuilder, CoordType};
+use crate::array::{CoordType, MixedGeometryArray, MixedGeometryBuilder};
 use crate::io::geozero::scalar::geometry::process_geometry;
 use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;

--- a/src/io/geozero/array/mod.rs
+++ b/src/io/geozero/array/mod.rs
@@ -1,3 +1,4 @@
+pub mod geometrycollection;
 pub mod linestring;
 pub mod mixed;
 pub mod multilinestring;

--- a/src/io/geozero/array/multilinestring.rs
+++ b/src/io/geozero/array/multilinestring.rs
@@ -30,15 +30,15 @@ pub trait ToMultiLineStringArray<O: OffsetSizeTrait> {
     fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<O>>;
 
     /// Convert to a GeoArrow MultiLineStringBuilder
-    fn to_mutable_line_string_array(&self) -> geozero::error::Result<MultiLineStringBuilder<O>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<O>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToMultiLineStringArray<O> for T {
     fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<O>> {
-        Ok(self.to_mutable_line_string_array()?.into())
+        Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_mutable_line_string_array(&self) -> geozero::error::Result<MultiLineStringBuilder<O>> {
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<O>> {
         let mut mutable_array = MultiLineStringBuilder::<O>::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)

--- a/src/io/geozero/array/multipoint.rs
+++ b/src/io/geozero/array/multipoint.rs
@@ -29,15 +29,15 @@ pub trait ToMultiPointArray<O: OffsetSizeTrait> {
     fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<O>>;
 
     /// Convert to a GeoArrow MultiPointBuilder
-    fn to_mutable_multi_point_array(&self) -> geozero::error::Result<MultiPointBuilder<O>>;
+    fn to_multi_point_builder(&self) -> geozero::error::Result<MultiPointBuilder<O>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToMultiPointArray<O> for T {
     fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<O>> {
-        Ok(self.to_mutable_multi_point_array()?.into())
+        Ok(self.to_multi_point_builder()?.into())
     }
 
-    fn to_mutable_multi_point_array(&self) -> geozero::error::Result<MultiPointBuilder<O>> {
+    fn to_multi_point_builder(&self) -> geozero::error::Result<MultiPointBuilder<O>> {
         let mut mutable_array = MultiPointBuilder::<O>::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)

--- a/src/io/geozero/array/multipolygon.rs
+++ b/src/io/geozero/array/multipolygon.rs
@@ -30,15 +30,15 @@ pub trait ToMultiPolygonArray<O: OffsetSizeTrait> {
     fn to_line_string_array(&self) -> geozero::error::Result<MultiPolygonArray<O>>;
 
     /// Convert to a GeoArrow MultiPolygonBuilder
-    fn to_mutable_line_string_array(&self) -> geozero::error::Result<MultiPolygonBuilder<O>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiPolygonBuilder<O>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToMultiPolygonArray<O> for T {
     fn to_line_string_array(&self) -> geozero::error::Result<MultiPolygonArray<O>> {
-        Ok(self.to_mutable_line_string_array()?.into())
+        Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_mutable_line_string_array(&self) -> geozero::error::Result<MultiPolygonBuilder<O>> {
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiPolygonBuilder<O>> {
         let mut mutable_array = MultiPolygonBuilder::<O>::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)

--- a/src/io/geozero/array/point.rs
+++ b/src/io/geozero/array/point.rs
@@ -27,15 +27,15 @@ pub trait ToPointArray {
     fn to_point_array(&self) -> geozero::error::Result<PointArray>;
 
     /// Convert to a GeoArrow PointBuilder
-    fn to_mutable_point_array(&self) -> geozero::error::Result<PointBuilder>;
+    fn to_point_builder(&self) -> geozero::error::Result<PointBuilder>;
 }
 
 impl<T: GeozeroGeometry> ToPointArray for T {
     fn to_point_array(&self) -> geozero::error::Result<PointArray> {
-        Ok(self.to_mutable_point_array()?.into())
+        Ok(self.to_point_builder()?.into())
     }
 
-    fn to_mutable_point_array(&self) -> geozero::error::Result<PointBuilder> {
+    fn to_point_builder(&self) -> geozero::error::Result<PointBuilder> {
         let mut mutable_point_array = PointBuilder::new();
         self.process_geom(&mut mutable_point_array)?;
         Ok(mutable_point_array)

--- a/src/io/geozero/array/polygon.rs
+++ b/src/io/geozero/array/polygon.rs
@@ -29,15 +29,15 @@ pub trait ToPolygonArray<O: OffsetSizeTrait> {
     fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<O>>;
 
     /// Convert to a GeoArrow PolygonBuilder
-    fn to_mutable_line_string_array(&self) -> geozero::error::Result<PolygonBuilder<O>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<PolygonBuilder<O>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToPolygonArray<O> for T {
     fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<O>> {
-        Ok(self.to_mutable_line_string_array()?.into())
+        Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_mutable_line_string_array(&self) -> geozero::error::Result<PolygonBuilder<O>> {
+    fn to_line_string_builder(&self) -> geozero::error::Result<PolygonBuilder<O>> {
         let mut mutable_array = PolygonBuilder::<O>::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)

--- a/src/io/geozero/mod.rs
+++ b/src/io/geozero/mod.rs
@@ -1,7 +1,9 @@
+pub mod api;
 pub mod array;
 pub mod scalar;
 pub mod table;
 
+pub use api::{FromEWKB, FromWKT};
 pub use array::ToLineStringArray;
 pub use array::ToMixedArray;
 pub use array::ToMultiLineStringArray;


### PR DESCRIPTION
### Change list

- Add traits for parsing WKT and EWKB to geoarrow via geozero. 
- This is relatively inefficient because it goes through `to_geo` first. In the future we should implement `GeometryCollectionStreamBuilder`


Closes https://github.com/geoarrow/geoarrow-rs/issues/251, closes https://github.com/geoarrow/geoarrow-rs/pull/254.