### PR TITLE
Parse Parquet geometry column after reading all files

### DIFF
--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -1762,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "object-store-wasm"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8ac31e06fafdb1bd13fc1f1820e40fd7647957069ce460c187bde26fcd9fc3"
+checksum = "09bb5cc988ec26a079e0507f05d95a98633a520478d343d573af9a9b5f2a986d"
 dependencies = [
  "async-trait",
  "backon",

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -92,7 +92,7 @@ geo = "0.28"
 geoarrow = { path = "../" }
 geodesy = { version = "0.12", optional = true, features = ["js"] }
 object_store = { version = "*", optional = true }
-object-store-wasm = { version = "0.0.1", optional = true, default-features = false, features = [
+object-store-wasm = { version = "0.0.2", optional = true, default-features = false, features = [
     "http",
 ] }
 parquet = { version = "51", optional = true, features = ["arrow", "base64"] }

--- a/src/io/parquet/reader/async.rs
+++ b/src/io/parquet/reader/async.rs
@@ -38,7 +38,7 @@ async fn read_builder<R: AsyncFileReader + Unpin + Send + 'static>(
     let batches = stream.try_collect::<_>().await?;
 
     let mut table = Table::try_new(arrow_schema, batches)?;
-    if table.len() > 0 {
+    if !table.is_empty() {
         table.parse_geometry_to_native(geometry_column_index, target_geo_data_type)?;
     } else {
         use crate::datatypes::GeoDataType;

--- a/src/io/parquet/reader/async.rs
+++ b/src/io/parquet/reader/async.rs
@@ -44,7 +44,7 @@ async fn read_builder<R: AsyncFileReader + Unpin + Send + 'static>(
         use crate::datatypes::GeoDataType;
         table.cast_geometry(
             geometry_column_index,
-            &target_geo_data_type.unwrap_or(GeoDataType::LargeMixed(*coord_type))
+            &target_geo_data_type.unwrap_or(GeoDataType::LargeMixed(*coord_type)),
         )?;
     }
     Ok(table)

--- a/src/io/parquet/reader/async.rs
+++ b/src/io/parquet/reader/async.rs
@@ -38,7 +38,15 @@ async fn read_builder<R: AsyncFileReader + Unpin + Send + 'static>(
     let batches = stream.try_collect::<_>().await?;
 
     let mut table = Table::try_new(arrow_schema, batches)?;
-    table.parse_geometry_to_native(geometry_column_index, target_geo_data_type)?;
+    if table.len() > 0 {
+        table.parse_geometry_to_native(geometry_column_index, target_geo_data_type)?;
+    } else {
+        use crate::datatypes::GeoDataType;
+        table.cast_geometry(
+            geometry_column_index,
+            &target_geo_data_type.unwrap_or(GeoDataType::LargeMixed(*coord_type))
+        )?;
+    }
     Ok(table)
 }
 


### PR DESCRIPTION
This is an alternative solution to #609.

One thing we always have to be careful about is ensuring that the schema across record batches is always the same. When the GeoParquet metadata declares the geometry type of the underlying data, we always know what to parse the geometry column to. But it's also allowed for the GeoParquet metadata to not declare the column types. In this case, we parse to a mixed array and then downcast.

But it would be bad to downcast each file of a dataset independently, as it would be possible for one file in a dataset to contain only points and for another to contain only polygons, even where the rest of the schema is the same. 

In this PR, we defer the parsing from WKB until after the data has already been materialized. Maybe this will slightly increase the wall time in the case where we have to wait a while to fetch the data and _then_ parse the data. But it's simpler than switching on whether the relevant metadata exists