### PR TITLE
Refactor schema operations from table

### DIFF
--- a/src/algorithm/native/downcast.rs
+++ b/src/algorithm/native/downcast.rs
@@ -13,6 +13,7 @@ use crate::array::*;
 use crate::chunked_array::*;
 use crate::datatypes::GeoDataType;
 use crate::error::Result;
+use crate::schema::GeoSchemaExt;
 use crate::table::Table;
 use crate::GeometryArrayTrait;
 
@@ -712,7 +713,9 @@ pub trait DowncastTable {
 impl DowncastTable for Table {
     fn downcast(&self, small_offsets: bool) -> Result<Table> {
         let downcasted_columns = self
-            .geometry_column_indices()
+            .schema()
+            .as_ref()
+            .geometry_columns()
             .iter()
             .map(|idx| {
                 let geometry = self.geometry_column(Some(*idx))?;

--- a/src/io/flatgeobuf/writer.rs
+++ b/src/io/flatgeobuf/writer.rs
@@ -4,6 +4,7 @@ use flatgeobuf::{FgbWriter, FgbWriterOptions};
 use geozero::GeozeroDatasource;
 
 use crate::error::GeoArrowError;
+use crate::schema::GeoSchemaExt;
 use crate::table::Table;
 
 // TODO: always write CRS saved in Table metadata (you can do this by adding an option)
@@ -34,11 +35,12 @@ pub fn write_flatgeobuf_with_options<W: Write>(
 
 fn infer_flatgeobuf_geometry_type(table: &Table) -> flatgeobuf::GeometryType {
     let fields = &table.schema().fields;
-    if table.geometry_column_indices().len() != 1 {
+    let geom_col_idxs = table.schema().as_ref().geometry_columns();
+    if geom_col_idxs.len() != 1 {
         panic!("Only one geometry column currently supported in FlatGeobuf writer");
     }
 
-    let geometry_field = &fields[table.geometry_column_indices()[0]];
+    let geometry_field = &fields[geom_col_idxs[0]];
     if let Some(extension_name) = geometry_field.metadata().get("ARROW:extension:name") {
         let geometry_type = match extension_name.as_str() {
             "geoarrow.point" => flatgeobuf::GeometryType::Point,

--- a/src/io/gdal/reader.rs
+++ b/src/io/gdal/reader.rs
@@ -46,6 +46,7 @@ pub fn read_gdal(layer: &mut Layer, batch_size: Option<usize>) -> Result<Table> 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::schema::GeoSchemaExt;
     use gdal::Dataset;
     use std::path::Path;
 
@@ -55,7 +56,7 @@ mod test {
         let dataset = Dataset::open(Path::new("fixtures/flatgeobuf/countries.fgb"))?;
         let mut layer = dataset.layer(0)?;
         let table = read_gdal(&mut layer, None)?;
-        dbg!(table.geometry_column_indices());
+        dbg!(table.schema().as_ref().geometry_columns());
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod geo_traits;
 pub mod indexed;
 pub mod io;
 pub mod scalar;
+pub mod schema;
 pub mod table;
 #[cfg(test)]
 pub(crate) mod test;

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,0 +1,27 @@
+//! Geospatial operations on Arrow schemas
+
+use crate::table::GEOARROW_EXTENSION_NAMES;
+
+/// Extra geospatial-specific functionality on Arrow schemas
+pub trait GeoSchemaExt {
+    /// Find the indices of all geometry columns in this schema.
+    ///
+    /// The returned `Vec` may be empty if the table contains no geometry columns, or it may
+    /// contain more than one element if the table contains multiple tagged geometry columns.
+    fn geometry_columns(&self) -> Vec<usize>;
+}
+
+impl GeoSchemaExt for &arrow_schema::Schema {
+    fn geometry_columns(&self) -> Vec<usize> {
+        let mut geom_indices = vec![];
+        for (field_idx, field) in self.fields().iter().enumerate() {
+            let meta = field.metadata();
+            if let Some(ext_name) = meta.get("ARROW:extension:name") {
+                if GEOARROW_EXTENSION_NAMES.contains(ext_name.as_str()) {
+                    geom_indices.push(field_idx);
+                }
+            }
+        }
+        geom_indices
+    }
+}


### PR DESCRIPTION
Add new `GeoSchemaExt` trait for geospatial operations on arrow schemas