### PR TITLE
GeoArrow array metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ flatgeobuf = ["dep:flatgeobuf", "geozero"]
 geos = ["dep:geos"]
 geozero = ["dep:geozero"]
 gdal = ["dep:gdal"]
-parquet = ["dep:parquet", "dep:serde", "dep:serde_json"]
+parquet = ["dep:parquet"]
 parquet_compression = [
   "parquet/snap",
   "parquet/brotli",
@@ -64,8 +64,8 @@ proj = { version = "0.27.2", optional = true, features = [
 rayon = { version = "1.8.0", optional = true }
 # Note: geo has a hard dependency on rstar, so there's no point in feature flagging it
 rstar = { version = "0.11" }
-serde = { version = "1", optional = true }
-serde_json = { version = "1", optional = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1" }
 sqlx = { version = "0.7", optional = true, default-features = false, features = [
   "chrono",
   "json",

--- a/benches/from_geo.rs
+++ b/benches/from_geo.rs
@@ -24,7 +24,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("convert Vec<geo::Polygon> to PolygonArray", |b| {
         b.iter(|| {
-            let mut_arr = PolygonBuilder::<i32>::from_polygons(&data, Default::default());
+            let mut_arr =
+                PolygonBuilder::<i32>::from_polygons(&data, Default::default(), Default::default());
             let _arr: PolygonArray<i32> = mut_arr.into();
         })
     });

--- a/benches/geos_buffer.rs
+++ b/benches/geos_buffer.rs
@@ -5,7 +5,7 @@ use geoarrow::array::{CoordBuffer, InterleavedCoordBuffer, PointArray, PolygonAr
 fn generate_data() -> PointArray {
     let coords = vec![0.0; 100_000];
     let coord_buffer = CoordBuffer::Interleaved(InterleavedCoordBuffer::new(coords.into()));
-    PointArray::new(coord_buffer, None)
+    PointArray::new(coord_buffer, None, Default::default())
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/js/src/data/mod.rs
+++ b/js/src/data/mod.rs
@@ -96,7 +96,11 @@ impl_data! {
 impl PointData {
     #[wasm_bindgen(constructor)]
     pub fn new(coords: CoordBuffer) -> Self {
-        Self(geoarrow::array::PointArray::new(coords.0, None))
+        Self(geoarrow::array::PointArray::new(
+            coords.0,
+            None,
+            Default::default(),
+        ))
     }
 }
 
@@ -108,6 +112,7 @@ impl LineStringData {
             coords.0,
             vec_to_offsets(geom_offsets),
             None,
+            Default::default(),
         ))
     }
 }
@@ -126,6 +131,7 @@ impl PolygonData {
             vec_to_offsets(geom_offsets),
             vec_to_offsets(ring_offsets),
             None,
+            Default::default(),
         ))
     }
 }
@@ -138,6 +144,7 @@ impl MultiPointData {
             coords.0,
             vec_to_offsets(geom_offsets),
             None,
+            Default::default(),
         ))
     }
 }
@@ -151,6 +158,7 @@ impl MultiLineStringData {
             vec_to_offsets(geom_offsets),
             vec_to_offsets(ring_offsets),
             None,
+            Default::default(),
         ))
     }
 }
@@ -170,6 +178,7 @@ impl MultiPolygonData {
             vec_to_offsets(polygon_offsets),
             vec_to_offsets(ring_offsets),
             None,
+            Default::default(),
         ))
     }
 }
