### PR TITLE
Asynchronous geoparquet reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,6 +3031,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
+ "futures",
  "half 2.3.1",
  "hashbrown",
  "lz4_flex",
@@ -2023,6 +2024,7 @@ dependencies = [
  "seq-macro",
  "snap",
  "thrift",
+ "tokio",
  "twox-hash",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ itertools = "0.12"
 num_enum = "0.7"
 parquet = { version = "50", optional = true, default-features = false, features = [
   "arrow",
+  "async",
 ] }
 phf = { version = "0.11", features = ["macros"] }
 proj = { version = "0.27.2", optional = true, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ gdal = { version = "0.16", features = ["bindgen"] }
 geozero = { version = "0.11", features = ["with-wkb"] }
 parquet = "50"
 sqlx = { version = "0.7", default-features = false, features = ["postgres"] }
-tokio = { version = "1.9", features = ["macros", "fs"] }
+tokio = { version = "1.9", features = ["macros", "fs", "rt-multi-thread"] }
 
 [lib]
 doctest = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ gdal = { version = "0.16", features = ["bindgen"] }
 geozero = { version = "0.11", features = ["with-wkb"] }
 parquet = "50"
 sqlx = { version = "0.7", default-features = false, features = ["postgres"] }
-tokio = { version = "1.9", features = ["macros"] }
+tokio = { version = "1.9", features = ["macros", "fs"] }
 
 [lib]
 doctest = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ geos = ["dep:geos"]
 geozero = ["dep:geozero"]
 gdal = ["dep:gdal"]
 parquet = ["dep:parquet"]
+parquet_async = ["parquet", "parquet/async", "dep:futures"]
 parquet_compression = [
   "parquet/snap",
   "parquet/brotli",
@@ -54,7 +55,6 @@ itertools = "0.12"
 num_enum = "0.7"
 parquet = { version = "50", optional = true, default-features = false, features = [
   "arrow",
-  "async",
 ] }
 phf = { version = "0.11", features = ["macros"] }
 proj = { version = "0.27.2", optional = true, features = [

--- a/src/io/parquet/geoparquet_metadata.rs
+++ b/src/io/parquet/geoparquet_metadata.rs
@@ -1,10 +1,12 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::array::CoordType;
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
 
 use arrow_schema::Schema;
+use parquet::arrow::arrow_reader::ArrowReaderBuilder;
 use parquet::file::metadata::FileMetaData;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -88,7 +90,7 @@ fn infer_geo_data_type(
     }
 }
 
-pub fn parse_geoparquet_metadata(
+fn parse_geoparquet_metadata(
     metadata: &FileMetaData,
     schema: &Schema,
     coord_type: CoordType,
@@ -115,4 +117,18 @@ pub fn parse_geoparquet_metadata(
         geometry_column_index,
         infer_geo_data_type(&geometry_types, coord_type)?,
     ))
+}
+
+pub fn build_arrow_schema<T>(
+    builder: &ArrowReaderBuilder<T>,
+    coord_type: &CoordType,
+) -> (Arc<Schema>, usize, Option<GeoDataType>) {
+    let parquet_meta = builder.metadata();
+    let arrow_schema = builder.schema().clone();
+    let Ok((geometry_column_index, target_geo_data_type)) =
+        parse_geoparquet_metadata(parquet_meta.file_metadata(), &arrow_schema, *coord_type)
+    else {
+        panic!("Cannot parse geoparquet metadata");
+    };
+    (arrow_schema, geometry_column_index, target_geo_data_type)
 }

--- a/src/io/parquet/geoparquet_metadata.rs
+++ b/src/io/parquet/geoparquet_metadata.rs
@@ -122,13 +122,10 @@ fn parse_geoparquet_metadata(
 pub fn build_arrow_schema<T>(
     builder: &ArrowReaderBuilder<T>,
     coord_type: &CoordType,
-) -> (Arc<Schema>, usize, Option<GeoDataType>) {
+) -> Result<(Arc<Schema>, usize, Option<GeoDataType>)> {
     let parquet_meta = builder.metadata();
     let arrow_schema = builder.schema().clone();
-    let Ok((geometry_column_index, target_geo_data_type)) =
-        parse_geoparquet_metadata(parquet_meta.file_metadata(), &arrow_schema, *coord_type)
-    else {
-        panic!("Cannot parse geoparquet metadata");
-    };
-    (arrow_schema, geometry_column_index, target_geo_data_type)
+    let (geometry_column_index, target_geo_data_type) =
+        parse_geoparquet_metadata(parquet_meta.file_metadata(), &arrow_schema, *coord_type)?;
+    Ok((arrow_schema, geometry_column_index, target_geo_data_type))
 }

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -1,4 +1,37 @@
 //! Read the [GeoParquet](https://github.com/opengeospatial/geoparquet) format.
+//!
+//!# Examples of reading GeoParquet file into a GeoTable
+//!
+//!## Synchronous reader
+//!
+//!```rust
+//! use geoarrow::io::parquet::read_geoparquet;
+//! use geoarrow::io::parquet::GeoParquetReaderOptions;
+//! use std::fs::File;
+//!
+//! let file = File::open("nybb.parquet").unwrap();
+//! let options = GeoParquetReaderOptions::new(65536, Default::default());
+//! let output_geotable = read_geoparquet(file, options).unwrap();
+//! println!("GeoTable schema: {}", output_geotable.schema());
+//!```
+//!
+//!## Asynchronous reader
+//!
+//!```rust
+//! use geoarrow::io::parquet::read_geoparquet_async;
+//! use geoarrow::io::parquet::GeoParquetReaderOptions;
+//! use tokio::fs::File;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let file = File::open("fixtures/geoparquet/nybb.parquet")
+//!         .await
+//!         .unwrap();
+//!     let options = GeoParquetReaderOptions::new(65536, Default::default());
+//!     let output_geotable = read_geoparquet_async(file, options).await.unwrap();
+//!     println!("GeoTable schema: {}", output_geotable.schema());
+//! }
+//!```
 
 mod geoparquet_metadata;
 mod reader;

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -3,4 +3,4 @@
 mod geoparquet_metadata;
 mod reader;
 
-pub use reader::{read_geoparquet, GeoParquetReaderOptions};
+pub use reader::{read_geoparquet, read_geoparquet_async, GeoParquetReaderOptions};

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -1,23 +1,23 @@
 //! Read the [GeoParquet](https://github.com/opengeospatial/geoparquet) format.
 //!
-//!# Examples of reading GeoParquet file into a GeoTable
+//! # Examples of reading GeoParquet file into a GeoTable
 //!
-//!## Synchronous reader
+//! ## Synchronous reader
 //!
-//!```rust
+//! ```rust
 //! use geoarrow::io::parquet::read_geoparquet;
 //! use geoarrow::io::parquet::GeoParquetReaderOptions;
 //! use std::fs::File;
 //!
-//! let file = File::open("nybb.parquet").unwrap();
+//! let file = File::open("fixtures/geoparquet/nybb.parquet").unwrap();
 //! let options = GeoParquetReaderOptions::new(65536, Default::default());
 //! let output_geotable = read_geoparquet(file, options).unwrap();
 //! println!("GeoTable schema: {}", output_geotable.schema());
-//!```
+//! ```
 //!
-//!## Asynchronous reader
+//! ## Asynchronous reader
 //!
-//!```rust
+//! ```rust
 //! use geoarrow::io::parquet::read_geoparquet_async;
 //! use geoarrow::io::parquet::GeoParquetReaderOptions;
 //! use tokio::fs::File;
@@ -31,7 +31,7 @@
 //!     let output_geotable = read_geoparquet_async(file, options).await.unwrap();
 //!     println!("GeoTable schema: {}", output_geotable.schema());
 //! }
-//!```
+//! ```
 
 mod geoparquet_metadata;
 mod reader;

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -2,5 +2,9 @@
 
 mod geoparquet_metadata;
 mod reader;
+#[cfg(feature = "parquet_async")]
+mod reader_async;
 
-pub use reader::{read_geoparquet, read_geoparquet_async, GeoParquetReaderOptions};
+pub use reader::{read_geoparquet, GeoParquetReaderOptions};
+#[cfg(feature = "parquet_async")]
+pub use reader_async::read_geoparquet_async;

--- a/src/io/parquet/reader.rs
+++ b/src/io/parquet/reader.rs
@@ -28,7 +28,7 @@ pub fn read_geoparquet<R: ChunkReader + 'static>(
         ParquetRecordBatchReaderBuilder::try_new(reader)?.with_batch_size(options.batch_size);
 
     let (arrow_schema, geometry_column_index, target_geo_data_type) =
-        build_arrow_schema(&builder, &options.coord_type);
+        build_arrow_schema(&builder, &options.coord_type)?;
 
     let reader = builder.build()?;
 

--- a/src/io/parquet/reader.rs
+++ b/src/io/parquet/reader.rs
@@ -1,91 +1,14 @@
-use futures::stream::TryStreamExt;
-use std::collections::HashSet;
-
 use crate::array::CoordType;
-use crate::datatypes::GeoDataType;
-use crate::error::{GeoArrowError, Result};
+use crate::error::Result;
+use crate::io::parquet::geoparquet_metadata::parse_geoparquet_metadata;
 use crate::table::GeoTable;
 
-use crate::io::parquet::geoparquet_metadata::GeoParquetMetadata;
-use arrow_schema::Schema;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use parquet::arrow::async_reader::{AsyncFileReader, ParquetRecordBatchStreamBuilder};
-use parquet::file::metadata::FileMetaData;
 use parquet::file::reader::ChunkReader;
 
-// TODO: deduplicate with `resolve_types` in `downcast.rs`
-fn infer_geo_data_type(
-    geometry_types: &HashSet<&str>,
-    coord_type: CoordType,
-) -> Result<Option<GeoDataType>> {
-    if geometry_types.iter().any(|t| t.contains(" Z")) {
-        return Err(GeoArrowError::General(
-            "3D coordinates not currently supported".to_string(),
-        ));
-    }
-
-    match geometry_types.len() {
-        0 => Ok(None),
-        1 => Ok(Some(match *geometry_types.iter().next().unwrap() {
-            "Point" => GeoDataType::Point(coord_type),
-            "LineString" => GeoDataType::LineString(coord_type),
-            "Polygon" => GeoDataType::Polygon(coord_type),
-            "MultiPoint" => GeoDataType::MultiPoint(coord_type),
-            "MultiLineString" => GeoDataType::MultiLineString(coord_type),
-            "MultiPolygon" => GeoDataType::MultiPolygon(coord_type),
-            "GeometryCollection" => GeoDataType::GeometryCollection(coord_type),
-            _ => unreachable!(),
-        })),
-        2 => {
-            if geometry_types.contains("Point") && geometry_types.contains("MultiPoint") {
-                Ok(Some(GeoDataType::MultiPoint(coord_type)))
-            } else if geometry_types.contains("LineString")
-                && geometry_types.contains("MultiLineString")
-            {
-                Ok(Some(GeoDataType::MultiLineString(coord_type)))
-            } else if geometry_types.contains("Polygon") && geometry_types.contains("MultiPolygon")
-            {
-                Ok(Some(GeoDataType::MultiPolygon(coord_type)))
-            } else {
-                Ok(Some(GeoDataType::Mixed(coord_type)))
-            }
-        }
-        _ => Ok(Some(GeoDataType::Mixed(coord_type))),
-    }
-}
-
-fn parse_geoparquet_metadata(
-    metadata: &FileMetaData,
-    schema: &Schema,
-    coord_type: CoordType,
-) -> Result<(usize, Option<GeoDataType>)> {
-    let meta = GeoParquetMetadata::from_parquet_meta(metadata)?;
-    let column_meta = meta
-        .columns
-        .get(&meta.primary_column)
-        .ok_or(GeoArrowError::General(format!(
-            "Expected {} in GeoParquet column metadata",
-            &meta.primary_column
-        )))?;
-
-    let geometry_column_index = schema
-        .fields()
-        .iter()
-        .position(|field| field.name() == &meta.primary_column)
-        .unwrap();
-    let mut geometry_types = HashSet::with_capacity(column_meta.geometry_types.len());
-    column_meta.geometry_types.iter().for_each(|t| {
-        geometry_types.insert(t.as_str());
-    });
-    Ok((
-        geometry_column_index,
-        infer_geo_data_type(&geometry_types, coord_type)?,
-    ))
-}
-
 pub struct GeoParquetReaderOptions {
-    batch_size: usize,
-    coord_type: CoordType,
+    pub batch_size: usize,
+    pub coord_type: CoordType,
 }
 
 impl GeoParquetReaderOptions {
@@ -121,36 +44,6 @@ pub fn read_geoparquet<R: ChunkReader + 'static>(
     for maybe_batch in reader {
         batches.push(maybe_batch?);
     }
-
-    GeoTable::from_arrow(
-        batches,
-        arrow_schema,
-        Some(geometry_column_index),
-        target_geo_data_type,
-    )
-}
-
-pub async fn read_geoparquet_async<T: AsyncFileReader + Unpin + Send + 'static>(
-    input: T,
-    options: GeoParquetReaderOptions,
-) -> Result<GeoTable> {
-    let builder = ParquetRecordBatchStreamBuilder::new(input)
-        .await?
-        .with_batch_size(options.batch_size);
-
-    let (arrow_schema, geometry_column_index, target_geo_data_type) = {
-        let parquet_meta = builder.metadata();
-        let arrow_schema = builder.schema().clone();
-        let (geometry_column_index, target_geo_data_type) = parse_geoparquet_metadata(
-            parquet_meta.file_metadata(),
-            &arrow_schema,
-            options.coord_type,
-        )?;
-        (arrow_schema, geometry_column_index, target_geo_data_type)
-    };
-
-    let stream = builder.build()?;
-    let batches = stream.try_collect::<_>().await?;
 
     GeoTable::from_arrow(
         batches,

--- a/src/io/parquet/reader.rs
+++ b/src/io/parquet/reader.rs
@@ -1,6 +1,6 @@
 use crate::array::CoordType;
 use crate::error::Result;
-use crate::io::parquet::geoparquet_metadata::parse_geoparquet_metadata;
+use crate::io::parquet::geoparquet_metadata::build_arrow_schema;
 use crate::table::GeoTable;
 
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -27,16 +27,8 @@ pub fn read_geoparquet<R: ChunkReader + 'static>(
     let builder =
         ParquetRecordBatchReaderBuilder::try_new(reader)?.with_batch_size(options.batch_size);
 
-    let (arrow_schema, geometry_column_index, target_geo_data_type) = {
-        let parquet_meta = builder.metadata();
-        let arrow_schema = builder.schema().clone();
-        let (geometry_column_index, target_geo_data_type) = parse_geoparquet_metadata(
-            parquet_meta.file_metadata(),
-            &arrow_schema,
-            options.coord_type,
-        )?;
-        (arrow_schema, geometry_column_index, target_geo_data_type)
-    };
+    let (arrow_schema, geometry_column_index, target_geo_data_type) =
+        build_arrow_schema(&builder, &options.coord_type);
 
     let reader = builder.build()?;
 

--- a/src/io/parquet/reader.rs
+++ b/src/io/parquet/reader.rs
@@ -20,6 +20,7 @@ impl GeoParquetReaderOptions {
     }
 }
 
+/// Read a GeoParquet file to a GeoTable.
 pub fn read_geoparquet<R: ChunkReader + 'static>(
     reader: R,
     options: GeoParquetReaderOptions,

--- a/src/io/parquet/reader_async.rs
+++ b/src/io/parquet/reader_async.rs
@@ -6,6 +6,7 @@ use crate::table::GeoTable;
 use futures::stream::TryStreamExt;
 use parquet::arrow::async_reader::{AsyncFileReader, ParquetRecordBatchStreamBuilder};
 
+/// Asynchronously read a GeoParquet file to a GeoTable.
 pub async fn read_geoparquet_async<R: AsyncFileReader + Unpin + Send + 'static>(
     reader: R,
     options: GeoParquetReaderOptions,

--- a/src/io/parquet/reader_async.rs
+++ b/src/io/parquet/reader_async.rs
@@ -39,6 +39,6 @@ mod test {
             .await
             .unwrap();
         let options = GeoParquetReaderOptions::new(65536, Default::default());
-        let _output_ipc = read_geoparquet_async(file, options).await.unwrap();
+        let _output_geotable = read_geoparquet_async(file, options).await.unwrap();
     }
 }

--- a/src/io/parquet/reader_async.rs
+++ b/src/io/parquet/reader_async.rs
@@ -6,11 +6,11 @@ use crate::table::GeoTable;
 use futures::stream::TryStreamExt;
 use parquet::arrow::async_reader::{AsyncFileReader, ParquetRecordBatchStreamBuilder};
 
-pub async fn read_geoparquet_async<T: AsyncFileReader + Unpin + Send + 'static>(
-    input: T,
+pub async fn read_geoparquet_async<R: AsyncFileReader + Unpin + Send + 'static>(
+    reader: R,
     options: GeoParquetReaderOptions,
 ) -> Result<GeoTable> {
-    let builder = ParquetRecordBatchStreamBuilder::new(input)
+    let builder = ParquetRecordBatchStreamBuilder::new(reader)
         .await?
         .with_batch_size(options.batch_size);
 

--- a/src/io/parquet/reader_async.rs
+++ b/src/io/parquet/reader_async.rs
@@ -1,0 +1,37 @@
+use crate::error::Result;
+use crate::io::parquet::geoparquet_metadata::parse_geoparquet_metadata;
+use crate::io::parquet::reader::GeoParquetReaderOptions;
+use crate::table::GeoTable;
+
+use futures::stream::TryStreamExt;
+use parquet::arrow::async_reader::{AsyncFileReader, ParquetRecordBatchStreamBuilder};
+
+pub async fn read_geoparquet_async<T: AsyncFileReader + Unpin + Send + 'static>(
+    input: T,
+    options: GeoParquetReaderOptions,
+) -> Result<GeoTable> {
+    let builder = ParquetRecordBatchStreamBuilder::new(input)
+        .await?
+        .with_batch_size(options.batch_size);
+
+    let (arrow_schema, geometry_column_index, target_geo_data_type) = {
+        let parquet_meta = builder.metadata();
+        let arrow_schema = builder.schema().clone();
+        let (geometry_column_index, target_geo_data_type) = parse_geoparquet_metadata(
+            parquet_meta.file_metadata(),
+            &arrow_schema,
+            options.coord_type,
+        )?;
+        (arrow_schema, geometry_column_index, target_geo_data_type)
+    };
+
+    let stream = builder.build()?;
+    let batches = stream.try_collect::<_>().await?;
+
+    GeoTable::from_arrow(
+        batches,
+        arrow_schema,
+        Some(geometry_column_index),
+        target_geo_data_type,
+    )
+}

--- a/src/io/parquet/reader_async.rs
+++ b/src/io/parquet/reader_async.rs
@@ -15,7 +15,7 @@ pub async fn read_geoparquet_async<R: AsyncFileReader + Unpin + Send + 'static>(
         .with_batch_size(options.batch_size);
 
     let (arrow_schema, geometry_column_index, target_geo_data_type) =
-        build_arrow_schema(&builder, &options.coord_type);
+        build_arrow_schema(&builder, &options.coord_type)?;
 
     let stream = builder.build()?;
     let batches = stream.try_collect::<_>().await?;

--- a/src/io/parquet/reader_async.rs
+++ b/src/io/parquet/reader_async.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::io::parquet::geoparquet_metadata::parse_geoparquet_metadata;
+use crate::io::parquet::geoparquet_metadata::build_arrow_schema;
 use crate::io::parquet::reader::GeoParquetReaderOptions;
 use crate::table::GeoTable;
 
@@ -14,16 +14,8 @@ pub async fn read_geoparquet_async<T: AsyncFileReader + Unpin + Send + 'static>(
         .await?
         .with_batch_size(options.batch_size);
 
-    let (arrow_schema, geometry_column_index, target_geo_data_type) = {
-        let parquet_meta = builder.metadata();
-        let arrow_schema = builder.schema().clone();
-        let (geometry_column_index, target_geo_data_type) = parse_geoparquet_metadata(
-            parquet_meta.file_metadata(),
-            &arrow_schema,
-            options.coord_type,
-        )?;
-        (arrow_schema, geometry_column_index, target_geo_data_type)
-    };
+    let (arrow_schema, geometry_column_index, target_geo_data_type) =
+        build_arrow_schema(&builder, &options.coord_type);
 
     let stream = builder.build()?;
     let batches = stream.try_collect::<_>().await?;

--- a/src/io/parquet/reader_async.rs
+++ b/src/io/parquet/reader_async.rs
@@ -27,3 +27,18 @@ pub async fn read_geoparquet_async<T: AsyncFileReader + Unpin + Send + 'static>(
         target_geo_data_type,
     )
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tokio::fs::File;
+
+    #[tokio::test]
+    async fn nybb() {
+        let file = File::open("fixtures/geoparquet/nybb.parquet")
+            .await
+            .unwrap();
+        let options = GeoParquetReaderOptions::new(65536, Default::default());
+        let _output_ipc = read_geoparquet_async(file, options).await.unwrap();
+    }
+}


### PR DESCRIPTION
Implementing an asynchronous GeoParquet file reader using [`ParquetRecordBatchStream`](https://docs.rs/parquet/50.0.0/parquet/arrow/async_reader/struct.ParquetRecordBatchStream.html).

TODO:
- [x] Initial implementation in `src/io/parquet/reader.rs`
- [x] Fix trait bounds
- [x] Refactor to have both `read_geoparquet` and `read_geoparquet_async` functions parse the GeoParquet metadata using the same function
- [ ] Bring in `object-store` crate to read from URL (if it gets complicated, maybe split it into a separate PR)
- [x] Document new function
- [x] Add unit test

Addresses #492

P.S. This is my first ever Rust PR, so take it easy :see_no_evil: