### PR TITLE
Support const generic buffers

### DIFF
--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -78,47 +78,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -126,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "approx"
@@ -141,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
+checksum = "6127ea5e585a12ec9f742232442828ebaf264dfa5eefdd71282376c599562b77"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -162,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7029a5b3efbeafbf4a12d12dc16b8f9e9bff20a410b8c25c5d28acc089e1043"
+checksum = "7add7f39210b7d726e2a8efc0083e7bf06e8f2d15bdb4896b564dce4410fbf5d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -177,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33238427c60271710695f17742f45b1a5dc5bcfc5c15331c25ddfe7abf70d97"
+checksum = "81c16ec702d3898c2f5cfdc148443c6cd7dbe5bac28399859eb0a3d38f072827"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -194,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9b95e825ae838efaf77e366c00d3fc8cca78134c9db497d6bda425f2e7b7c1"
+checksum = "cae6970bab043c4fbc10aee1660ceb5b306d0c42c8cc5f6ae564efcd9759b663"
 dependencies = [
  "bytes",
  "half",
@@ -205,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cf8385a9d5b5fcde771661dd07652b79b9139fea66193eda6a88664400ccab"
+checksum = "1c7ef44f26ef4f8edc392a048324ed5d757ad09135eff6d5509e6450d39e0398"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -215,7 +216,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.0",
+ "base64 0.22.1",
  "chrono",
  "half",
  "lexical-core",
@@ -225,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
+checksum = "5f843490bd258c5182b66e888161bb6f198f49f3792f7c7f98198b924ae0f564"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -244,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb29be98f987bcf217b070512bb7afba2f65180858bca462edf4a39d84a23e10"
+checksum = "a769666ffac256dd301006faca1ca553d0ae7cffcf4cd07095f73f95eb226514"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -256,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
+checksum = "dbf9c3fb57390a1af0b7bb3b5558c1ee1f63905f3eccf49ae7676a8d1e6e5a72"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -270,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2041380f94bd6437ab648e6c2085a045e45a0c44f91a1b9a4fe3fed3d379bfb1"
+checksum = "654e7f3724176b66ddfacba31af397c48e106fbe4d281c8144e7d237df5acfd7"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -290,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb56ed1547004e12203652f12fe12e824161ff9d1e5cf2a7dc4ff02ba94f413"
+checksum = "e8008370e624e8e3c68174faaf793540287106cfda8ad1da862fdc53d8e096b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -305,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575b42f1fc588f2da6977b94a5ca565459f5ab07b60545e17243fb9a7ed6d43e"
+checksum = "ca5e3a6b7fda8d9fe03f3b18a2d946354ea7f3c8e4076dbdb502ad50d9d44824"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -320,18 +321,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
+checksum = "dab1c12b40e29d9f3b699e0203c2a73ba558444c05e388a4377208f8f9c97eee"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
+checksum = "e80159088ffe8c48965cb9b1a7c968b2729f29f37363df7eca177fc3281fe7c3"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -343,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e435ada8409bcafc910bc3e0077f532a4daa20e99060a496685c0e3e53cc2597"
+checksum = "0fd04a6ea7de183648edbcb7a6dd925bbd04c210895f6384c780e27a9b54afcd"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -392,18 +393,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -416,10 +417,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.2.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backon"
@@ -435,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -456,9 +463,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -468,9 +475,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "brotli"
@@ -501,9 +508,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"
@@ -513,15 +520,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 dependencies = [
  "jobserver",
  "libc",
@@ -535,16 +542,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -571,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -591,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -603,27 +610,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -673,9 +680,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -766,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
@@ -823,9 +830,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -839,9 +846,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flatbuffers"
@@ -865,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -985,7 +992,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1117,7 +1124,7 @@ dependencies = [
  "object_store",
  "parquet",
  "range-reader",
- "reqwest",
+ "reqwest 0.12.5",
  "serde",
  "serde-wasm-bindgen",
  "thiserror",
@@ -1206,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1219,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "h2"
@@ -1234,7 +1241,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1264,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1312,21 +1338,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1342,17 +1402,17 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1365,16 +1425,76 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
- "hyper",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1444,6 +1564,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,9 +1604,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08474e32172238f2827bd160c67871cdb2801430f65c3979184dc362e3ca118"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -1496,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lexical-core"
@@ -1566,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -1582,21 +1708,21 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1604,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lz4_flex"
@@ -1619,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1631,9 +1757,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1651,11 +1777,10 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -1669,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -1683,20 +1808,19 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
@@ -1712,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1723,11 +1847,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1735,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -1761,14 +1884,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -1786,7 +1909,7 @@ dependencies = [
  "futures",
  "js-sys",
  "object_store",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde-wasm-bindgen",
  "snafu",
@@ -1831,7 +1954,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1848,7 +1971,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1886,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1896,22 +2019,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "parquet"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c3b5322cc1bbf67f11c079c42be41a55949099b78732f7dba9e15edde40eab"
+checksum = "0f22ba0d95db56dde8685e3fadcb915cdaadda31ab8abbe3ff7f0ad1ef333267"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1921,7 +2044,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.22.0",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
@@ -1954,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2004,7 +2127,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2033,7 +2156,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2065,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -2107,11 +2230,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2127,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2139,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2150,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -2165,11 +2288,52 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2182,18 +2346,31 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
- "winreg",
+ "winreg 0.52.0",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2215,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -2230,11 +2407,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2242,19 +2419,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -2294,11 +2502,11 @@ checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2307,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2317,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "seq-macro"
@@ -2329,9 +2537,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -2349,20 +2557,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -2432,9 +2640,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2442,15 +2650,21 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61addf9117b11d1f5b4bf6fe94242ba25f59d2d4b2080544b771bd647024fd00"
+checksum = "9f4ec45f91925e2c9ab3b6a857ee9ed36916990df76a1c475d783a328e247cc8"
 dependencies = [
  "hashbrown",
  "num-traits",
  "robust",
  "smallvec",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2471,6 +2685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2497,6 +2717,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -2542,22 +2768,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2582,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2597,9 +2823,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2613,13 +2839,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2633,24 +2859,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.10"
+name = "tokio-rustls"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
@@ -2662,6 +2898,27 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -2688,7 +2945,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2738,10 +2995,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.5.0"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2750,15 +3013,15 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "wasm-bindgen",
@@ -2824,7 +3087,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -2858,7 +3121,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2891,7 +3154,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2935,11 +3198,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2954,7 +3217,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2972,7 +3235,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2992,17 +3255,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3013,9 +3277,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3025,9 +3289,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3037,9 +3301,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3049,9 +3319,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3061,9 +3331,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3073,9 +3343,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3085,9 +3355,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -3109,6 +3379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wkt"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,23 +3402,29 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.71",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/js/src/data/coord.rs
+++ b/js/src/data/coord.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 /// An immutable buffer of interleaved coordinates in WebAssembly memory.
 #[wasm_bindgen]
-pub struct InterleavedCoordBuffer(pub(crate) geoarrow::array::InterleavedCoordBuffer);
+pub struct InterleavedCoordBuffer(pub(crate) geoarrow::array::InterleavedCoordBuffer<2>);
 
 #[wasm_bindgen]
 impl InterleavedCoordBuffer {
@@ -16,23 +16,23 @@ impl InterleavedCoordBuffer {
 
 /// An immutable buffer of separated coordinates in WebAssembly memory.
 #[wasm_bindgen]
-pub struct SeparatedCoordBuffer(pub(crate) geoarrow::array::SeparatedCoordBuffer);
+pub struct SeparatedCoordBuffer(pub(crate) geoarrow::array::SeparatedCoordBuffer<2>);
 
 #[wasm_bindgen]
 impl SeparatedCoordBuffer {
     #[wasm_bindgen(constructor)]
     pub fn new(x: Vec<f64>, y: Vec<f64>) -> Self {
-        Self(geoarrow::array::SeparatedCoordBuffer::new(
+        Self(geoarrow::array::SeparatedCoordBuffer::new([
             x.into(),
             y.into(),
-        ))
+        ]))
     }
 }
 
 /// An immutable buffer of coordinates in WebAssembly memory, that can be either interleaved or
 /// separated.
 #[wasm_bindgen]
-pub struct CoordBuffer(pub(crate) geoarrow::array::CoordBuffer);
+pub struct CoordBuffer(pub(crate) geoarrow::array::CoordBuffer<2>);
 
 #[wasm_bindgen]
 impl CoordBuffer {
@@ -46,7 +46,7 @@ impl CoordBuffer {
     /// Create a new CoordBuffer from two `Float64Array`s of X and Y
     #[wasm_bindgen(js_name = fromSeparated)]
     pub fn from_separated(x: Vec<f64>, y: Vec<f64>) -> Self {
-        let buffer = geoarrow::array::SeparatedCoordBuffer::new(x.into(), y.into());
+        let buffer = geoarrow::array::SeparatedCoordBuffer::new([x.into(), y.into()]);
         Self(geoarrow::array::CoordBuffer::Separated(buffer))
     }
 

--- a/python/core/src/array/mod.rs
+++ b/python/core/src/array/mod.rs
@@ -127,7 +127,7 @@ impl PointArray {
         x: PyScalarBuffer<Float64Type>,
         y: PyScalarBuffer<Float64Type>,
     ) -> PyGeoArrowResult<Self> {
-        let coords = SeparatedCoordBuffer::try_new(x.0, y.0)?;
+        let coords = SeparatedCoordBuffer::try_new([x.0, y.0])?;
         Ok(geoarrow::array::PointArray::new(coords.into(), None, Default::default()).into())
     }
 }

--- a/python/core/src/interop/shapely/to_shapely.rs
+++ b/python/core/src/interop/shapely/to_shapely.rs
@@ -26,7 +26,7 @@ fn check_nulls(nulls: Option<&NullBuffer>) -> PyGeoArrowResult<()> {
     }
 }
 
-fn coords_to_numpy(py: Python, coords: CoordBuffer) -> PyGeoArrowResult<PyObject> {
+fn coords_to_numpy(py: Python, coords: CoordBuffer<2>) -> PyGeoArrowResult<PyObject> {
     let interleaved_coords = match coords.into_coord_type(CoordType::Interleaved) {
         CoordBuffer::Interleaved(x) => x,
         _ => unreachable!(),

--- a/src/algorithm/geodesy/reproject.rs
+++ b/src/algorithm/geodesy/reproject.rs
@@ -59,10 +59,10 @@ impl CoordinateSet for SeparatedCoordsGeodesy<'_> {
 }
 
 fn reproject_coords(
-    coords: &CoordBuffer,
+    coords: &CoordBuffer<2>,
     definition: &str,
     direction: Direction,
-) -> Result<CoordBuffer> {
+) -> Result<CoordBuffer<2>> {
     let mut context = Minimal::new();
     // TODO: fix error handling
     let operation = context.op(definition).unwrap();
@@ -79,8 +79,8 @@ fn reproject_coords(
             CoordBuffer::Interleaved(InterleavedCoordBuffer::new(cloned_coords.into()))
         }
         CoordBuffer::Separated(separated_coords) => {
-            let mut x_coords = separated_coords.x.to_vec();
-            let mut y_coords = separated_coords.x.to_vec();
+            let mut x_coords = separated_coords.buffers[0].to_vec();
+            let mut y_coords = separated_coords.buffers[1].to_vec();
 
             let mut geodesy_coords = SeparatedCoordsGeodesy {
                 x: &mut x_coords,
@@ -89,7 +89,10 @@ fn reproject_coords(
             context
                 .apply(operation, direction, &mut geodesy_coords)
                 .unwrap();
-            CoordBuffer::Separated(SeparatedCoordBuffer::new(x_coords.into(), y_coords.into()))
+            CoordBuffer::Separated(SeparatedCoordBuffer::new([
+                x_coords.into(),
+                y_coords.into(),
+            ]))
         }
     };
 

--- a/src/algorithm/native/map_coords.rs
+++ b/src/algorithm/native/map_coords.rs
@@ -19,25 +19,25 @@ pub trait MapCoords {
 
     fn map_coords<F>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> geo::Coord + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> geo::Coord + Sync,
     {
         self.try_map_coords(|coord| Ok::<_, GeoArrowError>(map_op(coord)))
     }
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>;
 }
 
 // Scalar impls
 
-impl MapCoords for Coord<'_> {
+impl MapCoords for Coord<'_, 2> {
     type Output = geo::Coord;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(map_op(self)?)
@@ -49,7 +49,7 @@ impl MapCoords for Point<'_> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(geo::Point(map_op(&self.coord())?))
@@ -61,7 +61,7 @@ impl<O: OffsetSizeTrait> MapCoords for LineString<'_, O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let output_coords = self
@@ -77,7 +77,7 @@ impl<O: OffsetSizeTrait> MapCoords for Polygon<'_, O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         if self.exterior().is_none() {
@@ -99,7 +99,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPoint<'_, O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let points = self
@@ -115,7 +115,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiLineString<'_, O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let lines = self
@@ -132,7 +132,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPolygon<'_, O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let polygons = self
@@ -148,7 +148,7 @@ impl<O: OffsetSizeTrait> MapCoords for Geometry<'_, O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         match self.as_type() {
@@ -181,7 +181,7 @@ impl<O: OffsetSizeTrait> MapCoords for GeometryCollection<'_, O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let geoms = self
@@ -197,7 +197,7 @@ impl MapCoords for Rect<'_> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let (minx, miny) = self.lower();
@@ -218,7 +218,7 @@ impl MapCoords for PointArray {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = PointBuilder::with_capacity_and_options(
@@ -243,7 +243,7 @@ impl<O: OffsetSizeTrait> MapCoords for LineStringArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = LineStringBuilder::with_capacity_and_options(
@@ -268,7 +268,7 @@ impl<O: OffsetSizeTrait> MapCoords for PolygonArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = PolygonBuilder::with_capacity_and_options(
@@ -293,7 +293,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPointArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = MultiPointBuilder::with_capacity_and_options(
@@ -318,7 +318,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiLineStringArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = MultiLineStringBuilder::with_capacity_and_options(
@@ -343,7 +343,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPolygonArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = MultiPolygonBuilder::with_capacity_and_options(
@@ -368,7 +368,7 @@ impl<O: OffsetSizeTrait> MapCoords for MixedGeometryArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = MixedGeometryBuilder::with_capacity_and_options(
@@ -393,7 +393,7 @@ impl<O: OffsetSizeTrait> MapCoords for GeometryCollectionArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = GeometryCollectionBuilder::with_capacity_and_options(
@@ -418,7 +418,7 @@ impl MapCoords for RectArray {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let mut builder = RectBuilder::with_capacity(self.len(), self.metadata());
@@ -439,7 +439,7 @@ impl MapCoords for &dyn GeometryArrayTrait {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let result: Arc<dyn GeometryArrayTrait> = match self.data_type() {
@@ -488,7 +488,7 @@ impl MapCoords for ChunkedPointArray {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -502,7 +502,7 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedLineStringArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -516,7 +516,7 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedPolygonArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -530,7 +530,7 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPointArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -544,7 +544,7 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiLineStringArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -558,7 +558,7 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPolygonArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -572,7 +572,7 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedMixedGeometryArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -586,7 +586,7 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedGeometryCollectionArray<O> {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -600,7 +600,7 @@ impl MapCoords for ChunkedRectArray {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         Ok(ChunkedGeometryArray::new(
@@ -614,7 +614,7 @@ impl MapCoords for &dyn ChunkedGeometryArrayTrait {
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
-        F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
+        F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
         let result: Arc<dyn ChunkedGeometryArrayTrait> = match self.data_type() {

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -156,7 +156,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for WKBArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for WKBArray<O> {
-    fn with_coords(self, _coords: crate::array::CoordBuffer) -> Self {
+    fn with_coords(self, _coords: crate::array::CoordBuffer<2>) -> Self {
         unimplemented!()
     }
 

--- a/src/array/coord/combined/builder.rs
+++ b/src/array/coord/combined/builder.rs
@@ -7,12 +7,12 @@ use crate::geo_traits::{CoordTrait, PointTrait};
 ///
 /// Converting an [`CoordBufferBuilder`] into a [`CoordBuffer`] is `O(1)`.
 #[derive(Debug, Clone)]
-pub enum CoordBufferBuilder {
-    Interleaved(InterleavedCoordBufferBuilder),
-    Separated(SeparatedCoordBufferBuilder),
+pub enum CoordBufferBuilder<const D: usize> {
+    Interleaved(InterleavedCoordBufferBuilder<D>),
+    Separated(SeparatedCoordBufferBuilder<D>),
 }
 
-impl CoordBufferBuilder {
+impl<const D: usize> CoordBufferBuilder<D> {
     pub fn initialize(len: usize, interleaved: bool) -> Self {
         match interleaved {
             true => CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::initialize(len)),
@@ -59,6 +59,26 @@ impl CoordBufferBuilder {
         }
     }
 
+    pub fn len(&self) -> usize {
+        match self {
+            CoordBufferBuilder::Interleaved(cb) => cb.len(),
+            CoordBufferBuilder::Separated(cb) => cb.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn coord_type(&self) -> CoordType {
+        match self {
+            CoordBufferBuilder::Interleaved(_) => CoordType::Interleaved,
+            CoordBufferBuilder::Separated(_) => CoordType::Separated,
+        }
+    }
+}
+
+impl CoordBufferBuilder<2> {
     pub fn set_coord(&mut self, i: usize, coord: geo::Coord) {
         match self {
             CoordBufferBuilder::Interleaved(cb) => cb.set_coord(i, coord),
@@ -90,28 +110,10 @@ impl CoordBufferBuilder {
             CoordBufferBuilder::Separated(cb) => cb.push_xy(x, y),
         }
     }
-
-    pub fn len(&self) -> usize {
-        match self {
-            CoordBufferBuilder::Interleaved(cb) => cb.len(),
-            CoordBufferBuilder::Separated(cb) => cb.len(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn coord_type(&self) -> CoordType {
-        match self {
-            CoordBufferBuilder::Interleaved(_) => CoordType::Interleaved,
-            CoordBufferBuilder::Separated(_) => CoordType::Separated,
-        }
-    }
 }
 
-impl From<CoordBufferBuilder> for CoordBuffer {
-    fn from(value: CoordBufferBuilder) -> Self {
+impl<const D: usize> From<CoordBufferBuilder<D>> for CoordBuffer<D> {
+    fn from(value: CoordBufferBuilder<D>) -> Self {
         match value {
             CoordBufferBuilder::Interleaved(cb) => CoordBuffer::Interleaved(cb.into()),
             CoordBufferBuilder::Separated(cb) => CoordBuffer::Separated(cb.into()),

--- a/src/array/coord/interleaved/builder.rs
+++ b/src/array/coord/interleaved/builder.rs
@@ -7,25 +7,25 @@ use crate::geo_traits::CoordTrait;
 ///
 /// Converting an [`InterleavedCoordBufferBuilder`] into a [`InterleavedCoordBuffer`] is `O(1)`.
 #[derive(Debug, Clone)]
-pub struct InterleavedCoordBufferBuilder {
+pub struct InterleavedCoordBufferBuilder<const D: usize> {
     pub coords: Vec<f64>,
 }
 
-impl InterleavedCoordBufferBuilder {
+impl<const D: usize> InterleavedCoordBufferBuilder<D> {
     pub fn new() -> Self {
         Self::with_capacity(0)
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            coords: Vec::with_capacity(capacity * 2),
+            coords: Vec::with_capacity(capacity * D),
         }
     }
 
     /// Initialize a buffer of a given length with all coordinates set to 0.0
     pub fn initialize(len: usize) -> Self {
         Self {
-            coords: vec![0.0f64; len * 2],
+            coords: vec![0.0f64; len * D],
         }
     }
 
@@ -35,7 +35,7 @@ impl InterleavedCoordBufferBuilder {
     /// capacity will be greater than or equal to `self.len() + additional`.
     /// Does nothing if capacity is already sufficient.
     pub fn reserve(&mut self, additional: usize) {
-        self.coords.reserve(additional * 2);
+        self.coords.reserve(additional * D);
     }
 
     /// Reserves the minimum capacity for at least `additional` more coordinates to
@@ -51,14 +51,24 @@ impl InterleavedCoordBufferBuilder {
     ///
     /// [`reserve`]: Vec::reserve
     pub fn reserve_exact(&mut self, additional: usize) {
-        self.coords.reserve_exact(additional * 2);
+        self.coords.reserve_exact(additional * D);
     }
 
     /// Returns the total number of coordinates the vector can hold without reallocating.
     pub fn capacity(&self) -> usize {
-        self.coords.capacity() / 2
+        self.coords.capacity() / D
     }
 
+    pub fn len(&self) -> usize {
+        self.coords.len() / 2
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl InterleavedCoordBufferBuilder<2> {
     pub fn set_coord(&mut self, i: usize, coord: geo::Coord) {
         self.coords[i * 2] = coord.x;
         self.coords[i * 2 + 1] = coord.y;
@@ -78,29 +88,21 @@ impl InterleavedCoordBufferBuilder {
         self.coords.push(x);
         self.coords.push(y);
     }
-
-    pub fn len(&self) -> usize {
-        self.coords.len() / 2
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
 }
 
-impl Default for InterleavedCoordBufferBuilder {
+impl<const D: usize> Default for InterleavedCoordBufferBuilder<D> {
     fn default() -> Self {
         Self::with_capacity(0)
     }
 }
 
-impl From<InterleavedCoordBufferBuilder> for InterleavedCoordBuffer {
-    fn from(value: InterleavedCoordBufferBuilder) -> Self {
+impl<const D: usize> From<InterleavedCoordBufferBuilder<D>> for InterleavedCoordBuffer<D> {
+    fn from(value: InterleavedCoordBufferBuilder<D>) -> Self {
         InterleavedCoordBuffer::new(value.coords.into())
     }
 }
 
-impl<G: CoordTrait<T = f64>> From<&[G]> for InterleavedCoordBufferBuilder {
+impl<G: CoordTrait<T = f64>> From<&[G]> for InterleavedCoordBufferBuilder<2> {
     fn from(value: &[G]) -> Self {
         let mut buffer = InterleavedCoordBufferBuilder::with_capacity(value.len());
         for coord in value {

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
+use arrow::array::AsArray;
+use arrow::datatypes::Float64Type;
 // use arrow2::array::{Array, PrimitiveArray, StructArray};
-use arrow_array::{Array, Float64Array, StructArray};
+use arrow_array::{Array, ArrayRef, Float64Array, StructArray};
 use arrow_buffer::{NullBuffer, ScalarBuffer};
 use arrow_schema::{DataType, Field};
 
@@ -13,30 +15,29 @@ use crate::trait_::{GeometryArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::GeometryArrayTrait;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct SeparatedCoordBuffer {
-    pub(crate) x: ScalarBuffer<f64>,
-    pub(crate) y: ScalarBuffer<f64>,
+pub struct SeparatedCoordBuffer<const D: usize> {
+    pub(crate) buffers: [ScalarBuffer<f64>; D],
 }
 
-fn check(x: &ScalarBuffer<f64>, y: &ScalarBuffer<f64>) -> Result<()> {
-    if x.len() != y.len() {
+fn check<const D: usize>(buffers: &[ScalarBuffer<f64>; D]) -> Result<()> {
+    if !buffers.windows(2).all(|w| w[0] == w[1]) {
         return Err(GeoArrowError::General(
-            "x and y arrays must have the same length".to_string(),
+            "all buffers must have the same length".to_string(),
         ));
     }
 
     Ok(())
 }
 
-impl SeparatedCoordBuffer {
+impl<const D: usize> SeparatedCoordBuffer<D> {
     /// Construct a new SeparatedCoordBuffer
     ///
     /// # Panics
     ///
     /// - if the x and y buffers have different lengths
-    pub fn new(x: ScalarBuffer<f64>, y: ScalarBuffer<f64>) -> Self {
-        check(&x, &y).unwrap();
-        Self { x, y }
+    pub fn new(buffers: [ScalarBuffer<f64>; D]) -> Self {
+        check(&buffers).unwrap();
+        Self { buffers }
     }
 
     /// Construct a new SeparatedCoordBuffer
@@ -44,27 +45,39 @@ impl SeparatedCoordBuffer {
     /// # Errors
     ///
     /// - if the x and y buffers have different lengths
-    pub fn try_new(x: ScalarBuffer<f64>, y: ScalarBuffer<f64>) -> Result<Self> {
-        check(&x, &y)?;
-        Ok(Self { x, y })
+    pub fn try_new(buffers: [ScalarBuffer<f64>; D]) -> Result<Self> {
+        check(&buffers)?;
+        Ok(Self { buffers })
     }
 
-    pub fn values_array(&self) -> Vec<Arc<dyn Array>> {
-        vec![
-            Arc::new(Float64Array::new(self.x.clone(), None)),
-            Arc::new(Float64Array::new(self.y.clone(), None)),
-        ]
+    pub fn values_array(&self) -> Vec<ArrayRef> {
+        self.buffers
+            .iter()
+            .map(|buffer| Arc::new(Float64Array::new(buffer.clone(), None)) as ArrayRef)
+            .collect()
     }
 
     pub fn values_field(&self) -> Vec<Field> {
-        vec![
-            Field::new("x", DataType::Float64, false),
-            Field::new("y", DataType::Float64, false),
-        ]
+        match D {
+            2 => {
+                vec![
+                    Field::new("x", DataType::Float64, false),
+                    Field::new("y", DataType::Float64, false),
+                ]
+            }
+            3 => {
+                vec![
+                    Field::new("x", DataType::Float64, false),
+                    Field::new("y", DataType::Float64, false),
+                    Field::new("z", DataType::Float64, false),
+                ]
+            }
+            _ => todo!("only supports xy and xyz right now."),
+        }
     }
 }
 
-impl GeometryArrayTrait for SeparatedCoordBuffer {
+impl<const D: usize> GeometryArrayTrait for SeparatedCoordBuffer<D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -106,7 +119,7 @@ impl GeometryArrayTrait for SeparatedCoordBuffer {
     }
 
     fn len(&self) -> usize {
-        self.x.len()
+        self.buffers[0].len()
     }
 
     fn validity(&self) -> Option<&NullBuffer> {
@@ -118,8 +131,8 @@ impl GeometryArrayTrait for SeparatedCoordBuffer {
     }
 }
 
-impl GeometryArraySelfMethods for SeparatedCoordBuffer {
-    fn with_coords(self, _coords: crate::array::CoordBuffer) -> Self {
+impl<const D: usize> GeometryArraySelfMethods for SeparatedCoordBuffer<D> {
+    fn with_coords(self, _coords: crate::array::CoordBuffer<2>) -> Self {
         unimplemented!();
     }
 
@@ -132,32 +145,49 @@ impl GeometryArraySelfMethods for SeparatedCoordBuffer {
             offset + length <= self.len(),
             "offset + length may not exceed length of array"
         );
+
+        // Initialize array with existing buffers, then overwrite them
+        let mut sliced_buffers = self.buffers.clone();
+        for (i, buffer) in self.buffers.iter().enumerate() {
+            sliced_buffers[i] = buffer.slice(offset, length);
+        }
+
         Self {
-            x: self.x.slice(offset, length),
-            y: self.y.slice(offset, length),
+            buffers: sliced_buffers,
         }
     }
 
     fn owned_slice(&self, offset: usize, length: usize) -> Self {
-        let buffer = self.slice(offset, length);
-        Self::new(buffer.x.to_vec().into(), buffer.y.to_vec().into())
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+
+        // Initialize array with existing buffers, then overwrite them
+        let mut sliced_buffers = self.buffers.clone();
+        for (i, buffer) in self.buffers.iter().enumerate() {
+            sliced_buffers[i] = buffer.slice(offset, length).to_vec().into();
+        }
+
+        Self {
+            buffers: sliced_buffers,
+        }
     }
 }
 
-impl<'a> GeometryArrayAccessor<'a> for SeparatedCoordBuffer {
-    type Item = SeparatedCoord<'a>;
+impl<'a> GeometryArrayAccessor<'a> for SeparatedCoordBuffer<2> {
+    type Item = SeparatedCoord<'a, 2>;
     type ItemGeo = geo::Coord;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
         SeparatedCoord {
-            x: &self.x,
-            y: &self.y,
+            buffers: &self.buffers,
             i: index,
         }
     }
 }
 
-impl IntoArrow for SeparatedCoordBuffer {
+impl<const D: usize> IntoArrow for SeparatedCoordBuffer<D> {
     type ArrowArray = StructArray;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -165,13 +195,13 @@ impl IntoArrow for SeparatedCoordBuffer {
     }
 }
 
-impl From<SeparatedCoordBuffer> for StructArray {
-    fn from(value: SeparatedCoordBuffer) -> Self {
+impl<const D: usize> From<SeparatedCoordBuffer<D>> for StructArray {
+    fn from(value: SeparatedCoordBuffer<D>) -> Self {
         value.into_arrow()
     }
 }
 
-impl TryFrom<&StructArray> for SeparatedCoordBuffer {
+impl<const D: usize> TryFrom<&StructArray> for SeparatedCoordBuffer<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &StructArray) -> Result<Self> {
@@ -179,31 +209,36 @@ impl TryFrom<&StructArray> for SeparatedCoordBuffer {
 
         if !arrays.len() == 2 {
             return Err(GeoArrowError::General(
-                "Expected two child arrays of this StructArray.".to_string(),
+                "Expected {D} child arrays of this StructArray.".to_string(),
             ));
         }
 
-        let x_array_values = arrays[0].as_any().downcast_ref::<Float64Array>().unwrap();
-        let y_array_values = arrays[1].as_any().downcast_ref::<Float64Array>().unwrap();
+        let buffers =
+            core::array::from_fn(|i| arrays[i].as_primitive::<Float64Type>().values().clone());
+        Ok(Self::new(buffers))
+        // let buffers = [ScalarBuffer::<f64>::from(vec![]); D];
 
-        Ok(SeparatedCoordBuffer::new(
-            x_array_values.values().clone(),
-            y_array_values.values().clone(),
-        ))
+        // let x_array_values = arrays[0].as_any().downcast_ref::<Float64Array>().unwrap();
+        // let y_array_values = arrays[1].as_any().downcast_ref::<Float64Array>().unwrap();
+
+        // Ok(SeparatedCoordBuffer::new(
+        //     x_array_values.values().clone(),
+        //     y_array_values.values().clone(),
+        // ))
     }
 }
 
-impl TryFrom<(Vec<f64>, Vec<f64>)> for SeparatedCoordBuffer {
+impl TryFrom<(Vec<f64>, Vec<f64>)> for SeparatedCoordBuffer<2> {
     type Error = GeoArrowError;
 
     fn try_from(value: (Vec<f64>, Vec<f64>)) -> std::result::Result<Self, Self::Error> {
-        Self::try_new(value.0.into(), value.1.into())
+        Self::try_new([value.0.into(), value.1.into()])
     }
 }
 
-impl<G: CoordTrait<T = f64>> From<&[G]> for SeparatedCoordBuffer {
+impl<G: CoordTrait<T = f64>> From<&[G]> for SeparatedCoordBuffer<2> {
     fn from(other: &[G]) -> Self {
-        let mut_arr: SeparatedCoordBufferBuilder = other.into();
+        let mut_arr: SeparatedCoordBufferBuilder<2> = other.into();
         mut_arr.into()
     }
 }
@@ -217,13 +252,13 @@ mod test {
         let x1 = vec![0., 1., 2.];
         let y1 = vec![3., 4., 5.];
 
-        let buf1 = SeparatedCoordBuffer::new(x1.into(), y1.into()).slice(1, 1);
-        dbg!(&buf1.x);
-        dbg!(&buf1.y);
+        let buf1 = SeparatedCoordBuffer::new([x1.into(), y1.into()]).slice(1, 1);
+        dbg!(&buf1.buffers[0]);
+        dbg!(&buf1.buffers[1]);
 
         let x2 = vec![1.];
         let y2 = vec![4.];
-        let buf2 = SeparatedCoordBuffer::new(x2.into(), y2.into());
+        let buf2 = SeparatedCoordBuffer::new([x2.into(), y2.into()]);
 
         assert_eq!(buf1, buf2);
     }

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -20,7 +20,8 @@ pub struct SeparatedCoordBuffer<const D: usize> {
 }
 
 fn check<const D: usize>(buffers: &[ScalarBuffer<f64>; D]) -> Result<()> {
-    if !buffers.windows(2).all(|w| w[0] == w[1]) {
+    dbg!(buffers);
+    if !buffers.windows(2).all(|w| w[0].len() == w[1].len()) {
         return Err(GeoArrowError::General(
             "all buffers must have the same length".to_string(),
         ));

--- a/src/array/coord/separated/builder.rs
+++ b/src/array/coord/separated/builder.rs
@@ -7,33 +7,30 @@ use crate::geo_traits::CoordTrait;
 ///
 /// Converting an [`SeparatedCoordBufferBuilder`] into a [`SeparatedCoordBuffer`] is `O(1)`.
 #[derive(Debug, Clone)]
-pub struct SeparatedCoordBufferBuilder {
-    x: Vec<f64>,
-    y: Vec<f64>,
+pub struct SeparatedCoordBufferBuilder<const D: usize> {
+    buffers: [Vec<f64>; D],
 }
 
-impl SeparatedCoordBufferBuilder {
+impl<const D: usize> SeparatedCoordBufferBuilder<D> {
     // TODO: switch this new (initializing to zero) to default?
     pub fn new() -> Self {
         Self::with_capacity(0)
     }
 
-    pub fn from_vecs(x: Vec<f64>, y: Vec<f64>) -> Self {
-        Self { x, y }
+    pub fn from_vecs(buffers: [Vec<f64>; D]) -> Self {
+        Self { buffers }
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            x: Vec::with_capacity(capacity),
-            y: Vec::with_capacity(capacity),
+            buffers: core::array::from_fn(|_| Vec::with_capacity(capacity)),
         }
     }
 
     /// Initialize a buffer of a given length with all coordinates set to 0.0
     pub fn initialize(len: usize) -> Self {
         Self {
-            x: vec![0.0f64; len],
-            y: vec![0.0f64; len],
+            buffers: core::array::from_fn(|_| vec![0.0f64; len]),
         }
     }
 
@@ -43,8 +40,9 @@ impl SeparatedCoordBufferBuilder {
     /// capacity will be greater than or equal to `self.len() + additional`.
     /// Does nothing if capacity is already sufficient.
     pub fn reserve(&mut self, additional: usize) {
-        self.x.reserve(additional);
-        self.y.reserve(additional);
+        self.buffers
+            .iter_mut()
+            .for_each(|buffer| buffer.reserve(additional))
     }
 
     /// Reserves the minimum capacity for at least `additional` more coordinates to
@@ -60,37 +58,18 @@ impl SeparatedCoordBufferBuilder {
     ///
     /// [`reserve`]: Vec::reserve
     pub fn reserve_exact(&mut self, additional: usize) {
-        self.x.reserve_exact(additional);
-        self.y.reserve_exact(additional);
+        self.buffers
+            .iter_mut()
+            .for_each(|buffer| buffer.reserve_exact(additional))
     }
 
     /// Returns the total number of coordinates the vector can hold without reallocating.
     pub fn capacity(&self) -> usize {
-        self.x.capacity()
-    }
-
-    pub fn set_coord(&mut self, i: usize, coord: geo::Coord) {
-        self.x[i] = coord.x;
-        self.y[i] = coord.y;
-    }
-
-    pub fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) {
-        self.x.push(coord.x());
-        self.y.push(coord.y());
-    }
-
-    pub fn set_xy(&mut self, i: usize, x: f64, y: f64) {
-        self.x[i] = x;
-        self.y[i] = y;
-    }
-
-    pub fn push_xy(&mut self, x: f64, y: f64) {
-        self.x.push(x);
-        self.y.push(y);
+        self.buffers[0].capacity()
     }
 
     pub fn len(&self) -> usize {
-        self.x.len()
+        self.buffers[0].len()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -98,19 +77,46 @@ impl SeparatedCoordBufferBuilder {
     }
 }
 
-impl Default for SeparatedCoordBufferBuilder {
+impl SeparatedCoordBufferBuilder<2> {
+    pub fn set_coord(&mut self, i: usize, coord: geo::Coord) {
+        self.buffers[0][i] = coord.x;
+        self.buffers[1][i] = coord.y;
+    }
+
+    pub fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) {
+        self.buffers[0].push(coord.x());
+        self.buffers[1].push(coord.y());
+    }
+
+    pub fn set_xy(&mut self, i: usize, x: f64, y: f64) {
+        self.buffers[0][i] = x;
+        self.buffers[1][i] = y;
+    }
+
+    pub fn push_xy(&mut self, x: f64, y: f64) {
+        self.buffers[0].push(x);
+        self.buffers[1].push(y);
+    }
+}
+
+impl<const D: usize> Default for SeparatedCoordBufferBuilder<D> {
     fn default() -> Self {
         Self::with_capacity(0)
     }
 }
 
-impl From<SeparatedCoordBufferBuilder> for SeparatedCoordBuffer {
-    fn from(value: SeparatedCoordBufferBuilder) -> Self {
-        SeparatedCoordBuffer::new(value.x.into(), value.y.into())
+impl<const D: usize> From<SeparatedCoordBufferBuilder<D>> for SeparatedCoordBuffer<D> {
+    fn from(value: SeparatedCoordBufferBuilder<D>) -> Self {
+        // Initialize buffers with empty array, then mutate into it
+        let mut buffers = core::array::from_fn(|_| vec![].into());
+        for (i, buffer) in value.buffers.into_iter().enumerate() {
+            buffers[i] = buffer.into();
+        }
+        SeparatedCoordBuffer::new(buffers)
     }
 }
 
-impl<G: CoordTrait<T = f64>> From<&[G]> for SeparatedCoordBufferBuilder {
+impl<G: CoordTrait<T = f64>> From<&[G]> for SeparatedCoordBufferBuilder<2> {
     fn from(value: &[G]) -> Self {
         let mut buffer = SeparatedCoordBufferBuilder::with_capacity(value.len());
         for coord in value {

--- a/src/array/geometry/array.rs
+++ b/src/array/geometry/array.rs
@@ -173,7 +173,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for GeometryArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for GeometryArray<O> {
-    fn with_coords(self, coords: crate::array::CoordBuffer) -> Self {
+    fn with_coords(self, coords: crate::array::CoordBuffer<2>) -> Self {
         match self {
             GeometryArray::Point(arr) => GeometryArray::Point(arr.with_coords(coords)),
             GeometryArray::LineString(arr) => GeometryArray::LineString(arr.with_coords(coords)),

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -160,7 +160,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for GeometryCollectionArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for GeometryCollectionArray<O> {
-    fn with_coords(self, _coords: CoordBuffer) -> Self {
+    fn with_coords(self, _coords: CoordBuffer<2>) -> Self {
         todo!()
     }
 

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -30,7 +30,7 @@ pub struct LineStringArray<O: OffsetSizeTrait> {
 
     pub(crate) metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBuffer,
+    pub(crate) coords: CoordBuffer<2>,
 
     /// Offsets into the coordinate array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -40,7 +40,7 @@ pub struct LineStringArray<O: OffsetSizeTrait> {
 }
 
 pub(super) fn check<O: OffsetSizeTrait>(
-    coords: &CoordBuffer,
+    coords: &CoordBuffer<2>,
     validity_len: Option<usize>,
     geom_offsets: &OffsetBuffer<O>,
 ) -> Result<()> {
@@ -71,7 +71,7 @@ impl<O: OffsetSizeTrait> LineStringArray<O> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     pub fn new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
@@ -90,7 +90,7 @@ impl<O: OffsetSizeTrait> LineStringArray<O> {
     /// - if the validity buffer does not have the same length as the number of geometries
     /// - if the geometry offsets do not match the number of coordinates
     pub fn try_new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
@@ -123,7 +123,7 @@ impl<O: OffsetSizeTrait> LineStringArray<O> {
         }
     }
 
-    pub fn coords(&self) -> &CoordBuffer {
+    pub fn coords(&self) -> &CoordBuffer<2> {
         &self.coords
     }
 
@@ -211,7 +211,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for LineStringArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for LineStringArray<O> {
-    fn with_coords(self, coords: CoordBuffer) -> Self {
+    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(coords, self.geom_offsets, self.validity, self.metadata)
     }
@@ -306,7 +306,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for LineStringArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: &GenericListArray<O>) -> Result<Self> {
-        let coords: CoordBuffer = value.values().as_ref().try_into()?;
+        let coords: CoordBuffer<2> = value.values().as_ref().try_into()?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 

--- a/src/array/linestring/builder.rs
+++ b/src/array/linestring/builder.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 pub struct LineStringBuilder<O: OffsetSizeTrait> {
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBufferBuilder,
+    pub(crate) coords: CoordBufferBuilder<2>,
 
     /// Offsets into the coordinate array where each geometry starts
     pub(crate) geom_offsets: OffsetsBuilder<O>,
@@ -139,7 +139,7 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
     /// - The validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     pub fn try_new(
-        coords: CoordBufferBuilder,
+        coords: CoordBufferBuilder<2>,
         geom_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
         metadata: Arc<ArrayMetadata>,
@@ -158,7 +158,7 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
     }
 
     /// Extract the low-level APIs from the [`LineStringBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder, OffsetsBuilder<O>, NullBufferBuilder) {
+    pub fn into_inner(self) -> (CoordBufferBuilder<2>, OffsetsBuilder<O>, NullBufferBuilder) {
         (self.coords, self.geom_offsets, self.validity)
     }
 

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -390,7 +390,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MixedGeometryArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O> {
-    fn with_coords(self, _coords: crate::array::CoordBuffer) -> Self {
+    fn with_coords(self, _coords: crate::array::CoordBuffer<2>) -> Self {
         todo!();
     }
 

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -32,7 +32,7 @@ pub struct MultiLineStringArray<O: OffsetSizeTrait> {
 
     pub(crate) metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBuffer,
+    pub(crate) coords: CoordBuffer<2>,
 
     /// Offsets into the ring array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -45,7 +45,7 @@ pub struct MultiLineStringArray<O: OffsetSizeTrait> {
 }
 
 pub(super) fn check<O: OffsetSizeTrait>(
-    coords: &CoordBuffer,
+    coords: &CoordBuffer<2>,
     geom_offsets: &OffsetBuffer<O>,
     ring_offsets: &OffsetBuffer<O>,
     validity_len: Option<usize>,
@@ -84,7 +84,7 @@ impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
@@ -105,7 +105,7 @@ impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn try_new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
@@ -152,7 +152,7 @@ impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
         }
     }
 
-    pub fn coords(&self) -> &CoordBuffer {
+    pub fn coords(&self) -> &CoordBuffer<2> {
         &self.coords
     }
 
@@ -248,7 +248,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiLineStringArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiLineStringArray<O> {
-    fn with_coords(self, coords: CoordBuffer) -> Self {
+    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
             coords,
@@ -370,7 +370,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for MultiLineStringArray<
             .unwrap();
 
         let ring_offsets = rings_array.offsets();
-        let coords: CoordBuffer = rings_array.values().as_ref().try_into()?;
+        let coords: CoordBuffer<2> = rings_array.values().as_ref().try_into()?;
 
         Ok(Self::new(
             coords,

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -24,7 +24,7 @@ use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 pub struct MultiLineStringBuilder<O: OffsetSizeTrait> {
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBufferBuilder,
+    pub(crate) coords: CoordBufferBuilder<2>,
 
     /// OffsetsBuilder into the ring array where each geometry starts
     pub(crate) geom_offsets: OffsetsBuilder<O>,
@@ -37,7 +37,7 @@ pub struct MultiLineStringBuilder<O: OffsetSizeTrait> {
 }
 
 pub type MultiLineStringInner<O> = (
-    CoordBufferBuilder,
+    CoordBufferBuilder<2>,
     OffsetsBuilder<O>,
     OffsetsBuilder<O>,
     NullBufferBuilder,
@@ -153,7 +153,7 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn try_new(
-        coords: CoordBufferBuilder,
+        coords: CoordBufferBuilder<2>,
         geom_offsets: OffsetsBuilder<O>,
         ring_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -30,7 +30,7 @@ pub struct MultiPointArray<O: OffsetSizeTrait> {
 
     pub(crate) metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBuffer,
+    pub(crate) coords: CoordBuffer<2>,
 
     /// Offsets into the coordinate array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -40,7 +40,7 @@ pub struct MultiPointArray<O: OffsetSizeTrait> {
 }
 
 pub(super) fn check<O: OffsetSizeTrait>(
-    coords: &CoordBuffer,
+    coords: &CoordBuffer<2>,
     validity_len: Option<usize>,
     geom_offsets: &OffsetBuffer<O>,
 ) -> Result<()> {
@@ -71,7 +71,7 @@ impl<O: OffsetSizeTrait> MultiPointArray<O> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     pub fn new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
@@ -90,7 +90,7 @@ impl<O: OffsetSizeTrait> MultiPointArray<O> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the geometry offsets do not match the number of coordinates
     pub fn try_new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
@@ -123,7 +123,7 @@ impl<O: OffsetSizeTrait> MultiPointArray<O> {
         }
     }
 
-    pub fn coords(&self) -> &CoordBuffer {
+    pub fn coords(&self) -> &CoordBuffer<2> {
         &self.coords
     }
 
@@ -211,7 +211,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiPointArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPointArray<O> {
-    fn with_coords(self, coords: CoordBuffer) -> Self {
+    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(coords, self.geom_offsets, self.validity, self.metadata)
     }
@@ -306,7 +306,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for MultiPointArray<O> {
     type Error = GeoArrowError;
 
     fn try_from(value: &GenericListArray<O>) -> Result<Self> {
-        let coords: CoordBuffer = value.values().as_ref().try_into()?;
+        let coords: CoordBuffer<2> = value.values().as_ref().try_into()?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 

--- a/src/array/multipoint/builder.rs
+++ b/src/array/multipoint/builder.rs
@@ -23,7 +23,7 @@ use arrow_buffer::NullBufferBuilder;
 pub struct MultiPointBuilder<O: OffsetSizeTrait> {
     metadata: Arc<ArrayMetadata>,
 
-    coords: CoordBufferBuilder,
+    coords: CoordBufferBuilder<2>,
 
     geom_offsets: OffsetsBuilder<O>,
 
@@ -139,7 +139,7 @@ impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     pub fn try_new(
-        coords: CoordBufferBuilder,
+        coords: CoordBufferBuilder<2>,
         geom_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
         metadata: Arc<ArrayMetadata>,
@@ -158,7 +158,7 @@ impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
     }
 
     /// Extract the low-level APIs from the [`MultiPointBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder, OffsetsBuilder<O>, NullBufferBuilder) {
+    pub fn into_inner(self) -> (CoordBufferBuilder<2>, OffsetsBuilder<O>, NullBufferBuilder) {
         (self.coords, self.geom_offsets, self.validity)
     }
 

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -33,7 +33,7 @@ pub struct MultiPolygonArray<O: OffsetSizeTrait> {
 
     pub(crate) metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBuffer,
+    pub(crate) coords: CoordBuffer<2>,
 
     /// Offsets into the polygon array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -49,7 +49,7 @@ pub struct MultiPolygonArray<O: OffsetSizeTrait> {
 }
 
 pub(super) fn check<O: OffsetSizeTrait>(
-    coords: &CoordBuffer,
+    coords: &CoordBuffer<2>,
     geom_offsets: &OffsetBuffer<O>,
     polygon_offsets: &OffsetBuffer<O>,
     ring_offsets: &OffsetBuffer<O>,
@@ -95,7 +95,7 @@ impl<O: OffsetSizeTrait> MultiPolygonArray<O> {
     /// - if the largest polygon offset does not match the size of ring offsets
     /// - if the largest geometry offset does not match the size of polygon offsets
     pub fn new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         polygon_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
@@ -126,7 +126,7 @@ impl<O: OffsetSizeTrait> MultiPolygonArray<O> {
     /// - if the largest polygon offset does not match the size of ring offsets
     /// - if the largest geometry offset does not match the size of polygon offsets
     pub fn try_new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         polygon_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
@@ -185,7 +185,7 @@ impl<O: OffsetSizeTrait> MultiPolygonArray<O> {
         }
     }
 
-    pub fn coords(&self) -> &CoordBuffer {
+    pub fn coords(&self) -> &CoordBuffer<2> {
         &self.coords
     }
 
@@ -286,7 +286,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiPolygonArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPolygonArray<O> {
-    fn with_coords(self, coords: CoordBuffer) -> Self {
+    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
             coords,
@@ -442,7 +442,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for MultiPolygonArray<O> 
             .unwrap();
 
         let ring_offsets = rings_array.offsets();
-        let coords: CoordBuffer = rings_array.values().as_ref().try_into()?;
+        let coords: CoordBuffer<2> = rings_array.values().as_ref().try_into()?;
 
         Ok(Self::new(
             coords,

--- a/src/array/multipolygon/builder.rs
+++ b/src/array/multipolygon/builder.rs
@@ -19,7 +19,7 @@ use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 
 pub type MutableMultiPolygonParts<O> = (
-    CoordBufferBuilder,
+    CoordBufferBuilder<2>,
     OffsetsBuilder<O>,
     OffsetsBuilder<O>,
     OffsetsBuilder<O>,
@@ -33,7 +33,7 @@ pub type MutableMultiPolygonParts<O> = (
 pub struct MultiPolygonBuilder<O: OffsetSizeTrait> {
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBufferBuilder,
+    pub(crate) coords: CoordBufferBuilder<2>,
 
     /// OffsetsBuilder into the polygon array where each geometry starts
     pub(crate) geom_offsets: OffsetsBuilder<O>,
@@ -164,7 +164,7 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
     /// - if the largest polygon offset does not match the size of ring offsets
     /// - if the largest geometry offset does not match the size of polygon offsets
     pub fn try_new(
-        coords: CoordBufferBuilder,
+        coords: CoordBufferBuilder<2>,
         geom_offsets: OffsetsBuilder<O>,
         polygon_offsets: OffsetsBuilder<O>,
         ring_offsets: OffsetsBuilder<O>,

--- a/src/array/point/builder.rs
+++ b/src/array/point/builder.rs
@@ -20,7 +20,7 @@ use arrow_buffer::NullBufferBuilder;
 #[derive(Debug)]
 pub struct PointBuilder {
     metadata: Arc<ArrayMetadata>,
-    pub coords: CoordBufferBuilder,
+    pub coords: CoordBufferBuilder<2>,
     pub validity: NullBufferBuilder,
 }
 
@@ -97,7 +97,7 @@ impl PointBuilder {
     ///
     /// - The validity is not `None` and its length is different from the number of geometries
     pub fn try_new(
-        coords: CoordBufferBuilder,
+        coords: CoordBufferBuilder<2>,
         validity: NullBufferBuilder,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
@@ -110,7 +110,7 @@ impl PointBuilder {
     }
 
     /// Extract the low-level APIs from the [`PointBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder, NullBufferBuilder) {
+    pub fn into_inner(self) -> (CoordBufferBuilder<2>, NullBufferBuilder) {
         (self.coords, self.validity)
     }
 

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -32,7 +32,7 @@ pub struct PolygonArray<O: OffsetSizeTrait> {
 
     pub(crate) metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBuffer,
+    pub(crate) coords: CoordBuffer<2>,
 
     /// Offsets into the ring array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -45,7 +45,7 @@ pub struct PolygonArray<O: OffsetSizeTrait> {
 }
 
 pub(super) fn check<O: OffsetSizeTrait>(
-    coords: &CoordBuffer,
+    coords: &CoordBuffer<2>,
     geom_offsets: &OffsetBuffer<O>,
     ring_offsets: &OffsetBuffer<O>,
     validity_len: Option<usize>,
@@ -84,7 +84,7 @@ impl<O: OffsetSizeTrait> PolygonArray<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
@@ -105,7 +105,7 @@ impl<O: OffsetSizeTrait> PolygonArray<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn try_new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
@@ -153,7 +153,7 @@ impl<O: OffsetSizeTrait> PolygonArray<O> {
         }
     }
 
-    pub fn coords(&self) -> &CoordBuffer {
+    pub fn coords(&self) -> &CoordBuffer<2> {
         &self.coords
     }
 
@@ -249,7 +249,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for PolygonArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for PolygonArray<O> {
-    fn with_coords(self, coords: CoordBuffer) -> Self {
+    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
             coords,
@@ -371,7 +371,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for PolygonArray<O> {
             .unwrap();
 
         let ring_offsets = rings_array.offsets();
-        let coords: CoordBuffer = rings_array.values().as_ref().try_into()?;
+        let coords: CoordBuffer<2> = rings_array.values().as_ref().try_into()?;
 
         Ok(Self::new(
             coords,

--- a/src/array/polygon/builder.rs
+++ b/src/array/polygon/builder.rs
@@ -20,7 +20,7 @@ use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 
 pub type MutablePolygonParts<O> = (
-    CoordBufferBuilder,
+    CoordBufferBuilder<2>,
     OffsetsBuilder<O>,
     OffsetsBuilder<O>,
     NullBufferBuilder,
@@ -33,7 +33,7 @@ pub type MutablePolygonParts<O> = (
 pub struct PolygonBuilder<O: OffsetSizeTrait> {
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBufferBuilder,
+    pub(crate) coords: CoordBufferBuilder<2>,
 
     /// OffsetsBuilder into the ring array where each geometry starts
     pub(crate) geom_offsets: OffsetsBuilder<O>,
@@ -154,7 +154,7 @@ impl<O: OffsetSizeTrait> PolygonBuilder<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn try_new(
-        coords: CoordBufferBuilder,
+        coords: CoordBufferBuilder<2>,
         geom_offsets: OffsetsBuilder<O>,
         ring_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -126,7 +126,7 @@ impl GeometryArrayTrait for RectArray {
 }
 
 impl GeometryArraySelfMethods for RectArray {
-    fn with_coords(self, _coords: CoordBuffer) -> Self {
+    fn with_coords(self, _coords: CoordBuffer<2>) -> Self {
         unimplemented!()
     }
 

--- a/src/io/geos/scalar/coord/combined.rs
+++ b/src/io/geos/scalar/coord/combined.rs
@@ -1,10 +1,10 @@
 use crate::array::CoordBuffer;
 use geos::CoordSeq;
 
-impl TryFrom<CoordBuffer> for CoordSeq {
+impl TryFrom<CoordBuffer<2>> for CoordSeq {
     type Error = geos::Error;
 
-    fn try_from(value: CoordBuffer) -> std::result::Result<Self, geos::Error> {
+    fn try_from(value: CoordBuffer<2>) -> std::result::Result<Self, geos::Error> {
         match value {
             CoordBuffer::Separated(cb) => cb.try_into(),
             CoordBuffer::Interleaved(cb) => cb.try_into(),

--- a/src/io/geos/scalar/coord/interleaved.rs
+++ b/src/io/geos/scalar/coord/interleaved.rs
@@ -2,10 +2,10 @@ use crate::array::InterleavedCoordBuffer;
 use crate::GeometryArrayTrait;
 use geos::CoordSeq;
 
-impl TryFrom<InterleavedCoordBuffer> for CoordSeq {
+impl TryFrom<InterleavedCoordBuffer<2>> for CoordSeq {
     type Error = geos::Error;
 
-    fn try_from(value: InterleavedCoordBuffer) -> std::result::Result<Self, geos::Error> {
+    fn try_from(value: InterleavedCoordBuffer<2>) -> std::result::Result<Self, geos::Error> {
         CoordSeq::new_from_buffer(&value.coords, value.len(), false, false)
     }
 }

--- a/src/io/geos/scalar/coord/separated.rs
+++ b/src/io/geos/scalar/coord/separated.rs
@@ -1,10 +1,10 @@
 use crate::array::SeparatedCoordBuffer;
 use geos::CoordSeq;
 
-impl TryFrom<SeparatedCoordBuffer> for CoordSeq {
+impl TryFrom<SeparatedCoordBuffer<2>> for CoordSeq {
     type Error = geos::Error;
 
-    fn try_from(value: SeparatedCoordBuffer) -> std::result::Result<Self, geos::Error> {
-        CoordSeq::new_from_arrays(&value.x, &value.y, None, None)
+    fn try_from(value: SeparatedCoordBuffer<2>) -> std::result::Result<Self, geos::Error> {
+        CoordSeq::new_from_arrays(&value.buffers[0], &value.buffers[1], None, None)
     }
 }

--- a/src/scalar/coord/combined/scalar.rs
+++ b/src/scalar/coord/combined/scalar.rs
@@ -6,12 +6,12 @@ use crate::scalar::{InterleavedCoord, SeparatedCoord};
 use crate::trait_::GeometryScalarTrait;
 
 #[derive(Debug, Clone)]
-pub enum Coord<'a> {
-    Separated(SeparatedCoord<'a>),
-    Interleaved(InterleavedCoord<'a>),
+pub enum Coord<'a, const D: usize> {
+    Separated(SeparatedCoord<'a, D>),
+    Interleaved(InterleavedCoord<'a, D>),
 }
 
-impl<'a> GeometryScalarTrait for Coord<'a> {
+impl<'a, const D: usize> GeometryScalarTrait for Coord<'a, D> {
     type ScalarGeo = geo::Coord;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -29,26 +29,26 @@ impl<'a> GeometryScalarTrait for Coord<'a> {
     }
 }
 
-impl From<Coord<'_>> for geo::Coord {
-    fn from(value: Coord) -> Self {
+impl<const D: usize> From<Coord<'_, D>> for geo::Coord {
+    fn from(value: Coord<D>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&Coord<'_>> for geo::Coord {
-    fn from(value: &Coord) -> Self {
+impl<const D: usize> From<&Coord<'_, D>> for geo::Coord {
+    fn from(value: &Coord<D>) -> Self {
         coord_to_geo(value)
     }
 }
 
-impl From<Coord<'_>> for geo::Point {
-    fn from(value: Coord) -> Self {
+impl<const D: usize> From<Coord<'_, D>> for geo::Point {
+    fn from(value: Coord<D>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&Coord<'_>> for geo::Point {
-    fn from(value: &Coord) -> Self {
+impl<const D: usize> From<&Coord<'_, D>> for geo::Point {
+    fn from(value: &Coord<D>) -> Self {
         match value {
             Coord::Separated(c) => c.into(),
             Coord::Interleaved(c) => c.into(),
@@ -56,7 +56,7 @@ impl From<&Coord<'_>> for geo::Point {
     }
 }
 
-impl RTreeObject for Coord<'_> {
+impl<const D: usize> RTreeObject for Coord<'_, D> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -67,25 +67,25 @@ impl RTreeObject for Coord<'_> {
     }
 }
 
-impl PartialEq for Coord<'_> {
+impl<const D: usize> PartialEq for Coord<'_, D> {
     fn eq(&self, other: &Self) -> bool {
         self.x_y() == other.x_y()
     }
 }
 
-impl PartialEq<InterleavedCoord<'_>> for Coord<'_> {
-    fn eq(&self, other: &InterleavedCoord<'_>) -> bool {
+impl<const D: usize> PartialEq<InterleavedCoord<'_, D>> for Coord<'_, D> {
+    fn eq(&self, other: &InterleavedCoord<'_, D>) -> bool {
         self.x_y() == other.x_y()
     }
 }
 
-impl PartialEq<SeparatedCoord<'_>> for Coord<'_> {
-    fn eq(&self, other: &SeparatedCoord<'_>) -> bool {
+impl<const D: usize> PartialEq<SeparatedCoord<'_, D>> for Coord<'_, D> {
+    fn eq(&self, other: &SeparatedCoord<'_, D>) -> bool {
         self.x_y() == other.x_y()
     }
 }
 
-impl CoordTrait for Coord<'_> {
+impl<const D: usize> CoordTrait for Coord<'_, D> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -103,7 +103,7 @@ impl CoordTrait for Coord<'_> {
     }
 }
 
-impl CoordTrait for &Coord<'_> {
+impl<const D: usize> CoordTrait for &Coord<'_, D> {
     type T = f64;
 
     fn x(&self) -> Self::T {

--- a/src/scalar/coord/interleaved/scalar.rs
+++ b/src/scalar/coord/interleaved/scalar.rs
@@ -8,12 +8,12 @@ use crate::scalar::SeparatedCoord;
 use crate::trait_::GeometryScalarTrait;
 
 #[derive(Debug, Clone)]
-pub struct InterleavedCoord<'a> {
+pub struct InterleavedCoord<'a, const D: usize> {
     pub(crate) coords: &'a ScalarBuffer<f64>,
     pub(crate) i: usize,
 }
 
-impl<'a> GeometryScalarTrait for InterleavedCoord<'a> {
+impl<'a, const D: usize> GeometryScalarTrait for InterleavedCoord<'a, D> {
     type ScalarGeo = geo::Coord;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -31,32 +31,32 @@ impl<'a> GeometryScalarTrait for InterleavedCoord<'a> {
     }
 }
 
-impl From<InterleavedCoord<'_>> for geo::Coord {
-    fn from(value: InterleavedCoord) -> Self {
+impl<const D: usize> From<InterleavedCoord<'_, D>> for geo::Coord {
+    fn from(value: InterleavedCoord<D>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&InterleavedCoord<'_>> for geo::Coord {
-    fn from(value: &InterleavedCoord) -> Self {
+impl<const D: usize> From<&InterleavedCoord<'_, D>> for geo::Coord {
+    fn from(value: &InterleavedCoord<D>) -> Self {
         coord_to_geo(value)
     }
 }
 
-impl From<InterleavedCoord<'_>> for geo::Point {
-    fn from(value: InterleavedCoord<'_>) -> Self {
+impl<const D: usize> From<InterleavedCoord<'_, D>> for geo::Point {
+    fn from(value: InterleavedCoord<'_, D>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&InterleavedCoord<'_>> for geo::Point {
-    fn from(value: &InterleavedCoord<'_>) -> Self {
+impl<const D: usize> From<&InterleavedCoord<'_, D>> for geo::Point {
+    fn from(value: &InterleavedCoord<'_, D>) -> Self {
         let coord: geo::Coord = value.into();
         coord.into()
     }
 }
 
-impl RTreeObject for InterleavedCoord<'_> {
+impl<const D: usize> RTreeObject for InterleavedCoord<'_, D> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -64,19 +64,19 @@ impl RTreeObject for InterleavedCoord<'_> {
     }
 }
 
-impl PartialEq for InterleavedCoord<'_> {
+impl<const D: usize> PartialEq for InterleavedCoord<'_, D> {
     fn eq(&self, other: &Self) -> bool {
         coord_eq(self, other)
     }
 }
 
-impl PartialEq<SeparatedCoord<'_>> for InterleavedCoord<'_> {
-    fn eq(&self, other: &SeparatedCoord<'_>) -> bool {
+impl<const D: usize> PartialEq<SeparatedCoord<'_, D>> for InterleavedCoord<'_, D> {
+    fn eq(&self, other: &SeparatedCoord<'_, D>) -> bool {
         coord_eq(self, other)
     }
 }
 
-impl CoordTrait for InterleavedCoord<'_> {
+impl<const D: usize> CoordTrait for InterleavedCoord<'_, D> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -88,7 +88,7 @@ impl CoordTrait for InterleavedCoord<'_> {
     }
 }
 
-impl CoordTrait for &InterleavedCoord<'_> {
+impl<const D: usize> CoordTrait for &InterleavedCoord<'_, D> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -127,7 +127,7 @@ mod test {
 
         let x = vec![0.];
         let y = vec![3.];
-        let buf2 = SeparatedCoordBuffer::new(x.into(), y.into());
+        let buf2 = SeparatedCoordBuffer::new([x.into(), y.into()]);
         let coord2 = buf2.value(0);
 
         assert_eq!(coord1, coord2);

--- a/src/scalar/coord/separated/scalar.rs
+++ b/src/scalar/coord/separated/scalar.rs
@@ -7,13 +7,12 @@ use arrow_buffer::ScalarBuffer;
 use rstar::{RTreeObject, AABB};
 
 #[derive(Debug, Clone)]
-pub struct SeparatedCoord<'a> {
-    pub(crate) x: &'a ScalarBuffer<f64>,
-    pub(crate) y: &'a ScalarBuffer<f64>,
+pub struct SeparatedCoord<'a, const D: usize> {
+    pub(crate) buffers: &'a [ScalarBuffer<f64>; D],
     pub(crate) i: usize,
 }
 
-impl<'a> GeometryScalarTrait for SeparatedCoord<'a> {
+impl<'a, const D: usize> GeometryScalarTrait for SeparatedCoord<'a, D> {
     type ScalarGeo = geo::Coord;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -31,31 +30,31 @@ impl<'a> GeometryScalarTrait for SeparatedCoord<'a> {
     }
 }
 
-impl From<SeparatedCoord<'_>> for geo::Coord {
-    fn from(value: SeparatedCoord) -> Self {
+impl<const D: usize> From<SeparatedCoord<'_, D>> for geo::Coord {
+    fn from(value: SeparatedCoord<D>) -> Self {
         (&value).into()
     }
 }
-impl From<&SeparatedCoord<'_>> for geo::Coord {
-    fn from(value: &SeparatedCoord) -> Self {
+impl<const D: usize> From<&SeparatedCoord<'_, D>> for geo::Coord {
+    fn from(value: &SeparatedCoord<D>) -> Self {
         coord_to_geo(value)
     }
 }
 
-impl From<SeparatedCoord<'_>> for geo::Point {
-    fn from(value: SeparatedCoord<'_>) -> Self {
+impl<const D: usize> From<SeparatedCoord<'_, D>> for geo::Point {
+    fn from(value: SeparatedCoord<'_, D>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&SeparatedCoord<'_>> for geo::Point {
-    fn from(value: &SeparatedCoord<'_>) -> Self {
+impl<const D: usize> From<&SeparatedCoord<'_, D>> for geo::Point {
+    fn from(value: &SeparatedCoord<'_, D>) -> Self {
         let coord: geo::Coord = value.into();
         coord.into()
     }
 }
 
-impl RTreeObject for SeparatedCoord<'_> {
+impl<const D: usize> RTreeObject for SeparatedCoord<'_, D> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -63,39 +62,39 @@ impl RTreeObject for SeparatedCoord<'_> {
     }
 }
 
-impl PartialEq for SeparatedCoord<'_> {
-    fn eq(&self, other: &SeparatedCoord) -> bool {
+impl<const D: usize> PartialEq for SeparatedCoord<'_, D> {
+    fn eq(&self, other: &SeparatedCoord<D>) -> bool {
         coord_eq(self, other)
     }
 }
 
-impl PartialEq<InterleavedCoord<'_>> for SeparatedCoord<'_> {
-    fn eq(&self, other: &InterleavedCoord) -> bool {
+impl<const D: usize> PartialEq<InterleavedCoord<'_, D>> for SeparatedCoord<'_, D> {
+    fn eq(&self, other: &InterleavedCoord<D>) -> bool {
         coord_eq(self, other)
     }
 }
 
-impl CoordTrait for SeparatedCoord<'_> {
+impl<const D: usize> CoordTrait for SeparatedCoord<'_, D> {
     type T = f64;
 
     fn x(&self) -> Self::T {
-        self.x[self.i]
+        self.buffers[0][self.i]
     }
 
     fn y(&self) -> Self::T {
-        self.y[self.i]
+        self.buffers[1][self.i]
     }
 }
 
-impl CoordTrait for &SeparatedCoord<'_> {
+impl<const D: usize> CoordTrait for &SeparatedCoord<'_, D> {
     type T = f64;
 
     fn x(&self) -> Self::T {
-        self.x[self.i]
+        self.buffers[0][self.i]
     }
 
     fn y(&self) -> Self::T {
-        self.y[self.i]
+        self.buffers[1][self.i]
     }
 }
 
@@ -109,12 +108,12 @@ mod test {
     fn test_eq_other_index_false() {
         let x1 = vec![0., 1., 2.];
         let y1 = vec![3., 4., 5.];
-        let buf1 = SeparatedCoordBuffer::new(x1.into(), y1.into());
+        let buf1 = SeparatedCoordBuffer::new([x1.into(), y1.into()]);
         let coord1 = buf1.value(0);
 
         let x2 = vec![0., 100., 2.];
         let y2 = vec![3., 400., 5.];
-        let buf2 = SeparatedCoordBuffer::new(x2.into(), y2.into());
+        let buf2 = SeparatedCoordBuffer::new([x2.into(), y2.into()]);
         let coord2 = buf2.value(0);
 
         assert_eq!(coord1, coord2);
@@ -124,7 +123,7 @@ mod test {
     fn test_eq_against_interleaved_coord() {
         let x1 = vec![0., 1., 2.];
         let y1 = vec![3., 4., 5.];
-        let buf1 = SeparatedCoordBuffer::new(x1.into(), y1.into());
+        let buf1 = SeparatedCoordBuffer::new([x1.into(), y1.into()]);
         let coord1 = buf1.value(0);
 
         let coords2 = vec![0., 3., 1., 4., 2., 5.];

--- a/src/scalar/linestring/owned.rs
+++ b/src/scalar/linestring/owned.rs
@@ -7,7 +7,7 @@ use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
 pub struct OwnedLineString<O: OffsetSizeTrait> {
-    coords: CoordBuffer,
+    coords: CoordBuffer<2>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -16,7 +16,7 @@ pub struct OwnedLineString<O: OffsetSizeTrait> {
 }
 
 impl<O: OffsetSizeTrait> OwnedLineString<O> {
-    pub fn new(coords: CoordBuffer, geom_offsets: OffsetBuffer<O>, geom_index: usize) -> Self {
+    pub fn new(coords: CoordBuffer<2>, geom_offsets: OffsetBuffer<O>, geom_index: usize) -> Self {
         Self {
             coords,
             geom_offsets,

--- a/src/scalar/linestring/scalar.rs
+++ b/src/scalar/linestring/scalar.rs
@@ -14,7 +14,7 @@ use std::borrow::Cow;
 /// An Arrow equivalent of a LineString
 #[derive(Debug, Clone)]
 pub struct LineString<'a, O: OffsetSizeTrait> {
-    pub(crate) coords: Cow<'a, CoordBuffer>,
+    pub(crate) coords: Cow<'a, CoordBuffer<2>>,
 
     /// Offsets into the coordinate array where each geometry starts
     pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -26,7 +26,7 @@ pub struct LineString<'a, O: OffsetSizeTrait> {
 
 impl<'a, O: OffsetSizeTrait> LineString<'a, O> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer>,
+        coords: Cow<'a, CoordBuffer<2>>,
         geom_offsets: Cow<'a, OffsetBuffer<O>>,
         geom_index: usize,
     ) -> Self {
@@ -40,7 +40,7 @@ impl<'a, O: OffsetSizeTrait> LineString<'a, O> {
     }
 
     pub fn new_borrowed(
-        coords: &'a CoordBuffer,
+        coords: &'a CoordBuffer<2>,
         geom_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
@@ -52,7 +52,7 @@ impl<'a, O: OffsetSizeTrait> LineString<'a, O> {
     }
 
     pub fn new_owned(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
@@ -73,7 +73,7 @@ impl<'a, O: OffsetSizeTrait> LineString<'a, O> {
         Self::new_owned(sliced_arr.coords, sliced_arr.geom_offsets, 0)
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer, OffsetBuffer<O>, usize) {
+    pub fn into_owned_inner(self) -> (CoordBuffer<2>, OffsetBuffer<O>, usize) {
         let owned = self.into_owned();
         (
             owned.coords.into_owned(),

--- a/src/scalar/multilinestring/owned.rs
+++ b/src/scalar/multilinestring/owned.rs
@@ -7,7 +7,7 @@ use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
 pub struct OwnedMultiLineString<O: OffsetSizeTrait> {
-    coords: CoordBuffer,
+    coords: CoordBuffer<2>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -19,7 +19,7 @@ pub struct OwnedMultiLineString<O: OffsetSizeTrait> {
 
 impl<O: OffsetSizeTrait> OwnedMultiLineString<O> {
     pub fn new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         geom_index: usize,

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -15,7 +15,7 @@ use std::borrow::Cow;
 /// An Arrow equivalent of a MultiLineString
 #[derive(Debug, Clone)]
 pub struct MultiLineString<'a, O: OffsetSizeTrait> {
-    pub(crate) coords: Cow<'a, CoordBuffer>,
+    pub(crate) coords: Cow<'a, CoordBuffer<2>>,
 
     /// Offsets into the ring array where each geometry starts
     pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -30,7 +30,7 @@ pub struct MultiLineString<'a, O: OffsetSizeTrait> {
 
 impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer>,
+        coords: Cow<'a, CoordBuffer<2>>,
         geom_offsets: Cow<'a, OffsetBuffer<O>>,
         ring_offsets: Cow<'a, OffsetBuffer<O>>,
         geom_index: usize,
@@ -46,7 +46,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
     }
 
     pub fn new_borrowed(
-        coords: &'a CoordBuffer,
+        coords: &'a CoordBuffer<2>,
         geom_offsets: &'a OffsetBuffer<O>,
         ring_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
@@ -60,7 +60,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
     }
 
     pub fn new_owned(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         geom_index: usize,
@@ -93,7 +93,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
         )
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
+    pub fn into_owned_inner(self) -> (CoordBuffer<2>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
         let owned = self.into_owned();
         (
             owned.coords.into_owned(),

--- a/src/scalar/multipoint/owned.rs
+++ b/src/scalar/multipoint/owned.rs
@@ -7,7 +7,7 @@ use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
 pub struct OwnedMultiPoint<O: OffsetSizeTrait> {
-    coords: CoordBuffer,
+    coords: CoordBuffer<2>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -16,7 +16,7 @@ pub struct OwnedMultiPoint<O: OffsetSizeTrait> {
 }
 
 impl<O: OffsetSizeTrait> OwnedMultiPoint<O> {
-    pub fn new(coords: CoordBuffer, geom_offsets: OffsetBuffer<O>, geom_index: usize) -> Self {
+    pub fn new(coords: CoordBuffer<2>, geom_offsets: OffsetBuffer<O>, geom_index: usize) -> Self {
         Self {
             coords,
             geom_offsets,

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -16,7 +16,7 @@ use std::borrow::Cow;
 #[derive(Debug, Clone)]
 pub struct MultiPoint<'a, O: OffsetSizeTrait> {
     /// Buffer of coordinates
-    pub(crate) coords: Cow<'a, CoordBuffer>,
+    pub(crate) coords: Cow<'a, CoordBuffer<2>>,
 
     /// Offsets into the coordinate array where each geometry starts
     pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -28,7 +28,7 @@ pub struct MultiPoint<'a, O: OffsetSizeTrait> {
 
 impl<'a, O: OffsetSizeTrait> MultiPoint<'a, O> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer>,
+        coords: Cow<'a, CoordBuffer<2>>,
         geom_offsets: Cow<'a, OffsetBuffer<O>>,
         geom_index: usize,
     ) -> Self {
@@ -42,7 +42,7 @@ impl<'a, O: OffsetSizeTrait> MultiPoint<'a, O> {
     }
 
     pub fn new_borrowed(
-        coords: &'a CoordBuffer,
+        coords: &'a CoordBuffer<2>,
         geom_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
@@ -54,7 +54,7 @@ impl<'a, O: OffsetSizeTrait> MultiPoint<'a, O> {
     }
 
     pub fn new_owned(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
@@ -75,7 +75,7 @@ impl<'a, O: OffsetSizeTrait> MultiPoint<'a, O> {
         Self::new_owned(sliced_arr.coords, sliced_arr.geom_offsets, 0)
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer, OffsetBuffer<O>, usize) {
+    pub fn into_owned_inner(self) -> (CoordBuffer<2>, OffsetBuffer<O>, usize) {
         let owned = self.into_owned();
         (
             owned.coords.into_owned(),

--- a/src/scalar/multipolygon/owned.rs
+++ b/src/scalar/multipolygon/owned.rs
@@ -7,7 +7,7 @@ use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
 pub struct OwnedMultiPolygon<O: OffsetSizeTrait> {
-    coords: CoordBuffer,
+    coords: CoordBuffer<2>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -21,7 +21,7 @@ pub struct OwnedMultiPolygon<O: OffsetSizeTrait> {
 
 impl<O: OffsetSizeTrait> OwnedMultiPolygon<O> {
     pub fn new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         polygon_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -14,7 +14,7 @@ use std::borrow::Cow;
 /// An Arrow equivalent of a MultiPolygon
 #[derive(Debug, Clone)]
 pub struct MultiPolygon<'a, O: OffsetSizeTrait> {
-    pub(crate) coords: Cow<'a, CoordBuffer>,
+    pub(crate) coords: Cow<'a, CoordBuffer<2>>,
 
     /// Offsets into the polygon array where each geometry starts
     pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -32,7 +32,7 @@ pub struct MultiPolygon<'a, O: OffsetSizeTrait> {
 
 impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer>,
+        coords: Cow<'a, CoordBuffer<2>>,
         geom_offsets: Cow<'a, OffsetBuffer<O>>,
         polygon_offsets: Cow<'a, OffsetBuffer<O>>,
         ring_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -50,7 +50,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
     }
 
     pub fn new_borrowed(
-        coords: &'a CoordBuffer,
+        coords: &'a CoordBuffer<2>,
         geom_offsets: &'a OffsetBuffer<O>,
         polygon_offsets: &'a OffsetBuffer<O>,
         ring_offsets: &'a OffsetBuffer<O>,
@@ -66,7 +66,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
     }
 
     pub fn new_owned(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         polygon_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
@@ -106,7 +106,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
     pub fn into_owned_inner(
         self,
     ) -> (
-        CoordBuffer,
+        CoordBuffer<2>,
         OffsetBuffer<O>,
         OffsetBuffer<O>,
         OffsetBuffer<O>,

--- a/src/scalar/point/owned.rs
+++ b/src/scalar/point/owned.rs
@@ -7,16 +7,16 @@ use crate::trait_::GeometryArrayAccessor;
 
 #[derive(Clone, Debug)]
 pub struct OwnedPoint {
-    coords: CoordBuffer,
+    coords: CoordBuffer<2>,
     geom_index: usize,
 }
 
 impl OwnedPoint {
-    pub fn new(coords: CoordBuffer, geom_index: usize) -> Self {
+    pub fn new(coords: CoordBuffer<2>, geom_index: usize) -> Self {
         Self { coords, geom_index }
     }
 
-    pub fn coord(&self) -> Coord {
+    pub fn coord(&self) -> Coord<2> {
         self.coords.value(self.geom_index)
     }
 }

--- a/src/scalar/point/scalar.rs
+++ b/src/scalar/point/scalar.rs
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 /// An Arrow equivalent of a Point
 #[derive(Debug, Clone)]
 pub struct Point<'a> {
-    coords: Cow<'a, CoordBuffer>,
+    coords: Cow<'a, CoordBuffer<2>>,
     geom_index: usize,
 }
 
@@ -32,25 +32,25 @@ pub struct Point<'a> {
 // }
 
 impl<'a> Point<'a> {
-    pub fn new(coords: Cow<'a, CoordBuffer>, geom_index: usize) -> Self {
+    pub fn new(coords: Cow<'a, CoordBuffer<2>>, geom_index: usize) -> Self {
         Point { coords, geom_index }
     }
 
-    pub fn new_borrowed(coords: &'a CoordBuffer, geom_index: usize) -> Self {
+    pub fn new_borrowed(coords: &'a CoordBuffer<2>, geom_index: usize) -> Self {
         Point {
             coords: Cow::Borrowed(coords),
             geom_index,
         }
     }
 
-    pub fn new_owned(coords: CoordBuffer, geom_index: usize) -> Self {
+    pub fn new_owned(coords: CoordBuffer<2>, geom_index: usize) -> Self {
         Point {
             coords: Cow::Owned(coords),
             geom_index,
         }
     }
 
-    pub fn coord(&self) -> Coord {
+    pub fn coord(&self) -> Coord<2> {
         self.coords.value(self.geom_index)
     }
 
@@ -69,7 +69,7 @@ impl<'a> Point<'a> {
         }
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer, usize) {
+    pub fn into_owned_inner(self) -> (CoordBuffer<2>, usize) {
         let owned = self.into_owned();
         (owned.coords.into_owned(), owned.geom_index)
     }

--- a/src/scalar/polygon/owned.rs
+++ b/src/scalar/polygon/owned.rs
@@ -7,7 +7,7 @@ use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
 pub struct OwnedPolygon<O: OffsetSizeTrait> {
-    coords: CoordBuffer,
+    coords: CoordBuffer<2>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -19,7 +19,7 @@ pub struct OwnedPolygon<O: OffsetSizeTrait> {
 
 impl<O: OffsetSizeTrait> OwnedPolygon<O> {
     pub fn new(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         geom_index: usize,

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -14,7 +14,7 @@ use std::borrow::Cow;
 /// An Arrow equivalent of a Polygon
 #[derive(Debug, Clone)]
 pub struct Polygon<'a, O: OffsetSizeTrait> {
-    pub(crate) coords: Cow<'a, CoordBuffer>,
+    pub(crate) coords: Cow<'a, CoordBuffer<2>>,
 
     /// Offsets into the ring array where each geometry starts
     pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -29,7 +29,7 @@ pub struct Polygon<'a, O: OffsetSizeTrait> {
 
 impl<'a, O: OffsetSizeTrait> Polygon<'a, O> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer>,
+        coords: Cow<'a, CoordBuffer<2>>,
         geom_offsets: Cow<'a, OffsetBuffer<O>>,
         ring_offsets: Cow<'a, OffsetBuffer<O>>,
         geom_index: usize,
@@ -45,7 +45,7 @@ impl<'a, O: OffsetSizeTrait> Polygon<'a, O> {
     }
 
     pub fn new_borrowed(
-        coords: &'a CoordBuffer,
+        coords: &'a CoordBuffer<2>,
         geom_offsets: &'a OffsetBuffer<O>,
         ring_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
@@ -59,7 +59,7 @@ impl<'a, O: OffsetSizeTrait> Polygon<'a, O> {
     }
 
     pub fn new_owned(
-        coords: CoordBuffer,
+        coords: CoordBuffer<2>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         geom_index: usize,
@@ -92,7 +92,7 @@ impl<'a, O: OffsetSizeTrait> Polygon<'a, O> {
         )
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
+    pub fn into_owned_inner(self) -> (CoordBuffer<2>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
         let owned = self.into_owned();
         (
             owned.coords.into_owned(),

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -236,7 +236,7 @@ pub trait GeometryArraySelfMethods {
     ///
     /// This is useful if you want to apply an operation to _every_ coordinate in unison, such as a
     /// reprojection or a scaling operation, with no regards to each individual geometry
-    fn with_coords(self, coords: CoordBuffer) -> Self;
+    fn with_coords(self, coords: CoordBuffer<2>) -> Self;
 
     /// Cast the coordinate buffer of this geometry array to the given coordinate type.
     fn into_coord_type(self, coord_type: CoordType) -> Self;


### PR DESCRIPTION
This is initial work to support 3d/4d geometries in geoarrow-rs! 

### Change list

- Add const generic dimension parameter to coordinate buffers and scalars.
- For now, high-level geometry arrays are still 2D, but this opens up opportunities to parametrize the buffer dimension


For https://github.com/geoarrow/geoarrow-rs/issues/662