### PR TITLE
Parquet options updates

### DIFF
--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -1023,6 +1023,8 @@ dependencies = [
  "parquet",
  "range-reader",
  "reqwest",
+ "serde",
+ "serde-wasm-bindgen",
  "thiserror",
  "tokio",
  "wasm-bindgen",

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -97,6 +97,8 @@ thiserror = "1"
 tokio = { version = "*", default-features = false, optional = true }
 wasm-streams = { version = "0.3.0", optional = true }
 
+serde = { version = "1.0", features = ["derive"] }
+serde-wasm-bindgen = "0.6.5"
 
 # Pass "wasm" and "thin" down to the transitive zstd dependency
 zstd = { version = "*", features = [

--- a/js/src/io/parquet/mod.rs
+++ b/js/src/io/parquet/mod.rs
@@ -2,6 +2,7 @@
 pub mod r#async;
 #[cfg(feature = "io_parquet_async")]
 pub mod async_file_reader;
+pub mod options;
 pub mod sync;
 
 #[cfg(feature = "io_parquet_async")]

--- a/js/src/io/parquet/options.rs
+++ b/js/src/io/parquet/options.rs
@@ -1,0 +1,28 @@
+use geoarrow::array::CoordType;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct JsParquetReaderOptions {
+    /// The number of rows in each batch. If not provided, the upstream [parquet] default is 1024.
+    pub batch_size: Option<usize>,
+
+    /// See [parquet::arrow::arrow_reader::ArrowReaderBuilder::with_limit]
+    pub limit: Option<usize>,
+
+    /// See [parquet::arrow::arrow_reader::ArrowReaderBuilder::with_offset]
+    pub offset: Option<usize>,
+}
+
+impl From<JsParquetReaderOptions> for geoarrow::io::parquet::ParquetReaderOptions {
+    fn from(value: JsParquetReaderOptions) -> Self {
+        Self {
+            batch_size: value.batch_size,
+            limit: value.limit,
+            offset: value.offset,
+            projection: None,
+            coord_type: CoordType::Interleaved,
+            bbox: None,
+            bbox_paths: None,
+        }
+    }
+}

--- a/js/src/io/parquet/sync.rs
+++ b/js/src/io/parquet/sync.rs
@@ -1,7 +1,7 @@
 use arrow_wasm::Table;
 // use parquet_wasm::utils::assert_parquet_file_not_empty;
 use bytes::Bytes;
-use geoarrow::io::parquet::{read_geoparquet as _read_geoparquet, GeoParquetReaderOptions};
+use geoarrow::io::parquet::{read_geoparquet as _read_geoparquet, ParquetReaderOptions};
 use wasm_bindgen::prelude::*;
 
 use crate::error::WasmResult;
@@ -26,8 +26,8 @@ use crate::error::WasmResult;
 #[wasm_bindgen(js_name = readGeoParquet)]
 pub fn read_geoparquet(file: Vec<u8>) -> WasmResult<Table> {
     // assert_parquet_file_not_empty(parquet_file)?;
-    let options = GeoParquetReaderOptions {
-        batch_size: 65536,
+    let options = ParquetReaderOptions {
+        batch_size: Some(65536),
         ..Default::default()
     };
     let geo_table = _read_geoparquet(Bytes::from(file), options)?;

--- a/python/core/src/io/parquet/mod.rs
+++ b/python/core/src/io/parquet/mod.rs
@@ -1,2 +1,3 @@
+pub mod options;
 pub mod reader;
 pub mod writer;

--- a/python/core/src/io/parquet/options.rs
+++ b/python/core/src/io/parquet/options.rs
@@ -1,0 +1,53 @@
+use geo::coord;
+use geoarrow::array::CoordType;
+use geoarrow::io::parquet::ParquetReaderOptions;
+use pyo3::prelude::*;
+
+#[derive(FromPyObject)]
+pub struct GeoParquetBboxPaths {
+    #[pyo3(item)]
+    minx_path: Vec<String>,
+    #[pyo3(item)]
+    miny_path: Vec<String>,
+    #[pyo3(item)]
+    maxx_path: Vec<String>,
+    #[pyo3(item)]
+    maxy_path: Vec<String>,
+}
+
+impl From<GeoParquetBboxPaths> for geoarrow::io::parquet::ParquetBboxPaths {
+    fn from(value: GeoParquetBboxPaths) -> Self {
+        Self {
+            minx_path: value.minx_path,
+            miny_path: value.miny_path,
+            maxx_path: value.maxx_path,
+            maxy_path: value.maxy_path,
+        }
+    }
+}
+
+pub fn create_options(
+    batch_size: Option<usize>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+    bbox: Option<[f64; 4]>,
+    bbox_paths: Option<GeoParquetBboxPaths>,
+) -> ParquetReaderOptions {
+    let bbox = bbox.map(|item| {
+        geo::Rect::new(
+            coord! {x: item[0], y: item[1]},
+            coord! {x: item[2], y: item[3]},
+        )
+    });
+    let bbox_paths = bbox_paths.map(geoarrow::io::parquet::ParquetBboxPaths::from);
+
+    ParquetReaderOptions {
+        batch_size,
+        limit,
+        offset,
+        projection: None,
+        bbox,
+        bbox_paths,
+        coord_type: CoordType::Interleaved,
+    }
+}

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -45,9 +45,9 @@ mod reader;
 mod test;
 mod writer;
 
-pub use reader::{read_geoparquet, GeoParquetReaderOptions, ParquetBboxPaths};
+pub use reader::{read_geoparquet, ParquetBboxPaths, ParquetReaderOptions};
 #[cfg(feature = "parquet_async")]
-pub use reader::{read_geoparquet_async, ParquetDataset, ParquetFile, ParquetReaderOptions};
+pub use reader::{read_geoparquet_async, ParquetDataset, ParquetFile};
 pub use writer::{
     write_geoparquet, GeoParquetWriter, GeoParquetWriterEncoding, GeoParquetWriterOptions,
 };

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -6,12 +6,12 @@
 //!
 //! ```rust
 //! use geoarrow::io::parquet::read_geoparquet;
-//! use geoarrow::io::parquet::GeoParquetReaderOptions;
+//! use geoarrow::io::parquet::ParquetReaderOptions;
 //! use std::fs::File;
 //!
 //! let file = File::open("fixtures/geoparquet/nybb.parquet").unwrap();
-//! let options = GeoParquetReaderOptions {
-//!     batch_size: 65536,
+//! let options = ParquetReaderOptions {
+//!     batch_size: Some(65536),
 //!     ..Default::default()
 //! };
 //! let output_geotable = read_geoparquet(file, options).unwrap();
@@ -22,7 +22,7 @@
 //!
 //! ```rust
 //! use geoarrow::io::parquet::read_geoparquet_async;
-//! use geoarrow::io::parquet::GeoParquetReaderOptions;
+//! use geoarrow::io::parquet::ParquetReaderOptions;
 //! use tokio::fs::File;
 //!
 //! #[tokio::main]
@@ -30,8 +30,8 @@
 //!     let file = File::open("fixtures/geoparquet/nybb.parquet")
 //!         .await
 //!         .unwrap();
-//!     let options = GeoParquetReaderOptions {
-//!         batch_size: 65536,
+//!     let options = ParquetReaderOptions {
+//!         batch_size: Some(65536),
 //!         ..Default::default()
 //!     };
 //!     let output_geotable = read_geoparquet_async(file, options).await.unwrap();

--- a/src/io/parquet/reader/async.rs
+++ b/src/io/parquet/reader/async.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::array::{CoordType, PolygonArray, RectBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::parquet::metadata::{build_arrow_schema, GeoParquetMetadata};
@@ -10,6 +12,8 @@ use futures::stream::TryStreamExt;
 use geo::Rect;
 use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
 use parquet::arrow::async_reader::{AsyncFileReader, ParquetRecordBatchStreamBuilder};
+use parquet::file::metadata::ParquetMetaData;
+use parquet::schema::types::SchemaDescriptor;
 use serde_json::Value;
 
 /// Asynchronously read a GeoParquet file to a Table.
@@ -76,7 +80,17 @@ impl<R: AsyncFileReader + Unpin + Send + 'static> ParquetFile<R> {
         })
     }
 
-    /// The Arrow schema of the underlying data
+    /// Returns a reference to the [`ParquetMetaData`] for this parquet file
+    pub fn metadata(&self) -> &Arc<ParquetMetaData> {
+        self.meta.metadata()
+    }
+
+    /// Returns the parquet [`SchemaDescriptor`] for this parquet file
+    pub fn parquet_schema(&self) -> &SchemaDescriptor {
+        self.meta.parquet_schema()
+    }
+
+    /// Returns the Arrow [`SchemaRef`] of the underlying data
     ///
     /// Note that this schema is before conversion of any geometry column(s) to GeoArrow.
     pub fn schema(&self) -> SchemaRef {

--- a/src/io/parquet/reader/mod.rs
+++ b/src/io/parquet/reader/mod.rs
@@ -5,8 +5,8 @@ mod options;
 mod spatial_filter;
 mod sync;
 
-pub use options::GeoParquetReaderOptions;
+pub use options::ParquetReaderOptions;
 #[cfg(feature = "parquet_async")]
-pub use r#async::{read_geoparquet_async, ParquetDataset, ParquetFile, ParquetReaderOptions};
+pub use r#async::{read_geoparquet_async, ParquetDataset, ParquetFile};
 pub use spatial_filter::ParquetBboxPaths;
 pub use sync::read_geoparquet;

--- a/src/io/parquet/reader/spatial_filter.rs
+++ b/src/io/parquet/reader/spatial_filter.rs
@@ -21,6 +21,7 @@ use crate::trait_::GeometryArrayAccessor;
 /// A helper for interpreting bounding box row group statistics from GeoParquet files
 ///
 /// This is intended to be user facing
+#[derive(Debug, Clone)]
 pub struct ParquetBboxPaths {
     /// The path in the Parquet schema of the column that contains the xmin
     pub minx_path: Vec<String>,


### PR DESCRIPTION
- Refactor `ParquetFile::builder` to consume self, allowing it to be used in `read_geoparquet_async` without requiring a `Clone` bound
- Consolidate `ReadParquetOptions` to cover both the upstream `ArrowReaderOptions` and our own geospatial options.