### PR TITLE
bump js version to 0.2.0-beta.2

### DIFF
--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-wasm"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geoarrow-wasm"
-version = "0.2.0-beta.1"
+version = "0.2.0-beta.2"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2021"
 description = "Efficient, vectorized geospatial operations in WebAssembly."


### PR DESCRIPTION
In order to test `geoparquet-wasm` with recent improvements to downcasting. (fixed here: https://github.com/geoarrow/geoarrow-rs/pull/485/files#diff-2e54e1cdb510a4907fbb46e6f5a8024742517e4368d55e433b608e29d08d4e74R301-R305)