### PR TITLE
Zero-copy as_chunked

### DIFF
--- a/src/algorithm/native/as_chunked.rs
+++ b/src/algorithm/native/as_chunked.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use crate::chunked_array::{from_arrow_chunks, ChunkedGeometryArrayTrait};
+use crate::error::Result;
+use crate::GeometryArrayTrait;
+
+// TODO: don't go through Arc<dyn Array>
+// Update geometry array trait to put slice on the main trait
+// Put slice() on each individual array directly, and delegate to it from geom trait
+pub fn as_chunked_geometry_array(
+    array: &dyn GeometryArrayTrait,
+    chunk_lengths: &[usize],
+) -> Result<Arc<dyn ChunkedGeometryArrayTrait>> {
+    assert_eq!(array.len(), chunk_lengths.iter().sum::<usize>());
+
+    let mut new_chunks = Vec::with_capacity(chunk_lengths.len());
+    let mut offset = 0;
+    for length in chunk_lengths {
+        new_chunks.push(array.to_array_ref());
+        offset += length;
+    }
+
+    let array_refs = new_chunks
+        .iter()
+        .map(|arr| arr.as_ref())
+        .collect::<Vec<_>>();
+    from_arrow_chunks(array_refs.as_slice(), array.extension_field().as_ref())
+}

--- a/src/algorithm/native/mod.rs
+++ b/src/algorithm/native/mod.rs
@@ -3,6 +3,7 @@
 //! Where possible, operations on scalars are implemented in terms of [geometry
 //! traits](../../geo_traits).
 
+mod as_chunked;
 mod binary;
 pub mod bounding_rect;
 mod cast;
@@ -17,6 +18,7 @@ mod total_bounds;
 pub(crate) mod type_id;
 mod unary;
 
+pub use as_chunked::as_chunked_geometry_array;
 pub use binary::Binary;
 pub use cast::Cast;
 pub use concatenate::Concatenate;

--- a/src/chunked_array/chunked_array.rs
+++ b/src/chunked_array/chunked_array.rs
@@ -232,6 +232,8 @@ pub trait ChunkedGeometryArrayTrait: std::fmt::Debug + Send + Sync {
 
     /// The number of chunks in this chunked array.
     fn num_chunks(&self) -> usize;
+
+    fn chunk_lengths(&self) -> Vec<usize>;
 }
 
 impl ChunkedGeometryArrayTrait for ChunkedPointArray {
@@ -255,6 +257,10 @@ impl ChunkedGeometryArrayTrait for ChunkedPointArray {
 
     fn num_chunks(&self) -> usize {
         self.chunks.len()
+    }
+
+    fn chunk_lengths(&self) -> Vec<usize> {
+        self.chunks.iter().map(|chunk| chunk.len()).collect()
     }
 }
 
@@ -281,6 +287,10 @@ macro_rules! impl_trait {
 
             fn num_chunks(&self) -> usize {
                 self.chunks.len()
+            }
+
+            fn chunk_lengths(&self) -> Vec<usize> {
+                self.chunks.iter().map(|chunk| chunk.len()).collect()
             }
         }
     };
@@ -316,6 +326,10 @@ impl ChunkedGeometryArrayTrait for ChunkedRectArray {
 
     fn num_chunks(&self) -> usize {
         self.chunks.len()
+    }
+
+    fn chunk_lengths(&self) -> Vec<usize> {
+        self.chunks.iter().map(|chunk| chunk.len()).collect()
     }
 }
 


### PR DESCRIPTION
The thinking is that the _left_ side is always the "maintained chunking". So when left side is an array, the output will be an array, and when the left side is a chunked array, the output will be a chunked array. 

So this function handles converting a contiguous array into a chunked array in a zero-copy manner.