@@ -180,7 +189,10 @@ impl WKBData {
     pub fn new(values: Vec<u8>, offsets: Vec<i32>) -> Self {
         let binary_array = BinaryArray::new(vec_to_offsets(offsets), values.into(), None);
 
-        Self(geoarrow::array::WKBArray::new(binary_array))
+        Self(geoarrow::array::WKBArray::new(
+            binary_array,
+            Default::default(),
+        ))
     }
 
     /// Convert this WKBData into a PointArray

--- a/python/core/src/io/ewkb.rs
+++ b/python/core/src/io/ewkb.rs
@@ -26,10 +26,18 @@ pub fn from_ewkb(input: &PyAny) -> PyGeoArrowResult<PyObject> {
     let array = from_arrow_array(&array, &field)?;
     let ref_array = array.as_ref();
     let geo_array: Arc<dyn GeometryArrayTrait> = match array.data_type() {
-        GeoDataType::WKB => FromEWKB::from_ewkb(ref_array.as_wkb(), CoordType::Interleaved, false)?,
-        GeoDataType::LargeWKB => {
-            FromEWKB::from_ewkb(ref_array.as_large_wkb(), CoordType::Interleaved, false)?
-        }
+        GeoDataType::WKB => FromEWKB::from_ewkb(
+            ref_array.as_wkb(),
+            CoordType::Interleaved,
+            Default::default(),
+            false,
+        )?,
+        GeoDataType::LargeWKB => FromEWKB::from_ewkb(
+            ref_array.as_large_wkb(),
+            CoordType::Interleaved,
+            Default::default(),
+            false,
+        )?,
         other => {
             return Err(PyTypeError::new_err(format!("Unexpected array type {:?}", other)).into())
         }
@@ -57,12 +65,14 @@ macro_rules! impl_from_ewkb {
                     GeoDataType::WKB => Ok(<$geoarrow_array>::from_ewkb(
                         ref_array.as_wkb(),
                         CoordType::Interleaved,
+                        Default::default(),
                         false,
                     )?
                     .into()),
                     GeoDataType::LargeWKB => Ok(<$geoarrow_array>::from_ewkb(
                         ref_array.as_large_wkb(),
                         CoordType::Interleaved,
+                        Default::default(),
                         false,
                     )?
                     .into()),

--- a/python/core/src/io/wkt.rs
+++ b/python/core/src/io/wkt.rs
@@ -25,12 +25,18 @@ use crate::ffi::to_python::geometry_array_to_pyobject;
 pub fn from_wkt(input: &PyAny) -> PyGeoArrowResult<PyObject> {
     let (array, _field) = import_arrow_c_array(input)?;
     let geo_array: Arc<dyn GeometryArrayTrait> = match array.data_type() {
-        DataType::Utf8 => {
-            FromWKT::from_wkt(array.as_string::<i32>(), CoordType::Interleaved, false)?
-        }
-        DataType::LargeUtf8 => {
-            FromWKT::from_wkt(array.as_string::<i64>(), CoordType::Interleaved, false)?
-        }
+        DataType::Utf8 => FromWKT::from_wkt(
+            array.as_string::<i32>(),
+            CoordType::Interleaved,
+            Default::default(),
+            false,
+        )?,
+        DataType::LargeUtf8 => FromWKT::from_wkt(
+            array.as_string::<i64>(),
+            CoordType::Interleaved,
+            Default::default(),
+            false,
+        )?,
         other => {
             return Err(PyTypeError::new_err(format!("Unexpected array type {:?}", other)).into())
         }
@@ -56,12 +62,14 @@ macro_rules! impl_from_wkt {
                     DataType::Utf8 => Ok(<$geoarrow_array>::from_wkt(
                         array.as_string::<i32>(),
                         CoordType::Interleaved,
+                        Default::default(),
                         false,
                     )?
                     .into()),
                     DataType::LargeUtf8 => Ok(<$geoarrow_array>::from_wkt(
                         array.as_string::<i64>(),
                         CoordType::Interleaved,
+                        Default::default(),
                         false,
                     )?
                     .into()),

--- a/src/algorithm/native/cast.rs
+++ b/src/algorithm/native/cast.rs
@@ -62,16 +62,22 @@ impl Cast for PointArray {
         use GeoDataType::*;
         match to_type {
             Point(ct) => {
-                let mut builder =
-                    PointBuilder::with_capacity_and_options(self.buffer_lengths(), *ct);
+                let mut builder = PointBuilder::with_capacity_and_options(
+                    self.buffer_lengths(),
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter().for_each(|x| builder.push_point(x.as_ref()));
                 Ok(Arc::new(builder.finish()))
             }
             MultiPoint(ct) => {
                 let capacity =
                     MultiPointCapacity::new(self.buffer_lengths(), self.buffer_lengths());
-                let mut builder =
-                    MultiPointBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_point(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -79,8 +85,11 @@ impl Cast for PointArray {
             LargeMultiPoint(ct) => {
                 let capacity =
                     MultiPointCapacity::new(self.buffer_lengths(), self.buffer_lengths());
-                let mut builder =
-                    MultiPointBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_point(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -90,8 +99,11 @@ impl Cast for PointArray {
                     point: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter().for_each(|x| builder.push_point(x.as_ref()));
                 Ok(Arc::new(builder.finish()))
             }
@@ -100,8 +112,11 @@ impl Cast for PointArray {
                     point: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter().for_each(|x| builder.push_point(x.as_ref()));
                 Ok(Arc::new(builder.finish()))
             }
@@ -112,8 +127,11 @@ impl Cast for PointArray {
                 };
                 let capacity =
                     GeometryCollectionCapacity::new(mixed_capacity, self.buffer_lengths());
-                let mut builder =
-                    GeometryCollectionBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_point(x.as_ref(), false))?;
                 Ok(Arc::new(builder.finish()))
@@ -125,8 +143,11 @@ impl Cast for PointArray {
                 };
                 let capacity =
                     GeometryCollectionCapacity::new(mixed_capacity, self.buffer_lengths());
-                let mut builder =
-                    GeometryCollectionBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_point(x.as_ref(), false))?;
                 Ok(Arc::new(builder.finish()))
@@ -144,15 +165,21 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
         use GeoDataType::*;
         match to_type {
             LineString(ct) => {
-                let mut builder =
-                    LineStringBuilder::<i32>::with_capacity_and_options(self.buffer_lengths(), *ct);
+                let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
+                    self.buffer_lengths(),
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
             }
             LargeLineString(ct) => {
-                let mut builder =
-                    LineStringBuilder::<i64>::with_capacity_and_options(self.buffer_lengths(), *ct);
+                let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
+                    self.buffer_lengths(),
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -160,8 +187,11 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
             MultiLineString(ct) => {
                 let mut capacity = MultiLineStringCapacity::new_empty();
                 capacity += self.buffer_lengths();
-                let mut builder =
-                    MultiLineStringBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiLineStringBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -169,8 +199,11 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
             LargeMultiLineString(ct) => {
                 let mut capacity = MultiLineStringCapacity::new_empty();
                 capacity += self.buffer_lengths();
-                let mut builder =
-                    MultiLineStringBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiLineStringBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -180,8 +213,11 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
                     line_string: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -191,8 +227,11 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
                     line_string: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -203,8 +242,11 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_line_string(x.as_ref(), false))?;
                 Ok(Arc::new(builder.finish()))
@@ -215,8 +257,11 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_line_string(x.as_ref(), false))?;
                 Ok(Arc::new(builder.finish()))
@@ -234,15 +279,21 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
         use GeoDataType::*;
         match to_type {
             Polygon(ct) => {
-                let mut builder =
-                    PolygonBuilder::<i32>::with_capacity_and_options(self.buffer_lengths(), *ct);
+                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
+                    self.buffer_lengths(),
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
             }
             LargePolygon(ct) => {
-                let mut builder =
-                    PolygonBuilder::<i64>::with_capacity_and_options(self.buffer_lengths(), *ct);
+                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
+                    self.buffer_lengths(),
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -250,8 +301,11 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
             MultiPolygon(ct) => {
                 let mut capacity = MultiPolygonCapacity::new_empty();
                 capacity += self.buffer_lengths();
-                let mut builder =
-                    MultiPolygonBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPolygonBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -259,8 +313,11 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
             LargeMultiPolygon(ct) => {
                 let mut capacity = MultiPolygonCapacity::new_empty();
                 capacity += self.buffer_lengths();
-                let mut builder =
-                    MultiPolygonBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPolygonBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -270,8 +327,11 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
                     polygon: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -281,8 +341,11 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
                     polygon: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -293,8 +356,11 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_polygon(x.as_ref(), false))?;
                 Ok(Arc::new(builder.finish()))
@@ -305,8 +371,11 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_polygon(x.as_ref(), false))?;
                 Ok(Arc::new(builder.finish()))
@@ -328,23 +397,30 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O> {
                     return Err(GeoArrowError::General("Unable to cast".to_string()));
                 }
 
-                let mut builder = PointBuilder::with_capacity_and_options(self.len(), *ct);
+                let mut builder =
+                    PointBuilder::with_capacity_and_options(self.len(), *ct, self.metadata());
                 self.iter()
                     .for_each(|x| builder.push_point(x.map(|mp| mp.point(0).unwrap()).as_ref()));
                 Ok(Arc::new(builder.finish()))
             }
             MultiPoint(ct) => {
                 let capacity = self.buffer_lengths();
-                let mut builder =
-                    MultiPointBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_point(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
             }
             LargeMultiPoint(ct) => {
                 let capacity = self.buffer_lengths();
-                let mut builder =
-                    MultiPointBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_point(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -354,8 +430,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O> {
                     multi_point: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_point(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -365,8 +444,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O> {
                     multi_point: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_point(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -377,8 +459,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_point(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -389,8 +474,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_point(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -417,8 +505,11 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O> {
                     coord_capacity: existing_capacity.coord_capacity,
                     geom_capacity: existing_capacity.ring_capacity,
                 };
-                let mut builder =
-                    LineStringBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter().try_for_each(|x| {
                     builder.push_line_string(x.map(|mp| mp.line(0).unwrap()).as_ref())
                 })?;
@@ -434,8 +525,11 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O> {
                     coord_capacity: existing_capacity.coord_capacity,
                     geom_capacity: existing_capacity.ring_capacity,
                 };
-                let mut builder =
-                    LineStringBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter().try_for_each(|x| {
                     builder.push_line_string(x.map(|mp| mp.line(0).unwrap()).as_ref())
                 })?;
@@ -446,8 +540,11 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O> {
                     multi_line_string: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -457,8 +554,11 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O> {
                     multi_line_string: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -469,8 +569,11 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -481,8 +584,11 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_line_string(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -510,7 +616,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O> {
                     ring_capacity: existing_capacity.ring_capacity,
                     geom_capacity: existing_capacity.polygon_capacity,
                 };
-                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter().try_for_each(|x| {
                     builder.push_polygon(x.map(|mp| mp.polygon(0).unwrap()).as_ref())
                 })?;
@@ -527,7 +637,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O> {
                     ring_capacity: existing_capacity.ring_capacity,
                     geom_capacity: existing_capacity.polygon_capacity,
                 };
-                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter().try_for_each(|x| {
                     builder.push_polygon(x.map(|mp| mp.polygon(0).unwrap()).as_ref())
                 })?;
@@ -538,8 +652,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O> {
                     multi_polygon: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -549,8 +666,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O> {
                     multi_polygon: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder =
-                    MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -561,8 +681,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -573,8 +696,11 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_multi_polygon(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -601,7 +727,8 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     return Err(GeoArrowError::General("".to_string()));
                 }
 
-                let mut builder = PointBuilder::with_capacity_and_options(self.len(), *ct);
+                let mut builder =
+                    PointBuilder::with_capacity_and_options(self.len(), *ct, self.metadata());
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -631,8 +758,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity.geom_capacity += buffer_lengths.ring_capacity;
                 }
 
-                let mut builder =
-                    LineStringBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -662,8 +792,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity.geom_capacity += buffer_lengths.ring_capacity;
                 }
 
-                let mut builder =
-                    LineStringBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -694,7 +827,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity.geom_capacity += buffer_lengths.polygon_capacity;
                 }
 
-                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -725,7 +862,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity.geom_capacity += buffer_lengths.polygon_capacity;
                 }
 
-                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -750,8 +891,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity.geom_capacity += points.buffer_lengths();
                 }
 
-                let mut builder =
-                    MultiPointBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -776,8 +920,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity.geom_capacity += points.buffer_lengths();
                 }
 
-                let mut builder =
-                    MultiPointBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -800,8 +947,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity += line_strings.buffer_lengths();
                 }
 
-                let mut builder =
-                    MultiLineStringBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiLineStringBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -824,8 +974,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity += line_strings.buffer_lengths();
                 }
 
-                let mut builder =
-                    MultiLineStringBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiLineStringBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -848,8 +1001,11 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity += polygons.buffer_lengths();
                 }
 
-                let mut builder =
-                    MultiPolygonBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPolygonBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
@@ -872,40 +1028,55 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
                     capacity += polygons.buffer_lengths();
                 }
 
-                let mut builder =
-                    MultiPolygonBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MultiPolygonBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
             }
             Mixed(ct) => {
                 let capacity = self.buffer_lengths();
-                let mut builder =
-                    MixedGeometryBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
             }
             LargeMixed(ct) => {
                 let capacity = self.buffer_lengths();
-                let mut builder =
-                    MixedGeometryBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))
             }
             GeometryCollection(ct) => {
                 let capacity = GeometryCollectionCapacity::new(self.buffer_lengths(), self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i32>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref(), false))?;
                 Ok(Arc::new(builder.finish()))
             }
             LargeGeometryCollection(ct) => {
                 let capacity = GeometryCollectionCapacity::new(self.buffer_lengths(), self.len());
-                let mut builder =
-                    GeometryCollectionBuilder::<i64>::with_capacity_and_options(capacity, *ct);
+                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                    capacity,
+                    *ct,
+                    self.metadata(),
+                );
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref(), false))?;
                 Ok(Arc::new(builder.finish()))

--- a/src/algorithm/native/downcast.rs
+++ b/src/algorithm/native/downcast.rs
@@ -167,7 +167,11 @@ impl<O: OffsetSizeTrait> Downcast for MultiPointArray<O> {
     fn downcast(&self, small_offsets: bool) -> Self::Output {
         // Note: this won't allow a downcast for empty MultiPoints
         if self.geom_offsets.last().to_usize().unwrap() == self.len() {
-            return Arc::new(PointArray::new(self.coords.clone(), self.validity.clone()));
+            return Arc::new(PointArray::new(
+                self.coords.clone(),
+                self.validity.clone(),
+                self.metadata(),
+            ));
         }
 
         Arc::new(self.clone())
@@ -207,6 +211,7 @@ impl<O: OffsetSizeTrait> Downcast for MultiLineStringArray<O> {
                 self.coords.clone(),
                 self.ring_offsets.clone(),
                 self.validity.clone(),
+                self.metadata(),
             ));
         }
 
@@ -248,6 +253,7 @@ impl<O: OffsetSizeTrait> Downcast for MultiPolygonArray<O> {
                 self.polygon_offsets.clone(),
                 self.ring_offsets.clone(),
                 self.validity.clone(),
+                self.metadata(),
             ));
         }
 

--- a/src/algorithm/native/take.rs
+++ b/src/algorithm/native/take.rs
@@ -23,7 +23,11 @@ impl Take for PointArray {
     type Output = Self;
 
     fn take(&self, indices: &UInt32Array) -> Self::Output {
-        let mut builder = PointBuilder::with_capacity_and_options(indices.len(), self.coord_type());
+        let mut builder = PointBuilder::with_capacity_and_options(
+            indices.len(),
+            self.coord_type(),
+            self.metadata(),
+        );
         for index in indices.iter() {
             if let Some(index) = index {
                 builder.push_point(self.get(index.as_usize()).as_ref())
@@ -36,8 +40,11 @@ impl Take for PointArray {
     }
 
     fn take_range(&self, range: &Range<usize>) -> Self::Output {
-        let mut builder =
-            PointBuilder::with_capacity_and_options(range.end - range.start, self.coord_type());
+        let mut builder = PointBuilder::with_capacity_and_options(
+            range.end - range.start,
+            self.coord_type(),
+            self.metadata(),
+        );
         for i in range.start..range.end {
             builder.push_point(self.get(i).as_ref());
         }
@@ -59,8 +66,11 @@ macro_rules! take_impl {
                     capacity.$capacity_add_func(self.get(index.as_usize()).as_ref());
                 }
 
-                let mut builder =
-                    <$builder_type>::with_capacity_and_options(capacity, self.coord_type());
+                let mut builder = <$builder_type>::with_capacity_and_options(
+                    capacity,
+                    self.coord_type(),
+                    self.metadata(),
+                );
 
                 for index in indices.iter() {
                     if let Some(index) = index {
@@ -80,8 +90,11 @@ macro_rules! take_impl {
                     capacity.$capacity_add_func(self.get(i).as_ref());
                 }
 
-                let mut builder =
-                    <$builder_type>::with_capacity_and_options(capacity, self.coord_type());
+                let mut builder = <$builder_type>::with_capacity_and_options(
+                    capacity,
+                    self.coord_type(),
+                    self.metadata(),
+                );
 
                 for i in range.start..range.end {
                     builder.$push_func(self.get(i).as_ref())?;
@@ -141,8 +154,11 @@ macro_rules! take_impl_fallible {
                     capacity.$capacity_add_func(self.get(index.as_usize()).as_ref())?;
                 }
 
-                let mut builder =
-                    <$builder_type>::with_capacity_and_options(capacity, self.coord_type());
+                let mut builder = <$builder_type>::with_capacity_and_options(
+                    capacity,
+                    self.coord_type(),
+                    self.metadata(),
+                );
 
                 for index in indices.iter() {
                     if let Some(index) = index {
@@ -162,8 +178,11 @@ macro_rules! take_impl_fallible {
                     capacity.$capacity_add_func(self.get(i).as_ref())?;
                 }
 
-                let mut builder =
-                    <$builder_type>::with_capacity_and_options(capacity, self.coord_type());
+                let mut builder = <$builder_type>::with_capacity_and_options(
+                    capacity,
+                    self.coord_type(),
+                    self.metadata(),
+                );
 
                 for i in range.start..range.end {
                     builder.$push_func(self.get(i).as_ref())?;

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::array::binary::WKBCapacity;
+use crate::array::metadata::ArrayMetadata;
 use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 use crate::array::zip_validity::ZipValidity;
 use crate::array::{CoordType, WKBBuilder};
@@ -28,19 +29,26 @@ use arrow_schema::{DataType, Field};
 /// serialization purposes (e.g. to and from [GeoParquet](https://geoparquet.org/)) but convert to
 /// strongly-typed arrays (such as the [`PointArray`][crate::array::PointArray]) for computations.
 #[derive(Debug, Clone, PartialEq)]
-// TODO: convert to named struct
-pub struct WKBArray<O: OffsetSizeTrait>(GenericBinaryArray<O>, GeoDataType);
+pub struct WKBArray<O: OffsetSizeTrait> {
+    pub(crate) data_type: GeoDataType,
+    pub(crate) metadata: Arc<ArrayMetadata>,
+    pub(crate) array: GenericBinaryArray<O>,
+}
 
 // Implement geometry accessors
 impl<O: OffsetSizeTrait> WKBArray<O> {
     /// Create a new WKBArray from a BinaryArray
-    pub fn new(arr: GenericBinaryArray<O>) -> Self {
+    pub fn new(array: GenericBinaryArray<O>, metadata: Arc<ArrayMetadata>) -> Self {
         let data_type = match O::IS_LARGE {
             true => GeoDataType::LargeWKB,
             false => GeoDataType::WKB,
         };
 
-        Self(arr, data_type)
+        Self {
+            data_type,
+            metadata,
+            array,
+        }
     }
 
     /// Returns true if the array is empty
@@ -58,12 +66,12 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
     }
 
     // pub fn with_validity(&self, validity: Option<NullBuffer>) -> Self {
-    //     WKBArray::new(self.0.clone().with_validity(validity))
+    //     WKBArray::new(self.array.clone().with_validity(validity))
     // }
 
     pub fn buffer_lengths(&self) -> WKBCapacity {
         WKBCapacity::new(
-            self.0.offsets().last().unwrap().to_usize().unwrap(),
+            self.array.offsets().last().unwrap().to_usize().unwrap(),
             self.len(),
         )
     }
@@ -74,7 +82,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
     }
 
     pub fn into_inner(self) -> GenericBinaryArray<O> {
-        self.0
+        self.array
     }
 }
 
@@ -84,18 +92,22 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for WKBArray<O> {
     }
 
     fn data_type(&self) -> &GeoDataType {
-        &self.1
+        &self.data_type
     }
 
     fn storage_type(&self) -> DataType {
-        self.0.data_type().clone()
+        self.array.data_type().clone()
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        let mut metadata = HashMap::new();
+        let mut metadata = HashMap::with_capacity(2);
         metadata.insert(
             "ARROW:extension:name".to_string(),
             self.extension_name().to_string(),
+        );
+        metadata.insert(
+            "ARROW:extension:metadata".to_string(),
+            serde_json::to_string(self.metadata.as_ref()).unwrap(),
         );
         Arc::new(Field::new("geometry", self.storage_type(), true).with_metadata(metadata))
     }
@@ -117,15 +129,19 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for WKBArray<O> {
         CoordType::Interleaved
     }
 
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
+    }
+
     /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
-        self.0.len()
+        self.array.len()
     }
 
     /// Returns the optional validity.
     fn validity(&self) -> Option<&NullBuffer> {
-        self.0.nulls()
+        self.array.nulls()
     }
 
     fn as_ref(&self) -> &dyn GeometryArrayTrait {
@@ -151,7 +167,11 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for WKBArray<O> {
             offset + length <= self.len(),
             "offset + length may not exceed length of array"
         );
-        Self(self.0.slice(offset, length), self.1)
+        Self {
+            array: self.array.slice(offset, length),
+            data_type: self.data_type,
+            metadata: self.metadata(),
+        }
     }
 
     fn owned_slice(&self, _offset: usize, _length: usize) -> Self {
@@ -163,14 +183,14 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for WKBArray<O> {
         // assert!(length >= 1, "length must be at least 1");
 
         // // Find the start and end of the ring offsets
-        // let (start_idx, _) = self.0.offsets().start_end(offset);
-        // let (_, end_idx) = self.0.offsets().start_end(offset + length - 1);
+        // let (start_idx, _) = self.array.offsets().start_end(offset);
+        // let (_, end_idx) = self.array.offsets().start_end(offset + length - 1);
 
-        // let new_offsets = owned_slice_offsets(self.0.offsets(), offset, length);
+        // let new_offsets = owned_slice_offsets(self.array.offsets(), offset, length);
 
-        // let mut values = self.0.slice(start_idx, end_idx - start_idx);
+        // let mut values = self.array.slice(start_idx, end_idx - start_idx);
 
-        // let validity = owned_slice_validity(self.0.nulls(), offset, length);
+        // let validity = owned_slice_validity(self.array.nulls(), offset, length);
 
         // Self::new(GenericBinaryArray::new(
         //     new_offsets,
@@ -185,7 +205,7 @@ impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for WKBArray<O> {
     type ItemGeo = geo::Geometry;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        WKB::new_borrowed(&self.0, index)
+        WKB::new_borrowed(&self.array, index)
     }
 }
 
@@ -194,9 +214,9 @@ impl<O: OffsetSizeTrait> IntoArrow for WKBArray<O> {
 
     fn into_arrow(self) -> Self::ArrowArray {
         GenericBinaryArray::new(
-            self.0.offsets().clone(),
-            self.0.values().clone(),
-            self.0.nulls().cloned(),
+            self.array.offsets().clone(),
+            self.array.values().clone(),
+            self.array.nulls().cloned(),
         )
     }
 }
@@ -205,7 +225,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
     /// Returns the value at slot `i` as a GEOS geometry.
     #[cfg(feature = "geos")]
     pub fn value_as_geos(&self, i: usize) -> geos::Geometry {
-        let buf = self.0.value(i);
+        let buf = self.array.value(i);
         geos::Geometry::new_from_wkb(buf).expect("Unable to parse WKB")
     }
 
@@ -216,7 +236,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
             return None;
         }
 
-        let buf = self.0.value(i);
+        let buf = self.array.value(i);
         Some(geos::Geometry::new_from_wkb(buf).expect("Unable to parse WKB"))
     }
 
@@ -249,7 +269,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
 
 impl<O: OffsetSizeTrait> From<GenericBinaryArray<O>> for WKBArray<O> {
     fn from(value: GenericBinaryArray<O>) -> Self {
-        Self::new(value)
+        Self::new(value, Default::default())
     }
 }
 
@@ -297,13 +317,12 @@ impl TryFrom<&dyn Array> for WKBArray<i64> {
 
 impl From<WKBArray<i32>> for WKBArray<i64> {
     fn from(value: WKBArray<i32>) -> Self {
-        let binary_array = value.0;
+        let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
-        Self::new(LargeBinaryArray::new(
-            offsets_buffer_i32_to_i64(&offsets),
-            values,
-            nulls,
-        ))
+        Self::new(
+            LargeBinaryArray::new(offsets_buffer_i32_to_i64(&offsets), values, nulls),
+            value.metadata,
+        )
     }
 }
 
@@ -311,13 +330,12 @@ impl TryFrom<WKBArray<i64>> for WKBArray<i32> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<i64>) -> Result<Self> {
-        let binary_array = value.0;
+        let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
-        Ok(Self::new(BinaryArray::new(
-            offsets_buffer_i64_to_i32(&offsets)?,
-            values,
-            nulls,
-        )))
+        Ok(Self::new(
+            BinaryArray::new(offsets_buffer_i64_to_i32(&offsets)?, values, nulls),
+            value.metadata,
+        ))
     }
 }
 

--- a/src/array/coord/combined/array.rs
+++ b/src/array/coord/combined/array.rs
@@ -67,6 +67,10 @@ impl GeometryArrayTrait for CoordBuffer {
         panic!("Coordinate arrays do not have an extension name.")
     }
 
+    fn metadata(&self) -> Arc<crate::array::metadata::ArrayMetadata> {
+        panic!()
+    }
+
     fn into_array_ref(self) -> Arc<dyn Array> {
         self.into_arrow()
     }

--- a/src/array/coord/interleaved/array.rs
+++ b/src/array/coord/interleaved/array.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use std::sync::Arc;
 
 use crate::array::{CoordType, InterleavedCoordBufferBuilder};
@@ -75,6 +76,10 @@ impl GeometryArrayTrait for InterleavedCoordBuffer {
 
     fn extension_name(&self) -> &str {
         panic!("Coordinate arrays do not have an extension name.")
+    }
+
+    fn metadata(&self) -> Arc<crate::array::metadata::ArrayMetadata> {
+        panic!()
     }
 
     fn into_array_ref(self) -> Arc<dyn Array> {

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -97,6 +97,10 @@ impl GeometryArrayTrait for SeparatedCoordBuffer {
         CoordType::Separated
     }
 
+    fn metadata(&self) -> Arc<crate::array::metadata::ArrayMetadata> {
+        panic!()
+    }
+
     fn len(&self) -> usize {
         self.x.len()
     }

--- a/src/array/geometry/array.rs
+++ b/src/array/geometry/array.rs
@@ -83,6 +83,10 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for GeometryArray<O> {
         }
     }
 
+    fn metadata(&self) -> Arc<crate::array::metadata::ArrayMetadata> {
+        todo!()
+    }
+
     fn extension_name(&self) -> &str {
         match self {
             GeometryArray::Point(arr) => arr.extension_name(),

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -8,6 +8,7 @@ use arrow_schema::{DataType, Field};
 
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::geometrycollection::{GeometryCollectionBuilder, GeometryCollectionCapacity};
+use crate::array::metadata::ArrayMetadata;
 use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 use crate::array::zip_validity::ZipValidity;
 use crate::array::{CoordBuffer, CoordType, MixedGeometryArray, WKBArray};
@@ -26,6 +27,8 @@ use crate::GeometryArrayTrait;
 pub struct GeometryCollectionArray<O: OffsetSizeTrait> {
     // Always GeoDataType::GeometryCollection or GeoDataType::LargeGeometryCollection
     data_type: GeoDataType,
+
+    metadata: Arc<ArrayMetadata>,
 
     pub(crate) array: MixedGeometryArray<O>,
 
@@ -46,6 +49,7 @@ impl<O: OffsetSizeTrait> GeometryCollectionArray<O> {
         array: MixedGeometryArray<O>,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let coord_type = array.coord_type();
         let data_type = match O::IS_LARGE {
@@ -58,6 +62,7 @@ impl<O: OffsetSizeTrait> GeometryCollectionArray<O> {
             array,
             geom_offsets,
             validity,
+            metadata,
         }
     }
 
@@ -100,10 +105,14 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for GeometryCollectionArray<O> {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        let mut metadata = HashMap::new();
+        let mut metadata = HashMap::with_capacity(2);
         metadata.insert(
             "ARROW:extension:name".to_string(),
             self.extension_name().to_string(),
+        );
+        metadata.insert(
+            "ARROW:extension:metadata".to_string(),
+            serde_json::to_string(self.metadata.as_ref()).unwrap(),
         );
         Arc::new(Field::new("geometry", self.storage_type(), true).with_metadata(metadata))
     }
@@ -121,7 +130,11 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for GeometryCollectionArray<O> {
     }
 
     fn coord_type(&self) -> CoordType {
-        todo!()
+        self.array.coord_type()
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
     }
 
     /// Returns the number of geometries in this array
@@ -181,6 +194,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for GeometryCollectionArray<O>
             array: self.array.clone(),
             geom_offsets: self.geom_offsets.slice(offset, length),
             validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
+            metadata: self.metadata(),
         }
     }
 
@@ -270,7 +284,12 @@ impl TryFrom<&GenericListArray<i32>> for GeometryCollectionArray<i32> {
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
-        Ok(Self::new(geoms, geom_offsets.clone(), validity.cloned()))
+        Ok(Self::new(
+            geoms,
+            geom_offsets.clone(),
+            validity.cloned(),
+            Default::default(),
+        ))
     }
 }
 
@@ -282,7 +301,12 @@ impl TryFrom<&GenericListArray<i64>> for GeometryCollectionArray<i64> {
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
-        Ok(Self::new(geoms, geom_offsets.clone(), validity.cloned()))
+        Ok(Self::new(
+            geoms,
+            geom_offsets.clone(),
+            validity.cloned(),
+            Default::default(),
+        ))
     }
 }
 
@@ -363,6 +387,7 @@ impl From<GeometryCollectionArray<i32>> for GeometryCollectionArray<i64> {
             value.array.into(),
             offsets_buffer_i32_to_i64(&value.geom_offsets),
             value.validity,
+            value.metadata,
         )
     }
 }
@@ -375,6 +400,7 @@ impl TryFrom<GeometryCollectionArray<i64>> for GeometryCollectionArray<i32> {
             value.array.try_into()?,
             offsets_buffer_i64_to_i32(&value.geom_offsets)?,
             value.validity,
+            value.metadata,
         ))
     }
 }

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -4,6 +4,7 @@ use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::NullBufferBuilder;
 
 use crate::array::geometrycollection::GeometryCollectionCapacity;
+use crate::array::metadata::ArrayMetadata;
 use crate::array::offset_builder::OffsetsBuilder;
 use crate::array::{CoordType, GeometryCollectionArray, MixedGeometryBuilder, WKBArray};
 use crate::error::{GeoArrowError, Result};
@@ -17,6 +18,8 @@ use crate::trait_::{GeometryArrayBuilder, IntoArrow};
 
 #[derive(Debug)]
 pub struct GeometryCollectionBuilder<O: OffsetSizeTrait> {
+    metadata: Arc<ArrayMetadata>,
+
     pub(crate) geoms: MixedGeometryBuilder<O>,
 
     pub(crate) geom_offsets: OffsetsBuilder<O>,
@@ -27,43 +30,50 @@ pub struct GeometryCollectionBuilder<O: OffsetSizeTrait> {
 impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
     /// Creates a new empty [`GeometryCollectionBuilder`].
     pub fn new() -> Self {
-        Self::new_with_options(Default::default())
+        Self::new_with_options(Default::default(), Default::default())
     }
 
-    pub fn new_with_options(coord_type: CoordType) -> Self {
-        Self::with_capacity_and_options(Default::default(), coord_type)
+    pub fn new_with_options(coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+        Self::with_capacity_and_options(Default::default(), coord_type, metadata)
     }
 
     pub fn with_capacity(capacity: GeometryCollectionCapacity) -> Self {
-        Self::with_capacity_and_options(capacity, Default::default())
+        Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
     pub fn with_capacity_and_options(
         capacity: GeometryCollectionCapacity,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
+        // Should we be storing array metadata on child arrays?
         Self {
             geoms: MixedGeometryBuilder::with_capacity_and_options(
                 capacity.mixed_capacity,
                 coord_type,
+                metadata.clone(),
             ),
             geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity),
             validity: NullBufferBuilder::new(capacity.geom_capacity),
+            metadata,
         }
     }
 
     pub fn with_capacity_from_iter(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
     ) -> Result<Self> {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default())
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
     pub fn with_capacity_and_options_from_iter(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
-        Ok(Self::with_capacity_and_options(counter, coord_type))
+        Ok(Self::with_capacity_and_options(
+            counter, coord_type, metadata,
+        ))
     }
 
     pub fn reserve_from_iter(
@@ -313,11 +323,13 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
     pub fn from_geometry_collections(
         geoms: &[impl GeometryCollectionTrait<T = f64>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(Some),
             coord_type.unwrap_or_default(),
+            metadata,
         )?;
         array.extend_from_iter(geoms.iter().map(Some), prefer_multi);
         Ok(array)
@@ -326,11 +338,13 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
     pub fn from_nullable_geometry_collections(
         geoms: &[Option<impl GeometryCollectionTrait<T = f64>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(|x| x.as_ref()),
             coord_type.unwrap_or_default(),
+            metadata,
         )?;
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()), prefer_multi);
         Ok(array)
@@ -339,10 +353,12 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
     pub fn from_geometries(
         geoms: &[impl GeometryTrait<T = f64>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
         let capacity = GeometryCollectionCapacity::from_geometries(geoms.iter().map(Some))?;
-        let mut array = Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default());
+        let mut array =
+            Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default(), metadata);
         for geom in geoms {
             array.push_geometry(Some(geom), prefer_multi)?;
         }
@@ -352,11 +368,13 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
         let capacity =
             GeometryCollectionCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
-        let mut array = Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default());
+        let mut array =
+            Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default(), metadata);
         for geom in geoms {
             array.push_geometry(geom.as_ref(), prefer_multi)?;
         }
@@ -366,13 +384,14 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
     pub fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
         let wkb_objects2: Vec<Option<WKBGeometry>> = wkb_objects
             .iter()
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
             .collect();
-        Self::from_nullable_geometries(&wkb_objects2, coord_type, prefer_multi)
+        Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata, prefer_multi)
     }
 
     pub fn finish(self) -> GeometryCollectionArray<O> {
@@ -385,9 +404,13 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for GeometryCollectionBuilder<O> {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType) -> Self {
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let capacity = GeometryCollectionCapacity::new(Default::default(), geom_capacity);
-        Self::with_capacity_and_options(capacity, coord_type)
+        Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
     fn finish(self) -> Arc<dyn crate::GeometryArrayTrait> {
@@ -409,6 +432,14 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for GeometryCollectionBuilder<O> {
     fn coord_type(&self) -> CoordType {
         self.geoms.coord_type()
     }
+
+    fn set_metadata(&mut self, metadata: Arc<ArrayMetadata>) {
+        self.metadata = metadata;
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
+    }
 }
 
 impl<O: OffsetSizeTrait> IntoArrow for GeometryCollectionBuilder<O> {
@@ -429,7 +460,12 @@ impl<O: OffsetSizeTrait> Default for GeometryCollectionBuilder<O> {
 impl<O: OffsetSizeTrait> From<GeometryCollectionBuilder<O>> for GeometryCollectionArray<O> {
     fn from(other: GeometryCollectionBuilder<O>) -> Self {
         let validity = other.validity.finish_cloned();
-        Self::new(other.geoms.into(), other.geom_offsets.into(), validity)
+        Self::new(
+            other.geoms.into(),
+            other.geom_offsets.into(),
+            validity,
+            other.metadata,
+        )
     }
 }
 
@@ -443,7 +479,8 @@ impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<&[G]>
     for GeometryCollectionBuilder<O>
 {
     fn from(geoms: &[G]) -> Self {
-        Self::from_geometry_collections(geoms, Default::default(), true).unwrap()
+        Self::from_geometry_collections(geoms, Default::default(), Default::default(), true)
+            .unwrap()
     }
 }
 
@@ -451,7 +488,13 @@ impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<Vec<Option<G>
     for GeometryCollectionBuilder<O>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
-        Self::from_nullable_geometry_collections(&geoms, Default::default(), true).unwrap()
+        Self::from_nullable_geometry_collections(
+            &geoms,
+            Default::default(),
+            Default::default(),
+            true,
+        )
+        .unwrap()
     }
 }
 
@@ -459,7 +502,8 @@ impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<bumpalo::coll
     for GeometryCollectionBuilder<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_geometry_collections(&geoms, Default::default(), true).unwrap()
+        Self::from_geometry_collections(&geoms, Default::default(), Default::default(), true)
+            .unwrap()
     }
 }
 
@@ -467,7 +511,13 @@ impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>>
     From<bumpalo::collections::Vec<'_, Option<G>>> for GeometryCollectionBuilder<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_geometry_collections(&geoms, Default::default(), true).unwrap()
+        Self::from_nullable_geometry_collections(
+            &geoms,
+            Default::default(),
+            Default::default(),
+            true,
+        )
+        .unwrap()
     }
 }
 
@@ -475,7 +525,8 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for GeometryCollectionBuilder<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
+        let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, Default::default(), true)
+        Self::from_wkb(&wkb_objects, Default::default(), metadata, true)
     }
 }

--- a/src/array/linestring/builder.rs
+++ b/src/array/linestring/builder.rs
@@ -1,4 +1,5 @@
 use crate::array::linestring::capacity::LineStringCapacity;
+use crate::array::metadata::ArrayMetadata;
 // use super::array::check;
 use crate::array::offset_builder::OffsetsBuilder;
 use crate::array::{
@@ -19,6 +20,8 @@ use std::sync::Arc;
 /// Converting a [`LineStringBuilder`] into a [`LineStringArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct LineStringBuilder<O: OffsetSizeTrait> {
+    metadata: Arc<ArrayMetadata>,
+
     pub(crate) coords: CoordBufferBuilder,
 
     /// Offsets into the coordinate array where each geometry starts
@@ -31,19 +34,23 @@ pub struct LineStringBuilder<O: OffsetSizeTrait> {
 impl<O: OffsetSizeTrait> LineStringBuilder<O> {
     /// Creates a new empty [`LineStringBuilder`].
     pub fn new() -> Self {
-        Self::new_with_options(Default::default())
+        Self::new_with_options(Default::default(), Default::default())
     }
 
-    pub fn new_with_options(coord_type: CoordType) -> Self {
-        Self::with_capacity_and_options(Default::default(), coord_type)
+    pub fn new_with_options(coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+        Self::with_capacity_and_options(Default::default(), coord_type, metadata)
     }
 
     /// Creates a new [`LineStringBuilder`] with a capacity.
     pub fn with_capacity(capacity: LineStringCapacity) -> Self {
-        Self::with_capacity_and_options(capacity, Default::default())
+        Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options(capacity: LineStringCapacity, coord_type: CoordType) -> Self {
+    pub fn with_capacity_and_options(
+        capacity: LineStringCapacity,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let coords = match coord_type {
             CoordType::Interleaved => CoordBufferBuilder::Interleaved(
                 InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity()),
@@ -56,21 +63,23 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
             coords,
             geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity()),
             validity: NullBufferBuilder::new(capacity.geom_capacity()),
+            metadata,
         }
     }
 
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
     ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default())
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
     pub fn with_capacity_and_options_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let counter = LineStringCapacity::from_line_strings(geoms);
-        Self::with_capacity_and_options(counter, coord_type)
+        Self::with_capacity_and_options(counter, coord_type, metadata)
     }
 
     pub fn reserve_from_iter<'a>(
@@ -132,6 +141,7 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
         coords: CoordBufferBuilder,
         geom_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         // check(
         //     &coords.clone().into(),
@@ -142,6 +152,7 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
             coords,
             geom_offsets,
             validity,
+            metadata,
         })
     }
 
@@ -236,10 +247,12 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
     pub fn from_line_strings(
         geoms: &[impl LineStringTrait<T = f64>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(Some),
             coord_type.unwrap_or_default(),
+            metadata,
         );
         array.extend_from_iter(geoms.iter().map(Some));
         array
@@ -248,10 +261,12 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
     pub fn from_nullable_line_strings(
         geoms: &[Option<impl LineStringTrait<T = f64>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(|x| x.as_ref()),
             coord_type.unwrap_or_default(),
+            metadata,
         );
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
@@ -260,6 +275,7 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
     pub fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         let wkb_objects2: Vec<Option<WKBLineString>> = wkb_objects
             .iter()
@@ -269,7 +285,11 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
                     .map(|wkb| wkb.to_wkb_object().into_line_string())
             })
             .collect();
-        Ok(Self::from_nullable_line_strings(&wkb_objects2, coord_type))
+        Ok(Self::from_nullable_line_strings(
+            &wkb_objects2,
+            coord_type,
+            metadata,
+        ))
     }
 
     pub fn finish(self) -> LineStringArray<O> {
@@ -282,9 +302,13 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for LineStringBuilder<O> {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType) -> Self {
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let capacity = LineStringCapacity::new(0, geom_capacity);
-        Self::with_capacity_and_options(capacity, coord_type)
+        Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
     fn finish(self) -> Arc<dyn crate::GeometryArrayTrait> {
@@ -306,6 +330,14 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for LineStringBuilder<O> {
     fn coord_type(&self) -> CoordType {
         self.coords.coord_type()
     }
+
+    fn set_metadata(&mut self, metadata: Arc<ArrayMetadata>) {
+        self.metadata = metadata;
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
+    }
 }
 
 impl<O: OffsetSizeTrait> IntoArrow for LineStringBuilder<O> {
@@ -326,7 +358,12 @@ impl<O: OffsetSizeTrait> Default for LineStringBuilder<O> {
 impl<O: OffsetSizeTrait> From<LineStringBuilder<O>> for LineStringArray<O> {
     fn from(other: LineStringBuilder<O>) -> Self {
         let validity = other.validity.finish_cloned();
-        Self::new(other.coords.into(), other.geom_offsets.into(), validity)
+        Self::new(
+            other.coords.into(),
+            other.geom_offsets.into(),
+            validity,
+            other.metadata,
+        )
     }
 }
 
@@ -338,7 +375,7 @@ impl<O: OffsetSizeTrait> From<LineStringBuilder<O>> for GenericListArray<O> {
 
 impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<&[G]> for LineStringBuilder<O> {
     fn from(geoms: &[G]) -> Self {
-        Self::from_line_strings(geoms, Default::default())
+        Self::from_line_strings(geoms, Default::default(), Default::default())
     }
 }
 
@@ -346,7 +383,7 @@ impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<Vec<Option<G>>>
     for LineStringBuilder<O>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
-        Self::from_nullable_line_strings(&geoms, Default::default())
+        Self::from_nullable_line_strings(&geoms, Default::default(), Default::default())
     }
 }
 
@@ -354,7 +391,7 @@ impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<bumpalo::collections:
     for LineStringBuilder<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_line_strings(&geoms, Default::default())
+        Self::from_line_strings(&geoms, Default::default(), Default::default())
     }
 }
 
@@ -362,7 +399,7 @@ impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<bumpalo::collections:
     for LineStringBuilder<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_line_strings(&geoms, Default::default())
+        Self::from_nullable_line_strings(&geoms, Default::default(), Default::default())
     }
 }
 
@@ -370,8 +407,9 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringBuilder<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
+        let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, Default::default())
+        Self::from_wkb(&wkb_objects, Default::default(), metadata)
     }
 }
 
@@ -379,6 +417,12 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringBuilder<O> {
 /// the semantic type
 impl<O: OffsetSizeTrait> From<LineStringBuilder<O>> for MultiPointBuilder<O> {
     fn from(value: LineStringBuilder<O>) -> Self {
-        Self::try_new(value.coords, value.geom_offsets, value.validity).unwrap()
+        Self::try_new(
+            value.coords,
+            value.geom_offsets,
+            value.validity,
+            value.metadata,
+        )
+        .unwrap()
     }
 }

--- a/src/array/metadata.rs
+++ b/src/array/metadata.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]
+pub enum Edges {
+    #[serde(rename = "spherical")]
+    Spherical,
+}
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]
+pub struct ArrayMetadata {
+    crs: Option<String>,
+    edges: Option<Edges>,
+}

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod coord;
 pub(crate) mod geometry;
 pub(crate) mod geometrycollection;
 pub(crate) mod linestring;
+pub mod metadata;
 pub(crate) mod mixed;
 pub(crate) mod multilinestring;
 pub(crate) mod multipoint;

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use super::MultiPointBuilder;
 use crate::algorithm::native::eq::offset_buffer_eq;
+use crate::array::metadata::ArrayMetadata;
 use crate::array::multipoint::MultiPointCapacity;
 use crate::array::offset_builder::OffsetsBuilder;
 use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, OffsetBufferUtils};
@@ -28,6 +29,8 @@ use arrow_schema::{DataType, Field};
 pub struct MultiPointArray<O: OffsetSizeTrait> {
     // Always GeoDataType::MultiPoint or GeoDataType::LargeMultiPoint
     data_type: GeoDataType,
+
+    metadata: Arc<ArrayMetadata>,
 
     pub(crate) coords: CoordBuffer,
 
@@ -73,8 +76,9 @@ impl<O: OffsetSizeTrait> MultiPointArray<O> {
         coords: CoordBuffer,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
-        Self::try_new(coords, geom_offsets, validity).unwrap()
+        Self::try_new(coords, geom_offsets, validity, metadata).unwrap()
     }
 
     /// Create a new MultiPointArray from parts
@@ -91,6 +95,7 @@ impl<O: OffsetSizeTrait> MultiPointArray<O> {
         coords: CoordBuffer,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         check(&coords, validity.as_ref().map(|v| v.len()), &geom_offsets)?;
 
@@ -105,6 +110,7 @@ impl<O: OffsetSizeTrait> MultiPointArray<O> {
             coords,
             geom_offsets,
             validity,
+            metadata,
         })
     }
 
@@ -143,10 +149,14 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiPointArray<O> {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        let mut metadata = HashMap::new();
+        let mut metadata = HashMap::with_capacity(2);
         metadata.insert(
             "ARROW:extension:name".to_string(),
             self.extension_name().to_string(),
+        );
+        metadata.insert(
+            "ARROW:extension:metadata".to_string(),
+            serde_json::to_string(self.metadata.as_ref()).unwrap(),
         );
         Arc::new(Field::new("geometry", self.storage_type(), true).with_metadata(metadata))
     }
@@ -165,6 +175,10 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiPointArray<O> {
 
     fn coord_type(&self) -> CoordType {
         self.coords.coord_type()
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
     }
 
     /// Returns the number of geometries in this array
@@ -187,7 +201,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiPointArray<O> {
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPointArray<O> {
     fn with_coords(self, coords: CoordBuffer) -> Self {
         assert_eq!(coords.len(), self.coords.len());
-        Self::new(coords, self.geom_offsets, self.validity)
+        Self::new(coords, self.geom_offsets, self.validity, self.metadata)
     }
 
     fn into_coord_type(self, coord_type: CoordType) -> Self {
@@ -195,6 +209,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPointArray<O> {
             self.coords.into_coord_type(coord_type),
             self.geom_offsets,
             self.validity,
+            self.metadata,
         )
     }
 
@@ -227,6 +242,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPointArray<O> {
             coords: self.coords.clone(),
             geom_offsets: self.geom_offsets.slice(offset, length),
             validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
+            metadata: self.metadata(),
         }
     }
 
@@ -249,7 +265,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPointArray<O> {
 
         let validity = owned_slice_validity(self.nulls(), offset, length);
 
-        Self::new(coords, geom_offsets, validity)
+        Self::new(coords, geom_offsets, validity, self.metadata())
     }
 }
 
@@ -325,7 +341,12 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for MultiPointArray<O> {
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
-        Ok(Self::new(coords, geom_offsets.clone(), validity.cloned()))
+        Ok(Self::new(
+            coords,
+            geom_offsets.clone(),
+            validity.cloned(),
+            Default::default(),
+        ))
     }
 }
 
@@ -418,7 +439,12 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPointArray<O> {
 /// the semantic type
 impl<O: OffsetSizeTrait> From<MultiPointArray<O>> for LineStringArray<O> {
     fn from(value: MultiPointArray<O>) -> Self {
-        Self::new(value.coords, value.geom_offsets, value.validity)
+        Self::new(
+            value.coords,
+            value.geom_offsets,
+            value.validity,
+            value.metadata,
+        )
     }
 }
 
@@ -437,7 +463,12 @@ impl<O: OffsetSizeTrait> TryFrom<PointArray> for MultiPointArray<O> {
             geom_offsets.try_push_usize(1)?;
         }
 
-        Ok(Self::new(coords, geom_offsets.into(), validity))
+        Ok(Self::new(
+            coords,
+            geom_offsets.into(),
+            validity,
+            value.metadata,
+        ))
     }
 }
 
@@ -447,6 +478,7 @@ impl From<MultiPointArray<i32>> for MultiPointArray<i64> {
             value.coords,
             offsets_buffer_i32_to_i64(&value.geom_offsets),
             value.validity,
+            value.metadata,
         )
     }
 }
@@ -459,6 +491,7 @@ impl TryFrom<MultiPointArray<i64>> for MultiPointArray<i32> {
             value.coords,
             offsets_buffer_i64_to_i32(&value.geom_offsets)?,
             value.validity,
+            value.metadata,
         ))
     }
 }

--- a/src/array/multipolygon/builder.rs
+++ b/src/array/multipolygon/builder.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::array::metadata::ArrayMetadata;
 use crate::array::multipolygon::MultiPolygonCapacity;
 // use super::array::check;
 use crate::array::offset_builder::OffsetsBuilder;
@@ -29,6 +30,8 @@ pub type MutableMultiPolygonParts<O> = (
 /// Converting a [`MultiPolygonBuilder`] into a [`MultiPolygonArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct MultiPolygonBuilder<O: OffsetSizeTrait> {
+    metadata: Arc<ArrayMetadata>,
+
     pub(crate) coords: CoordBufferBuilder,
 
     /// OffsetsBuilder into the polygon array where each geometry starts
@@ -47,21 +50,22 @@ pub struct MultiPolygonBuilder<O: OffsetSizeTrait> {
 impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
     /// Creates a new empty [`MultiPolygonBuilder`].
     pub fn new() -> Self {
-        Self::new_with_options(Default::default())
+        Self::new_with_options(Default::default(), Default::default())
     }
 
-    pub fn new_with_options(coord_type: CoordType) -> Self {
-        Self::with_capacity_and_options(Default::default(), coord_type)
+    pub fn new_with_options(coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+        Self::with_capacity_and_options(Default::default(), coord_type, metadata)
     }
 
     /// Creates a new [`MultiPolygonBuilder`] with a capacity.
     pub fn with_capacity(capacity: MultiPolygonCapacity) -> Self {
-        Self::with_capacity_and_options(capacity, Default::default())
+        Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
     pub fn with_capacity_and_options(
         capacity: MultiPolygonCapacity,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let coords = match coord_type {
             CoordType::Interleaved => CoordBufferBuilder::Interleaved(
@@ -78,21 +82,23 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
             polygon_offsets: OffsetsBuilder::with_capacity(capacity.polygon_capacity),
             ring_offsets: OffsetsBuilder::with_capacity(capacity.ring_capacity),
             validity: NullBufferBuilder::new(capacity.geom_capacity),
+            metadata,
         }
     }
 
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
     ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default())
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
     pub fn with_capacity_and_options_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let counter = MultiPolygonCapacity::from_multi_polygons(geoms);
-        Self::with_capacity_and_options(counter, coord_type)
+        Self::with_capacity_and_options(counter, coord_type, metadata)
     }
 
     /// Reserves capacity for at least `additional` more LineStrings to be inserted
@@ -162,6 +168,7 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
         polygon_offsets: OffsetsBuilder<O>,
         ring_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         // check(
         //     &coords.clone().into(),
@@ -176,6 +183,7 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
             polygon_offsets,
             ring_offsets,
             validity,
+            metadata,
         })
     }
 
