### PR TITLE
skip serializing ArrayMetadata fields if `None`

### DIFF
--- a/src/array/metadata.rs
+++ b/src/array/metadata.rs
@@ -25,9 +25,11 @@ pub struct ArrayMetadata {
     /// to the wording in the GeoPackage WKB binary encoding: axis order is always (longitude,
     /// latitude) and (easting, northing) regardless of the the axis order encoded in the CRS
     /// specification.
+    #[serde(skip_serializing_if = "Option::is_none")]
     crs: Option<String>,
 
     /// If present, instructs consumers that edges follow a spherical path rather than a planar
     /// one. If this value is omitted, edges will be interpreted as planar.
+    #[serde(skip_serializing_if = "Option::is_none")]
     edges: Option<Edges>,
 }


### PR DESCRIPTION
This PR adds a serialize_if macro to the fields of `ArrayMetadata` struct. This should prevent `crs` or `edges` from being serialized if they are empty. Closes https://github.com/geoarrow/geoarrow-r/issues/34