### PR TITLE
Implement python record batch reader

### DIFF
--- a/js/src/io/geojson.rs
+++ b/js/src/io/geojson.rs
@@ -39,8 +39,8 @@ pub fn read_geojson(file: &[u8], batch_size: Option<usize>) -> WasmResult<Table>
 #[wasm_bindgen(js_name = writeGeoJSON)]
 pub fn write_geojson(table: Table) -> WasmResult<Vec<u8>> {
     let (schema, batches) = table.into_inner();
-    let mut rust_table = geoarrow::table::Table::try_new(schema, batches)?;
+    let rust_table = geoarrow::table::Table::try_new(schema, batches)?;
     let mut output_file: Vec<u8> = vec![];
-    _write_geojson(&mut rust_table, &mut output_file)?;
+    _write_geojson(rust_table, &mut output_file)?;
     Ok(output_file)
 }

--- a/python/core/src/ffi/from_python/mod.rs
+++ b/python/core/src/ffi/from_python/mod.rs
@@ -3,6 +3,7 @@ pub mod chunked;
 pub mod ffi_stream;
 pub mod input;
 pub mod record_batch;
+pub mod record_batch_reader;
 pub mod scalar;
 pub mod schema;
 pub mod table;

--- a/python/core/src/ffi/from_python/record_batch_reader.rs
+++ b/python/core/src/ffi/from_python/record_batch_reader.rs
@@ -1,0 +1,15 @@
+use crate::ffi::from_python::utils::import_arrow_c_stream;
+use crate::stream::PyRecordBatchReader;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::{PyAny, PyResult};
+
+impl<'a> FromPyObject<'a> for PyRecordBatchReader {
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        let stream = import_arrow_c_stream(ob)?;
+        let stream_reader = arrow::ffi_stream::ArrowArrayStreamReader::try_new(stream)
+            .map_err(|err| PyValueError::new_err(err.to_string()))?;
+
+        Ok(Self(Some(Box::new(stream_reader))))
+    }
+}

--- a/python/core/src/ffi/to_python/mod.rs
+++ b/python/core/src/ffi/to_python/mod.rs
@@ -1,6 +1,7 @@
 pub mod array;
 pub mod chunked;
 pub mod ffi_stream;
+pub mod record_batch_reader;
 pub mod scalar;
 pub mod table;
 

--- a/python/core/src/ffi/to_python/record_batch_reader.rs
+++ b/python/core/src/ffi/to_python/record_batch_reader.rs
@@ -1,0 +1,35 @@
+use crate::error::PyGeoArrowResult;
+use crate::stream::PyRecordBatchReader;
+use arrow::ffi_stream::FFI_ArrowArrayStream;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+use std::ffi::CString;
+
+#[pymethods]
+impl PyRecordBatchReader {
+    /// An implementation of the [Arrow PyCapsule
+    /// Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html).
+    /// This dunder method should not be called directly, but enables zero-copy
+    /// data transfer to other Python libraries that understand Arrow memory.
+    ///
+    /// For example, you can call [`pyarrow.table()`][pyarrow.table] to convert this array
+    /// into a pyarrow table, without copying memory.
+    fn __arrow_c_stream__(
+        &mut self,
+        _requested_schema: Option<PyObject>,
+    ) -> PyGeoArrowResult<PyObject> {
+        let reader = self.0.take().ok_or(PyValueError::new_err(
+            "Cannot read from closed RecordBatchReader",
+        ))?;
+
+        let ffi_stream = FFI_ArrowArrayStream::new(reader);
+        let stream_capsule_name = CString::new("arrow_array_stream").unwrap();
+
+        Python::with_gil(|py| {
+            let stream_capsule = PyCapsule::new(py, ffi_stream, Some(stream_capsule_name))?;
+            Ok(stream_capsule.to_object(py))
+        })
+    }
+}

--- a/python/core/src/io/csv.rs
+++ b/python/core/src/io/csv.rs
@@ -5,7 +5,6 @@ use crate::table::GeoTable;
 use geoarrow::io::csv::read_csv as _read_csv;
 use geoarrow::io::csv::write_csv as _write_csv;
 use geoarrow::io::csv::CSVReaderOptions;