@@ -392,10 +400,12 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
     pub fn from_multi_polygons(
         geoms: &[impl MultiPolygonTrait<T = f64>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(Some),
             coord_type.unwrap_or_default(),
+            metadata,
         );
         array.extend_from_iter(geoms.iter().map(Some));
         array
@@ -404,10 +414,12 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
     pub fn from_nullable_multi_polygons(
         geoms: &[Option<impl MultiPolygonTrait<T = f64>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(|x| x.as_ref()),
             coord_type.unwrap_or_default(),
+            metadata,
         );
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
@@ -416,6 +428,7 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
     pub fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         let wkb_objects2: Vec<Option<WKBMaybeMultiPolygon>> = wkb_objects
             .iter()
@@ -428,6 +441,7 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
         Ok(Self::from_nullable_multi_polygons(
             &wkb_objects2,
             coord_type,
+            metadata,
         ))
     }
 
@@ -447,14 +461,18 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiPolygonBuilder<O> {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType) -> Self {
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let capacity = MultiPolygonCapacity::new(
             Default::default(),
             Default::default(),
             Default::default(),
             geom_capacity,
         );
-        Self::with_capacity_and_options(capacity, coord_type)
+        Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
     fn finish(self) -> Arc<dyn crate::GeometryArrayTrait> {
@@ -475,6 +493,14 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiPolygonBuilder<O> {
 
     fn coord_type(&self) -> CoordType {
         self.coords.coord_type()
+    }
+
+    fn set_metadata(&mut self, metadata: Arc<ArrayMetadata>) {
+        self.metadata = metadata;
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
     }
 }
 
@@ -501,13 +527,14 @@ impl<O: OffsetSizeTrait> From<MultiPolygonBuilder<O>> for MultiPolygonArray<O> {
             polygon_offsets,
             ring_offsets,
             validity,
+            other.metadata,
         )
     }
 }
 
 impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<&[G]> for MultiPolygonBuilder<O> {
     fn from(geoms: &[G]) -> Self {
-        Self::from_multi_polygons(geoms, Default::default())
+        Self::from_multi_polygons(geoms, Default::default(), Default::default())
     }
 }
 
@@ -515,7 +542,7 @@ impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<Vec<Option<G>>>
     for MultiPolygonBuilder<O>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
-        Self::from_nullable_multi_polygons(&geoms, Default::default())
+        Self::from_nullable_multi_polygons(&geoms, Default::default(), Default::default())
     }
 }
 
