### PR TITLE
Add CI to build features in isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Test
-        run: cargo build ${{ matrix.args }}
+        run: cargo check ${{ matrix.args }}
   build-with-external-dependencies:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,60 @@ jobs:
         run: |
           cargo test --all
           cargo test --all --all-features
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        args:
+          - ""
+          - "-F csv"
+          - "-F flatgeobuf"
+          - "-F flatgeobuf_async"
+          - "-F geozero"
+          - "-F ipc_compression"
+          - "-F parquet"
+          - "-F parquet_async"
+          - "-F parquet_compression"
+          - "-F polylabel"
+          - "-F postgis"
+          - "-F rayon"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Test
+        run: cargo build ${{ matrix.args }}
+  build-with-external-dependencies:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        args:
+          - "-F gdal -F gdal/bindgen"
+          - "-F geos"
+          - "-F proj"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Pixi
+        run: |
+          curl -fsSL https://pixi.sh/install.sh | bash
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+          echo "GDAL_HOME=$(pwd)/build/.pixi/envs/default" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
+          echo "GEOS_LIB_DIR=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
+          # TODO: infer from toml file/lockfile
+          echo "GEOS_VERSION=3.12.1" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
+      - name: Install build requirements
+        run: |
+          cd build
+          pixi install
+      - name: Test
+        run: cargo build ${{ matrix.args }}

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -9,6 +9,8 @@
 //! use geoarrow::io::parquet::ParquetReaderOptions;
 //! use std::fs::File;
 //!
+//! # #[cfg(feature = "parquet_compression")]
+//! # {
 //! let file = File::open("fixtures/geoparquet/nybb.parquet").unwrap();
 //! let options = ParquetReaderOptions {
 //!     batch_size: Some(65536),
@@ -16,11 +18,14 @@
 //! };
 //! let output_geotable = read_geoparquet(file, options).unwrap();
 //! println!("GeoTable schema: {}", output_geotable.schema());
+//! # }
 //! ```
 //!
 //! ## Asynchronous reader
 //!
 //! ```rust
+//! # #[cfg(feature = "parquet_async")]
+//! # {
 //! use geoarrow::io::parquet::read_geoparquet_async;
 //! use geoarrow::io::parquet::ParquetReaderOptions;
 //! use tokio::fs::File;
@@ -37,6 +42,7 @@
 //!     let output_geotable = read_geoparquet_async(file, options).await.unwrap();
 //!     println!("GeoTable schema: {}", output_geotable.schema());
 //! }
+//! # }
 //! ```
 
 mod metadata;

--- a/src/io/parquet/reader/mod.rs
+++ b/src/io/parquet/reader/mod.rs
@@ -10,3 +10,17 @@ pub use options::ParquetReaderOptions;
 pub use r#async::{read_geoparquet_async, ParquetDataset, ParquetFile};
 pub use spatial_filter::ParquetBboxPaths;
 pub use sync::read_geoparquet;
+
+pub(crate) fn parse_table_geometries_to_native(
+    table: &mut crate::table::Table,
+    metadata: &parquet::file::metadata::FileMetaData,
+    coord_type: &crate::array::CoordType,
+) -> crate::error::Result<()> {
+    let geom_cols =
+        super::metadata::find_geoparquet_geom_columns(metadata, table.schema(), *coord_type)?;
+    geom_cols
+        .iter()
+        .try_for_each(|(geom_col_idx, target_geo_data_type)| {
+            table.parse_geometry_to_native(*geom_col_idx, *target_geo_data_type)
+        })
+}

--- a/src/io/parquet/reader/sync.rs
+++ b/src/io/parquet/reader/sync.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::io::parquet::reader::r#async::parse_table_geometries_to_native;
+use crate::io::parquet::reader::parse_table_geometries_to_native;
 use crate::io::parquet::ParquetReaderOptions;
 use crate::table::Table;
 
@@ -36,6 +36,7 @@ mod test {
     use std::fs::File;
 
     #[test]
+    #[cfg(feature = "parquet_compression")]
     fn nybb() {
         let file = File::open("fixtures/geoparquet/nybb.parquet").unwrap();
         let options = Default::default();

--- a/src/io/parquet/writer/mod.rs
+++ b/src/io/parquet/writer/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "parquet_async")]
 mod r#async;
 mod encode;
 mod metadata;


### PR DESCRIPTION
## Description

If downstreams want to just depend on a single feature, we need to make sure we can build w/ just that feature enabled ... e.g. as of this writing, `parquet` implicitly depends on `async` but isn't configured as such in `Cargo.toml`.

We can't test w/o installing GDAL and friends because `gdal` is a dev dependency, so we just build.