### PR TITLE
Fix datetime column across multiple batches

### DIFF
--- a/src/io/geozero/table/builder/anyvalue.rs
+++ b/src/io/geozero/table/builder/anyvalue.rs
@@ -218,10 +218,11 @@ impl AnyBuilder {
             AnyBuilder::DateTime(arr) => {
                 arr.append_value(value.naive_utc().timestamp_micros());
             }
-            _ => {
-                return Err(GeoArrowError::General(
-                    "Unexpected type in add_timestamp_value".to_string(),
-                ))
+            builder_type => {
+                return Err(GeoArrowError::General(format!(
+                    "Unexpected type in add_timestamp_value, {:?}",
+                    builder_type
+                )))
             }
         }
         Ok(())

--- a/src/io/geozero/table/builder/anyvalue.rs
+++ b/src/io/geozero/table/builder/anyvalue.rs
@@ -321,7 +321,7 @@ impl AnyBuilder {
             Float64(_) => DataType::Float64,
             String(_) => DataType::Utf8,
             Json(_) => DataType::Utf8,
-            DateTime(_) => DataType::Timestamp(TimeUnit::Microsecond, None),
+            DateTime(_) => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
             Binary(_) => DataType::Binary,
         }
     }

--- a/src/io/geozero/table/builder/anyvalue.rs
+++ b/src/io/geozero/table/builder/anyvalue.rs
@@ -12,7 +12,7 @@ use arrow_array::builder::{
 };
 use arrow_array::Array;
 use arrow_cast::parse::string_to_datetime;
-use arrow_schema::DataType;
+use arrow_schema::{DataType, TimeUnit};
 use chrono::{DateTime, Utc};
 use geozero::ColumnValue;
 
@@ -321,7 +321,7 @@ impl AnyBuilder {
             Float64(_) => DataType::Float64,
             String(_) => DataType::Utf8,
             Json(_) => DataType::Utf8,
-            DateTime(_) => DataType::Utf8,
+            DateTime(_) => DataType::Timestamp(TimeUnit::Microsecond, None),
             Binary(_) => DataType::Binary,
         }
     }