@@ -523,7 +550,7 @@ impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<bumpalo::collection
     for MultiPolygonBuilder<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_multi_polygons(&geoms, Default::default())
+        Self::from_multi_polygons(&geoms, Default::default(), Default::default())
     }
 }
 
@@ -531,7 +558,7 @@ impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>>
     From<bumpalo::collections::Vec<'_, Option<G>>> for MultiPolygonBuilder<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_multi_polygons(&geoms, Default::default())
+        Self::from_nullable_multi_polygons(&geoms, Default::default(), Default::default())
     }
 }
 
@@ -539,7 +566,8 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPolygonBuilder<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
+        let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, Default::default())
+        Self::from_wkb(&wkb_objects, Default::default(), metadata)
     }
 }

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::algorithm::native::eq::coord_eq_allow_nan;
+use crate::array::metadata::ArrayMetadata;
 use crate::array::zip_validity::ZipValidity;
 use crate::array::{
     CoordBuffer, CoordType, InterleavedCoordBuffer, PointBuilder, SeparatedCoordBuffer, WKBArray,
@@ -25,6 +26,7 @@ use arrow_schema::{DataType, Field};
 pub struct PointArray {
     // Always GeoDataType::Point
     data_type: GeoDataType,
+    pub(crate) metadata: Arc<ArrayMetadata>,
     pub(crate) coords: CoordBuffer,
     pub(crate) validity: Option<NullBuffer>,
 }
@@ -52,8 +54,12 @@ impl PointArray {
     /// # Panics
     ///
     /// - if the validity is not `None` and its length is different from the number of geometries
-    pub fn new(coords: CoordBuffer, validity: Option<NullBuffer>) -> Self {
-        Self::try_new(coords, validity).unwrap()
+    pub fn new(
+        coords: CoordBuffer,
+        validity: Option<NullBuffer>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        Self::try_new(coords, validity, metadata).unwrap()
     }
 
     /// Create a new PointArray from parts
@@ -68,6 +74,7 @@ impl PointArray {
     pub fn try_new(
         coords: CoordBuffer,
         validity: Option<NullBuffer>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self, GeoArrowError> {
         check(&coords, validity.as_ref().map(|v| v.len()))?;
         let data_type = GeoDataType::Point(coords.coord_type());
@@ -75,6 +82,7 @@ impl PointArray {
             data_type,
             coords,
             validity,
+            metadata,
         })
     }
 
@@ -106,10 +114,14 @@ impl GeometryArrayTrait for PointArray {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        let mut metadata = HashMap::new();
+        let mut metadata = HashMap::with_capacity(2);
         metadata.insert(
             "ARROW:extension:name".to_string(),
             self.extension_name().to_string(),
+        );
+        metadata.insert(
+            "ARROW:extension:metadata".to_string(),
+            serde_json::to_string(self.metadata.as_ref()).unwrap(),
         );
         Arc::new(Field::new("geometry", self.storage_type(), true).with_metadata(metadata))
     }
@@ -128,6 +140,10 @@ impl GeometryArrayTrait for PointArray {
 
     fn coord_type(&self) -> CoordType {
         self.coords.coord_type()
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
     }
 
     /// Returns the number of geometries in this array
@@ -150,11 +166,15 @@ impl GeometryArrayTrait for PointArray {
 impl GeometryArraySelfMethods for PointArray {
     fn with_coords(self, coords: CoordBuffer) -> Self {
         assert_eq!(coords.len(), self.coords.len());
-        Self::new(coords, self.validity)
+        Self::new(coords, self.validity, self.metadata)
     }
 
     fn into_coord_type(self, coord_type: CoordType) -> Self {
-        Self::new(self.coords.into_coord_type(coord_type), self.validity)
+        Self::new(
+            self.coords.into_coord_type(coord_type),
+            self.validity,
+            self.metadata,
+        )
     }
 
     /// Slices this [`PointArray`] in place.
@@ -170,6 +190,7 @@ impl GeometryArraySelfMethods for PointArray {
             data_type: self.data_type,
             coords: self.coords.slice(offset, length),
             validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
+            metadata: self.metadata(),
         }
     }
 
@@ -184,7 +205,7 @@ impl GeometryArraySelfMethods for PointArray {
 
         let validity = owned_slice_validity(self.nulls(), offset, length);
 
-        Self::new(coords, validity)
+        Self::new(coords, validity, self.metadata())
     }
 }
 
@@ -270,6 +291,7 @@ impl TryFrom<&FixedSizeListArray> for PointArray {
         Ok(Self::new(
             CoordBuffer::Interleaved(interleaved_coords),
             value.nulls().cloned(),
+            Default::default(),
         ))
     }
 }
@@ -283,6 +305,7 @@ impl TryFrom<&StructArray> for PointArray {
         Ok(Self::new(
             CoordBuffer::Separated(separated_coords),
             validity.cloned(),
+            Default::default(),
         ))
     }
 }

--- a/src/array/polygon/builder.rs
+++ b/src/array/polygon/builder.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::array::metadata::ArrayMetadata;
 // use super::array::check;
 use crate::array::offset_builder::OffsetsBuilder;
 use crate::array::polygon::PolygonCapacity;
@@ -29,6 +30,8 @@ pub type MutablePolygonParts<O> = (
 /// Converting a [`PolygonBuilder`] into a [`PolygonArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct PolygonBuilder<O: OffsetSizeTrait> {
+    metadata: Arc<ArrayMetadata>,
+
     pub(crate) coords: CoordBufferBuilder,
 
     /// OffsetsBuilder into the ring array where each geometry starts
@@ -44,19 +47,23 @@ pub struct PolygonBuilder<O: OffsetSizeTrait> {
 impl<O: OffsetSizeTrait> PolygonBuilder<O> {
     /// Creates a new empty [`PolygonBuilder`].
     pub fn new() -> Self {
-        Self::new_with_options(Default::default())
+        Self::new_with_options(Default::default(), Default::default())
     }
 
-    pub fn new_with_options(coord_type: CoordType) -> Self {
-        Self::with_capacity_and_options(Default::default(), coord_type)
+    pub fn new_with_options(coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+        Self::with_capacity_and_options(Default::default(), coord_type, metadata)
     }
 
     /// Creates a new [`PolygonBuilder`] with given capacity and no validity.
     pub fn with_capacity(capacity: PolygonCapacity) -> Self {
-        Self::with_capacity_and_options(capacity, Default::default())
+        Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options(capacity: PolygonCapacity, coord_type: CoordType) -> Self {
+    pub fn with_capacity_and_options(
+        capacity: PolygonCapacity,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let coords = match coord_type {
             CoordType::Interleaved => CoordBufferBuilder::Interleaved(
                 InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
@@ -70,21 +77,23 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
             geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity),
             ring_offsets: OffsetsBuilder::with_capacity(capacity.ring_capacity),
             validity: NullBufferBuilder::new(capacity.geom_capacity),
+            metadata,
         }
     }
 
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
     ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default())
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
     pub fn with_capacity_and_options_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let counter = PolygonCapacity::from_polygons(geoms);
-        Self::with_capacity_and_options(counter, coord_type)
+        Self::with_capacity_and_options(counter, coord_type, metadata)
     }
 
     /// Reserves capacity for at least `additional` more LineStrings to be inserted
@@ -148,6 +157,7 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
         geom_offsets: OffsetsBuilder<O>,
         ring_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         // check(
         //     &coords.clone().into(),
@@ -160,6 +170,7 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
             geom_offsets,
             ring_offsets,
             validity,
+            metadata,
         })
     }
 
@@ -337,10 +348,12 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
     pub fn from_polygons(
         geoms: &[impl PolygonTrait<T = f64>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(Some),
             coord_type.unwrap_or_default(),
+            metadata,
         );
         array.extend_from_iter(geoms.iter().map(Some));
         array
@@ -349,10 +362,12 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
     pub fn from_nullable_polygons(
         geoms: &[Option<impl PolygonTrait<T = f64>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(|x| x.as_ref()),
             coord_type.unwrap_or_default(),
+            metadata,
         );
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
@@ -361,6 +376,7 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
     pub fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
         coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         let wkb_objects2: Vec<Option<WKBPolygon>> = wkb_objects
             .iter()
@@ -370,7 +386,11 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
                     .map(|wkb| wkb.to_wkb_object().into_polygon())
             })
             .collect();
-        Ok(Self::from_nullable_polygons(&wkb_objects2, coord_type))
+        Ok(Self::from_nullable_polygons(
+            &wkb_objects2,
+            coord_type,
+            metadata,
+        ))
     }
 
     pub fn finish(self) -> PolygonArray<O> {
@@ -389,9 +409,13 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for PolygonBuilder<O> {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType) -> Self {
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let capacity = PolygonCapacity::new(0, 0, geom_capacity);
-        Self::with_capacity_and_options(capacity, coord_type)
+        Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
     fn finish(self) -> Arc<dyn crate::GeometryArrayTrait> {
@@ -413,6 +437,14 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for PolygonBuilder<O> {
     fn coord_type(&self) -> CoordType {
         self.coords.coord_type()
     }
+
+    fn set_metadata(&mut self, metadata: Arc<ArrayMetadata>) {
+        self.metadata = metadata;
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
+    }
 }
 
 impl<O: OffsetSizeTrait> IntoArrow for PolygonBuilder<O> {
@@ -431,19 +463,25 @@ impl<O: OffsetSizeTrait> From<PolygonBuilder<O>> for PolygonArray<O> {
         let geom_offsets: OffsetBuffer<O> = other.geom_offsets.into();
         let ring_offsets: OffsetBuffer<O> = other.ring_offsets.into();
 
-        Self::new(other.coords.into(), geom_offsets, ring_offsets, validity)
+        Self::new(
+            other.coords.into(),
+            geom_offsets,
+            ring_offsets,
+            validity,
+            other.metadata,
+        )
     }
 }
 
 impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<&[G]> for PolygonBuilder<O> {
     fn from(geoms: &[G]) -> Self {
-        Self::from_polygons(geoms, Default::default())
+        Self::from_polygons(geoms, Default::default(), Default::default())
     }
 }
 
 impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<Vec<Option<G>>> for PolygonBuilder<O> {
     fn from(geoms: Vec<Option<G>>) -> Self {
-        Self::from_nullable_polygons(&geoms, Default::default())
+        Self::from_nullable_polygons(&geoms, Default::default(), Default::default())
     }
 }
 
@@ -451,14 +489,14 @@ impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<bumpalo::collections::Ve
     for PolygonBuilder<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_polygons(&geoms, Default::default())
+        Self::from_polygons(&geoms, Default::default(), Default::default())
     }
 }
 impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<bumpalo::collections::Vec<'_, Option<G>>>
     for PolygonBuilder<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_polygons(&geoms, Default::default())
+        Self::from_nullable_polygons(&geoms, Default::default(), Default::default())
     }
 }
 
@@ -466,8 +504,9 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PolygonBuilder<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
+        let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, Default::default())
+        Self::from_wkb(&wkb_objects, Default::default(), metadata)
     }
 }
 
@@ -480,6 +519,7 @@ impl<O: OffsetSizeTrait> From<PolygonBuilder<O>> for MultiLineStringBuilder<O> {
             value.geom_offsets,
             value.ring_offsets,
             value.validity,
+            value.metadata,
         )
         .unwrap()
     }

--- a/src/io/csv/reader.rs
+++ b/src/io/csv/reader.rs
@@ -41,6 +41,7 @@ pub fn read_csv<R: Read>(
         Some(options.batch_size),
         None,
         None,
+        Default::default(),
     );
     let mut geo_table =
         GeoTableBuilder::<MixedGeometryStreamBuilder<i32>>::new_with_options(table_builder_options);

--- a/src/io/flatgeobuf/reader.rs
+++ b/src/io/flatgeobuf/reader.rs
@@ -50,12 +50,14 @@ pub fn read_flatgeobuf<R: Read + Seek>(
 
     let schema = infer_schema(header);
 
+    // TODO: propagate CRS
     let options = GeoTableBuilderOptions::new(
         coord_type,
         true,
         batch_size,
         Some(Arc::new(schema.finish())),
         features_count,
+        Default::default(),
     );
 
     match header.geometry_type() {

--- a/src/io/geojson/reader.rs
+++ b/src/io/geojson/reader.rs
@@ -10,7 +10,15 @@ use crate::table::GeoTable;
 
 pub fn read_geojson<R: Read>(reader: R, batch_size: Option<usize>) -> Result<GeoTable> {
     let mut geojson = GeoJsonReader(reader);
-    let options = GeoTableBuilderOptions::new(CoordType::Interleaved, true, batch_size, None, None);
+    // TODO: set CRS to epsg:4326?
+    let options = GeoTableBuilderOptions::new(
+        CoordType::Interleaved,
+        true,
+        batch_size,
+        None,
+        None,
+        Default::default(),
+    );
     let mut geo_table =
         GeoTableBuilder::<MixedGeometryStreamBuilder<i32>>::new_with_options(options);
     geojson.process(&mut geo_table)?;

--- a/src/io/geojson_lines/reader.rs
+++ b/src/io/geojson_lines/reader.rs
@@ -13,7 +13,15 @@ use crate::table::GeoTable;
 /// This expects a GeoJSON Feature on each line of a text file, with a newline character separating
 /// each Feature.
 pub fn read_geojson_lines<R: BufRead>(reader: R, batch_size: Option<usize>) -> Result<GeoTable> {
-    let options = GeoTableBuilderOptions::new(CoordType::Interleaved, true, batch_size, None, None);
+    // TODO: set crs to epsg:4326?
+    let options = GeoTableBuilderOptions::new(
+        CoordType::Interleaved,
+        true,
+        batch_size,
+        None,
+        None,
+        Default::default(),
+    );
     let mut geo_table =
         GeoTableBuilder::<MixedGeometryStreamBuilder<i32>>::new_with_options(options);
 

--- a/src/io/geozero/api/wkt.rs
+++ b/src/io/geozero/api/wkt.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::algorithm::native::Downcast;
 use crate::array::geometrycollection::GeometryCollectionBuilder;
+use crate::array::metadata::ArrayMetadata;
 use crate::array::*;
 use crate::chunked_array::{
     ChunkedArray, ChunkedGeometryArrayTrait, ChunkedGeometryCollectionArray,
@@ -19,6 +20,7 @@ pub trait FromWKT: Sized {
     fn from_wkt<O: OffsetSizeTrait>(
         arr: &Self::Input<O>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self>;
 }
@@ -29,9 +31,11 @@ impl<OOutput: OffsetSizeTrait> FromWKT for MixedGeometryArray<OOutput> {
     fn from_wkt<O: OffsetSizeTrait>(
         arr: &Self::Input<O>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        let mut builder = MixedGeometryStreamBuilder::new_with_options(coord_type, prefer_multi);
+        let mut builder =
+            MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 let wkt_str = geozero::wkt::WktStr(arr.value(i));
@@ -51,10 +55,11 @@ impl<OOutput: OffsetSizeTrait> FromWKT for GeometryCollectionArray<OOutput> {
     fn from_wkt<O: OffsetSizeTrait>(
         arr: &Self::Input<O>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
         // TODO: Add GeometryCollectionStreamBuilder and use that instead of going through geo
-        let mut builder = GeometryCollectionBuilder::new_with_options(coord_type);
+        let mut builder = GeometryCollectionBuilder::new_with_options(coord_type, metadata);
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 let wkt_str = geozero::wkt::WktStr(arr.value(i));
@@ -75,9 +80,11 @@ impl FromWKT for Arc<dyn GeometryArrayTrait> {
     fn from_wkt<O: OffsetSizeTrait>(
         arr: &Self::Input<O>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        let geom_arr = GeometryCollectionArray::<i64>::from_wkt(arr, coord_type, prefer_multi)?;
+        let geom_arr =
+            GeometryCollectionArray::<i64>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
@@ -88,9 +95,10 @@ impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedMixedGeometryArray<OOutput> {
     fn from_wkt<O: OffsetSizeTrait>(
         arr: &Self::Input<O>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, prefer_multi))?
+        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?
             .try_into()
     }
 }
@@ -101,9 +109,10 @@ impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedGeometryCollectionArray<OOutpu
     fn from_wkt<O: OffsetSizeTrait>(
         arr: &Self::Input<O>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, prefer_multi))?
+        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?
             .try_into()
     }
 }
@@ -114,10 +123,15 @@ impl FromWKT for Arc<dyn ChunkedGeometryArrayTrait> {
     fn from_wkt<O: OffsetSizeTrait>(
         arr: &Self::Input<O>,
         coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        let geom_arr =
-            ChunkedGeometryCollectionArray::<i64>::from_wkt(arr, coord_type, prefer_multi)?;
+        let geom_arr = ChunkedGeometryCollectionArray::<i64>::from_wkt(
+            arr,
+            coord_type,
+            metadata,
+            prefer_multi,
+        )?;
         Ok(geom_arr.downcast(true))
     }
 }
@@ -141,8 +155,13 @@ mod test {
         wkt_geoms.iter().for_each(|s| builder.append_value(s));
         let arr = builder.finish();
         // dbg!(arr);
-        let geom_arr =
-            MixedGeometryArray::<i32>::from_wkt(&arr, Default::default(), false).unwrap();
+        let geom_arr = MixedGeometryArray::<i32>::from_wkt(
+            &arr,
+            Default::default(),
+            Default::default(),
+            false,
+        )
+        .unwrap();
         let geo_point = geo::Point::try_from(geom_arr.value(0).to_geo().unwrap()).unwrap();
         assert_eq!(geo_point.x(), 30.0);
         assert_eq!(geo_point.y(), 10.0);
@@ -155,7 +174,9 @@ mod test {
         wkt_geoms.iter().for_each(|s| builder.append_value(s));
         let arr = builder.finish();
         // dbg!(arr);
-        let geom_arr = MixedGeometryArray::<i32>::from_wkt(&arr, Default::default(), true).unwrap();
+        let geom_arr =
+            MixedGeometryArray::<i32>::from_wkt(&arr, Default::default(), Default::default(), true)
+                .unwrap();
         let geom_arr = geom_arr.downcast(true);
         assert!(matches!(geom_arr.data_type(), GeoDataType::Point(_)));
     }

--- a/src/io/geozero/array/mixed.rs
+++ b/src/io/geozero/array/mixed.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::array::metadata::ArrayMetadata;
 use crate::array::mixed::array::GeometryType;
 use crate::array::{CoordType, MixedGeometryArray, MixedGeometryBuilder};
 use crate::io::geozero::scalar::process_geometry;
@@ -68,9 +69,13 @@ impl<O: OffsetSizeTrait> MixedGeometryStreamBuilder<O> {
         }
     }
 
-    pub fn new_with_options(coord_type: CoordType, prefer_multi: bool) -> Self {
+    pub fn new_with_options(
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Self {
         Self {
-            builder: MixedGeometryBuilder::<O>::new_with_options(coord_type),
+            builder: MixedGeometryBuilder::<O>::new_with_options(coord_type, metadata),
             current_geom_type: GeometryType::Point,
             prefer_multi,
         }
@@ -265,15 +270,23 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MixedGeometryStreamBuilder<O> 
     }
 
     fn new() -> Self {
-        Self::with_geom_capacity_and_options(0, Default::default())
+        Self::with_geom_capacity_and_options(0, Default::default(), Default::default())
     }
 
     fn into_array_ref(self) -> Arc<dyn arrow_array::Array> {
         self.builder.into_array_ref()
     }
 
-    fn with_geom_capacity_and_options(_geom_capacity: usize, coord_type: CoordType) -> Self {
-        Self::new_with_options(coord_type, true)
+    fn with_geom_capacity_and_options(
+        _geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        Self::new_with_options(coord_type, metadata, true)
+    }
+
+    fn set_metadata(&mut self, metadata: Arc<ArrayMetadata>) {
+        self.builder.set_metadata(metadata)
     }
 
     fn finish(self) -> std::sync::Arc<dyn GeometryArrayTrait> {
@@ -282,5 +295,9 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MixedGeometryStreamBuilder<O> 
 
     fn coord_type(&self) -> CoordType {
         self.builder.coord_type()
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.builder.metadata()
     }
 }

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -26,7 +26,7 @@ impl FromWKB for PointArray {
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = PointBuilder::from_wkb(&wkb_objects, Some(coord_type))?;
+        let builder = PointBuilder::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
         Ok(builder.finish())
     }
 }
@@ -41,7 +41,7 @@ macro_rules! impl_from_wkb {
                 coord_type: CoordType,
             ) -> Result<Self> {
                 let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-                let builder = <$builder>::from_wkb(&wkb_objects, Some(coord_type))?;
+                let builder = <$builder>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
                 Ok(builder.finish())
             }
         }
@@ -62,8 +62,12 @@ impl<OOutput: OffsetSizeTrait> FromWKB for MixedGeometryArray<OOutput> {
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder =
-            MixedGeometryBuilder::<OOutput>::from_wkb(&wkb_objects, Some(coord_type), true)?;
+        let builder = MixedGeometryBuilder::<OOutput>::from_wkb(
+            &wkb_objects,
+            Some(coord_type),
+            arr.metadata(),
+            true,
+        )?;
         Ok(builder.finish())
     }
 }
@@ -73,8 +77,12 @@ impl<OOutput: OffsetSizeTrait> FromWKB for GeometryCollectionArray<OOutput> {
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder =
-            GeometryCollectionBuilder::<OOutput>::from_wkb(&wkb_objects, Some(coord_type), true)?;
+        let builder = GeometryCollectionBuilder::<OOutput>::from_wkb(
+            &wkb_objects,
+            Some(coord_type),
+            arr.metadata(),
+            true,
+        )?;
         Ok(builder.finish())
     }
 }
@@ -84,8 +92,12 @@ impl FromWKB for Arc<dyn GeometryArrayTrait> {
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder =
-            GeometryCollectionBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type), true)?;
+        let builder = GeometryCollectionBuilder::<i64>::from_wkb(
+            &wkb_objects,
+            Some(coord_type),
+            arr.metadata(),
+            true,
+        )?;
         Ok(builder.finish().downcast(true))
     }
 }
@@ -136,53 +148,76 @@ pub fn from_wkb<O: OffsetSizeTrait>(
     let wkb_objects: Vec<Option<crate::scalar::WKB<'_, O>>> = arr.iter().collect();
     match target_geo_data_type {
         Point(coord_type) => {
-            let builder = PointBuilder::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder = PointBuilder::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         LineString(coord_type) => {
-            let builder = LineStringBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder =
+                LineStringBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         LargeLineString(coord_type) => {
-            let builder = LineStringBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder =
+                LineStringBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         Polygon(coord_type) => {
-            let builder = PolygonBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder =
+                PolygonBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         LargePolygon(coord_type) => {
-            let builder = PolygonBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder =
+                PolygonBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiPoint(coord_type) => {
-            let builder = MultiPointBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder =
+                MultiPointBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         LargeMultiPoint(coord_type) => {
-            let builder = MultiPointBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder =
+                MultiPointBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiLineString(coord_type) => {
-            let builder = MultiLineStringBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder = MultiLineStringBuilder::<i32>::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+            )?;
             Ok(Arc::new(builder.finish()))
         }
         LargeMultiLineString(coord_type) => {
-            let builder = MultiLineStringBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder = MultiLineStringBuilder::<i64>::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+            )?;
             Ok(Arc::new(builder.finish()))
         }
         MultiPolygon(coord_type) => {
-            let builder = MultiPolygonBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder = MultiPolygonBuilder::<i32>::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+            )?;
             Ok(Arc::new(builder.finish()))
         }
         LargeMultiPolygon(coord_type) => {
-            let builder = MultiPolygonBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type))?;
+            let builder = MultiPolygonBuilder::<i64>::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+            )?;
             Ok(Arc::new(builder.finish()))
         }
         Mixed(coord_type) => {
             let builder = MixedGeometryBuilder::<i32>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
+                arr.metadata(),
                 prefer_multi,
             )?;
             Ok(Arc::new(builder.finish()))
@@ -191,6 +226,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             let builder = MixedGeometryBuilder::<i64>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
+                arr.metadata(),
                 prefer_multi,
             )?;
             Ok(Arc::new(builder.finish()))
@@ -199,6 +235,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             let builder = GeometryCollectionBuilder::<i32>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
+                arr.metadata(),
                 prefer_multi,
             )?;
             Ok(Arc::new(builder.finish()))
@@ -207,6 +244,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             let builder = GeometryCollectionBuilder::<i64>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
+                arr.metadata(),
                 prefer_multi,
             )?;
             Ok(Arc::new(builder.finish()))

--- a/src/io/wkb/writer/geometry.rs
+++ b/src/io/wkb/writer/geometry.rs
@@ -78,7 +78,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MixedGeometryArray<A>> for WK
 
         let binary_arr =
             GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
-        WKBArray::new(binary_arr)
+        WKBArray::new(binary_arr, value.metadata())
     }
 }
 

--- a/src/io/wkb/writer/geometrycollection.rs
+++ b/src/io/wkb/writer/geometrycollection.rs
@@ -73,7 +73,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&GeometryCollectionArray<A>> f
 
         let binary_arr =
             GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
-        WKBArray::new(binary_arr)
+        WKBArray::new(binary_arr, value.metadata())
     }
 }
 

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -64,7 +64,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&LineStringArray<A>> for WKBAr
 
         let binary_arr =
             GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