-use geoarrow::io::geozero::RecordBatchReader;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -52,6 +51,6 @@ pub fn write_csv(
         .0
         .take()
         .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
-    _write_csv(&mut RecordBatchReader::new(stream), writer)?;
+    _write_csv(&mut stream.into(), writer)?;
     Ok(())
 }

--- a/python/core/src/io/csv.rs
+++ b/python/core/src/io/csv.rs
@@ -5,7 +5,6 @@ use crate::table::GeoTable;
 use geoarrow::io::csv::read_csv as _read_csv;
 use geoarrow::io::csv::write_csv as _write_csv;
 use geoarrow::io::csv::CSVReaderOptions;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 /// Read a CSV file from a path on disk into a GeoTable.
@@ -41,16 +40,8 @@ pub fn read_csv(
 ///     None
 #[pyfunction]
 #[pyo3(signature = (table, file))]
-pub fn write_csv(
-    py: Python,
-    mut table: PyRecordBatchReader,
-    file: PyObject,
-) -> PyGeoArrowResult<()> {
+pub fn write_csv(py: Python, table: PyRecordBatchReader, file: PyObject) -> PyGeoArrowResult<()> {
     let writer = file.extract::<BinaryFileWriter>(py)?;
-    let stream = table
-        .0
-        .take()
-        .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
-    _write_csv(&mut stream.into(), writer)?;
+    _write_csv(table.into_reader()?, writer)?;
     Ok(())
 }

--- a/python/core/src/io/flatgeobuf.rs
+++ b/python/core/src/io/flatgeobuf.rs
@@ -185,7 +185,7 @@ pub fn read_flatgeobuf_async(
 #[pyo3(signature = (table, file, *, write_index=true))]
 pub fn write_flatgeobuf(
     py: Python,
-    mut table: PyRecordBatchReader,
+    table: PyRecordBatchReader,
     file: PyObject,
     write_index: bool,
 ) -> PyGeoArrowResult<()> {
@@ -196,12 +196,8 @@ pub fn write_flatgeobuf(
         write_index,
         ..Default::default()
     };
-    let stream = table
-        .0
-        .take()
-        .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
     _write_flatgeobuf(
-        &mut stream.into(),
+        table.into_reader()?,
         writer,
         name.as_deref().unwrap_or(""),
         options,

--- a/python/core/src/io/flatgeobuf.rs
+++ b/python/core/src/io/flatgeobuf.rs
@@ -8,7 +8,6 @@ use flatgeobuf::FgbWriterOptions;
 use geoarrow::io::flatgeobuf::read_flatgeobuf_async as _read_flatgeobuf_async;
 use geoarrow::io::flatgeobuf::write_flatgeobuf_with_options as _write_flatgeobuf;
 use geoarrow::io::flatgeobuf::{read_flatgeobuf as _read_flatgeobuf, FlatGeobufReaderOptions};
-use geoarrow::io::geozero::RecordBatchReader;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -202,7 +201,7 @@ pub fn write_flatgeobuf(
         .take()
         .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
     _write_flatgeobuf(
-        &mut RecordBatchReader::new(stream),
+        &mut stream.into(),
         writer,
         name.as_deref().unwrap_or(""),
         options,

--- a/python/core/src/io/geojson.rs
+++ b/python/core/src/io/geojson.rs
@@ -4,7 +4,6 @@ use crate::stream::PyRecordBatchReader;
 use crate::table::GeoTable;
 use geoarrow::io::geojson::read_geojson as _read_geojson;
 use geoarrow::io::geojson::write_geojson as _write_geojson;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 /// Read a GeoJSON file from a path on disk into a GeoTable.
@@ -37,14 +36,10 @@ pub fn read_geojson(py: Python, file: PyObject, batch_size: usize) -> PyGeoArrow
 #[pyfunction]
 pub fn write_geojson(
     py: Python,
-    mut table: PyRecordBatchReader,
+    table: PyRecordBatchReader,
     file: PyObject,
 ) -> PyGeoArrowResult<()> {
     let writer = file.extract::<BinaryFileWriter>(py)?;
-    let stream = table
-        .0
-        .take()
-        .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
-    _write_geojson(&mut stream.into(), writer)?;
+    _write_geojson(table.into_reader()?, writer)?;
     Ok(())
 }

--- a/python/core/src/io/geojson.rs
+++ b/python/core/src/io/geojson.rs
@@ -4,7 +4,6 @@ use crate::stream::PyRecordBatchReader;
 use crate::table::GeoTable;
 use geoarrow::io::geojson::read_geojson as _read_geojson;
 use geoarrow::io::geojson::write_geojson as _write_geojson;
-use geoarrow::io::geozero::RecordBatchReader;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -46,6 +45,6 @@ pub fn write_geojson(
         .0
         .take()
         .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
-    _write_geojson(&mut RecordBatchReader::new(stream), writer)?;
+    _write_geojson(&mut stream.into(), writer)?;
     Ok(())
 }

--- a/python/core/src/io/geojson_lines.rs
+++ b/python/core/src/io/geojson_lines.rs
@@ -4,7 +4,6 @@ use crate::stream::PyRecordBatchReader;
 use crate::table::GeoTable;
 use geoarrow::io::geojson_lines::read_geojson_lines as _read_geojson_lines;
 use geoarrow::io::geojson_lines::write_geojson_lines as _write_geojson_lines;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 /// Read a newline-delimited GeoJSON file from a path on disk into a GeoTable.
@@ -43,14 +42,10 @@ pub fn read_geojson_lines(
 #[pyfunction]
 pub fn write_geojson_lines(
     py: Python,
-    mut table: PyRecordBatchReader,
+    table: PyRecordBatchReader,
     file: PyObject,
 ) -> PyGeoArrowResult<()> {
     let writer = file.extract::<BinaryFileWriter>(py)?;
-    let stream = table
-        .0
-        .take()
-        .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
-    _write_geojson_lines(&mut stream.into(), writer)?;
+    _write_geojson_lines(table.into_reader()?, writer)?;
     Ok(())
 }

--- a/python/core/src/io/geojson_lines.rs
+++ b/python/core/src/io/geojson_lines.rs
@@ -4,7 +4,6 @@ use crate::stream::PyRecordBatchReader;
 use crate::table::GeoTable;
 use geoarrow::io::geojson_lines::read_geojson_lines as _read_geojson_lines;
 use geoarrow::io::geojson_lines::write_geojson_lines as _write_geojson_lines;
-use geoarrow::io::geozero::RecordBatchReader;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -52,6 +51,6 @@ pub fn write_geojson_lines(
         .0
         .take()
         .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
-    _write_geojson_lines(&mut RecordBatchReader::new(stream), writer)?;
+    _write_geojson_lines(&mut stream.into(), writer)?;
     Ok(())
 }

--- a/python/core/src/io/ipc.rs
+++ b/python/core/src/io/ipc.rs
@@ -2,7 +2,6 @@ use crate::error::PyGeoArrowResult;
 use crate::io::input::sync::{BinaryFileReader, BinaryFileWriter};
 use crate::stream::PyRecordBatchReader;
 use crate::table::GeoTable;
-use geoarrow::io::geozero::RecordBatchReader;
 use geoarrow::io::ipc::read_ipc as _read_ipc;
 use geoarrow::io::ipc::read_ipc_stream as _read_ipc_stream;
 use geoarrow::io::ipc::write_ipc as _write_ipc;
@@ -59,7 +58,7 @@ pub fn write_ipc(
         .0
         .take()
         .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
-    _write_ipc(&mut RecordBatchReader::new(stream), writer)?;
+    _write_ipc(&mut stream.into(), writer)?;
     Ok(())
 }
 
@@ -82,6 +81,6 @@ pub fn write_ipc_stream(
         .0
         .take()
         .ok_or(PyValueError::new_err("Cannot write from closed stream."))?;
-    _write_ipc_stream(&mut RecordBatchReader::new(stream), writer)?;
+    _write_ipc_stream(&mut stream.into(), writer)?;
     Ok(())
 }

--- a/python/core/src/lib.rs
+++ b/python/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod io;
 pub mod record_batch;
 pub mod scalar;
 pub mod schema;
+pub mod stream;
 pub mod table;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -91,6 +92,9 @@ fn _rust(_py: Python, m: &PyModule) -> PyResult<()> {
     // m.add_class::<chunked_array::ChunkedUInt32Array>()?;
     // m.add_class::<chunked_array::ChunkedUInt64Array>()?;
     // m.add_class::<chunked_array::ChunkedUInt8Array>()?;
+
+    // RecordBatchReader
+    m.add_class::<stream::PyRecordBatchReader>()?;
 
     // Table
     m.add_class::<table::GeoTable>()?;

--- a/python/core/src/stream/mod.rs
+++ b/python/core/src/stream/mod.rs
@@ -2,7 +2,7 @@ use arrow_array::RecordBatchReader as _RecordBatchReader;
 use geoarrow::error::GeoArrowError;
 use pyo3::prelude::*;
 
-use crate::error::{PyGeoArrowError, PyGeoArrowResult};
+use crate::error::PyGeoArrowResult;
 
 /// A wrapper around an [arrow_array::RecordBatchReader]
 #[pyclass(

--- a/python/core/src/stream/mod.rs
+++ b/python/core/src/stream/mod.rs
@@ -1,0 +1,10 @@
+use arrow_array::RecordBatchReader as _RecordBatchReader;
+use pyo3::prelude::*;
+
+/// A wrapper around an [arrow_array::RecordBatchReader]
+#[pyclass(
+    module = "geoarrow.rust.core._rust",
+    name = "RecordBatchReader",
+    subclass
+)]
+pub struct PyRecordBatchReader(pub(crate) Option<Box<dyn _RecordBatchReader + Send>>);

--- a/python/core/src/stream/mod.rs
+++ b/python/core/src/stream/mod.rs
@@ -1,5 +1,8 @@
 use arrow_array::RecordBatchReader as _RecordBatchReader;
+use geoarrow::error::GeoArrowError;
 use pyo3::prelude::*;
+
+use crate::error::{PyGeoArrowError, PyGeoArrowResult};
 
 /// A wrapper around an [arrow_array::RecordBatchReader]
 #[pyclass(
@@ -8,3 +11,12 @@ use pyo3::prelude::*;
     subclass
 )]
 pub struct PyRecordBatchReader(pub(crate) Option<Box<dyn _RecordBatchReader + Send>>);
+
+impl PyRecordBatchReader {
+    pub fn into_reader(mut self) -> PyGeoArrowResult<Box<dyn _RecordBatchReader + Send>> {
+        let stream = self.0.take().ok_or(GeoArrowError::General(
+            "Cannot write from closed stream.".to_string(),
+        ))?;
+        Ok(stream)
+    }
+}

--- a/src/io/csv/writer.rs
+++ b/src/io/csv/writer.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::io::geozero::RecordBatchReader;
+use crate::io::stream::RecordBatchReader;
 use geozero::csv::CsvWriter;
 use geozero::GeozeroDatasource;
 use std::io::Write;

--- a/src/io/csv/writer.rs
+++ b/src/io/csv/writer.rs
@@ -5,9 +5,9 @@ use geozero::GeozeroDatasource;
 use std::io::Write;
 
 /// Write a Table to CSV
-pub fn write_csv<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
+pub fn write_csv<W: Write, S: Into<RecordBatchReader>>(stream: S, writer: W) -> Result<()> {
     let mut csv_writer = CsvWriter::new(writer);
-    table.process(&mut csv_writer)?;
+    stream.into().process(&mut csv_writer)?;
     Ok(())
 }
 
@@ -23,7 +23,7 @@ mod test {
 
         let mut output_buffer = Vec::new();
         let writer = BufWriter::new(&mut output_buffer);
-        write_csv(&mut table.into(), writer).unwrap();
+        write_csv(&table, writer).unwrap();
         let output_string = String::from_utf8(output_buffer).unwrap();
         println!("{}", output_string);
     }

--- a/src/io/csv/writer.rs
+++ b/src/io/csv/writer.rs
@@ -1,11 +1,11 @@
 use crate::error::Result;
-use crate::table::Table;
+use crate::io::geozero::RecordBatchReader;
 use geozero::csv::CsvWriter;
 use geozero::GeozeroDatasource;
 use std::io::Write;
 
 /// Write a Table to CSV
-pub fn write_csv<W: Write>(table: &mut Table, writer: W) -> Result<()> {
+pub fn write_csv<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
     let mut csv_writer = CsvWriter::new(writer);
     table.process(&mut csv_writer)?;
     Ok(())
@@ -19,11 +19,11 @@ mod test {
 
     #[test]
     fn test_write() {
-        let mut table = point::table();
+        let table = point::table();
 
         let mut output_buffer = Vec::new();
         let writer = BufWriter::new(&mut output_buffer);
-        write_csv(&mut table, writer).unwrap();
+        write_csv(&mut table.into(), writer).unwrap();
         let output_string = String::from_utf8(output_buffer).unwrap();
         println!("{}", output_string);
     }

--- a/src/io/flatgeobuf/writer.rs
+++ b/src/io/flatgeobuf/writer.rs
@@ -4,7 +4,7 @@ use flatgeobuf::{FgbWriter, FgbWriterOptions};
 use geozero::GeozeroDatasource;
 
 use crate::error::Result;
-use crate::io::geozero::RecordBatchReader;
+use crate::io::stream::RecordBatchReader;
 use crate::schema::GeoSchemaExt;
 
 // TODO: always write CRS saved in Table metadata (you can do this by adding an option)

--- a/src/io/flatgeobuf/writer.rs
+++ b/src/io/flatgeobuf/writer.rs
@@ -9,32 +9,33 @@ use crate::schema::GeoSchemaExt;
 
 // TODO: always write CRS saved in Table metadata (you can do this by adding an option)
 /// Write a Table to a FlatGeobuf file.
-pub fn write_flatgeobuf<W: Write>(
-    table: &mut RecordBatchReader,
+pub fn write_flatgeobuf<W: Write, S: Into<RecordBatchReader>>(
+    stream: S,
     writer: W,
     name: &str,
 ) -> Result<()> {
-    write_flatgeobuf_with_options(table, writer, name, Default::default())
+    write_flatgeobuf_with_options(stream, writer, name, Default::default())
 }
 
 /// Write a Table to a FlatGeobuf file with specific writer options.
 ///
 /// Note: this `name` argument is what OGR observes as the layer name of the file.
-pub fn write_flatgeobuf_with_options<W: Write>(
-    table: &mut RecordBatchReader,
+pub fn write_flatgeobuf_with_options<W: Write, S: Into<RecordBatchReader>>(
+    stream: S,
     writer: W,
     name: &str,
     options: FgbWriterOptions,
 ) -> Result<()> {
+    let mut stream = stream.into();
     let mut fgb =
-        FgbWriter::create_with_options(name, infer_flatgeobuf_geometry_type(table)?, options)?;
-    table.process(&mut fgb)?;
+        FgbWriter::create_with_options(name, infer_flatgeobuf_geometry_type(&stream)?, options)?;
+    stream.process(&mut fgb)?;
     fgb.write(writer)?;
     Ok(())
 }
 
-fn infer_flatgeobuf_geometry_type(table: &RecordBatchReader) -> Result<flatgeobuf::GeometryType> {
-    let schema = table.schema()?;
+fn infer_flatgeobuf_geometry_type(stream: &RecordBatchReader) -> Result<flatgeobuf::GeometryType> {
+    let schema = stream.schema()?;
     let fields = &schema.fields;
     let geom_col_idxs = schema.as_ref().geometry_columns();
     if geom_col_idxs.len() != 1 {
@@ -73,7 +74,7 @@ mod test {
 
         let mut output_buffer = Vec::new();
         let writer = BufWriter::new(&mut output_buffer);
-        write_flatgeobuf(&mut table.into(), writer, "name").unwrap();
+        write_flatgeobuf(&table, writer, "name").unwrap();
 
         let mut reader = Cursor::new(output_buffer);
         let new_table = read_flatgeobuf(&mut reader, Default::default()).unwrap();

--- a/src/io/geojson/writer.rs
+++ b/src/io/geojson/writer.rs
@@ -1,6 +1,6 @@
 use super::geojson_writer::GeoJsonWriter;
 use crate::error::Result;
-use crate::io::geozero::table::RecordBatchReader;
+use crate::io::stream::RecordBatchReader;
 use geozero::GeozeroDatasource;
 use std::io::Write;
 

--- a/src/io/geojson/writer.rs
+++ b/src/io/geojson/writer.rs
@@ -1,13 +1,13 @@
 use super::geojson_writer::GeoJsonWriter;
 use crate::error::Result;
-use crate::table::Table;
+use crate::io::geozero::table::RecordBatchReader;
 use geozero::GeozeroDatasource;
 use std::io::Write;
 
 /// Write a Table to GeoJSON
 ///
 /// Note: Does not reproject to WGS84 for you
-pub fn write_geojson<W: Write>(table: &mut Table, writer: W) -> Result<()> {
+pub fn write_geojson<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
     let mut geojson = GeoJsonWriter::new(writer);
     table.process(&mut geojson)?;
     Ok(())
@@ -21,11 +21,11 @@ mod test {
 
     #[test]
     fn test_write() {
-        let mut table = point::table();
+        let table = point::table();
 
         let mut output_buffer = Vec::new();
         let writer = BufWriter::new(&mut output_buffer);
-        write_geojson(&mut table, writer).unwrap();
+        write_geojson(&mut table.into(), writer).unwrap();
         let output_string = String::from_utf8(output_buffer).unwrap();
         println!("{}", output_string);
     }

--- a/src/io/geojson/writer.rs
+++ b/src/io/geojson/writer.rs
@@ -7,9 +7,9 @@ use std::io::Write;
 /// Write a Table to GeoJSON
 ///
 /// Note: Does not reproject to WGS84 for you
-pub fn write_geojson<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
+pub fn write_geojson<W: Write, S: Into<RecordBatchReader>>(stream: S, writer: W) -> Result<()> {
     let mut geojson = GeoJsonWriter::new(writer);
-    table.process(&mut geojson)?;
+    stream.into().process(&mut geojson)?;
     Ok(())
 }
 
@@ -25,7 +25,7 @@ mod test {
 
         let mut output_buffer = Vec::new();
         let writer = BufWriter::new(&mut output_buffer);
-        write_geojson(&mut table.into(), writer).unwrap();
+        write_geojson(&table, writer).unwrap();
         let output_string = String::from_utf8(output_buffer).unwrap();
         println!("{}", output_string);
     }

--- a/src/io/geojson_lines/writer.rs
+++ b/src/io/geojson_lines/writer.rs
@@ -3,7 +3,7 @@ use geozero::GeozeroDatasource;
 use std::io::Write;
 
 use crate::error::Result;
-use crate::io::geozero::RecordBatchReader;
+use crate::io::stream::RecordBatchReader;
 
 /// Write a table to newline-delimited GeoJSON
 pub fn write_geojson_lines<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {

--- a/src/io/geojson_lines/writer.rs
+++ b/src/io/geojson_lines/writer.rs
@@ -3,10 +3,10 @@ use geozero::GeozeroDatasource;
 use std::io::Write;
 
 use crate::error::Result;
-use crate::table::Table;
+use crate::io::geozero::RecordBatchReader;
 
 /// Write a table to newline-delimited GeoJSON
-pub fn write_geojson_lines<W: Write>(table: &mut Table, writer: W) -> Result<()> {
+pub fn write_geojson_lines<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
     let mut geojson_writer = GeoJsonLineWriter::new(writer);
     table.process(&mut geojson_writer)?;
     Ok(())

--- a/src/io/geojson_lines/writer.rs
+++ b/src/io/geojson_lines/writer.rs
@@ -6,8 +6,11 @@ use crate::error::Result;
 use crate::io::stream::RecordBatchReader;
 
 /// Write a table to newline-delimited GeoJSON
-pub fn write_geojson_lines<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
+pub fn write_geojson_lines<W: Write, S: Into<RecordBatchReader>>(
+    stream: S,
+    writer: W,
+) -> Result<()> {
     let mut geojson_writer = GeoJsonLineWriter::new(writer);
-    table.process(&mut geojson_writer)?;
+    stream.into().process(&mut geojson_writer)?;
     Ok(())
 }

--- a/src/io/geozero/mod.rs
+++ b/src/io/geozero/mod.rs
@@ -12,4 +12,3 @@ pub use array::{
     ToMultiPolygonArray, ToPointArray, ToPolygonArray,
 };
 pub use scalar::ToGeometry;
-pub use table::RecordBatchReader;

--- a/src/io/geozero/mod.rs
+++ b/src/io/geozero/mod.rs
@@ -12,3 +12,4 @@ pub use array::{
     ToMultiPolygonArray, ToPointArray, ToPolygonArray,
 };
 pub use scalar::ToGeometry;
+pub use table::RecordBatchReader;

--- a/src/io/geozero/table/data_source.rs
+++ b/src/io/geozero/table/data_source.rs
@@ -57,6 +57,12 @@ impl From<Box<dyn _RecordBatchReader>> for RecordBatchReader {
     }
 }
 
+impl From<Box<dyn _RecordBatchReader + Send>> for RecordBatchReader {
+    fn from(value: Box<dyn _RecordBatchReader + Send>) -> Self {
+        Self(Some(value))
+    }
+}
+
 impl GeozeroDatasource for RecordBatchReader {
     fn process<P: FeatureProcessor>(&mut self, processor: &mut P) -> Result<(), GeozeroError> {
         let reader = self.0.take().ok_or(GeozeroError::Dataset(

--- a/src/io/geozero/table/mod.rs
+++ b/src/io/geozero/table/mod.rs
@@ -3,4 +3,3 @@ mod data_source;
 mod json_encoder;
 
 pub use builder::{GeoTableBuilder, GeoTableBuilderOptions};
-pub use data_source::RecordBatchReader;

--- a/src/io/geozero/table/mod.rs
+++ b/src/io/geozero/table/mod.rs
@@ -3,3 +3,4 @@ mod data_source;
 mod json_encoder;
 
 pub use builder::{GeoTableBuilder, GeoTableBuilderOptions};
+pub use data_source::RecordBatchReader;

--- a/src/io/ipc/writer.rs
+++ b/src/io/ipc/writer.rs
@@ -2,27 +2,35 @@ use std::io::Write;
 
 use arrow_ipc::writer::{FileWriter, StreamWriter};
 
-use crate::error::Result;
-use crate::table::Table;
+use crate::error::{GeoArrowError, Result};
+use crate::io::geozero::RecordBatchReader;
 
 /// Write a Table to an Arrow IPC (Feather v2) file
-pub fn write_ipc<W: Write>(table: &mut Table, writer: W) -> Result<()> {
-    let mut writer = FileWriter::try_new(writer, table.schema())?;
-    table
-        .batches()
-        .iter()
-        .try_for_each(|batch| writer.write(batch))?;
+pub fn write_ipc<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
+    let inner = table
+        .take()
+        .ok_or(GeoArrowError::General("Closed stream".to_string()))?;
+
+    let schema = inner.schema();
+    let mut writer = FileWriter::try_new(writer, &schema)?;
+    for batch in inner {
+        writer.write(&batch?)?;
+    }
     writer.finish()?;
     Ok(())
 }
 
 /// Write a Table to an Arrow IPC stream
-pub fn write_ipc_stream<W: Write>(table: &mut Table, writer: W) -> Result<()> {
-    let mut writer = StreamWriter::try_new(writer, table.schema())?;
-    table
-        .batches()
-        .iter()
-        .try_for_each(|batch| writer.write(batch))?;
+pub fn write_ipc_stream<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
+    let inner = table
+        .take()
+        .ok_or(GeoArrowError::General("Closed stream".to_string()))?;
+
+    let schema = inner.schema();
+    let mut writer = StreamWriter::try_new(writer, &schema)?;
+    for batch in inner {
+        writer.write(&batch?)?;
+    }
     writer.finish()?;
     Ok(())
 }

--- a/src/io/ipc/writer.rs
+++ b/src/io/ipc/writer.rs
@@ -6,8 +6,9 @@ use crate::error::{GeoArrowError, Result};
 use crate::io::stream::RecordBatchReader;
 
 /// Write a Table to an Arrow IPC (Feather v2) file
-pub fn write_ipc<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
-    let inner = table
+pub fn write_ipc<W: Write, S: Into<RecordBatchReader>>(stream: S, writer: W) -> Result<()> {
+    let inner = stream
+        .into()
         .take()
         .ok_or(GeoArrowError::General("Closed stream".to_string()))?;
 
@@ -21,8 +22,9 @@ pub fn write_ipc<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<(
 }
 
 /// Write a Table to an Arrow IPC stream
-pub fn write_ipc_stream<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {
-    let inner = table
+pub fn write_ipc_stream<W: Write, S: Into<RecordBatchReader>>(stream: S, writer: W) -> Result<()> {
+    let inner = stream
+        .into()
         .take()
         .ok_or(GeoArrowError::General("Closed stream".to_string()))?;
 

--- a/src/io/ipc/writer.rs
+++ b/src/io/ipc/writer.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use arrow_ipc::writer::{FileWriter, StreamWriter};
 
 use crate::error::{GeoArrowError, Result};
-use crate::io::geozero::RecordBatchReader;
+use crate::io::stream::RecordBatchReader;
 
 /// Write a Table to an Arrow IPC (Feather v2) file
 pub fn write_ipc<W: Write>(table: &mut RecordBatchReader, writer: W) -> Result<()> {

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -23,4 +23,5 @@ pub mod ipc;
 pub mod parquet;
 #[cfg(feature = "postgis")]
 pub mod postgis;
+pub mod stream;
 pub mod wkb;

--- a/src/io/stream.rs
+++ b/src/io/stream.rs
@@ -1,0 +1,48 @@
+use crate::error::GeoArrowError;
+use crate::table::Table;
+use arrow_array::{RecordBatchIterator, RecordBatchReader as _RecordBatchReader};
+use arrow_schema::SchemaRef;
+
+/// A wrapper around an [arrow_array::RecordBatchReader] so that we can impl the GeozeroDatasource
+/// trait.
+pub struct RecordBatchReader(Option<Box<dyn _RecordBatchReader>>);
+
+impl RecordBatchReader {
+    pub fn new(reader: Box<dyn _RecordBatchReader>) -> Self {
+        Self(Some(reader))
+    }
+
+    pub fn schema(&self) -> Result<SchemaRef, GeoArrowError> {
+        let reader = self
+            .0
+            .as_ref()
+            .ok_or(GeoArrowError::General("Closed stream".to_string()))?;
+        Ok(reader.schema())
+    }
+
+    pub fn take(&mut self) -> Option<Box<dyn _RecordBatchReader>> {
+        self.0.take()
+    }
+}
+
+impl From<Table> for RecordBatchReader {
+    fn from(value: Table) -> Self {
+        let (schema, batches) = value.into_inner();
+        Self(Some(Box::new(RecordBatchIterator::new(
+            batches.into_iter().map(Ok),
+            schema,
+        ))))
+    }
+}
+
+impl From<Box<dyn _RecordBatchReader>> for RecordBatchReader {
+    fn from(value: Box<dyn _RecordBatchReader>) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl From<Box<dyn _RecordBatchReader + Send>> for RecordBatchReader {
+    fn from(value: Box<dyn _RecordBatchReader + Send>) -> Self {
+        Self(Some(value))
+    }
+}

--- a/src/io/stream.rs
+++ b/src/io/stream.rs
@@ -35,6 +35,12 @@ impl From<Table> for RecordBatchReader {
     }
 }
 
+impl From<&Table> for RecordBatchReader {
+    fn from(value: &Table) -> Self {
+        value.clone().into()
+    }
+}
+
 impl From<Box<dyn _RecordBatchReader>> for RecordBatchReader {
     fn from(value: Box<dyn _RecordBatchReader>) -> Self {
         Self(Some(value))


### PR DESCRIPTION
### Change list

- Adds Python `RecordBatchReader` class to store a stream of Arrow record batches
- Implements `__arrow_c_stream__` for exporting a Rust stream of record batches to Python
- Implements `FromPyObject` to read from an `__arrow_c_stream__`
- Updates geozero-based writers to read from the stream instead of from a materialized table
- Updates writing Arrow IPC and IPC Stream to not materialize the table

Updating writing GeoParquet from a stream instead of a table is left for future work.

Closes https://github.com/geoarrow/geoarrow-rs/issues/633