--- a/src/io/postgis/reader.rs
+++ b/src/io/postgis/reader.rs
@@ -84,6 +84,11 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                 } else {
                     // The type is outside of geozero's type system so we handle it manually
                     match our_type_info.0 {
+                        Timestamp => {
+                            let value: DateTime<Utc> = row.try_get(i)?;
+                            self.properties_builder_mut()
+                                .add_timestamp_property(column_name, value)?;
+                        }
                         Timestamptz => {
                             let value: DateTime<Utc> = row.try_get(i)?;
                             self.properties_builder_mut()

--- a/src/io/postgis/reader.rs
+++ b/src/io/postgis/reader.rs
@@ -143,8 +143,8 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     Int8 => DataType::Int64,
                     Float4 => DataType::Float32,
                     Float8 => DataType::Float64,
-                    Timestamp => DataType::Utf8,
-                    Timestamptz => DataType::UInt8,
+                    Timestamp => DataType::Timestamp(TimeUnit::Microsecond, None),
+                    Timestamptz => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
                     // Timestamp => DataType::Timestamp(TimeUnit::Microsecond, None),
                     // Timestamptz => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
                     Text | Varchar | Char | Json | Jsonb => {

--- a/src/io/postgis/reader.rs
+++ b/src/io/postgis/reader.rs
@@ -136,6 +136,7 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     Int8 => DataType::Int64,
                     Float4 => DataType::Float32,
                     Float8 => DataType::Float64,
+                    Timestamp => DataType::Timestamp(TimeUnit::Microsecond, None),
                     Timestamptz => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
                     Text | Varchar | Char | Json | Jsonb => DataType::Utf8,
                     v => todo!("unimplemented type in initialization: {}", v.display_name()),

--- a/src/io/postgis/reader.rs
+++ b/src/io/postgis/reader.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use futures::stream::TryStreamExt;
 use geozero::wkb::process_ewkb_geom;
 use geozero::{ColumnValue, FeatureProcessor, GeomProcessor, GeozeroGeometry, PropertyProcessor};
-use sqlx::postgres::{PgRow, PgTypeInfo};
+use sqlx::postgres::{PgRow, PgTypeInfo, PgValueRef};
 use sqlx::{Column, Decode, Executor, Postgres, Row, Type, TypeInfo};
 use std::io::Cursor;
 use std::sync::Arc;
@@ -75,6 +75,13 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     Text | Varchar | Char | Json | Jsonb => {
                         Some(ColumnValue::String(row.try_get(i)?))
                     }
+                    // Timestamp | Timestamptz => {
+                    //     row.try_get(index)
+                    //     let test = row.try_get_raw(i)?;
+                    //     let test2 = test.as_bytes().unwrap();
+                    //     dbg!(test2);
+                    //     todo!()
+                    // } // Some(ColumnValue::String(row.try_get(i)?)),
                     _ => None,
                 };
 
@@ -136,9 +143,15 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     Int8 => DataType::Int64,
                     Float4 => DataType::Float32,
                     Float8 => DataType::Float64,
-                    Timestamp => DataType::Timestamp(TimeUnit::Microsecond, None),
-                    Timestamptz => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
-                    Text | Varchar | Char | Json | Jsonb => DataType::Utf8,
+                    Timestamp => DataType::Utf8,
+                    Timestamptz => DataType::UInt8,
+                    // Timestamp => DataType::Timestamp(TimeUnit::Microsecond, None),
+                    // Timestamptz => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                    Text | Varchar | Char | Json | Jsonb => {
+                        dbg!(our_type_info.0);
+
+                        DataType::Utf8
+                    }
                     v => todo!("unimplemented type in initialization: {}", v.display_name()),
                 };
                 schema.push(Field::new(column_name, data_type, true))
@@ -203,7 +216,7 @@ mod test {
     use super::*;
     use sqlx::postgres::PgPoolOptions;
 
-    #[ignore = "don't test postgres on ci"]
+    // #[ignore = "don't test postgres on ci"]
     #[tokio::test]
     async fn test() {
         let connection_url = "postgresql://username:password@localhost:54321/postgis";

--- a/src/io/postgis/reader.rs
+++ b/src/io/postgis/reader.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use futures::stream::TryStreamExt;
 use geozero::wkb::process_ewkb_geom;
 use geozero::{ColumnValue, FeatureProcessor, GeomProcessor, GeozeroGeometry, PropertyProcessor};
-use sqlx::postgres::{PgRow, PgTypeInfo, PgValueRef};
+use sqlx::postgres::{PgRow, PgTypeInfo};
 use sqlx::{Column, Decode, Executor, Postgres, Row, Type, TypeInfo};
 use std::io::Cursor;
 use std::sync::Arc;
@@ -75,13 +75,6 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     Text | Varchar | Char | Json | Jsonb => {
                         Some(ColumnValue::String(row.try_get(i)?))
                     }
-                    // Timestamp | Timestamptz => {
-                    //     row.try_get(index)
-                    //     let test = row.try_get_raw(i)?;
-                    //     let test2 = test.as_bytes().unwrap();
-                    //     dbg!(test2);
-                    //     todo!()
-                    // } // Some(ColumnValue::String(row.try_get(i)?)),
                     _ => None,
                 };
 
@@ -145,13 +138,7 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     Float8 => DataType::Float64,
                     Timestamp => DataType::Timestamp(TimeUnit::Microsecond, None),
                     Timestamptz => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
-                    // Timestamp => DataType::Timestamp(TimeUnit::Microsecond, None),
-                    // Timestamptz => DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
-                    Text | Varchar | Char | Json | Jsonb => {
-                        dbg!(our_type_info.0);
-
-                        DataType::Utf8
-                    }
+                    Text | Varchar | Char | Json | Jsonb => DataType::Utf8,
                     v => todo!("unimplemented type in initialization: {}", v.display_name()),
                 };
                 schema.push(Field::new(column_name, data_type, true))
@@ -216,7 +203,7 @@ mod test {
     use super::*;
     use sqlx::postgres::PgPoolOptions;
 
-    // #[ignore = "don't test postgres on ci"]
+    #[ignore = "don't test postgres on ci"]
     #[tokio::test]
     async fn test() {
         let connection_url = "postgresql://username:password@localhost:54321/postgis";


### PR DESCRIPTION
Previously we were inferring a string datatype from a datetime column for the next batch. This was erroring whenever we had enough rows for multiple batches.