-        WKBArray::new(binary_arr)
+        WKBArray::new(binary_arr, value.metadata())
     }
 }
 

--- a/src/io/wkb/writer/multilinestring.rs
+++ b/src/io/wkb/writer/multilinestring.rs
@@ -72,7 +72,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiLineStringArray<A>> for 
 
         let binary_arr =
             GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
-        WKBArray::new(binary_arr)
+        WKBArray::new(binary_arr, value.metadata())
     }
 }
 

--- a/src/io/wkb/writer/multipoint.rs
+++ b/src/io/wkb/writer/multipoint.rs
@@ -64,7 +64,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiPointArray<A>> for WKBAr
 
         let binary_arr =
             GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
-        WKBArray::new(binary_arr)
+        WKBArray::new(binary_arr, value.metadata())
     }
 }
 

--- a/src/io/wkb/writer/multipolygon.rs
+++ b/src/io/wkb/writer/multipolygon.rs
@@ -72,7 +72,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiPolygonArray<A>> for WKB
 
         let binary_arr =
             GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
-        WKBArray::new(binary_arr)
+        WKBArray::new(binary_arr, value.metadata())
     }
 }
 

--- a/src/io/wkb/writer/point.rs
+++ b/src/io/wkb/writer/point.rs
@@ -53,7 +53,7 @@ impl<O: OffsetSizeTrait> From<&PointArray> for WKBArray<O> {
         };
 
         let binary_arr = GenericBinaryArray::new(offsets.into(), values.into(), validity);
