### PR TITLE
Minor doc fixups

### DIFF
--- a/src/algorithm/broadcasting/mod.rs
+++ b/src/algorithm/broadcasting/mod.rs
@@ -12,9 +12,6 @@
 //!
 //! The objects in this module are enums with two variants: `Scalar` and `Array`. Create an object
 //! with the variant desired for your operation.
-//!
-//! For simplicity, the `Scalar` variants of the geometry broadcasting enums, such as
-//! [`BroadcastablePoint`] accept a [`geo`] object, not a GeoArrow scalar object.
 
 // mod geometry;
 // mod linestring;

--- a/src/algorithm/broadcasting/primitive.rs
+++ b/src/algorithm/broadcasting/primitive.rs
@@ -3,7 +3,7 @@ use arrow_array::types::ArrowPrimitiveType;
 use arrow_array::PrimitiveArray;
 use arrow_buffer::ArrowNativeType;
 
-/// An enum over primitive types defined by [`arrow2::types::NativeType`]. These include u8, i32,
+/// An enum over primitive types defined by [`ArrowPrimitiveType`]. These include u8, i32,
 /// f64, etc.
 ///
 /// [`IntoIterator`] is implemented for this, where it will iterate over the `Array` variant

--- a/src/algorithm/geo/within.rs
+++ b/src/algorithm/geo/within.rs
@@ -26,7 +26,7 @@ use geo::Within as _Within;
 /// assert!(! point!(x: 0.0, y: 0.0).is_within(&line_string));
 /// ```
 ///
-/// `Within` is equivalent to [`Contains`] with the arguments swapped.
+/// `Within` is equivalent to [`Contains`](geo::Contains) with the arguments swapped.
 ///
 /// ```
 /// use geo::{point, line_string};

--- a/src/algorithm/polylabel.rs
+++ b/src/algorithm/polylabel.rs
@@ -19,7 +19,7 @@ use crate::GeometryArrayTrait;
 /// The calculation uses an iterative grid-based algorithm, ported from the original [JavaScript
 /// implementation](https://github.com/mapbox/polylabel).
 ///
-/// This binds to the existing Rust implementation in [polylabel].
+/// This binds to the existing Rust implementation in [mod@polylabel].
 pub trait Polylabel {
     type Output;
 

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -125,7 +125,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
         self.geom_offsets.reserve_exact(additional.geom_capacity);
     }
 
-    /// Extract the low-level APIs from the [`LineStringBuilder`].
+    /// Extract the low-level APIs from the [`GeometryCollectionBuilder`].
     pub fn into_inner(
         self,
     ) -> (

--- a/src/array/metadata.rs
+++ b/src/array/metadata.rs
@@ -16,7 +16,7 @@ pub enum Edges {
 /// A GeoArrow metadata object following the extension metadata [defined by the GeoArrow
 /// specification](https://geoarrow.org/extension-types).
 ///
-/// This is serialized to JSON when a [`geoarrow`] array is exported to an [`arrow`] array and
+/// This is serialized to JSON when a [`geoarrow`](self) array is exported to an [`arrow`] array and
 /// deserialized when imported from an [`arrow`] array.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ArrayMetadata {

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -21,7 +21,7 @@ use crate::GeometryArrayTrait;
 /// but is included here for parity with georust/geo, and to save memory for the output of
 /// `bounds()`.
 ///
-/// Internally this is implemented as a FixedSizeList[4], laid out as minx, miny, maxx, maxy.
+/// Internally this is implemented as a FixedSizeList, laid out as minx, miny, maxx, maxy.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RectArray {
     // Always GeoDataType::Rect

--- a/src/io/geojson/geojson_writer.rs
+++ b/src/io/geojson/geojson_writer.rs
@@ -1,5 +1,5 @@
 //! Vendored from geozero under the MIT/Apache 2 license until
-//! https://github.com/georust/geozero/pull/208 is merged and released.
+//! <https://github.com/georust/geozero/pull/208> is merged and released.
 
 use geozero::error::Result;
 use geozero::{ColumnValue, CoordDimensions, FeatureProcessor, GeomProcessor, PropertyProcessor};

--- a/src/io/geozero/mod.rs
+++ b/src/io/geozero/mod.rs
@@ -1,4 +1,4 @@
-//! Implements the geometry and dataset conversion APIs defined by the [`geozero`][::geozero]
+//! Implements the geometry and dataset conversion APIs defined by the [`geozero`]
 //! crate.
 
 mod api;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! A Rust implementation of the [GeoArrow](https://github.com/geoarrow/geoarrow) specification,
 //! plus algorithms implemented on and returning these GeoArrow arrays.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 pub use trait_::GeometryArrayTrait;
 
 pub mod algorithm;

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -149,7 +149,7 @@ pub trait GeometryArrayTrait: std::fmt::Debug + Send + Sync {
 ///
 /// # Validity
 ///
-/// An [`ArrayAccessor`] must always return a well-defined value for an index that is
+/// An [`GeometryArrayAccessor`] must always return a well-defined value for an index that is
 /// within the bounds `0..Array::len`, including for null indexes where [`Array::is_null`] is true.
 ///
 /// The value at null indexes is unspecified, and implementations must not rely on a specific


### PR DESCRIPTION
- Clean up some docs warnings
- Add `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to `lib.rs` to turn on feature flags in docs.rs, e.g. this from **stac-rs**: 

<img src=https://github.com/geoarrow/geoarrow-rs/assets/58314/fe542aea-d36a-4119-89a5-06b32fb5be2d height=100>