### PR TITLE
Swap AsyncHttpFileReader for HttpObjectStore

### DIFF
--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -1770,7 +1770,6 @@ dependencies = [
  "backon",
  "bytes",
  "chrono",
- "console_error_panic_hook",
  "futures",
  "js-sys",
  "object_store",

--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -421,6 +421,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "backon"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67782c3f868daa71d3533538e98a8e13713231969def7536e8039606fc46bf0"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,14 +1031,16 @@ dependencies = [
  "geo",
  "geoarrow",
  "geodesy",
+ "object-store-wasm",
  "object_store",
  "parquet",
  "range-reader",
- "reqwest",
+ "reqwest 0.12.2",
  "serde",
  "serde-wasm-bindgen",
  "thiserror",
  "tokio",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -1111,6 +1125,25 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
@@ -1120,7 +1153,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1188,6 +1221,17 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1199,12 +1243,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -1215,8 +1270,8 @@ checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1227,10 +1282,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1241,9 +1326,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1260,7 +1345,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.2.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1277,9 +1362,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1676,6 +1761,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "object-store-wasm"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8ac31e06fafdb1bd13fc1f1820e40fd7647957069ce460c187bde26fcd9fc3"
+dependencies = [
+ "async-trait",
+ "backon",
+ "bytes",
+ "chrono",
+ "console_error_panic_hook",
+ "futures",
+ "js-sys",
+ "object_store",
+ "reqwest 0.11.27",
+ "snafu",
+ "tokio",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "object_store"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1912,7 @@ dependencies = [
  "lz4_flex",
  "num",
  "num-bigint",
+ "object_store",
  "paste",
  "seq-macro",
  "snap",
@@ -2006,6 +2116,44 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
@@ -2015,11 +2163,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "http-body-util",
- "hyper",
+ "hyper 1.2.0",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -2769,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -35,14 +35,16 @@ io_object_store = [
     "dep:object_store",
     "dep:reqwest",
     "dep:tokio",
+    "dep:object-store-wasm",
+    "dep:url",
+    "parquet/object_store"
 ]
 io_parquet = ["geoarrow/parquet", "table", "dep:bytes", "dep:parquet"]
 io_parquet_async = [
     "async-stream",
     "geoarrow/parquet_async",
     "io_http",
-    # We don't currently use object_store in Parque
-    # "io_object_store",
+    "io_object_store",
     "io_parquet",
     "range-reader",
     "wasm-streams",
@@ -95,7 +97,7 @@ range-reader = { version = "0.2", optional = true }
 reqwest = { version = "*", optional = true }
 thiserror = "1"
 tokio = { version = "*", default-features = false, optional = true }
-wasm-streams = { version = "0.3.0", optional = true }
+wasm-streams = { version = "0.4.0", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
@@ -109,6 +111,10 @@ zstd = { version = "*", features = [
 # TODO: temporary to fix parquet wasm build
 # upstream issue: https://github.com/gyscos/zstd-rs/issues/269
 zstd-sys = { version = "=2.0.9", optional = true, default-features = false }
+object-store-wasm = { version = "0.0.1", optional = true, default-features = false, features = [
+    "http"
+] }
+url = { version = "2.5.0", optional = true }
 
 
 [dependencies.web-sys]

--- a/js/src/io/parquet/async.rs
+++ b/js/src/io/parquet/async.rs
@@ -1,22 +1,31 @@
+use crate::error::WasmResult;
+use crate::io::parquet::options::JsParquetReaderOptions;
 use arrow_wasm::Table;
+use futures::future::join_all;
 use geoarrow::io::parquet::ParquetDataset as _ParquetDataset;
 use geoarrow::io::parquet::ParquetFile as _ParquetFile;
+use object_store::ObjectStore;
+use object_store_wasm::http::HttpStore;
+use parquet::arrow::async_reader::ParquetObjectReader;
+use std::sync::Arc;
+use url::Url;
 use wasm_bindgen::prelude::*;
-
-use crate::error::WasmResult;
-use crate::io::parquet::async_file_reader::HTTPFileReader;
-use crate::io::parquet::options::JsParquetReaderOptions;
 
 #[wasm_bindgen]
 pub struct ParquetFile {
-    file: _ParquetFile<HTTPFileReader>,
+    file: _ParquetFile<ParquetObjectReader>,
 }
 
 #[wasm_bindgen]
 impl ParquetFile {
     #[wasm_bindgen(constructor)]
     pub async fn new(url: String) -> WasmResult<ParquetFile> {
-        let reader = HTTPFileReader::new(url, Default::default(), 500_000);
+        let parsed_url = Url::parse(&url)?;
+        let base_url = Url::parse(&parsed_url.origin().unicode_serialization())?;
+        let storage_container = Arc::new(HttpStore::new(base_url));
+        let location = object_store::path::Path::parse(parsed_url.path()).unwrap();
+        let file_meta = storage_container.head(&location).await.unwrap();
+        let reader = ParquetObjectReader::new(storage_container, file_meta);
         let file = _ParquetFile::new(reader).await?;
         Ok(Self { file })
     }
@@ -71,18 +80,26 @@ impl ParquetFile {
 
 #[wasm_bindgen]
 pub struct ParquetDataset {
-    inner: _ParquetDataset<HTTPFileReader>,
+    inner: _ParquetDataset<ParquetObjectReader>,
 }
 
 #[wasm_bindgen]
 impl ParquetDataset {
     #[wasm_bindgen(constructor)]
     pub async fn new(urls: Vec<String>) -> WasmResult<ParquetDataset> {
-        let readers = urls
+        let readers: Vec<_> = urls
             .into_iter()
-            .map(|url| HTTPFileReader::new(url, Default::default(), 500_000))
+            .map(|url| async move {
+                let parsed_url = Url::parse(&url).unwrap();
+                let base_url = Url::parse(&parsed_url.origin().unicode_serialization()).unwrap();
+                let storage_container = Arc::new(HttpStore::new(base_url));
+                let location = object_store::path::Path::parse(parsed_url.path()).unwrap();
+                let file_meta = storage_container.head(&location).await.unwrap();
+                let reader = ParquetObjectReader::new(storage_container, file_meta);
+                reader
+            })
             .collect();
-        let dataset = _ParquetDataset::new(readers).await?;
+        let dataset = _ParquetDataset::new(join_all(readers).await).await?;
         Ok(Self { inner: dataset })
     }
 

--- a/js/src/io/parquet/async.rs
+++ b/js/src/io/parquet/async.rs
@@ -95,8 +95,8 @@ impl ParquetDataset {
                 let storage_container = Arc::new(HttpStore::new(base_url));
                 let location = object_store::path::Path::parse(parsed_url.path()).unwrap();
                 let file_meta = storage_container.head(&location).await.unwrap();
-                let reader = ParquetObjectReader::new(storage_container, file_meta);
-                reader
+
+                ParquetObjectReader::new(storage_container, file_meta)
             })
             .collect();
         let dataset = _ParquetDataset::new(join_all(readers).await).await?;


### PR DESCRIPTION
Directly copied from the equivalent parquet-wasm PR :stuck_out_tongue: .

I'm strongly considering just wrapping [object_store_s3_wasm](https://github.com/JanKaul/object_store_s3_wasm) in object-store-wasm this weekend, so if there's no particular rush, I can work the coveted fsspec-like protocol-differentiated IO into this PR.

Also, one question for any maintainer - `io_parquet_async` implies object-store-wasm::http at a minimum, right? I'm thinking in terms of the other cloud providers, which I imagine would be worth feature-gating at the level of this consuming crate (it's a shame toggling transitive dependency features isn't a thing).