### PR TITLE
fix python-core-wheels ci

### DIFF
--- a/.github/workflows/python-core-wheels.yml
+++ b/.github/workflows/python-core-wheels.yml
@@ -3,7 +3,7 @@ name: Python (Core) Wheels
 on:
   push:
     tags:
-      - "py-core-v*"
+      - "py-v*"
 
 jobs:
   linux:


### PR DESCRIPTION
was set to run on the wrong tag