### PR TITLE
parse WKB when converting table from arrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "itertools 0.12.0",
  "num_enum",
  "parquet",
+ "phf",
  "proj",
  "rayon",
  "rstar",
@@ -1557,6 +1558,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1696,21 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -1843,6 +1901,12 @@ name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ geozero = { version = "0.11", features = ["with-wkb"], optional = true }
 indexmap = "2"
 itertools = "0.12"
 num_enum = "0.7"
+phf = { version = "0.11", features = ["macros"] }
 proj = { version = "0.27.2", optional = true, features = [
   "pkg_config",
   "geo-types",

--- a/python/core/Cargo.lock
+++ b/python/core/Cargo.lock
@@ -337,7 +337,9 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 
@@ -548,12 +550,14 @@ dependencies = [
  "arrow-schema",
  "bumpalo",
  "byteorder",
+ "chrono",
  "flatgeobuf",
  "geo",
  "geozero",
  "indexmap",
  "itertools 0.12.0",
  "num_enum",
+ "phf",
  "rayon",
  "rstar",
  "thiserror",
@@ -570,7 +574,6 @@ dependencies = [
  "geoarrow",
  "ndarray",
  "numpy",
- "phf",
  "pyo3",
  "thiserror",
 ]

--- a/python/core/Cargo.toml
+++ b/python/core/Cargo.toml
@@ -22,7 +22,6 @@ arrow-buffer = { git = "https://github.com/apache/arrow-rs", rev = "fbbb61d94282
 arrow = { git = "https://github.com/apache/arrow-rs", rev = "fbbb61d94282165f9bb9f73fb4d00a3af16d4aee", features = [
     "ffi",
 ] }
-phf = { version = "0.11", features = ["macros"] }
 pyo3 = { version = "0.20.0", features = [
     "abi3-py38",
     "multiple-pymethods",

--- a/python/core/python/geoarrow/rust/core/rust.pyi
+++ b/python/core/python/geoarrow/rust/core/rust.pyi
@@ -661,6 +661,7 @@ class GeoTable:
     def __len__(self) -> int: ...
     @classmethod
     def from_arrow(cls, ob: ArrowStreamExportable) -> Self: ...
+    @property
     def geometry(
         self,
     ) -> (
@@ -673,6 +674,8 @@ class GeoTable:
         | ChunkedMixedGeometryArray
         | ChunkedGeometryCollectionArray
     ): ...
+    @property
+    def num_columns(self) -> int: ...
 
 # Operations
 def area(input: ArrowArrayExportable) -> Float64Array: ...

--- a/python/core/src/table.rs
+++ b/python/core/src/table.rs
@@ -16,8 +16,27 @@ impl GeoTable {
     ///
     /// Returns:
     ///     A chunked geometry array
+    #[getter]
     pub fn geometry(&self) -> PyGeoArrowResult<PyObject> {
         let chunked_geom_arr = self.0.geometry()?;
         Python::with_gil(|py| chunked_geometry_array_to_pyobject(py, chunked_geom_arr))
+    }
+
+    /// Number of columns in this table.
+    #[getter]
+    fn num_columns(&self) -> usize {
+        self.0.num_columns()
+    }
+}
+
+impl From<geoarrow::table::GeoTable> for GeoTable {
+    fn from(value: geoarrow::table::GeoTable) -> Self {
+        Self(value)
+    }
+}
+
+impl From<GeoTable> for geoarrow::table::GeoTable {
+    fn from(value: GeoTable) -> Self {
+        value.0
     }
 }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -127,7 +127,7 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn Geom
                 }
                 _ => panic!("Unexpected data type"),
             },
-            "geoarrow.wkb" => match field.data_type() {
+            "geoarrow.wkb" | "ogc.wkb" => match field.data_type() {
                 DataType::Binary => Arc::new(WKBArray::<i32>::try_from(array).unwrap()),
                 DataType::LargeBinary => Arc::new(WKBArray::<i64>::try_from(array).unwrap()),
                 _ => panic!("Unexpected data type"),

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -217,7 +217,7 @@ impl TryFrom<&Field> for GeoDataType {
                 "geoarrow.multipolygon" => parse_multi_polygon(field),
                 "geoarrow.geometry" => parse_geometry(field),
                 "geoarrow.geometrycollection" => parse_geometry_collection(field),
-                "geoarrow.wkb" => parse_wkb(field),
+                "geoarrow.wkb" | "ogc.wkb" => parse_wkb(field),
                 name => {
                     return Err(GeoArrowError::General(format!(
                         "Unexpected extension name {}",


### PR DESCRIPTION
This works now!

```py
from geoarrow.rust.core import GeoTable
from pyogrio.raw import read_arrow
path = '/Users/kyle/github/geoarrow/geoarrow-rs/python/core/ne_10m_roads_north_america/ne_10m_roads_north_america.shp'
meta, table = read_arrow(path)

table = GeoTable.from_arrow(table)
table.geometry
# <geoarrow.rust.core.rust.ChunkedMultiLineStringArray at 0x16a160cf0>
```