-        WKBArray::new(binary_arr)
+        WKBArray::new(binary_arr, value.metadata())
     }
 }
 

--- a/src/io/wkb/writer/polygon.rs
+++ b/src/io/wkb/writer/polygon.rs
@@ -95,7 +95,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&PolygonArray<A>> for WKBArray
 
         let binary_arr =
             GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
-        WKBArray::new(binary_arr)
+        WKBArray::new(binary_arr, value.metadata())
     }
 }
 

--- a/src/scalar/linestring/scalar.rs
+++ b/src/scalar/linestring/scalar.rs
@@ -68,6 +68,7 @@ impl<'a, O: OffsetSizeTrait> LineString<'a, O> {
             self.coords.into_owned(),
             self.geom_offsets.into_owned(),
             None,
+            Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         Self::new_owned(sliced_arr.coords, sliced_arr.geom_offsets, 0)

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -78,6 +78,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
             self.geom_offsets.into_owned(),
             self.ring_offsets.into_owned(),
             None,
+            Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         Self::new_owned(

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -69,6 +69,7 @@ impl<'a, O: OffsetSizeTrait> MultiPoint<'a, O> {
             self.coords.into_owned(),
             self.geom_offsets.into_owned(),
             None,
+            Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         Self::new_owned(sliced_arr.coords, sliced_arr.geom_offsets, 0)

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -87,6 +87,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
             self.polygon_offsets.into_owned(),
             self.ring_offsets.into_owned(),
             None,
+            Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         Self::new_owned(

--- a/src/scalar/point/scalar.rs
+++ b/src/scalar/point/scalar.rs
@@ -172,12 +172,12 @@ mod test {
         let x1 = vec![0., 1., 2.];
         let y1 = vec![3., 4., 5.];
         let buf1 = CoordBuffer::Separated((x1, y1).try_into().unwrap());
-        let arr1 = PointArray::new(buf1, None);
+        let arr1 = PointArray::new(buf1, None, Default::default());
 
         let x2 = vec![0., 100., 2.];
         let y2 = vec![3., 400., 5.];
         let buf2 = CoordBuffer::Separated((x2, y2).try_into().unwrap());
-        let arr2 = PointArray::new(buf2, None);
+        let arr2 = PointArray::new(buf2, None, Default::default());
 
         assert_eq!(arr1.value(0), arr2.value(0));
     }

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -78,6 +78,7 @@ impl<'a, O: OffsetSizeTrait> Polygon<'a, O> {
             self.geom_offsets.into_owned(),
             self.ring_offsets.into_owned(),
             None,
+            Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         Self::new_owned(

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -1,5 +1,6 @@
 //! Defines [`GeometryArrayTrait`], which all geometry arrays implement.
 
+use crate::array::metadata::ArrayMetadata;
 use crate::array::{CoordBuffer, CoordType};
 use crate::datatypes::GeoDataType;
 use arrow_array::{Array, ArrayRef};
@@ -107,6 +108,8 @@ pub trait GeometryArrayTrait: std::fmt::Debug + Send + Sync {
     fn logical_nulls(&self) -> Option<NullBuffer> {
         self.nulls().cloned()
     }
+
+    fn metadata(&self) -> Arc<ArrayMetadata>;
 
     /// The number of null slots in this array.
     /// # Implementation
@@ -248,17 +251,28 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
 
     fn new() -> Self;
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType) -> Self;
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self;
 
     fn with_geom_capacity(geom_capacity: usize) -> Self {
-        GeometryArrayBuilder::with_geom_capacity_and_options(geom_capacity, Default::default())
-        // Self::with_geom_capacity_and_options(geom_capacity, Default::default())
+        GeometryArrayBuilder::with_geom_capacity_and_options(
+            geom_capacity,
+            Default::default(),
+            Default::default(),
+        )
     }
+
+    fn set_metadata(&mut self, metadata: Arc<ArrayMetadata>);
 
     fn finish(self) -> Arc<dyn GeometryArrayTrait>;
 
     /// Get the coordinate type of this geometry array, either interleaved or separated.
     fn coord_type(&self) -> CoordType;
+
+    fn metadata(&self) -> Arc<ArrayMetadata>;
 
     // /// Convert itself to an (immutable) [`GeometryArray`].
     // fn as_box(&mut self) -> Box<GeometryArrayTrait>;


### PR DESCRIPTION
Implementation of https://github.com/geoarrow/geoarrow/blob/main/extension-types.md#extension-metadata

Follow ups:

- Don't include `ARROW:extension:metadata` key if neither `crs` nor `edges` exists
- Allow python bindings to pass in CRS
- Pass on CRS in GeoParquet reader

Closes https://github.com/geoarrow/geoarrow-rs/issues/218, 