### PR TITLE
Use const generic for dimension in geometry arrays to support Z, M, ZM data

### DIFF
--- a/benches/area.rs
+++ b/benches/area.rs
@@ -4,11 +4,11 @@ use geoarrow::array::{AsChunkedGeometryArray, MultiPolygonArray};
 use geoarrow::io::flatgeobuf::read_flatgeobuf;
 use std::fs::File;
 
-fn load_file() -> MultiPolygonArray<i32> {
+fn load_file() -> MultiPolygonArray<i32, 2> {
     let mut file = File::open("fixtures/flatgeobuf/countries.fgb").unwrap();
     let table = read_flatgeobuf(&mut file, Default::default()).unwrap();
     table
-        .geometry()
+        .geometry_column(None)
         .unwrap()
         .as_ref()
         .as_multi_polygon()

--- a/benches/from_geo.rs
+++ b/benches/from_geo.rs
@@ -24,9 +24,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("convert Vec<geo::Polygon> to PolygonArray", |b| {
         b.iter(|| {
-            let mut_arr =
-                PolygonBuilder::<i32>::from_polygons(&data, Default::default(), Default::default());
-            let _arr: PolygonArray<i32> = mut_arr.into();
+            let mut_arr = PolygonBuilder::<i32, 2>::from_polygons(
+                &data,
+                Default::default(),
+                Default::default(),
+            );
+            let _arr: PolygonArray<i32, 2> = mut_arr.into();
         })
     });
 }

--- a/benches/geos_buffer.rs
+++ b/benches/geos_buffer.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use geoarrow::algorithm::geos::Buffer;
 use geoarrow::array::{CoordBuffer, InterleavedCoordBuffer, PointArray, PolygonArray};
 
-fn generate_data() -> PointArray {
+fn generate_data() -> PointArray<2> {
     let coords = vec![0.0; 100_000];
     let coord_buffer = CoordBuffer::Interleaved(InterleavedCoordBuffer::new(coords.into()));
     PointArray::new(coord_buffer, None, Default::default())
@@ -13,7 +13,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("buffer", |b| {
         b.iter(|| {
-            let _buffered: PolygonArray<i32> = point_array.buffer(1.0, 8).unwrap();
+            let _buffered: PolygonArray<i32, 2> = point_array.buffer(1.0, 8).unwrap();
         })
     });
 }

--- a/benches/nybb.rs
+++ b/benches/nybb.rs
@@ -6,7 +6,7 @@ use geoarrow::algorithm::geo::EuclideanDistance;
 use geoarrow::array::{MultiPolygonArray, PointArray};
 use geoarrow::trait_::GeometryArrayAccessor;
 
-fn load_nybb() -> MultiPolygonArray<i32> {
+fn load_nybb() -> MultiPolygonArray<i32, 2> {
     let file = File::open("fixtures/nybb.arrow").unwrap();
     let reader = FileReader::try_new(file, None).unwrap();
 
@@ -20,7 +20,7 @@ fn load_nybb() -> MultiPolygonArray<i32> {
             .position(|field| field.name() == "geometry")
             .unwrap();
         let arr = record_batch.column(geom_idx);
-        let multi_poly_arr: MultiPolygonArray<i32> = arr.as_ref().try_into().unwrap();
+        let multi_poly_arr: MultiPolygonArray<i32, 2> = arr.as_ref().try_into().unwrap();
         arrays.push(multi_poly_arr);
     }
 

--- a/benches/translate.rs
+++ b/benches/translate.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use geoarrow::algorithm::geo::Translate;
 use geoarrow::array::PolygonArray;
 
-fn create_data() -> PolygonArray<i32> {
+fn create_data() -> PolygonArray<i32, 2> {
     // An L shape
     // https://github.com/georust/geo/blob/7cb7d0ffa6bf1544c5ca9922bd06100c36f815d7/README.md?plain=1#L40
     let poly = polygon![

--- a/benches/wkb.rs
+++ b/benches/wkb.rs
@@ -30,14 +30,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("parse WKBArray to geoarrow MultiPolygonArray", |b| {
         b.iter(|| {
-            let _values: MultiPolygonArray<i32> = array.clone().try_into().unwrap();
+            let _values: MultiPolygonArray<i32, 2> = array.clone().try_into().unwrap();
         })
     });
     c.bench_function(
         "parse WKBArray to geoarrow MultiPolygonArray then to Vec<geo::Geometry>",
         |b| {
             b.iter(|| {
-                let array: MultiPolygonArray<i32> = array.clone().try_into().unwrap();
+                let array: MultiPolygonArray<i32, 2> = array.clone().try_into().unwrap();
                 let _out: Vec<geo::Geometry> = array
                     .iter_geo_values()
                     .map(geo::Geometry::MultiPolygon)

--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -526,9 +526,9 @@ checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",

--- a/js/src/broadcasting/linestring.rs
+++ b/js/src/broadcasting/linestring.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 enum _BroadcastableLineString {
     Scalar(geoarrow::scalar::OwnedLineString<i32>),
-    Array(geoarrow::array::LineStringArray<i32>),
+    Array(geoarrow::array::LineStringArray<i32, 2>),
 }
 
 #[wasm_bindgen]

--- a/js/src/broadcasting/multilinestring.rs
+++ b/js/src/broadcasting/multilinestring.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 enum _BroadcastableMultiLineString {
     Scalar(geoarrow::scalar::OwnedMultiLineString<i32>),
-    Array(geoarrow::array::MultiLineStringArray<i32>),
+    Array(geoarrow::array::MultiLineStringArray<i32, 2>),
 }
 
 #[wasm_bindgen]

--- a/js/src/data/mod.rs
+++ b/js/src/data/mod.rs
@@ -44,42 +44,42 @@ macro_rules! impl_data {
 impl_data! {
     /// An immutable array of Point geometries in WebAssembly memory using GeoArrow's in-memory
     /// representation.
-    pub struct PointData(pub(crate) geoarrow::array::PointArray);
+    pub struct PointData(pub(crate) geoarrow::array::PointArray<2>);
 }
 impl_data! {
     /// An immutable array of LineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct LineStringData(pub(crate) geoarrow::array::LineStringArray<i32>);
+    pub struct LineStringData(pub(crate) geoarrow::array::LineStringArray<i32, 2>);
 }
 impl_data! {
     /// An immutable array of Polygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct PolygonData(pub(crate) geoarrow::array::PolygonArray<i32>);
+    pub struct PolygonData(pub(crate) geoarrow::array::PolygonArray<i32, 2>);
 }
 impl_data! {
     /// An immutable array of MultiPoint geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPointData(pub(crate) geoarrow::array::MultiPointArray<i32>);
+    pub struct MultiPointData(pub(crate) geoarrow::array::MultiPointArray<i32, 2>);
 }
 impl_data! {
     /// An immutable array of MultiLineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiLineStringData(pub(crate) geoarrow::array::MultiLineStringArray<i32>);
+    pub struct MultiLineStringData(pub(crate) geoarrow::array::MultiLineStringArray<i32, 2>);
 }
 impl_data! {
     /// An immutable array of MultiPolygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPolygonData(pub(crate) geoarrow::array::MultiPolygonArray<i32>);
+    pub struct MultiPolygonData(pub(crate) geoarrow::array::MultiPolygonArray<i32, 2>);
 }
 impl_data! {
     /// An immutable array of Geometry geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MixedGeometryData(pub(crate) geoarrow::array::MixedGeometryArray<i32>);
+    pub struct MixedGeometryData(pub(crate) geoarrow::array::MixedGeometryArray<i32, 2>);
 }
 impl_data! {
     /// An immutable array of GeometryCollection geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct GeometryCollectionData(pub(crate) geoarrow::array::GeometryCollectionArray<i32>);
+    pub struct GeometryCollectionData(pub(crate) geoarrow::array::GeometryCollectionArray<i32, 2>);
 }
 impl_data! {
     /// An immutable array of WKB-encoded geometries in WebAssembly memory using GeoArrow's
@@ -203,7 +203,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoPointArray)]
     pub fn into_point_array(self) -> WasmResult<PointData> {
-        let arr: geoarrow::array::PointArray = self.0.try_into().unwrap();
+        let arr: geoarrow::array::PointArray<2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -215,7 +215,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoLineStringArray)]
     pub fn into_line_string_array(self) -> WasmResult<LineStringData> {
-        let arr: geoarrow::array::LineStringArray<i32> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::LineStringArray<i32, 2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -227,7 +227,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoPolygonArray)]
     pub fn into_polygon_array(self) -> WasmResult<PolygonData> {
-        let arr: geoarrow::array::PolygonArray<i32> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::PolygonArray<i32, 2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -239,7 +239,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiPointArray)]
     pub fn into_multi_point_array(self) -> WasmResult<MultiPointData> {
-        let arr: geoarrow::array::MultiPointArray<i32> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiPointArray<i32, 2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -251,7 +251,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiLineStringArray)]
     pub fn into_multi_line_string_array(self) -> WasmResult<MultiLineStringData> {
-        let arr: geoarrow::array::MultiLineStringArray<i32> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiLineStringArray<i32, 2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -263,7 +263,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiPolygonArray)]
     pub fn into_multi_polygon_array(self) -> WasmResult<MultiPolygonData> {
-        let arr: geoarrow::array::MultiPolygonArray<i32> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiPolygonArray<i32, 2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 }

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -7,8 +7,8 @@ pub mod data;
 pub mod error;
 pub mod ffi;
 pub mod io;
-#[cfg(feature = "geodesy")]
-pub mod reproject;
+// #[cfg(feature = "geodesy")]
+// pub mod reproject;
 #[cfg(feature = "scalar")]
 pub mod scalar;
 #[cfg(feature = "vector")]

--- a/js/src/scalar/linestring.rs
+++ b/js/src/scalar/linestring.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedLineString;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct LineString(pub(crate) OwnedLineString<i32>);
+pub struct LineString(pub(crate) OwnedLineString<i32, 2>);
 
-impl<'a> From<LineString> for geoarrow::scalar::LineString<'a, i32> {
+impl<'a> From<LineString> for geoarrow::scalar::LineString<'a, i32, 2> {
     fn from(value: LineString) -> Self {
         value.0.into()
     }
 }
 
-impl From<LineString> for geoarrow::scalar::OwnedLineString<i32> {
+impl From<LineString> for geoarrow::scalar::OwnedLineString<i32, 2> {
     fn from(value: LineString) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::LineString<'a, i32>> for LineString {
-    fn from(value: geoarrow::scalar::LineString<'a, i32>) -> Self {
+impl<'a> From<geoarrow::scalar::LineString<'a, i32, 2>> for LineString {
+    fn from(value: geoarrow::scalar::LineString<'a, i32, 2>) -> Self {
         LineString(value.into())
     }
 }

--- a/js/src/scalar/multilinestring.rs
+++ b/js/src/scalar/multilinestring.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedMultiLineString;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiLineString(pub(crate) OwnedMultiLineString<i32>);
+pub struct MultiLineString(pub(crate) OwnedMultiLineString<i32, 2>);
 
-impl<'a> From<MultiLineString> for geoarrow::scalar::MultiLineString<'a, i32> {
+impl<'a> From<MultiLineString> for geoarrow::scalar::MultiLineString<'a, i32, 2> {
     fn from(value: MultiLineString) -> Self {
         value.0.into()
     }
 }
 
-impl From<MultiLineString> for geoarrow::scalar::OwnedMultiLineString<i32> {
+impl From<MultiLineString> for geoarrow::scalar::OwnedMultiLineString<i32, 2> {
     fn from(value: MultiLineString) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiLineString<'a, i32>> for MultiLineString {
-    fn from(value: geoarrow::scalar::MultiLineString<'a, i32>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiLineString<'a, i32, 2>> for MultiLineString {
+    fn from(value: geoarrow::scalar::MultiLineString<'a, i32, 2>) -> Self {
         MultiLineString(value.into())
     }
 }

--- a/js/src/scalar/multipoint.rs
+++ b/js/src/scalar/multipoint.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedMultiPoint;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiPoint(pub(crate) OwnedMultiPoint<i32>);
+pub struct MultiPoint(pub(crate) OwnedMultiPoint<i32, 2>);
 
-impl<'a> From<MultiPoint> for geoarrow::scalar::MultiPoint<'a, i32> {
+impl<'a> From<MultiPoint> for geoarrow::scalar::MultiPoint<'a, i32, 2> {
     fn from(value: MultiPoint) -> Self {
         value.0.into()
     }
 }
 
-impl From<MultiPoint> for geoarrow::scalar::OwnedMultiPoint<i32> {
+impl From<MultiPoint> for geoarrow::scalar::OwnedMultiPoint<i32, 2> {
     fn from(value: MultiPoint) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiPoint<'a, i32>> for MultiPoint {
-    fn from(value: geoarrow::scalar::MultiPoint<'a, i32>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiPoint<'a, i32, 2>> for MultiPoint {
+    fn from(value: geoarrow::scalar::MultiPoint<'a, i32, 2>) -> Self {
         MultiPoint(value.into())
     }
 }

--- a/js/src/scalar/multipolygon.rs
+++ b/js/src/scalar/multipolygon.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedMultiPolygon;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiPolygon(pub(crate) OwnedMultiPolygon<i32>);
+pub struct MultiPolygon(pub(crate) OwnedMultiPolygon<i32, 2>);
 
-impl<'a> From<MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, i32> {
+impl<'a> From<MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, i32, 2> {
     fn from(value: MultiPolygon) -> Self {
         value.0.into()
     }
 }
 
-impl From<MultiPolygon> for geoarrow::scalar::OwnedMultiPolygon<i32> {
+impl From<MultiPolygon> for geoarrow::scalar::OwnedMultiPolygon<i32, 2> {
     fn from(value: MultiPolygon) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiPolygon<'a, i32>> for MultiPolygon {
-    fn from(value: geoarrow::scalar::MultiPolygon<'a, i32>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiPolygon<'a, i32, 2>> for MultiPolygon {
+    fn from(value: geoarrow::scalar::MultiPolygon<'a, i32, 2>) -> Self {
         MultiPolygon(value.into())
     }
 }

--- a/js/src/scalar/point.rs
+++ b/js/src/scalar/point.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedPoint;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct Point(pub(crate) OwnedPoint);
+pub struct Point(pub(crate) OwnedPoint<2>);
 
-impl<'a> From<Point> for geoarrow::scalar::Point<'a> {
+impl<'a> From<Point> for geoarrow::scalar::Point<'a, 2> {
     fn from(value: Point) -> Self {
         value.0.into()
     }
 }
 
-impl From<Point> for geoarrow::scalar::OwnedPoint {
+impl From<Point> for geoarrow::scalar::OwnedPoint<2> {
     fn from(value: Point) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::Point<'a>> for Point {
-    fn from(value: geoarrow::scalar::Point<'a>) -> Self {
+impl<'a> From<geoarrow::scalar::Point<'a, 2>> for Point {
+    fn from(value: geoarrow::scalar::Point<'a, 2>) -> Self {
         Point(value.into())
     }
 }

--- a/js/src/scalar/polygon.rs
+++ b/js/src/scalar/polygon.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedPolygon;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct Polygon(pub(crate) OwnedPolygon<i32>);
+pub struct Polygon(pub(crate) OwnedPolygon<i32, 2>);
 
-impl<'a> From<Polygon> for geoarrow::scalar::Polygon<'a, i32> {
+impl<'a> From<Polygon> for geoarrow::scalar::Polygon<'a, i32, 2> {
     fn from(value: Polygon) -> Self {
         value.0.into()
     }
 }
 
-impl From<Polygon> for geoarrow::scalar::OwnedPolygon<i32> {
+impl From<Polygon> for geoarrow::scalar::OwnedPolygon<i32, 2> {
     fn from(value: Polygon) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::Polygon<'a, i32>> for Polygon {
-    fn from(value: geoarrow::scalar::Polygon<'a, i32>) -> Self {
+impl<'a> From<geoarrow::scalar::Polygon<'a, i32, 2>> for Polygon {
+    fn from(value: geoarrow::scalar::Polygon<'a, i32, 2>) -> Self {
         Polygon(value.into())
     }
 }

--- a/js/src/vector/mod.rs
+++ b/js/src/vector/mod.rs
@@ -26,42 +26,42 @@ macro_rules! impl_vector {
 impl_vector! {
     /// An immutable chunked array of Point geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct PointVector(pub(crate) geoarrow::chunked_array::ChunkedPointArray);
+    pub struct PointVector(pub(crate) geoarrow::chunked_array::ChunkedPointArray<2>);
 }
 impl_vector! {
     /// An immutable chunked array of LineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct LineStringVector(pub(crate) geoarrow::chunked_array::ChunkedLineStringArray<i32>);
+    pub struct LineStringVector(pub(crate) geoarrow::chunked_array::ChunkedLineStringArray<i32, 2>);
 }
 impl_vector! {
     /// An immutable chunked array of Polygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct PolygonVector(pub(crate) geoarrow::chunked_array::ChunkedPolygonArray<i32>);
+    pub struct PolygonVector(pub(crate) geoarrow::chunked_array::ChunkedPolygonArray<i32, 2>);
 }
 impl_vector! {
     /// An immutable chunked array of MultiPoint geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPointVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPointArray<i32>);
+    pub struct MultiPointVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPointArray<i32, 2>);
 }
 impl_vector! {
     /// An immutable chunked array of MultiLineString geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MultiLineStringVector(pub(crate) geoarrow::chunked_array::ChunkedMultiLineStringArray<i32>);
+    pub struct MultiLineStringVector(pub(crate) geoarrow::chunked_array::ChunkedMultiLineStringArray<i32, 2>);
 }
 impl_vector! {
     /// An immutable chunked array of MultiPolygon geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MultiPolygonVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPolygonArray<i32>);
+    pub struct MultiPolygonVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPolygonArray<i32, 2>);
 }
 impl_vector! {
     /// An immutable chunked array of Geometry geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MixedGeometryVector(pub(crate) geoarrow::chunked_array::ChunkedMixedGeometryArray<i32>);
+    pub struct MixedGeometryVector(pub(crate) geoarrow::chunked_array::ChunkedMixedGeometryArray<i32, 2>);
 }
 impl_vector! {
     /// An immutable chunked array of GeometryCollection geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct GeometryCollectionVector(pub(crate) geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32>);
+    pub struct GeometryCollectionVector(pub(crate) geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32, 2>);
 }
 impl_vector! {
     /// An immutable chunked array of WKB-encoded geometries in WebAssembly memory using GeoArrow's

--- a/python/core/Cargo.lock
+++ b/python/core/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
+checksum = "6127ea5e585a12ec9f742232442828ebaf264dfa5eefdd71282376c599562b77"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7029a5b3efbeafbf4a12d12dc16b8f9e9bff20a410b8c25c5d28acc089e1043"
+checksum = "7add7f39210b7d726e2a8efc0083e7bf06e8f2d15bdb4896b564dce4410fbf5d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33238427c60271710695f17742f45b1a5dc5bcfc5c15331c25ddfe7abf70d97"
+checksum = "81c16ec702d3898c2f5cfdc148443c6cd7dbe5bac28399859eb0a3d38f072827"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9b95e825ae838efaf77e366c00d3fc8cca78134c9db497d6bda425f2e7b7c1"
+checksum = "cae6970bab043c4fbc10aee1660ceb5b306d0c42c8cc5f6ae564efcd9759b663"
 dependencies = [
  "bytes",
  "half",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cf8385a9d5b5fcde771661dd07652b79b9139fea66193eda6a88664400ccab"
+checksum = "1c7ef44f26ef4f8edc392a048324ed5d757ad09135eff6d5509e6450d39e0398"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
+checksum = "5f843490bd258c5182b66e888161bb6f198f49f3792f7c7f98198b924ae0f564"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb29be98f987bcf217b070512bb7afba2f65180858bca462edf4a39d84a23e10"
+checksum = "a769666ffac256dd301006faca1ca553d0ae7cffcf4cd07095f73f95eb226514"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
+checksum = "dbf9c3fb57390a1af0b7bb3b5558c1ee1f63905f3eccf49ae7676a8d1e6e5a72"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2041380f94bd6437ab648e6c2085a045e45a0c44f91a1b9a4fe3fed3d379bfb1"
+checksum = "654e7f3724176b66ddfacba31af397c48e106fbe4d281c8144e7d237df5acfd7"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb56ed1547004e12203652f12fe12e824161ff9d1e5cf2a7dc4ff02ba94f413"
+checksum = "e8008370e624e8e3c68174faaf793540287106cfda8ad1da862fdc53d8e096b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575b42f1fc588f2da6977b94a5ca565459f5ab07b60545e17243fb9a7ed6d43e"
+checksum = "ca5e3a6b7fda8d9fe03f3b18a2d946354ea7f3c8e4076dbdb502ad50d9d44824"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -274,18 +274,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
+checksum = "dab1c12b40e29d9f3b699e0203c2a73ba558444c05e388a4377208f8f9c97eee"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
+checksum = "e80159088ffe8c48965cb9b1a7c968b2729f29f37363df7eca177fc3281fe7c3"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e435ada8409bcafc910bc3e0077f532a4daa20e99060a496685c0e3e53cc2597"
+checksum = "0fd04a6ea7de183648edbcb7a6dd925bbd04c210895f6384c780e27a9b54afcd"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -331,18 +331,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -407,9 +407,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -464,19 +464,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -497,7 +496,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -715,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
 ]
@@ -937,7 +936,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1317,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -1334,7 +1333,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1372,9 +1371,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1396,16 +1395,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1422,9 +1421,9 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -1439,7 +1438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -1453,7 +1452,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1463,16 +1462,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1713,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lz4_flex"
@@ -1849,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1952,7 +1951,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1973,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -1992,7 +1991,7 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "itertools 0.12.1",
  "md-5",
  "parking_lot",
@@ -2023,7 +2022,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2040,7 +2039,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2098,16 +2097,16 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "parquet"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c3b5322cc1bbf67f11c079c42be41a55949099b78732f7dba9e15edde40eab"
+checksum = "0f22ba0d95db56dde8685e3fadcb915cdaadda31ab8abbe3ff7f0ad1ef333267"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2209,7 +2208,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2238,7 +2237,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2399,7 +2398,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2412,7 +2411,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2436,7 +2435,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "thiserror",
  "tokio",
  "tracing",
@@ -2452,7 +2451,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "slab",
  "thiserror",
  "tinyvec",
@@ -2557,11 +2556,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2607,7 +2606,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.29",
+ "hyper 0.14.30",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -2646,9 +2645,9 @@ dependencies = [
  "futures-util",
  "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.1",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -2661,7 +2660,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-native-certs",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
@@ -2762,7 +2761,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2782,23 +2781,23 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.2",
@@ -2844,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2901,11 +2900,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2914,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2936,29 +2935,29 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -3212,7 +3211,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -3255,7 +3254,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "chrono",
  "crc",
@@ -3335,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3352,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.67"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3396,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "tempfile"
@@ -3414,22 +3413,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3454,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3469,9 +3468,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3492,7 +3491,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3511,7 +3510,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.10",
+ "rustls 0.23.11",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3604,7 +3603,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3770,7 +3769,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -3804,7 +3803,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3869,7 +3868,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3887,7 +3886,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3907,18 +3906,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3929,9 +3928,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3941,9 +3940,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3953,15 +3952,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3971,9 +3970,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3983,9 +3982,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3995,9 +3994,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4007,9 +4006,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -4054,22 +4053,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.67",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4080,27 +4079,27 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/python/core/src/array/mod.rs
+++ b/python/core/src/array/mod.rs
@@ -40,36 +40,36 @@ macro_rules! impl_array {
 
 impl_array! {
     /// An immutable array of Point geometries using GeoArrow's in-memory representation.
-    pub struct PointArray(pub(crate) geoarrow::array::PointArray);
+    pub struct PointArray(pub(crate) geoarrow::array::PointArray<2>);
 }
 impl_array! {
     /// An immutable array of LineString geometries using GeoArrow's in-memory representation.
-    pub struct LineStringArray(pub(crate) geoarrow::array::LineStringArray<i32>);
+    pub struct LineStringArray(pub(crate) geoarrow::array::LineStringArray<i32, 2>);
 }
 impl_array! {
     /// An immutable array of Polygon geometries using GeoArrow's in-memory representation.
-    pub struct PolygonArray(pub(crate) geoarrow::array::PolygonArray<i32>);
+    pub struct PolygonArray(pub(crate) geoarrow::array::PolygonArray<i32, 2>);
 }
 impl_array! {
     /// An immutable array of MultiPoint geometries using GeoArrow's in-memory representation.
-    pub struct MultiPointArray(pub(crate) geoarrow::array::MultiPointArray<i32>);
+    pub struct MultiPointArray(pub(crate) geoarrow::array::MultiPointArray<i32, 2>);
 }
 impl_array! {
     /// An immutable array of MultiLineString geometries using GeoArrow's in-memory representation.
-    pub struct MultiLineStringArray(pub(crate) geoarrow::array::MultiLineStringArray<i32>);
+    pub struct MultiLineStringArray(pub(crate) geoarrow::array::MultiLineStringArray<i32, 2>);
 }
 impl_array! {
     /// An immutable array of MultiPolygon geometries using GeoArrow's in-memory representation.
-    pub struct MultiPolygonArray(pub(crate) geoarrow::array::MultiPolygonArray<i32>);
+    pub struct MultiPolygonArray(pub(crate) geoarrow::array::MultiPolygonArray<i32, 2>);
 }
 impl_array! {
     /// An immutable array of Geometry geometries using GeoArrow's in-memory representation.
-    pub struct MixedGeometryArray(pub(crate) geoarrow::array::MixedGeometryArray<i32>);
+    pub struct MixedGeometryArray(pub(crate) geoarrow::array::MixedGeometryArray<i32, 2>);
 }
 impl_array! {
     /// An immutable array of GeometryCollection geometries using GeoArrow's in-memory
     /// representation.
-    pub struct GeometryCollectionArray(pub(crate) geoarrow::array::GeometryCollectionArray<i32>);
+    pub struct GeometryCollectionArray(pub(crate) geoarrow::array::GeometryCollectionArray<i32, 2>);
 }
 impl_array! {
     /// An immutable array of WKB-encoded geometries using GeoArrow's in-memory representation.

--- a/python/core/src/chunked_array/mod.rs
+++ b/python/core/src/chunked_array/mod.rs
@@ -37,41 +37,41 @@ macro_rules! impl_chunked_array {
 
 impl_chunked_array! {
     /// An immutable chunked array of Point geometries using GeoArrow's in-memory representation.
-    pub struct ChunkedPointArray(pub(crate) geoarrow::chunked_array::ChunkedPointArray);
+    pub struct ChunkedPointArray(pub(crate) geoarrow::chunked_array::ChunkedPointArray<2>);
 }
 impl_chunked_array! {
     /// An immutable chunked array of LineString geometries using GeoArrow's in-memory
     /// representation.
-    pub struct ChunkedLineStringArray(pub(crate) geoarrow::chunked_array::ChunkedLineStringArray<i32>);
+    pub struct ChunkedLineStringArray(pub(crate) geoarrow::chunked_array::ChunkedLineStringArray<i32, 2>);
 }
 impl_chunked_array! {
     /// An immutable chunked array of Polygon geometries using GeoArrow's in-memory representation.
-    pub struct ChunkedPolygonArray(pub(crate) geoarrow::chunked_array::ChunkedPolygonArray<i32>);
+    pub struct ChunkedPolygonArray(pub(crate) geoarrow::chunked_array::ChunkedPolygonArray<i32, 2>);
 }
 impl_chunked_array! {
     /// An immutable chunked array of MultiPoint geometries using GeoArrow's in-memory
     /// representation.
-    pub struct ChunkedMultiPointArray(pub(crate) geoarrow::chunked_array::ChunkedMultiPointArray<i32>);
+    pub struct ChunkedMultiPointArray(pub(crate) geoarrow::chunked_array::ChunkedMultiPointArray<i32, 2>);
 }
 impl_chunked_array! {
     /// An immutable chunked array of MultiLineString geometries using GeoArrow's in-memory
     /// representation.
-    pub struct ChunkedMultiLineStringArray(pub(crate) geoarrow::chunked_array::ChunkedMultiLineStringArray<i32>);
+    pub struct ChunkedMultiLineStringArray(pub(crate) geoarrow::chunked_array::ChunkedMultiLineStringArray<i32, 2>);
 }
 impl_chunked_array! {
     /// An immutable chunked array of MultiPolygon geometries using GeoArrow's in-memory
     /// representation.
-    pub struct ChunkedMultiPolygonArray(pub(crate) geoarrow::chunked_array::ChunkedMultiPolygonArray<i32>);
+    pub struct ChunkedMultiPolygonArray(pub(crate) geoarrow::chunked_array::ChunkedMultiPolygonArray<i32, 2>);
 }
 impl_chunked_array! {
     /// An immutable chunked array of Geometry geometries using GeoArrow's in-memory
     /// representation.
-    pub struct ChunkedMixedGeometryArray(pub(crate) geoarrow::chunked_array::ChunkedMixedGeometryArray<i32>);
+    pub struct ChunkedMixedGeometryArray(pub(crate) geoarrow::chunked_array::ChunkedMixedGeometryArray<i32, 2>);
 }
 impl_chunked_array! {
     /// An immutable chunked array of GeometryCollection geometries using GeoArrow's in-memory
     /// representation.
-    pub struct ChunkedGeometryCollectionArray(pub(crate) geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32>);
+    pub struct ChunkedGeometryCollectionArray(pub(crate) geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32, 2>);
 }
 impl_chunked_array! {
     /// An immutable chunked array of WKB-encoded geometries using GeoArrow's in-memory

--- a/python/core/src/ffi/from_python/array.rs
+++ b/python/core/src/ffi/from_python/array.rs
@@ -19,20 +19,20 @@ macro_rules! impl_from_py_object {
 }
 
 impl_from_py_object!(WKBArray, geoarrow::array::WKBArray<i32>);
-impl_from_py_object!(PointArray, geoarrow::array::PointArray);
-impl_from_py_object!(LineStringArray, geoarrow::array::LineStringArray<i32>);
-impl_from_py_object!(PolygonArray, geoarrow::array::PolygonArray<i32>);
-impl_from_py_object!(MultiPointArray, geoarrow::array::MultiPointArray<i32>);
+impl_from_py_object!(PointArray, geoarrow::array::PointArray<2>);
+impl_from_py_object!(LineStringArray, geoarrow::array::LineStringArray<i32, 2>);
+impl_from_py_object!(PolygonArray, geoarrow::array::PolygonArray<i32, 2>);
+impl_from_py_object!(MultiPointArray, geoarrow::array::MultiPointArray<i32, 2>);
 impl_from_py_object!(
     MultiLineStringArray,
-    geoarrow::array::MultiLineStringArray<i32>
+    geoarrow::array::MultiLineStringArray<i32, 2>
 );
-impl_from_py_object!(MultiPolygonArray, geoarrow::array::MultiPolygonArray<i32>);
-impl_from_py_object!(MixedGeometryArray, geoarrow::array::MixedGeometryArray<i32>);
+impl_from_py_object!(MultiPolygonArray, geoarrow::array::MultiPolygonArray<i32, 2>);
+impl_from_py_object!(MixedGeometryArray, geoarrow::array::MixedGeometryArray<i32, 2>);
 // impl_from_py_object!(RectArray);
 impl_from_py_object!(
     GeometryCollectionArray,
-    geoarrow::array::GeometryCollectionArray<i32>
+    geoarrow::array::GeometryCollectionArray<i32, 2>
 );
 
 macro_rules! impl_from_arrow {

--- a/python/core/src/ffi/from_python/chunked.rs
+++ b/python/core/src/ffi/from_python/chunked.rs
@@ -31,38 +31,38 @@ macro_rules! impl_extract {
 
 impl_extract!(
     ChunkedPointArray,
-    geoarrow::array::PointArray,
-    geoarrow::chunked_array::ChunkedPointArray
+    geoarrow::array::PointArray<2>,
+    geoarrow::chunked_array::ChunkedPointArray<2>
 );
 impl_extract!(
     ChunkedLineStringArray,
-    geoarrow::array::LineStringArray<i32>,
-    geoarrow::chunked_array::ChunkedLineStringArray<i32>
+    geoarrow::array::LineStringArray<i32, 2>,
+    geoarrow::chunked_array::ChunkedLineStringArray<i32, 2>
 );
 impl_extract!(
     ChunkedPolygonArray,
-    geoarrow::array::PolygonArray<i32>,
-    geoarrow::chunked_array::ChunkedPolygonArray<i32>
+    geoarrow::array::PolygonArray<i32, 2>,
+    geoarrow::chunked_array::ChunkedPolygonArray<i32, 2>
 );
 impl_extract!(
     ChunkedMultiPointArray,
-    geoarrow::array::MultiPointArray<i32>,
-    geoarrow::chunked_array::ChunkedMultiPointArray<i32>
+    geoarrow::array::MultiPointArray<i32, 2>,
+    geoarrow::chunked_array::ChunkedMultiPointArray<i32, 2>
 );
 impl_extract!(
     ChunkedMultiLineStringArray,
-    geoarrow::array::MultiLineStringArray<i32>,
-    geoarrow::chunked_array::ChunkedMultiLineStringArray<i32>
+    geoarrow::array::MultiLineStringArray<i32, 2>,
+    geoarrow::chunked_array::ChunkedMultiLineStringArray<i32, 2>
 );
 impl_extract!(
     ChunkedMultiPolygonArray,
-    geoarrow::array::MultiPolygonArray<i32>,
-    geoarrow::chunked_array::ChunkedMultiPolygonArray<i32>
+    geoarrow::array::MultiPolygonArray<i32, 2>,
+    geoarrow::chunked_array::ChunkedMultiPolygonArray<i32, 2>
 );
 impl_extract!(
     ChunkedMixedGeometryArray,
-    geoarrow::array::MixedGeometryArray<i32>,
-    geoarrow::chunked_array::ChunkedMixedGeometryArray<i32>
+    geoarrow::array::MixedGeometryArray<i32, 2>,
+    geoarrow::chunked_array::ChunkedMixedGeometryArray<i32, 2>
 );
 // impl_extract!(
 //     ChunkedRectArray,
@@ -71,8 +71,8 @@ impl_extract!(
 // );
 impl_extract!(
     ChunkedGeometryCollectionArray,
-    geoarrow::array::GeometryCollectionArray<i32>,
-    geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32>
+    geoarrow::array::GeometryCollectionArray<i32, 2>,
+    geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32, 2>
 );
 impl_extract!(
     ChunkedWKBArray,
@@ -114,37 +114,37 @@ macro_rules! impl_from_arrow_chunks {
 impl_from_arrow_chunks!(
     ChunkedPointArray,
     PointArray,
-    geoarrow::chunked_array::ChunkedPointArray
+    geoarrow::chunked_array::ChunkedPointArray<2>
 );
 impl_from_arrow_chunks!(
     ChunkedLineStringArray,
     LineStringArray,
-    geoarrow::chunked_array::ChunkedLineStringArray<i32>
+    geoarrow::chunked_array::ChunkedLineStringArray<i32, 2>
 );
 impl_from_arrow_chunks!(
     ChunkedPolygonArray,
     PolygonArray,
-    geoarrow::chunked_array::ChunkedPolygonArray<i32>
+    geoarrow::chunked_array::ChunkedPolygonArray<i32, 2>
 );
 impl_from_arrow_chunks!(
     ChunkedMultiPointArray,
     MultiPointArray,
-    geoarrow::chunked_array::ChunkedMultiPointArray<i32>
+    geoarrow::chunked_array::ChunkedMultiPointArray<i32, 2>
 );
 impl_from_arrow_chunks!(
     ChunkedMultiLineStringArray,
     MultiLineStringArray,
-    geoarrow::chunked_array::ChunkedMultiLineStringArray<i32>
+    geoarrow::chunked_array::ChunkedMultiLineStringArray<i32, 2>
 );
 impl_from_arrow_chunks!(
     ChunkedMultiPolygonArray,
     MultiPolygonArray,
-    geoarrow::chunked_array::ChunkedMultiPolygonArray<i32>
+    geoarrow::chunked_array::ChunkedMultiPolygonArray<i32, 2>
 );
 impl_from_arrow_chunks!(
     ChunkedMixedGeometryArray,
     MixedGeometryArray,
-    geoarrow::chunked_array::ChunkedMixedGeometryArray<i32>
+    geoarrow::chunked_array::ChunkedMixedGeometryArray<i32, 2>
 );
 // impl_from_arrow_chunks!(
 //     ChunkedRectArray,
@@ -154,7 +154,7 @@ impl_from_arrow_chunks!(
 impl_from_arrow_chunks!(
     ChunkedGeometryCollectionArray,
     GeometryCollectionArray,
-    geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32>
+    geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32, 2>
 );
 impl_from_arrow_chunks!(
     ChunkedWKBArray,

--- a/python/core/src/ffi/from_python/input.rs
+++ b/python/core/src/ffi/from_python/input.rs
@@ -61,7 +61,7 @@ impl<'a> FromPyObject<'a> for AnyArrayInput {
     }
 }
 
-pub struct GeometryScalarInput(pub geoarrow::scalar::OwnedGeometry<i32>);
+pub struct GeometryScalarInput(pub geoarrow::scalar::OwnedGeometry<i32, 2>);
 
 impl<'a> FromPyObject<'a> for GeometryScalarInput {
     fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {

--- a/python/core/src/ffi/to_python/array.rs
+++ b/python/core/src/ffi/to_python/array.rs
@@ -63,7 +63,7 @@ impl_arrow_c_array!(GeometryCollectionArray);
 impl_arrow_c_array!(WKBArray);
 impl_arrow_c_array!(RectArray);
 
-pub fn geometry_to_pyobject(py: Python, geom: geoarrow::scalar::Geometry<'_, i32>) -> PyObject {
+pub fn geometry_to_pyobject(py: Python, geom: geoarrow::scalar::Geometry<'_, i32, 2>) -> PyObject {
     match geom {
         geoarrow::scalar::Geometry::Point(g) => Point(g.into()).into_py(py),
         geoarrow::scalar::Geometry::LineString(g) => LineString(g.into()).into_py(py),

--- a/python/core/src/io/ewkb.rs
+++ b/python/core/src/io/ewkb.rs
@@ -90,8 +90,8 @@ macro_rules! impl_from_ewkb {
     };
 }
 
-impl_from_ewkb!(MixedGeometryArray, geoarrow::array::MixedGeometryArray<i32>);
+impl_from_ewkb!(MixedGeometryArray, geoarrow::array::MixedGeometryArray<i32, 2>);
 impl_from_ewkb!(
     GeometryCollectionArray,
-    geoarrow::array::GeometryCollectionArray<i32>
+    geoarrow::array::GeometryCollectionArray<i32, 2>
 );

--- a/python/core/src/io/wkb.rs
+++ b/python/core/src/io/wkb.rs
@@ -106,19 +106,19 @@ macro_rules! impl_from_wkb {
     };
 }
 
-impl_from_wkb!(PointArray, geoarrow::array::PointArray);
-impl_from_wkb!(LineStringArray, geoarrow::array::LineStringArray<i32>);
-impl_from_wkb!(PolygonArray, geoarrow::array::PolygonArray<i32>);
-impl_from_wkb!(MultiPointArray, geoarrow::array::MultiPointArray<i32>);
+impl_from_wkb!(PointArray, geoarrow::array::PointArray<2>);
+impl_from_wkb!(LineStringArray, geoarrow::array::LineStringArray<i32, 2>);
+impl_from_wkb!(PolygonArray, geoarrow::array::PolygonArray<i32, 2>);
+impl_from_wkb!(MultiPointArray, geoarrow::array::MultiPointArray<i32, 2>);
 impl_from_wkb!(
     MultiLineStringArray,
-    geoarrow::array::MultiLineStringArray<i32>
+    geoarrow::array::MultiLineStringArray<i32, 2>
 );
-impl_from_wkb!(MultiPolygonArray, geoarrow::array::MultiPolygonArray<i32>);
-impl_from_wkb!(MixedGeometryArray, geoarrow::array::MixedGeometryArray<i32>);
+impl_from_wkb!(MultiPolygonArray, geoarrow::array::MultiPolygonArray<i32, 2>);
+impl_from_wkb!(MixedGeometryArray, geoarrow::array::MixedGeometryArray<i32, 2>);
 impl_from_wkb!(
     GeometryCollectionArray,
-    geoarrow::array::GeometryCollectionArray<i32>
+    geoarrow::array::GeometryCollectionArray<i32, 2>
 );
 
 // macro_rules! impl_from_wkb_chunked {

--- a/python/core/src/io/wkt.rs
+++ b/python/core/src/io/wkt.rs
@@ -87,8 +87,8 @@ macro_rules! impl_from_wkt {
     };
 }
 
-impl_from_wkt!(MixedGeometryArray, geoarrow::array::MixedGeometryArray<i32>);
+impl_from_wkt!(MixedGeometryArray, geoarrow::array::MixedGeometryArray<i32, 2>);
 impl_from_wkt!(
     GeometryCollectionArray,
-    geoarrow::array::GeometryCollectionArray<i32>
+    geoarrow::array::GeometryCollectionArray<i32, 2>
 );

--- a/python/core/src/scalar/geo_interface.rs
+++ b/python/core/src/scalar/geo_interface.rs
@@ -27,14 +27,14 @@ macro_rules! impl_geo_interface {
     };
 }
 
-impl_geo_interface!(Point, geoarrow::scalar::Point);
-impl_geo_interface!(LineString, geoarrow::scalar::LineString<i32>);
-impl_geo_interface!(Polygon, geoarrow::scalar::Polygon<i32>);
-impl_geo_interface!(MultiPoint, geoarrow::scalar::MultiPoint<i32>);
-impl_geo_interface!(MultiLineString, geoarrow::scalar::MultiLineString<i32>);
-impl_geo_interface!(MultiPolygon, geoarrow::scalar::MultiPolygon<i32>);
-impl_geo_interface!(Geometry, geoarrow::scalar::Geometry<i32>);
+impl_geo_interface!(Point, geoarrow::scalar::Point<2>);
+impl_geo_interface!(LineString, geoarrow::scalar::LineString<i32, 2>);
+impl_geo_interface!(Polygon, geoarrow::scalar::Polygon<i32, 2>);
+impl_geo_interface!(MultiPoint, geoarrow::scalar::MultiPoint<i32, 2>);
+impl_geo_interface!(MultiLineString, geoarrow::scalar::MultiLineString<i32, 2>);
+impl_geo_interface!(MultiPolygon, geoarrow::scalar::MultiPolygon<i32, 2>);
+impl_geo_interface!(Geometry, geoarrow::scalar::Geometry<i32, 2>);
 impl_geo_interface!(
     GeometryCollection,
-    geoarrow::scalar::GeometryCollection<i32>
+    geoarrow::scalar::GeometryCollection<i32, 2>
 );

--- a/python/core/src/scalar/mod.rs
+++ b/python/core/src/scalar/mod.rs
@@ -31,56 +31,56 @@ impl_scalar! {
     ///
     /// **Note**: for best performance, do as many operations as possible on arrays or chunked
     /// arrays instead of scalars.
-    pub struct Point(pub(crate) geoarrow::scalar::OwnedPoint);
+    pub struct Point(pub(crate) geoarrow::scalar::OwnedPoint<2>);
 }
 impl_scalar! {
     /// An immutable LineString scalar using GeoArrow's in-memory representation.
     ///
     /// **Note**: for best performance, do as many operations as possible on arrays or chunked
     /// arrays instead of scalars.
-    pub struct LineString(pub(crate) geoarrow::scalar::OwnedLineString<i32>);
+    pub struct LineString(pub(crate) geoarrow::scalar::OwnedLineString<i32, 2>);
 }
 impl_scalar! {
     /// An immutable Polygon scalar using GeoArrow's in-memory representation.
     ///
     /// **Note**: for best performance, do as many operations as possible on arrays or chunked
     /// arrays instead of scalars.
-    pub struct Polygon(pub(crate) geoarrow::scalar::OwnedPolygon<i32>);
+    pub struct Polygon(pub(crate) geoarrow::scalar::OwnedPolygon<i32, 2>);
 }
 impl_scalar! {
     /// An immutable MultiPoint scalar using GeoArrow's in-memory representation.
     ///
     /// **Note**: for best performance, do as many operations as possible on arrays or chunked
     /// arrays instead of scalars.
-    pub struct MultiPoint(pub(crate) geoarrow::scalar::OwnedMultiPoint<i32>);
+    pub struct MultiPoint(pub(crate) geoarrow::scalar::OwnedMultiPoint<i32, 2>);
 }
 impl_scalar! {
     /// An immutable MultiLineString scalar using GeoArrow's in-memory representation.
     ///
     /// **Note**: for best performance, do as many operations as possible on arrays or chunked
     /// arrays instead of scalars.
-    pub struct MultiLineString(pub(crate) geoarrow::scalar::OwnedMultiLineString<i32>);
+    pub struct MultiLineString(pub(crate) geoarrow::scalar::OwnedMultiLineString<i32, 2>);
 }
 impl_scalar! {
     /// An immutable MultiPolygon scalar using GeoArrow's in-memory representation.
     ///
     /// **Note**: for best performance, do as many operations as possible on arrays or chunked
     /// arrays instead of scalars.
-    pub struct MultiPolygon(pub(crate) geoarrow::scalar::OwnedMultiPolygon<i32>);
+    pub struct MultiPolygon(pub(crate) geoarrow::scalar::OwnedMultiPolygon<i32, 2>);
 }
 impl_scalar! {
     /// An immutable Geometry scalar using GeoArrow's in-memory representation.
     ///
     /// **Note**: for best performance, do as many operations as possible on arrays or chunked
     /// arrays instead of scalars.
-    pub struct Geometry(pub(crate) geoarrow::scalar::OwnedGeometry<i32>);
+    pub struct Geometry(pub(crate) geoarrow::scalar::OwnedGeometry<i32, 2>);
 }
 impl_scalar! {
     /// An immutable GeometryCollection scalar using GeoArrow's in-memory representation.
     ///
     /// **Note**: for best performance, do as many operations as possible on arrays or chunked
     /// arrays instead of scalars.
-    pub struct GeometryCollection(pub(crate) geoarrow::scalar::OwnedGeometryCollection<i32>);
+    pub struct GeometryCollection(pub(crate) geoarrow::scalar::OwnedGeometryCollection<i32, 2>);
 }
 impl_scalar! {
     /// An immutable WKB-encoded scalar using GeoArrow's in-memory representation.

--- a/python/core/src/scalar/repr.rs
+++ b/python/core/src/scalar/repr.rs
@@ -51,40 +51,40 @@ macro_rules! impl_repr_svg {
     };
 }
 
-impl_repr_svg!(Point, geoarrow::scalar::Point, bounding_rect_point);
+impl_repr_svg!(Point, geoarrow::scalar::Point<2>, bounding_rect_point);
 impl_repr_svg!(
     LineString,
-    geoarrow::scalar::LineString<i32>,
+    geoarrow::scalar::LineString<i32, 2>,
     bounding_rect_linestring
 );
 impl_repr_svg!(
     Polygon,
-    geoarrow::scalar::Polygon<i32>,
+    geoarrow::scalar::Polygon<i32, 2>,
     bounding_rect_polygon
 );
 impl_repr_svg!(
     MultiPoint,
-    geoarrow::scalar::MultiPoint<i32>,
+    geoarrow::scalar::MultiPoint<i32, 2>,
     bounding_rect_multipoint
 );
 impl_repr_svg!(
     MultiLineString,
-    geoarrow::scalar::MultiLineString<i32>,
+    geoarrow::scalar::MultiLineString<i32, 2>,
     bounding_rect_multilinestring
 );
 impl_repr_svg!(
     MultiPolygon,
-    geoarrow::scalar::MultiPolygon<i32>,
+    geoarrow::scalar::MultiPolygon<i32, 2>,
     bounding_rect_multipolygon
 );
 impl_repr_svg!(
     Geometry,
-    geoarrow::scalar::Geometry<i32>,
+    geoarrow::scalar::Geometry<i32, 2>,
     bounding_rect_geometry
 );
 impl_repr_svg!(
     GeometryCollection,
-    geoarrow::scalar::GeometryCollection<i32>,
+    geoarrow::scalar::GeometryCollection<i32, 2>,
     bounding_rect_geometry_collection
 );
 // impl_repr_svg!(WKB, geoarrow::scalar::WKB<i32>, bounding_rect_geometry);
@@ -103,16 +103,16 @@ macro_rules! impl_repr {
     };
 }
 
-impl_repr!(Point, geoarrow::scalar::Point);
-impl_repr!(LineString, geoarrow::scalar::LineString<i32>);
-impl_repr!(Polygon, geoarrow::scalar::Polygon<i32>);
-impl_repr!(MultiPoint, geoarrow::scalar::MultiPoint<i32>);
-impl_repr!(MultiLineString, geoarrow::scalar::MultiLineString<i32>);
-impl_repr!(MultiPolygon, geoarrow::scalar::MultiPolygon<i32>);
-impl_repr!(Geometry, geoarrow::scalar::Geometry<i32>);
+impl_repr!(Point, geoarrow::scalar::Point<2>);
+impl_repr!(LineString, geoarrow::scalar::LineString<i32, 2>);
+impl_repr!(Polygon, geoarrow::scalar::Polygon<i32, 2>);
+impl_repr!(MultiPoint, geoarrow::scalar::MultiPoint<i32, 2>);
+impl_repr!(MultiLineString, geoarrow::scalar::MultiLineString<i32, 2>);
+impl_repr!(MultiPolygon, geoarrow::scalar::MultiPolygon<i32, 2>);
+impl_repr!(Geometry, geoarrow::scalar::Geometry<i32, 2>);
 impl_repr!(
     GeometryCollection,
-    geoarrow::scalar::GeometryCollection<i32>
+    geoarrow::scalar::GeometryCollection<i32, 2>
 );
 impl_repr!(WKB, geoarrow::scalar::WKB<i32>);
 impl_repr!(Rect, geoarrow::scalar::Rect);

--- a/src/algorithm/broadcasting/linestring.rs
+++ b/src/algorithm/broadcasting/linestring.rs
@@ -11,7 +11,7 @@ use crate::scalar::LineString;
 #[derive(Debug, Clone)]
 pub enum BroadcastableLineString<'a, O: OffsetSizeTrait> {
     Scalar(LineString<'a, O>),
-    Array(LineStringArray<O>),
+    Array(LineStringArray<O, 2>),
 }
 
 pub enum BroadcastLineStringIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/broadcasting/multilinestring.rs
+++ b/src/algorithm/broadcasting/multilinestring.rs
@@ -11,7 +11,7 @@ use crate::scalar::MultiLineString;
 #[derive(Debug, Clone)]
 pub enum BroadcastableMultiLineString<'a, O: OffsetSizeTrait> {
     Scalar(MultiLineString<'a, O>),
-    Array(MultiLineStringArray<O>),
+    Array(MultiLineStringArray<O, 2>),
 }
 
 pub enum BroadcastMultiLineStringIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/broadcasting/multipoint.rs
+++ b/src/algorithm/broadcasting/multipoint.rs
@@ -11,7 +11,7 @@ use crate::scalar::MultiPoint;
 #[derive(Debug, Clone)]
 pub enum BroadcastableMultiPoint<'a, O: OffsetSizeTrait> {
     Scalar(MultiPoint<'a, O>),
-    Array(MultiPointArray<O>),
+    Array(MultiPointArray<O, 2>),
 }
 
 pub enum BroadcastMultiPointIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/broadcasting/multipolygon.rs
+++ b/src/algorithm/broadcasting/multipolygon.rs
@@ -11,7 +11,7 @@ use crate::scalar::MultiPolygon;
 #[derive(Debug, Clone)]
 pub enum BroadcastableMultiPolygon<'a, O: OffsetSizeTrait> {
     Scalar(MultiPolygon<'a, O>),
-    Array(MultiPolygonArray<O>),
+    Array(MultiPolygonArray<O, 2>),
 }
 
 pub enum BroadcastMultiPolygonIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/broadcasting/polygon.rs
+++ b/src/algorithm/broadcasting/polygon.rs
@@ -11,7 +11,7 @@ use crate::scalar::Polygon;
 #[derive(Debug, Clone)]
 pub enum BroadcastablePolygon<'a, O: OffsetSizeTrait> {
     Scalar(Polygon<'a, O>),
-    Array(PolygonArray<O>),
+    Array(PolygonArray<O, 2>),
 }
 
 pub enum BroadcastPolygonIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/geo/affine_ops.rs
+++ b/src/algorithm/geo/affine_ops.rs
@@ -60,7 +60,7 @@ pub trait AffineOps<Rhs> {
 // └─────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl AffineOps<&AffineTransform> for PointArray {
+impl AffineOps<&AffineTransform> for PointArray<2> {
     type Output = Self;
 
     fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
@@ -103,27 +103,27 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, LineStringBuilder<O>, push_line_string);
-iter_geo_impl!(PolygonArray<O>, PolygonBuilder<O>, push_polygon);
-iter_geo_impl!(MultiPointArray<O>, MultiPointBuilder<O>, push_multi_point);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O>,
-    MultiLineStringBuilder<O>,
+    MultiLineStringArray<O, 2>,
+    MultiLineStringBuilder<O, 2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O>,
-    MultiPolygonBuilder<O>,
+    MultiPolygonArray<O, 2>,
+    MultiPolygonBuilder<O, 2>,
     push_multi_polygon
 );
 iter_geo_impl!(
-    MixedGeometryArray<O>,
-    MixedGeometryBuilder<O>,
+    MixedGeometryArray<O, 2>,
+    MixedGeometryBuilder<O, 2>,
     push_geometry
 );
 iter_geo_impl!(
-    GeometryCollectionArray<O>,
-    GeometryCollectionBuilder<O>,
+    GeometryCollectionArray<O, 2>,
+    GeometryCollectionBuilder<O, 2>,
     push_geometry_collection
 );
 
@@ -163,7 +163,7 @@ impl AffineOps<&AffineTransform> for &dyn GeometryArrayTrait {
     }
 }
 
-impl AffineOps<&AffineTransform> for ChunkedPointArray {
+impl AffineOps<&AffineTransform> for ChunkedPointArray<2> {
     type Output = Self;
 
     fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
@@ -187,13 +187,13 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<O>);
-impl_chunked!(ChunkedPolygonArray<O>);
-impl_chunked!(ChunkedMultiPointArray<O>);
-impl_chunked!(ChunkedMultiLineStringArray<O>);
-impl_chunked!(ChunkedMultiPolygonArray<O>);
-impl_chunked!(ChunkedMixedGeometryArray<O>);
-impl_chunked!(ChunkedGeometryCollectionArray<O>);
+impl_chunked!(ChunkedLineStringArray<O, 2>);
+impl_chunked!(ChunkedPolygonArray<O, 2>);
+impl_chunked!(ChunkedMultiPointArray<O, 2>);
+impl_chunked!(ChunkedMultiLineStringArray<O, 2>);
+impl_chunked!(ChunkedMultiPolygonArray<O, 2>);
+impl_chunked!(ChunkedMixedGeometryArray<O, 2>);
+impl_chunked!(ChunkedGeometryCollectionArray<O, 2>);
 
 impl AffineOps<&AffineTransform> for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<Arc<dyn ChunkedGeometryArrayTrait>>;
@@ -236,7 +236,7 @@ impl AffineOps<&AffineTransform> for &dyn ChunkedGeometryArrayTrait {
 // └────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl AffineOps<&[AffineTransform]> for PointArray {
+impl AffineOps<&[AffineTransform]> for PointArray<2> {
     type Output = Self;
 
     fn affine_transform(&self, transform: &[AffineTransform]) -> Self::Output {
@@ -283,27 +283,27 @@ macro_rules! iter_geo_impl2 {
     };
 }
 
-iter_geo_impl2!(LineStringArray<O>, LineStringBuilder<O>, push_line_string);
-iter_geo_impl2!(PolygonArray<O>, PolygonBuilder<O>, push_polygon);
-iter_geo_impl2!(MultiPointArray<O>, MultiPointBuilder<O>, push_multi_point);
+iter_geo_impl2!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
+iter_geo_impl2!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
+iter_geo_impl2!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
 iter_geo_impl2!(
-    MultiLineStringArray<O>,
-    MultiLineStringBuilder<O>,
+    MultiLineStringArray<O, 2>,
+    MultiLineStringBuilder<O, 2>,
     push_multi_line_string
 );
 iter_geo_impl2!(
-    MultiPolygonArray<O>,
-    MultiPolygonBuilder<O>,
+    MultiPolygonArray<O, 2>,
+    MultiPolygonBuilder<O, 2>,
     push_multi_polygon
 );
 iter_geo_impl2!(
-    MixedGeometryArray<O>,
-    MixedGeometryBuilder<O>,
+    MixedGeometryArray<O, 2>,
+    MixedGeometryBuilder<O, 2>,
     push_geometry
 );
 iter_geo_impl2!(
-    GeometryCollectionArray<O>,
-    GeometryCollectionBuilder<O>,
+    GeometryCollectionArray<O, 2>,
+    GeometryCollectionBuilder<O, 2>,
     push_geometry_collection
 );
 

--- a/src/algorithm/geo/area.rs
+++ b/src/algorithm/geo/area.rs
@@ -50,7 +50,7 @@ pub trait Area {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Area for PointArray {
+impl Area for PointArray<2> {
     type Output = Float64Array;
 
     fn signed_area(&self) -> Self::Output {
@@ -79,9 +79,9 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(LineStringArray<O>);
-zero_impl!(MultiPointArray<O>);
-zero_impl!(MultiLineStringArray<O>);
+zero_impl!(LineStringArray<O, 2>);
+zero_impl!(MultiPointArray<O, 2>);
+zero_impl!(MultiLineStringArray<O, 2>);
 
 macro_rules! iter_geo_impl {
     ($type:ty) => {
@@ -99,10 +99,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>);
-iter_geo_impl!(MixedGeometryArray<O>);
-iter_geo_impl!(GeometryCollectionArray<O>);
+iter_geo_impl!(PolygonArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>);
+iter_geo_impl!(MixedGeometryArray<O, 2>);
+iter_geo_impl!(GeometryCollectionArray<O, 2>);
 iter_geo_impl!(WKBArray<O>);
 
 impl Area for &dyn GeometryArrayTrait {

--- a/src/algorithm/geo/area.rs
+++ b/src/algorithm/geo/area.rs
@@ -32,8 +32,8 @@ use geo::prelude::Area as GeoArea;
 ///     line_string.0.reverse();
 /// });
 ///
-/// let polygon_array: PolygonArray<i32> = vec![polygon].as_slice().into();
-/// let reversed_polygon_array: PolygonArray<i32> = vec![reversed_polygon].as_slice().into();
+/// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
+/// let reversed_polygon_array: PolygonArray<i32, 2> = vec![reversed_polygon].as_slice().into();
 ///
 /// assert_eq!(polygon_array.signed_area().value(0), 30.);
 /// assert_eq!(polygon_array.unsigned_area().value(0), 30.);

--- a/src/algorithm/geo/bounding_rect.rs
+++ b/src/algorithm/geo/bounding_rect.rs
@@ -36,7 +36,7 @@ pub trait BoundingRect {
     fn bounding_rect(&self) -> Self::Output;
 }
 
-impl BoundingRect for PointArray {
+impl BoundingRect for PointArray<2> {
     type Output = RectArray;
 
     fn bounding_rect(&self) -> Self::Output {
@@ -67,13 +67,13 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>);
-iter_geo_impl!(MultiPointArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>);
-iter_geo_impl!(MixedGeometryArray<O>);
-iter_geo_impl!(GeometryCollectionArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>);
+iter_geo_impl!(MixedGeometryArray<O, 2>);
+iter_geo_impl!(GeometryCollectionArray<O, 2>);
 iter_geo_impl!(WKBArray<O>);
 
 impl BoundingRect for &dyn GeometryArrayTrait {

--- a/src/algorithm/geo/center.rs
+++ b/src/algorithm/geo/center.rs
@@ -16,8 +16,8 @@ pub trait Center {
     fn center(&self) -> Self::Output;
 }
 
-impl Center for PointArray {
-    type Output = PointArray;
+impl Center for PointArray<2> {
+    type Output = PointArray<2>;
 
     fn center(&self) -> Self::Output {
         self.clone()
@@ -28,7 +28,7 @@ impl Center for PointArray {
 macro_rules! iter_geo_impl {
     ($type:ty) => {
         impl<O: OffsetSizeTrait> Center for $type {
-            type Output = PointArray;
+            type Output = PointArray<2>;
 
             fn center(&self) -> Self::Output {
                 let mut output_array = PointBuilder::with_capacity(self.len());
@@ -45,17 +45,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>);
-iter_geo_impl!(MultiPointArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>);
-iter_geo_impl!(MixedGeometryArray<O>);
-iter_geo_impl!(GeometryCollectionArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>);
+iter_geo_impl!(MixedGeometryArray<O, 2>);
+iter_geo_impl!(GeometryCollectionArray<O, 2>);
 iter_geo_impl!(WKBArray<O>);
 
 impl Center for &dyn GeometryArrayTrait {
-    type Output = Result<PointArray>;
+    type Output = Result<PointArray<2>>;
 
     fn center(&self) -> Self::Output {
         let result = match self.data_type() {
@@ -81,7 +81,7 @@ impl Center for &dyn GeometryArrayTrait {
 }
 
 impl<G: GeometryArrayTrait> Center for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedGeometryArray<PointArray>>;
+    type Output = Result<ChunkedPointArray<2>>;
 
     fn center(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().center())?.try_into()
@@ -89,7 +89,7 @@ impl<G: GeometryArrayTrait> Center for ChunkedGeometryArray<G> {
 }
 
 impl Center for &dyn ChunkedGeometryArrayTrait {
-    type Output = Result<ChunkedPointArray>;
+    type Output = Result<ChunkedPointArray<2>>;
 
     fn center(&self) -> Self::Output {
         match self.data_type() {

--- a/src/algorithm/geo/centroid.rs
+++ b/src/algorithm/geo/centroid.rs
@@ -65,8 +65,8 @@ pub trait Centroid {
     fn centroid(&self) -> Self::Output;
 }
 
-impl Centroid for PointArray {
-    type Output = PointArray;
+impl Centroid for PointArray<2> {
+    type Output = PointArray<2>;
 
     fn centroid(&self) -> Self::Output {
         self.clone()
@@ -77,7 +77,7 @@ impl Centroid for PointArray {
 macro_rules! iter_geo_impl {
     ($type:ty) => {
         impl<O: OffsetSizeTrait> Centroid for $type {
-            type Output = PointArray;
+            type Output = PointArray<2>;
 
             fn centroid(&self) -> Self::Output {
                 let mut output_array = PointBuilder::with_capacity(self.len());
@@ -90,17 +90,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>);
-iter_geo_impl!(MultiPointArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>);
-iter_geo_impl!(MixedGeometryArray<O>);
-iter_geo_impl!(GeometryCollectionArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>);
+iter_geo_impl!(MixedGeometryArray<O, 2>);
+iter_geo_impl!(GeometryCollectionArray<O, 2>);
 iter_geo_impl!(WKBArray<O>);
 
 impl Centroid for &dyn GeometryArrayTrait {
-    type Output = Result<PointArray>;
+    type Output = Result<PointArray<2>>;
 
     fn centroid(&self) -> Self::Output {
         let result = match self.data_type() {
@@ -128,7 +128,7 @@ impl Centroid for &dyn GeometryArrayTrait {
 }
 
 impl<G: GeometryArrayTrait> Centroid for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedPointArray>;
+    type Output = Result<ChunkedPointArray<2>>;
 
     fn centroid(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().centroid())?.try_into()
@@ -136,7 +136,7 @@ impl<G: GeometryArrayTrait> Centroid for ChunkedGeometryArray<G> {
 }
 
 impl Centroid for &dyn ChunkedGeometryArrayTrait {
-    type Output = Result<ChunkedPointArray>;
+    type Output = Result<ChunkedPointArray<2>>;
 
     fn centroid(&self) -> Self::Output {
         match self.data_type() {

--- a/src/algorithm/geo/centroid.rs
+++ b/src/algorithm/geo/centroid.rs
@@ -31,7 +31,7 @@ use geo::algorithm::centroid::Centroid as GeoCentroid;
 ///     (x: 1., y: -1.),
 ///     (x: -2., y: 1.),
 /// ];
-/// let polygon_array: PolygonArray<i32> = vec![polygon].as_slice().into();
+/// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
 ///
 /// assert_eq!(
 ///     Some(point!(x: 1., y: 1.)),
@@ -55,7 +55,7 @@ pub trait Centroid {
     ///     (x: 40.02f64, y: 116.34),
     ///     (x: 40.02f64, y: 118.23),
     /// ];
-    /// let line_string_array: LineStringArray<i32> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray<i32, 2> = vec![line_string].as_slice().into();
     ///
     /// assert_eq!(
     ///     Some(point!(x: 40.02, y: 117.285)),

--- a/src/algorithm/geo/chaikin_smoothing.rs
+++ b/src/algorithm/geo/chaikin_smoothing.rs
@@ -47,10 +47,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, geo::LineString);
-iter_geo_impl!(PolygonArray<O>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
+iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
+iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
 
 impl ChaikinSmoothing for &dyn GeometryArrayTrait {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
@@ -101,10 +101,10 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<O>);
-impl_chunked!(ChunkedPolygonArray<O>);
-impl_chunked!(ChunkedMultiLineStringArray<O>);
-impl_chunked!(ChunkedMultiPolygonArray<O>);
+impl_chunked!(ChunkedLineStringArray<O, 2>);
+impl_chunked!(ChunkedPolygonArray<O, 2>);
+impl_chunked!(ChunkedMultiLineStringArray<O, 2>);
+impl_chunked!(ChunkedMultiPolygonArray<O, 2>);
 
 impl ChaikinSmoothing for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<Arc<dyn ChunkedGeometryArrayTrait>>;

--- a/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -47,8 +47,8 @@ use geo::prelude::ChamberlainDuquetteArea as GeoChamberlainDuquetteArea;
 ///     line_string.0.reverse();
 /// });
 ///
-/// let polygon_array: PolygonArray<i32> = vec![polygon].as_slice().into();
-/// let reversed_polygon_array: PolygonArray<i32> = vec![reversed_polygon].as_slice().into();
+/// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
+/// let reversed_polygon_array: PolygonArray<i32, 2> = vec![reversed_polygon].as_slice().into();
 ///
 /// // 78,478 meters²
 /// assert_eq!(78_478., polygon_array.chamberlain_duquette_unsigned_area().value(0).round());

--- a/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -66,7 +66,7 @@ pub trait ChamberlainDuquetteArea {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl ChamberlainDuquetteArea for PointArray {
+impl ChamberlainDuquetteArea for PointArray<2> {
     type Output = Float64Array;
 
     fn chamberlain_duquette_signed_area(&self) -> Self::Output {
@@ -95,9 +95,9 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(LineStringArray<O>);
-zero_impl!(MultiPointArray<O>);
-zero_impl!(MultiLineStringArray<O>);
+zero_impl!(LineStringArray<O, 2>);
+zero_impl!(MultiPointArray<O, 2>);
+zero_impl!(MultiLineStringArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -126,10 +126,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>);
-iter_geo_impl!(MixedGeometryArray<O>);
-iter_geo_impl!(GeometryCollectionArray<O>);
+iter_geo_impl!(PolygonArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>);
+iter_geo_impl!(MixedGeometryArray<O, 2>);
+iter_geo_impl!(GeometryCollectionArray<O, 2>);
 iter_geo_impl!(WKBArray<O>);
 
 impl ChamberlainDuquetteArea for &dyn GeometryArrayTrait {

--- a/src/algorithm/geo/contains.rs
+++ b/src/algorithm/geo/contains.rs
@@ -59,7 +59,7 @@ pub trait Contains<Rhs = Self> {
 // └────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl Contains for PointArray {
+impl Contains for PointArray<2> {
     fn contains(&self, rhs: &Self) -> BooleanArray {
         self.try_binary_boolean(rhs, |left, right| {
             Ok(left.to_geo().contains(&right.to_geo()))
@@ -83,51 +83,51 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray, LineStringArray<O>);
-iter_geo_impl!(PointArray, PolygonArray<O>);
-iter_geo_impl!(PointArray, MultiPointArray<O>);
-iter_geo_impl!(PointArray, MultiLineStringArray<O>);
-iter_geo_impl!(PointArray, MultiPolygonArray<O>);
+iter_geo_impl!(PointArray<2>, LineStringArray<O, 2>);
+iter_geo_impl!(PointArray<2>, PolygonArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiPointArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiPolygonArray<O, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<O>, PointArray);
-iter_geo_impl!(LineStringArray<O>, LineStringArray<O>);
-iter_geo_impl!(LineStringArray<O>, PolygonArray<O>);
-iter_geo_impl!(LineStringArray<O>, MultiPointArray<O>);
-iter_geo_impl!(LineStringArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(LineStringArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>, PointArray<2>);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<O>, PointArray);
-iter_geo_impl!(PolygonArray<O>, LineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>, PolygonArray<O>);
-iter_geo_impl!(PolygonArray<O>, MultiPointArray<O>);
-iter_geo_impl!(PolygonArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(PolygonArray<O, 2>, PointArray<2>);
+iter_geo_impl!(PolygonArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<O>, PointArray);
-iter_geo_impl!(MultiPointArray<O>, LineStringArray<O>);
-iter_geo_impl!(MultiPointArray<O>, PolygonArray<O>);
-iter_geo_impl!(MultiPointArray<O>, MultiPointArray<O>);
-iter_geo_impl!(MultiPointArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(MultiPointArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiPointArray<O, 2>, PointArray<2>);
+iter_geo_impl!(MultiPointArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<O>, PointArray);
-iter_geo_impl!(MultiLineStringArray<O>, LineStringArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>, PolygonArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>, MultiPointArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, PointArray<2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<O>, PointArray);
-iter_geo_impl!(MultiPolygonArray<O>, LineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>, PolygonArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>, MultiPointArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, PointArray<2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
@@ -137,7 +137,7 @@ pub trait ContainsPoint<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: PointTrait<T = f64>> ContainsPoint<G> for PointArray {
+impl<G: PointTrait<T = f64>> ContainsPoint<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = point_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -157,13 +157,13 @@ macro_rules! impl_contains_point {
     };
 }
 
-impl_contains_point!(LineStringArray<O>);
-impl_contains_point!(PolygonArray<O>);
-impl_contains_point!(MultiPointArray<O>);
-impl_contains_point!(MultiLineStringArray<O>);
-impl_contains_point!(MultiPolygonArray<O>);
-impl_contains_point!(MixedGeometryArray<O>);
-impl_contains_point!(GeometryCollectionArray<O>);
+impl_contains_point!(LineStringArray<O, 2>);
+impl_contains_point!(PolygonArray<O, 2>);
+impl_contains_point!(MultiPointArray<O, 2>);
+impl_contains_point!(MultiLineStringArray<O, 2>);
+impl_contains_point!(MultiPolygonArray<O, 2>);
+impl_contains_point!(MixedGeometryArray<O, 2>);
+impl_contains_point!(GeometryCollectionArray<O, 2>);
 
 impl<G: PointTrait<T = f64>> ContainsPoint<G> for &dyn GeometryArrayTrait {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -206,7 +206,7 @@ pub trait ContainsLineString<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for PointArray {
+impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = line_string_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -232,13 +232,13 @@ macro_rules! impl_contains_line_string {
     };
 }
 
-impl_contains_line_string!(LineStringArray<O>);
-impl_contains_line_string!(PolygonArray<O>);
-impl_contains_line_string!(MultiPointArray<O>);
-impl_contains_line_string!(MultiLineStringArray<O>);
-impl_contains_line_string!(MultiPolygonArray<O>);
-impl_contains_line_string!(MixedGeometryArray<O>);
-impl_contains_line_string!(GeometryCollectionArray<O>);
+impl_contains_line_string!(LineStringArray<O, 2>);
+impl_contains_line_string!(PolygonArray<O, 2>);
+impl_contains_line_string!(MultiPointArray<O, 2>);
+impl_contains_line_string!(MultiLineStringArray<O, 2>);
+impl_contains_line_string!(MultiPolygonArray<O, 2>);
+impl_contains_line_string!(MixedGeometryArray<O, 2>);
+impl_contains_line_string!(GeometryCollectionArray<O, 2>);
 
 impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for &dyn GeometryArrayTrait {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -285,7 +285,7 @@ pub trait ContainsPolygon<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for PointArray {
+impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = polygon_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -305,13 +305,13 @@ macro_rules! impl_contains_polygon {
     };
 }
 
-impl_contains_polygon!(LineStringArray<O>);
-impl_contains_polygon!(PolygonArray<O>);
-impl_contains_polygon!(MultiPointArray<O>);
-impl_contains_polygon!(MultiLineStringArray<O>);
-impl_contains_polygon!(MultiPolygonArray<O>);
-impl_contains_polygon!(MixedGeometryArray<O>);
-impl_contains_polygon!(GeometryCollectionArray<O>);
+impl_contains_polygon!(LineStringArray<O, 2>);
+impl_contains_polygon!(PolygonArray<O, 2>);
+impl_contains_polygon!(MultiPointArray<O, 2>);
+impl_contains_polygon!(MultiLineStringArray<O, 2>);
+impl_contains_polygon!(MultiPolygonArray<O, 2>);
+impl_contains_polygon!(MixedGeometryArray<O, 2>);
+impl_contains_polygon!(GeometryCollectionArray<O, 2>);
 
 impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for &dyn GeometryArrayTrait {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -354,7 +354,7 @@ pub trait ContainsMultiPoint<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for PointArray {
+impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_point_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -374,13 +374,13 @@ macro_rules! impl_contains_multi_point {
     };
 }
 
-impl_contains_multi_point!(LineStringArray<O>);
-impl_contains_multi_point!(PolygonArray<O>);
-impl_contains_multi_point!(MultiPointArray<O>);
-impl_contains_multi_point!(MultiLineStringArray<O>);
-impl_contains_multi_point!(MultiPolygonArray<O>);
-impl_contains_multi_point!(MixedGeometryArray<O>);
-impl_contains_multi_point!(GeometryCollectionArray<O>);
+impl_contains_multi_point!(LineStringArray<O, 2>);
+impl_contains_multi_point!(PolygonArray<O, 2>);
+impl_contains_multi_point!(MultiPointArray<O, 2>);
+impl_contains_multi_point!(MultiLineStringArray<O, 2>);
+impl_contains_multi_point!(MultiPolygonArray<O, 2>);
+impl_contains_multi_point!(MixedGeometryArray<O, 2>);
+impl_contains_multi_point!(GeometryCollectionArray<O, 2>);
 
 impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for &dyn GeometryArrayTrait {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -427,7 +427,7 @@ pub trait ContainsMultiLineString<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for PointArray {
+impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_line_string_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -449,13 +449,13 @@ macro_rules! impl_contains_multi_line_string {
     };
 }
 
-impl_contains_multi_line_string!(LineStringArray<O>);
-impl_contains_multi_line_string!(PolygonArray<O>);
-impl_contains_multi_line_string!(MultiPointArray<O>);
-impl_contains_multi_line_string!(MultiLineStringArray<O>);
-impl_contains_multi_line_string!(MultiPolygonArray<O>);
-impl_contains_multi_line_string!(MixedGeometryArray<O>);
-impl_contains_multi_line_string!(GeometryCollectionArray<O>);
+impl_contains_multi_line_string!(LineStringArray<O, 2>);
+impl_contains_multi_line_string!(PolygonArray<O, 2>);
+impl_contains_multi_line_string!(MultiPointArray<O, 2>);
+impl_contains_multi_line_string!(MultiLineStringArray<O, 2>);
+impl_contains_multi_line_string!(MultiPolygonArray<O, 2>);
+impl_contains_multi_line_string!(MixedGeometryArray<O, 2>);
+impl_contains_multi_line_string!(GeometryCollectionArray<O, 2>);
 
 impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for &dyn GeometryArrayTrait {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -508,7 +508,7 @@ pub trait ContainsMultiPolygon<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for PointArray {
+impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_polygon_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -528,13 +528,13 @@ macro_rules! impl_contains_multi_polygon {
     };
 }
 
-impl_contains_multi_polygon!(LineStringArray<O>);
-impl_contains_multi_polygon!(PolygonArray<O>);
-impl_contains_multi_polygon!(MultiPointArray<O>);
-impl_contains_multi_polygon!(MultiLineStringArray<O>);
-impl_contains_multi_polygon!(MultiPolygonArray<O>);
-impl_contains_multi_polygon!(MixedGeometryArray<O>);
-impl_contains_multi_polygon!(GeometryCollectionArray<O>);
+impl_contains_multi_polygon!(LineStringArray<O, 2>);
+impl_contains_multi_polygon!(PolygonArray<O, 2>);
+impl_contains_multi_polygon!(MultiPointArray<O, 2>);
+impl_contains_multi_polygon!(MultiLineStringArray<O, 2>);
+impl_contains_multi_polygon!(MultiPolygonArray<O, 2>);
+impl_contains_multi_polygon!(MixedGeometryArray<O, 2>);
+impl_contains_multi_polygon!(GeometryCollectionArray<O, 2>);
 
 impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for &dyn GeometryArrayTrait {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -587,7 +587,7 @@ pub trait ContainsGeometry<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for PointArray {
+impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = geometry_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -607,13 +607,13 @@ macro_rules! impl_contains_geometry {
     };
 }
 
-impl_contains_geometry!(LineStringArray<O>);
-impl_contains_geometry!(PolygonArray<O>);
-// impl_contains_geometry!(MultiPointArray<O>); // Not implemented in geo
-impl_contains_geometry!(MultiLineStringArray<O>);
-// impl_contains_geometry!(MultiPolygonArray<O>); // Not implemented in geo
-impl_contains_geometry!(MixedGeometryArray<O>);
-impl_contains_geometry!(GeometryCollectionArray<O>);
+impl_contains_geometry!(LineStringArray<O, 2>);
+impl_contains_geometry!(PolygonArray<O, 2>);
+// impl_contains_geometry!(MultiPointArray<O, 2>); // Not implemented in geo
+impl_contains_geometry!(MultiLineStringArray<O, 2>);
+// impl_contains_geometry!(MultiPolygonArray<O, 2>); // Not implemented in geo
+impl_contains_geometry!(MixedGeometryArray<O, 2>);
+impl_contains_geometry!(GeometryCollectionArray<O, 2>);
 
 impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for &dyn GeometryArrayTrait {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -660,7 +660,7 @@ pub trait ContainsGeometryCollection<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for PointArray {
+impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = geometry_collection_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -682,13 +682,13 @@ macro_rules! impl_contains_geometry_collection {
     };
 }
 
-impl_contains_geometry_collection!(LineStringArray<O>);
-impl_contains_geometry_collection!(PolygonArray<O>);
-impl_contains_geometry_collection!(MultiPointArray<O>);
-impl_contains_geometry_collection!(MultiLineStringArray<O>);
-impl_contains_geometry_collection!(MultiPolygonArray<O>);
-impl_contains_geometry_collection!(MixedGeometryArray<O>);
-impl_contains_geometry_collection!(GeometryCollectionArray<O>);
+impl_contains_geometry_collection!(LineStringArray<O, 2>);
+impl_contains_geometry_collection!(PolygonArray<O, 2>);
+impl_contains_geometry_collection!(MultiPointArray<O, 2>);
+impl_contains_geometry_collection!(MultiLineStringArray<O, 2>);
+impl_contains_geometry_collection!(MultiPolygonArray<O, 2>);
+impl_contains_geometry_collection!(MixedGeometryArray<O, 2>);
+impl_contains_geometry_collection!(GeometryCollectionArray<O, 2>);
 
 impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G>
     for &dyn GeometryArrayTrait

--- a/src/algorithm/geo/convex_hull.rs
+++ b/src/algorithm/geo/convex_hull.rs
@@ -50,8 +50,8 @@ pub trait ConvexHull<O: OffsetSizeTrait> {
     fn convex_hull(&self) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> ConvexHull<O> for PointArray {
-    type Output = PolygonArray<O>;
+impl<O: OffsetSizeTrait> ConvexHull<O> for PointArray<2> {
+    type Output = PolygonArray<O, 2>;
 
     fn convex_hull(&self) -> Self::Output {
         let output_geoms: Vec<Option<Polygon>> = self
@@ -67,7 +67,7 @@ impl<O: OffsetSizeTrait> ConvexHull<O> for PointArray {
 macro_rules! iter_geo_impl {
     ($type:ty) => {
         impl<O: OffsetSizeTrait, O2: OffsetSizeTrait> ConvexHull<O> for $type {
-            type Output = PolygonArray<O>;
+            type Output = PolygonArray<O, 2>;
 
             fn convex_hull(&self) -> Self::Output {
                 let output_geoms: Vec<Option<Polygon>> = self
@@ -81,17 +81,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O2>);
-iter_geo_impl!(PolygonArray<O2>);
-iter_geo_impl!(MultiPointArray<O2>);
-iter_geo_impl!(MultiLineStringArray<O2>);
-iter_geo_impl!(MultiPolygonArray<O2>);
-iter_geo_impl!(MixedGeometryArray<O2>);
-iter_geo_impl!(GeometryCollectionArray<O2>);
+iter_geo_impl!(LineStringArray<O2, 2>);
+iter_geo_impl!(PolygonArray<O2, 2>);
+iter_geo_impl!(MultiPointArray<O2, 2>);
+iter_geo_impl!(MultiLineStringArray<O2, 2>);
+iter_geo_impl!(MultiPolygonArray<O2, 2>);
+iter_geo_impl!(MixedGeometryArray<O2, 2>);
+iter_geo_impl!(GeometryCollectionArray<O2, 2>);
 iter_geo_impl!(WKBArray<O2>);
 
 impl<O: OffsetSizeTrait> ConvexHull<O> for &dyn GeometryArrayTrait {
-    type Output = Result<PolygonArray<O>>;
+    type Output = Result<PolygonArray<O, 2>>;
 
     fn convex_hull(&self) -> Self::Output {
         let result = match self.data_type() {
@@ -119,7 +119,7 @@ impl<O: OffsetSizeTrait> ConvexHull<O> for &dyn GeometryArrayTrait {
 }
 
 impl<O: OffsetSizeTrait, G: GeometryArrayTrait> ConvexHull<O> for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedGeometryArray<PolygonArray<O>>>;
+    type Output = Result<ChunkedGeometryArray<PolygonArray<O, 2>>>;
 
     fn convex_hull(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().convex_hull())?
@@ -128,7 +128,7 @@ impl<O: OffsetSizeTrait, G: GeometryArrayTrait> ConvexHull<O> for ChunkedGeometr
 }
 
 impl<O: OffsetSizeTrait> ConvexHull<O> for &dyn ChunkedGeometryArrayTrait {
-    type Output = Result<ChunkedPolygonArray<O>>;
+    type Output = Result<ChunkedPolygonArray<O, 2>>;
 
     fn convex_hull(&self) -> Self::Output {
         match self.data_type() {
@@ -177,8 +177,8 @@ mod tests {
             Point::new(0.0, 10.0),
         ]
         .into();
-        let input_array: MultiPointArray<i64> = vec![input_geom].as_slice().into();
-        let result_array: PolygonArray<i32> = input_array.convex_hull();
+        let input_array: MultiPointArray<i64, 2> = vec![input_geom].as_slice().into();
+        let result_array: PolygonArray<i32, 2> = input_array.convex_hull();
 
         let expected = polygon![
             (x:0.0, y: -10.0),
@@ -205,8 +205,8 @@ mod tests {
             (x: 0.0, y: 10.0),
         ];
 
-        let input_array: LineStringArray<i64> = vec![input_geom].as_slice().into();
-        let result_array: PolygonArray<i32> = input_array.convex_hull();
+        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
+        let result_array: PolygonArray<i32, 2> = input_array.convex_hull();
 
         let expected = polygon![
             (x: 0.0, y: -10.0),

--- a/src/algorithm/geo/densify.rs
+++ b/src/algorithm/geo/densify.rs
@@ -49,10 +49,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, geo::LineString);
-iter_geo_impl!(PolygonArray<O>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
+iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
+iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
 
 impl Densify for &dyn GeometryArrayTrait {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
@@ -95,10 +95,10 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<O>);
-impl_chunked!(ChunkedPolygonArray<O>);
-impl_chunked!(ChunkedMultiLineStringArray<O>);
-impl_chunked!(ChunkedMultiPolygonArray<O>);
+impl_chunked!(ChunkedLineStringArray<O, 2>);
+impl_chunked!(ChunkedPolygonArray<O, 2>);
+impl_chunked!(ChunkedMultiLineStringArray<O, 2>);
+impl_chunked!(ChunkedMultiPolygonArray<O, 2>);
 
 impl Densify for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<Arc<dyn ChunkedGeometryArrayTrait>>;

--- a/src/algorithm/geo/dimensions.rs
+++ b/src/algorithm/geo/dimensions.rs
@@ -36,7 +36,7 @@ pub trait HasDimensions {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl HasDimensions for PointArray {
+impl HasDimensions for PointArray<2> {
     type Output = BooleanArray;
 
     fn is_empty(&self) -> Self::Output {
@@ -63,13 +63,13 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>);
-iter_geo_impl!(MultiPointArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>);
-iter_geo_impl!(MixedGeometryArray<O>);
-iter_geo_impl!(GeometryCollectionArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>);
+iter_geo_impl!(MixedGeometryArray<O, 2>);
+iter_geo_impl!(GeometryCollectionArray<O, 2>);
 iter_geo_impl!(WKBArray<O>);
 
 impl HasDimensions for &dyn GeometryArrayTrait {

--- a/src/algorithm/geo/euclidean_distance.rs
+++ b/src/algorithm/geo/euclidean_distance.rs
@@ -92,9 +92,9 @@ pub trait EuclideanDistance<Rhs> {
 // └────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl EuclideanDistance<PointArray> for PointArray {
+impl EuclideanDistance<PointArray<2>> for PointArray<2> {
     /// Minimum distance between two Points
-    fn euclidean_distance(&self, other: &PointArray) -> Float64Array {
+    fn euclidean_distance(&self, other: &PointArray<2>) -> Float64Array {
         assert_eq!(self.len(), other.len());
         let mut output_array = Float64Builder::with_capacity(self.len());
 
@@ -135,60 +135,60 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray, LineStringArray<O>);
-iter_geo_impl!(PointArray, PolygonArray<O>);
-iter_geo_impl!(PointArray, MultiPointArray<O>);
-iter_geo_impl!(PointArray, MultiLineStringArray<O>);
-iter_geo_impl!(PointArray, MultiPolygonArray<O>);
+iter_geo_impl!(PointArray<2>, LineStringArray<O, 2>);
+iter_geo_impl!(PointArray<2>, PolygonArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiPointArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiPolygonArray<O, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<O>, PointArray);
-iter_geo_impl!(LineStringArray<O>, LineStringArray<O>);
-iter_geo_impl!(LineStringArray<O>, PolygonArray<O>);
-// iter_geo_impl!(LineStringArray<O>, MultiPointArray<O>);
-// iter_geo_impl!(LineStringArray<O>, MultiLineStringArray<O>);
-// iter_geo_impl!(LineStringArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>, PointArray<2>);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, PolygonArray<O, 2>);
+// iter_geo_impl!(LineStringArray<O, 2>, MultiPointArray<O, 2>);
+// iter_geo_impl!(LineStringArray<O, 2>, MultiLineStringArray<O, 2>);
+// iter_geo_impl!(LineStringArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<O>, PointArray);
-iter_geo_impl!(PolygonArray<O>, LineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>, PolygonArray<O>);
-// iter_geo_impl!(PolygonArray<O>, MultiPointArray<O>);
-// iter_geo_impl!(PolygonArray<O>, MultiLineStringArray<O>);
-// iter_geo_impl!(PolygonArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(PolygonArray<O, 2>, PointArray<2>);
+iter_geo_impl!(PolygonArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonArray<O, 2>);
+// iter_geo_impl!(PolygonArray<O, 2>, MultiPointArray<O, 2>);
+// iter_geo_impl!(PolygonArray<O, 2>, MultiLineStringArray<O, 2>);
+// iter_geo_impl!(PolygonArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<O>, PointArray);
-// iter_geo_impl!(MultiPointArray<O>, LineStringArray<O>);
-// iter_geo_impl!(MultiPointArray<O>, PolygonArray<O>);
-// iter_geo_impl!(MultiPointArray<O>, MultiPointArray<O>);
-// iter_geo_impl!(MultiPointArray<O>, MultiLineStringArray<O>);
-// iter_geo_impl!(MultiPointArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiPointArray<O, 2>, PointArray<2>);
+// iter_geo_impl!(MultiPointArray<O, 2>, LineStringArray<O, 2>);
+// iter_geo_impl!(MultiPointArray<O, 2>, PolygonArray<O, 2>);
+// iter_geo_impl!(MultiPointArray<O, 2>, MultiPointArray<O, 2>);
+// iter_geo_impl!(MultiPointArray<O, 2>, MultiLineStringArray<O, 2>);
+// iter_geo_impl!(MultiPointArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<O>, PointArray);
-// iter_geo_impl!(MultiLineStringArray<O>, LineStringArray<O>);
-// iter_geo_impl!(MultiLineStringArray<O>, PolygonArray<O>);
-// iter_geo_impl!(MultiLineStringArray<O>, MultiPointArray<O>);
-// iter_geo_impl!(MultiLineStringArray<O>, MultiLineStringArray<O>);
-// iter_geo_impl!(MultiLineStringArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, PointArray<2>);
+// iter_geo_impl!(MultiLineStringArray<O, 2>, LineStringArray<O, 2>);
+// iter_geo_impl!(MultiLineStringArray<O, 2>, PolygonArray<O, 2>);
+// iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPointArray<O, 2>);
+// iter_geo_impl!(MultiLineStringArray<O, 2>, MultiLineStringArray<O, 2>);
+// iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<O>, PointArray);
-// iter_geo_impl!(MultiPolygonArray<O>, LineStringArray<O>);
-// iter_geo_impl!(MultiPolygonArray<O>, PolygonArray<O>);
-// iter_geo_impl!(MultiPolygonArray<O>, MultiPointArray<O>);
-// iter_geo_impl!(MultiPolygonArray<O>, MultiLineStringArray<O>);
-// iter_geo_impl!(MultiPolygonArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, PointArray<2>);
+// iter_geo_impl!(MultiPolygonArray<O, 2>, LineStringArray<O, 2>);
+// iter_geo_impl!(MultiPolygonArray<O, 2>, PolygonArray<O, 2>);
+// iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPointArray<O, 2>);
+// iter_geo_impl!(MultiPolygonArray<O, 2>, MultiLineStringArray<O, 2>);
+// iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
 // └─────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl<'a> EuclideanDistance<Point<'a>> for PointArray {
+impl<'a> EuclideanDistance<Point<'a, 2>> for PointArray<2> {
     /// Minimum distance between two Points
-    fn euclidean_distance(&self, other: &Point<'a>) -> Float64Array {
+    fn euclidean_distance(&self, other: &Point<'a, 2>) -> Float64Array {
         let mut output_array = Float64Builder::with_capacity(self.len());
 
         self.iter_geo().for_each(|maybe_point| {
@@ -220,48 +220,48 @@ macro_rules! iter_geo_impl_scalar {
 }
 
 // Implementations on PointArray
-iter_geo_impl_scalar!(PointArray, LineString<'a, O>);
-iter_geo_impl_scalar!(PointArray, Polygon<'a, O>);
-iter_geo_impl_scalar!(PointArray, MultiPoint<'a, O>);
-iter_geo_impl_scalar!(PointArray, MultiLineString<'a, O>);
-iter_geo_impl_scalar!(PointArray, MultiPolygon<'a, O>);
+iter_geo_impl_scalar!(PointArray<2>, LineString<'a, O, 2>);
+iter_geo_impl_scalar!(PointArray<2>, Polygon<'a, O, 2>);
+iter_geo_impl_scalar!(PointArray<2>, MultiPoint<'a, O, 2>);
+iter_geo_impl_scalar!(PointArray<2>, MultiLineString<'a, O, 2>);
+iter_geo_impl_scalar!(PointArray<2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl_scalar!(LineStringArray<O>, Point<'a>);
-iter_geo_impl_scalar!(LineStringArray<O>, LineString<'a, O>);
-iter_geo_impl_scalar!(LineStringArray<O>, Polygon<'a, O>);
-// iter_geo_impl_scalar!(LineStringArray<O>, MultiPoint<'a, O>);
-// iter_geo_impl_scalar!(LineStringArray<O>, MultiLineString<'a, O>);
-// iter_geo_impl_scalar!(LineStringArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_scalar!(LineStringArray<O, 2>, Point<'a, 2>);
+iter_geo_impl_scalar!(LineStringArray<O, 2>, LineString<'a, O, 2>);
+iter_geo_impl_scalar!(LineStringArray<O, 2>, Polygon<'a, O, 2>);
+// iter_geo_impl_scalar!(LineStringArray<O, 2>, MultiPoint<'a, O, 2>);
+// iter_geo_impl_scalar!(LineStringArray<O, 2>, MultiLineString<'a, O, 2>);
+// iter_geo_impl_scalar!(LineStringArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl_scalar!(PolygonArray<O>, Point<'a>);
-iter_geo_impl_scalar!(PolygonArray<O>, LineString<'a, O>);
-iter_geo_impl_scalar!(PolygonArray<O>, Polygon<'a, O>);
-// iter_geo_impl_scalar!(PolygonArray<O>, MultiPoint<'a, O>);
-// iter_geo_impl_scalar!(PolygonArray<O>, MultiLineString<'a, O>);
-// iter_geo_impl_scalar!(PolygonArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_scalar!(PolygonArray<O, 2>, Point<'a, 2>);
+iter_geo_impl_scalar!(PolygonArray<O, 2>, LineString<'a, O, 2>);
+iter_geo_impl_scalar!(PolygonArray<O, 2>, Polygon<'a, O, 2>);
+// iter_geo_impl_scalar!(PolygonArray<O, 2>, MultiPoint<'a, O, 2>);
+// iter_geo_impl_scalar!(PolygonArray<O, 2>, MultiLineString<'a, O, 2>);
+// iter_geo_impl_scalar!(PolygonArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl_scalar!(MultiPointArray<O>, Point<'a>);
-// iter_geo_impl_scalar!(MultiPointArray<O>, LineString<'a, O>);
-// iter_geo_impl_scalar!(MultiPointArray<O>, Polygon<'a, O>);
-// iter_geo_impl_scalar!(MultiPointArray<O>, MultiPoint<'a, O>);
-// iter_geo_impl_scalar!(MultiPointArray<O>, MultiLineString<'a, O>);
-// iter_geo_impl_scalar!(MultiPointArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_scalar!(MultiPointArray<O, 2>, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<O, 2>, LineString<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<O, 2>, Polygon<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<O, 2>, MultiPoint<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<O, 2>, MultiLineString<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_scalar!(MultiLineStringArray<O>, Point<'a>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O>, LineString<'a, O>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O>, Polygon<'a, O>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O>, MultiPoint<'a, O>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O>, MultiLineString<'a, O>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, LineString<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, Polygon<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, MultiPoint<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, MultiLineString<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_scalar!(MultiPolygonArray<O>, Point<'a>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O>, LineString<'a, O>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O>, Polygon<'a, O>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O>, MultiPoint<'a, O>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O>, MultiLineString<'a, O>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, LineString<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, Polygon<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, MultiPoint<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, MultiLineString<'a, O, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, MultiPolygon<'a, O, 2>);

--- a/src/algorithm/geo/euclidean_length.rs
+++ b/src/algorithm/geo/euclidean_length.rs
@@ -38,7 +38,7 @@ pub trait EuclideanLength {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl EuclideanLength for PointArray {
+impl EuclideanLength for PointArray<2> {
     type Output = Float64Array;
 
     fn euclidean_length(&self) -> Self::Output {
@@ -59,7 +59,7 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(MultiPointArray<O>);
+zero_impl!(MultiPointArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -74,8 +74,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
 
 impl EuclideanLength for &dyn GeometryArrayTrait {
     type Output = Result<Float64Array>;
@@ -107,7 +107,7 @@ impl EuclideanLength for &dyn GeometryArrayTrait {
     }
 }
 
-impl EuclideanLength for ChunkedGeometryArray<PointArray> {
+impl EuclideanLength for ChunkedGeometryArray<PointArray<2>> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn euclidean_length(&self) -> Self::Output {
@@ -128,9 +128,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
 
 impl EuclideanLength for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -178,7 +178,7 @@ mod tests {
             (x: 10., y: 1.),
             (x: 11., y: 1.)
         ];
-        let input_array: LineStringArray<i64> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
         let result_array = input_array.euclidean_length();
 
         let expected = 10.0_f64;

--- a/src/algorithm/geo/euclidean_length.rs
+++ b/src/algorithm/geo/euclidean_length.rs
@@ -25,7 +25,7 @@ pub trait EuclideanLength {
     ///     (x: 40.02f64, y: 116.34),
     ///     (x: 42.02f64, y: 116.34),
     /// ];
-    /// let linestring_array: LineStringArray<i32> = vec![line_string].as_slice().into();
+    /// let linestring_array: LineStringArray<i32, 2> = vec![line_string].as_slice().into();
     ///
     /// let length_array = linestring_array.euclidean_length();
     ///

--- a/src/algorithm/geo/frechet_distance.rs
+++ b/src/algorithm/geo/frechet_distance.rs
@@ -26,12 +26,12 @@ pub trait FrechetDistance<Rhs = Self> {
     fn frechet_distance(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<O1: OffsetSizeTrait, O2: OffsetSizeTrait> FrechetDistance<LineStringArray<O2>>
-    for LineStringArray<O1>
+impl<O1: OffsetSizeTrait, O2: OffsetSizeTrait> FrechetDistance<LineStringArray<O2, 2>>
+    for LineStringArray<O1, 2>
 {
     type Output = Float64Array;
 
-    fn frechet_distance(&self, rhs: &LineStringArray<O2>) -> Self::Output {
+    fn frechet_distance(&self, rhs: &LineStringArray<O2, 2>) -> Self::Output {
         self.try_binary_primitive(rhs, |left, right| {
             Ok(left.to_geo().frechet_distance(&right.to_geo()))
         })
@@ -39,12 +39,12 @@ impl<O1: OffsetSizeTrait, O2: OffsetSizeTrait> FrechetDistance<LineStringArray<O
     }
 }
 
-impl<O1: OffsetSizeTrait, O2: OffsetSizeTrait> FrechetDistance<ChunkedLineStringArray<O2>>
-    for ChunkedLineStringArray<O1>
+impl<O1: OffsetSizeTrait, O2: OffsetSizeTrait> FrechetDistance<ChunkedLineStringArray<O2, 2>>
+    for ChunkedLineStringArray<O1, 2>
 {
     type Output = ChunkedArray<Float64Array>;
 
-    fn frechet_distance(&self, rhs: &ChunkedLineStringArray<O2>) -> Self::Output {
+    fn frechet_distance(&self, rhs: &ChunkedLineStringArray<O2, 2>) -> Self::Output {
         ChunkedArray::new(self.binary_map(rhs.chunks(), |(left, right)| {
             FrechetDistance::frechet_distance(left, right)
         }))
@@ -114,7 +114,7 @@ pub trait FrechetDistanceLineString<Rhs> {
 }
 
 impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> FrechetDistanceLineString<G>
-    for LineStringArray<O>
+    for LineStringArray<O, 2>
 {
     type Output = Float64Array;
 
@@ -128,7 +128,7 @@ impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> FrechetDistanceLineString<
 }
 
 impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64> + Sync> FrechetDistanceLineString<G>
-    for ChunkedLineStringArray<O>
+    for ChunkedLineStringArray<O, 2>
 {
     type Output = ChunkedArray<Float64Array>;
 

--- a/src/algorithm/geo/geodesic_area.rs
+++ b/src/algorithm/geo/geodesic_area.rs
@@ -176,7 +176,7 @@ pub trait GeodesicArea {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl GeodesicArea for PointArray {
+impl GeodesicArea for PointArray<2> {
     type OutputSingle = Float64Array;
     type OutputDouble = (Float64Array, Float64Array);
 
@@ -243,9 +243,9 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(LineStringArray<O>);
-zero_impl!(MultiPointArray<O>);
-zero_impl!(MultiLineStringArray<O>);
+zero_impl!(LineStringArray<O, 2>);
+zero_impl!(MultiPointArray<O, 2>);
+zero_impl!(MultiLineStringArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -323,10 +323,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>);
-iter_geo_impl!(MixedGeometryArray<O>);
-iter_geo_impl!(GeometryCollectionArray<O>);
+iter_geo_impl!(PolygonArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>);
+iter_geo_impl!(MixedGeometryArray<O, 2>);
+iter_geo_impl!(GeometryCollectionArray<O, 2>);
 iter_geo_impl!(WKBArray<O>);
 
 impl GeodesicArea for &dyn GeometryArrayTrait {

--- a/src/algorithm/geo/geodesic_area.rs
+++ b/src/algorithm/geo/geodesic_area.rs
@@ -60,7 +60,7 @@ pub trait GeodesicArea {
     ///     (x: 0.00185608, y: 51.501770),
     ///     (x: 0.00388383, y: 51.501574),
     /// ];
-    /// let polygon_array: PolygonArray<i32> = vec![polygon].as_slice().into();
+    /// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
     ///
     /// let area_array = polygon_array.geodesic_area_signed();
     ///
@@ -100,7 +100,7 @@ pub trait GeodesicArea {
     ///     (x: 1.0, y: 1.0),
     ///     (x: 1.0, y: 0.0),
     /// ];
-    /// let polygon_array: PolygonArray<i32> = vec![polygon].as_slice().into();
+    /// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
     ///
     /// let area_array = polygon_array.geodesic_area_unsigned();
     ///

--- a/src/algorithm/geo/geodesic_length.rs
+++ b/src/algorithm/geo/geodesic_length.rs
@@ -58,7 +58,7 @@ pub trait GeodesicLength {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl GeodesicLength for PointArray {
+impl GeodesicLength for PointArray<2> {
     type Output = Float64Array;
 
     fn geodesic_length(&self) -> Self::Output {
@@ -79,7 +79,7 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(MultiPointArray<O>);
+zero_impl!(MultiPointArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -94,8 +94,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
 
 impl GeodesicLength for &dyn GeometryArrayTrait {
     type Output = Result<Float64Array>;
@@ -127,7 +127,7 @@ impl GeodesicLength for &dyn GeometryArrayTrait {
     }
 }
 
-impl GeodesicLength for ChunkedGeometryArray<PointArray> {
+impl GeodesicLength for ChunkedGeometryArray<PointArray<2>> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn geodesic_length(&self) -> Self::Output {
@@ -148,9 +148,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
 
 impl GeodesicLength for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -198,7 +198,7 @@ mod tests {
             // Osaka
             (x: 135.5244559, y: 34.687455),
         ];
-        let input_array: LineStringArray<i64> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
         let result_array = input_array.geodesic_length();
 
         // Meters

--- a/src/algorithm/geo/geodesic_length.rs
+++ b/src/algorithm/geo/geodesic_length.rs
@@ -43,7 +43,7 @@ pub trait GeodesicLength {
     ///     // Osaka
     ///     (135.5244559, 34.687455)
     /// ]);
-    /// let linestring_array: LineStringArray<i32> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray<i32, 2> = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.geodesic_length();
     ///

--- a/src/algorithm/geo/haversine_length.rs
+++ b/src/algorithm/geo/haversine_length.rs
@@ -52,7 +52,7 @@ pub trait HaversineLength {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl HaversineLength for PointArray {
+impl HaversineLength for PointArray<2> {
     type Output = Float64Array;
 
     fn haversine_length(&self) -> Self::Output {
@@ -73,7 +73,7 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(MultiPointArray<O>);
+zero_impl!(MultiPointArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -88,8 +88,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
 
 impl HaversineLength for &dyn GeometryArrayTrait {
     type Output = Result<Float64Array>;
@@ -121,7 +121,7 @@ impl HaversineLength for &dyn GeometryArrayTrait {
     }
 }
 
-impl HaversineLength for ChunkedGeometryArray<PointArray> {
+impl HaversineLength for ChunkedGeometryArray<PointArray<2>> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn haversine_length(&self) -> Self::Output {
@@ -142,9 +142,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
 
 impl HaversineLength for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -190,7 +190,7 @@ mod tests {
             // London
             (x: -0.1278, y: 51.5074),
         ];
-        let input_array: LineStringArray<i64> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
         let result_array = input_array.haversine_length();
 
         // Meters

--- a/src/algorithm/geo/haversine_length.rs
+++ b/src/algorithm/geo/haversine_length.rs
@@ -37,7 +37,7 @@ pub trait HaversineLength {
     ///     // London
     ///     (-0.1278, 51.5074),
     /// ]);
-    /// let linestring_array: LineStringArray<i32> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray<i32, 2> = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.haversine_length();
     ///

--- a/src/algorithm/geo/intersects.rs
+++ b/src/algorithm/geo/intersects.rs
@@ -55,7 +55,7 @@ pub trait Intersects<Rhs = Self> {
 }
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl Intersects for IndexedPointArray {
+impl Intersects for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &Self) -> Self::Output {
@@ -83,71 +83,71 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(IndexedPointArray, IndexedLineStringArray<O>);
-iter_geo_impl!(IndexedPointArray, IndexedPolygonArray<O>);
-iter_geo_impl!(IndexedPointArray, IndexedMultiPointArray<O>);
-iter_geo_impl!(IndexedPointArray, IndexedMultiLineStringArray<O>);
-iter_geo_impl!(IndexedPointArray, IndexedMultiPolygonArray<O>);
-iter_geo_impl!(IndexedPointArray, IndexedMixedGeometryArray<O>);
-iter_geo_impl!(IndexedPointArray, IndexedGeometryCollectionArray<O>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedLineStringArray<O, 2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedPolygonArray<O, 2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedMultiPointArray<O, 2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedMultiLineStringArray<O, 2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedMultiPolygonArray<O, 2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedMixedGeometryArray<O, 2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedGeometryCollectionArray<O, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl!(IndexedLineStringArray<O>, IndexedPointArray);
-iter_geo_impl!(IndexedLineStringArray<O>, IndexedLineStringArray<O>);
-iter_geo_impl!(IndexedLineStringArray<O>, IndexedPolygonArray<O>);
-iter_geo_impl!(IndexedLineStringArray<O>, IndexedMultiPointArray<O>);
-iter_geo_impl!(IndexedLineStringArray<O>, IndexedMultiLineStringArray<O>);
-iter_geo_impl!(IndexedLineStringArray<O>, IndexedMultiPolygonArray<O>);
-iter_geo_impl!(IndexedLineStringArray<O>, IndexedMixedGeometryArray<O>);
-iter_geo_impl!(IndexedLineStringArray<O>, IndexedGeometryCollectionArray<O>);
+iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedLineStringArray<O, 2>);
+iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedPolygonArray<O, 2>);
+iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedMultiPointArray<O, 2>);
+iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedMultiLineStringArray<O, 2>);
+iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
+iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
+iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedGeometryCollectionArray<O, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl!(IndexedPolygonArray<O>, IndexedPointArray);
-iter_geo_impl!(IndexedPolygonArray<O>, IndexedLineStringArray<O>);
-iter_geo_impl!(IndexedPolygonArray<O>, IndexedPolygonArray<O>);
-iter_geo_impl!(IndexedPolygonArray<O>, IndexedMultiPointArray<O>);
-iter_geo_impl!(IndexedPolygonArray<O>, IndexedMultiLineStringArray<O>);
-iter_geo_impl!(IndexedPolygonArray<O>, IndexedMultiPolygonArray<O>);
-iter_geo_impl!(IndexedPolygonArray<O>, IndexedMixedGeometryArray<O>);
-iter_geo_impl!(IndexedPolygonArray<O>, IndexedGeometryCollectionArray<O>);
+iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedLineStringArray<O, 2>);
+iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedPolygonArray<O, 2>);
+iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedMultiPointArray<O, 2>);
+iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedMultiLineStringArray<O, 2>);
+iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
+iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
+iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedGeometryCollectionArray<O, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(IndexedMultiPointArray<O>, IndexedPointArray);
-iter_geo_impl!(IndexedMultiPointArray<O>, IndexedLineStringArray<O>);
-iter_geo_impl!(IndexedMultiPointArray<O>, IndexedPolygonArray<O>);
-iter_geo_impl!(IndexedMultiPointArray<O>, IndexedMultiPointArray<O>);
-iter_geo_impl!(IndexedMultiPointArray<O>, IndexedMultiLineStringArray<O>);
-iter_geo_impl!(IndexedMultiPointArray<O>, IndexedMultiPolygonArray<O>);
-iter_geo_impl!(IndexedMultiPointArray<O>, IndexedMixedGeometryArray<O>);
-iter_geo_impl!(IndexedMultiPointArray<O>, IndexedGeometryCollectionArray<O>);
+iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedLineStringArray<O, 2>);
+iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedPolygonArray<O, 2>);
+iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedMultiPointArray<O, 2>);
+iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedMultiLineStringArray<O, 2>);
+iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
+iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
+iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedGeometryCollectionArray<O, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(IndexedMultiLineStringArray<O>, IndexedPointArray);
-iter_geo_impl!(IndexedMultiLineStringArray<O>, IndexedLineStringArray<O>);
-iter_geo_impl!(IndexedMultiLineStringArray<O>, IndexedPolygonArray<O>);
-iter_geo_impl!(IndexedMultiLineStringArray<O>, IndexedMultiPointArray<O>);
+iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedLineStringArray<O, 2>);
+iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedPolygonArray<O, 2>);
+iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedMultiPointArray<O, 2>);
 iter_geo_impl!(
-    IndexedMultiLineStringArray<O>,
-    IndexedMultiLineStringArray<O>
+    IndexedMultiLineStringArray<O, 2>,
+    IndexedMultiLineStringArray<O, 2>
 );
-iter_geo_impl!(IndexedMultiLineStringArray<O>, IndexedMultiPolygonArray<O>);
-iter_geo_impl!(IndexedMultiLineStringArray<O>, IndexedMixedGeometryArray<O>);
+iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
+iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
 iter_geo_impl!(
-    IndexedMultiLineStringArray<O>,
-    IndexedGeometryCollectionArray<O>
+    IndexedMultiLineStringArray<O, 2>,
+    IndexedGeometryCollectionArray<O, 2>
 );
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(IndexedMultiPolygonArray<O>, IndexedPointArray);
-iter_geo_impl!(IndexedMultiPolygonArray<O>, IndexedLineStringArray<O>);
-iter_geo_impl!(IndexedMultiPolygonArray<O>, IndexedPolygonArray<O>);
-iter_geo_impl!(IndexedMultiPolygonArray<O>, IndexedMultiPointArray<O>);
-iter_geo_impl!(IndexedMultiPolygonArray<O>, IndexedMultiLineStringArray<O>);
-iter_geo_impl!(IndexedMultiPolygonArray<O>, IndexedMultiPolygonArray<O>);
-iter_geo_impl!(IndexedMultiPolygonArray<O>, IndexedMixedGeometryArray<O>);
+iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedLineStringArray<O, 2>);
+iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedPolygonArray<O, 2>);
+iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedMultiPointArray<O, 2>);
+iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedMultiLineStringArray<O, 2>);
+iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
+iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
 iter_geo_impl!(
-    IndexedMultiPolygonArray<O>,
-    IndexedGeometryCollectionArray<O>
+    IndexedMultiPolygonArray<O, 2>,
+    IndexedGeometryCollectionArray<O, 2>
 );
 
 // ┌─────────────────────────────────┐
@@ -160,7 +160,7 @@ pub trait IntersectsPoint<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedPointArray {
+impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -182,15 +182,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O>);
-impl_intersects!(IndexedPolygonArray<O>);
-impl_intersects!(IndexedMultiPointArray<O>);
-impl_intersects!(IndexedMultiLineStringArray<O>);
-impl_intersects!(IndexedMultiPolygonArray<O>);
-impl_intersects!(IndexedMixedGeometryArray<O>);
-impl_intersects!(IndexedGeometryCollectionArray<O>);
+impl_intersects!(IndexedLineStringArray<O, 2>);
+impl_intersects!(IndexedPolygonArray<O, 2>);
+impl_intersects!(IndexedMultiPointArray<O, 2>);
+impl_intersects!(IndexedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
 
-impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedChunkedPointArray {
+impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -216,13 +216,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O>);
-impl_intersects!(IndexedChunkedPolygonArray<O>);
-impl_intersects!(IndexedChunkedMultiPointArray<O>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O>);
+impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
 
 pub trait IntersectsLineString<Rhs> {
     type Output;
@@ -230,7 +230,7 @@ pub trait IntersectsLineString<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedPointArray {
+impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -258,15 +258,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O>);
-impl_intersects!(IndexedPolygonArray<O>);
-impl_intersects!(IndexedMultiPointArray<O>);
-impl_intersects!(IndexedMultiLineStringArray<O>);
-impl_intersects!(IndexedMultiPolygonArray<O>);
-impl_intersects!(IndexedMixedGeometryArray<O>);
-impl_intersects!(IndexedGeometryCollectionArray<O>);
+impl_intersects!(IndexedLineStringArray<O, 2>);
+impl_intersects!(IndexedPolygonArray<O, 2>);
+impl_intersects!(IndexedMultiPointArray<O, 2>);
+impl_intersects!(IndexedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
 
-impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedChunkedPointArray {
+impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -294,13 +294,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O>);
-impl_intersects!(IndexedChunkedPolygonArray<O>);
-impl_intersects!(IndexedChunkedMultiPointArray<O>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O>);
+impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
 
 pub trait IntersectsPolygon<Rhs> {
     type Output;
@@ -308,7 +308,7 @@ pub trait IntersectsPolygon<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedPointArray {
+impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -334,15 +334,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O>);
-impl_intersects!(IndexedPolygonArray<O>);
-impl_intersects!(IndexedMultiPointArray<O>);
-impl_intersects!(IndexedMultiLineStringArray<O>);
-impl_intersects!(IndexedMultiPolygonArray<O>);
-impl_intersects!(IndexedMixedGeometryArray<O>);
-impl_intersects!(IndexedGeometryCollectionArray<O>);
+impl_intersects!(IndexedLineStringArray<O, 2>);
+impl_intersects!(IndexedPolygonArray<O, 2>);
+impl_intersects!(IndexedMultiPointArray<O, 2>);
+impl_intersects!(IndexedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
 
-impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedChunkedPointArray {
+impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -368,13 +368,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O>);
-impl_intersects!(IndexedChunkedPolygonArray<O>);
-impl_intersects!(IndexedChunkedMultiPointArray<O>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O>);
+impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
 
 pub trait IntersectsMultiPoint<Rhs> {
     type Output;
@@ -382,7 +382,7 @@ pub trait IntersectsMultiPoint<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedPointArray {
+impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -410,15 +410,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O>);
-impl_intersects!(IndexedPolygonArray<O>);
-impl_intersects!(IndexedMultiPointArray<O>);
-impl_intersects!(IndexedMultiLineStringArray<O>);
-impl_intersects!(IndexedMultiPolygonArray<O>);
-impl_intersects!(IndexedMixedGeometryArray<O>);
-impl_intersects!(IndexedGeometryCollectionArray<O>);
+impl_intersects!(IndexedLineStringArray<O, 2>);
+impl_intersects!(IndexedPolygonArray<O, 2>);
+impl_intersects!(IndexedMultiPointArray<O, 2>);
+impl_intersects!(IndexedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
 
-impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedChunkedPointArray {
+impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -446,13 +446,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O>);
-impl_intersects!(IndexedChunkedPolygonArray<O>);
-impl_intersects!(IndexedChunkedMultiPointArray<O>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O>);
+impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
 
 pub trait IntersectsMultiLineString<Rhs> {
     type Output;
@@ -460,7 +460,7 @@ pub trait IntersectsMultiLineString<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedPointArray {
+impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -488,15 +488,17 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O>);
-impl_intersects!(IndexedPolygonArray<O>);
-impl_intersects!(IndexedMultiPointArray<O>);
-impl_intersects!(IndexedMultiLineStringArray<O>);
-impl_intersects!(IndexedMultiPolygonArray<O>);
-impl_intersects!(IndexedMixedGeometryArray<O>);
-impl_intersects!(IndexedGeometryCollectionArray<O>);
+impl_intersects!(IndexedLineStringArray<O, 2>);
+impl_intersects!(IndexedPolygonArray<O, 2>);
+impl_intersects!(IndexedMultiPointArray<O, 2>);
+impl_intersects!(IndexedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
 
-impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedChunkedPointArray {
+impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G>
+    for IndexedChunkedPointArray<2>
+{
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -524,13 +526,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O>);
-impl_intersects!(IndexedChunkedPolygonArray<O>);
-impl_intersects!(IndexedChunkedMultiPointArray<O>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O>);
+impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
 
 pub trait IntersectsMultiPolygon<Rhs> {
     type Output;
@@ -538,7 +540,7 @@ pub trait IntersectsMultiPolygon<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedPointArray {
+impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -566,15 +568,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O>);
-impl_intersects!(IndexedPolygonArray<O>);
-impl_intersects!(IndexedMultiPointArray<O>);
-impl_intersects!(IndexedMultiLineStringArray<O>);
-impl_intersects!(IndexedMultiPolygonArray<O>);
-impl_intersects!(IndexedMixedGeometryArray<O>);
-impl_intersects!(IndexedGeometryCollectionArray<O>);
+impl_intersects!(IndexedLineStringArray<O, 2>);
+impl_intersects!(IndexedPolygonArray<O, 2>);
+impl_intersects!(IndexedMultiPointArray<O, 2>);
+impl_intersects!(IndexedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
 
-impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedChunkedPointArray {
+impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -602,13 +604,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O>);
-impl_intersects!(IndexedChunkedPolygonArray<O>);
-impl_intersects!(IndexedChunkedMultiPointArray<O>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O>);
+impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
 
 pub trait IntersectsGeometry<Rhs> {
     type Output;
@@ -616,7 +618,7 @@ pub trait IntersectsGeometry<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedPointArray {
+impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -642,15 +644,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O>);
-impl_intersects!(IndexedPolygonArray<O>);
-impl_intersects!(IndexedMultiPointArray<O>);
-impl_intersects!(IndexedMultiLineStringArray<O>);
-impl_intersects!(IndexedMultiPolygonArray<O>);
-impl_intersects!(IndexedMixedGeometryArray<O>);
-impl_intersects!(IndexedGeometryCollectionArray<O>);
+impl_intersects!(IndexedLineStringArray<O, 2>);
+impl_intersects!(IndexedPolygonArray<O, 2>);
+impl_intersects!(IndexedMultiPointArray<O, 2>);
+impl_intersects!(IndexedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
 
-impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedChunkedPointArray {
+impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -676,13 +678,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O>);
-impl_intersects!(IndexedChunkedPolygonArray<O>);
-impl_intersects!(IndexedChunkedMultiPointArray<O>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O>);
+impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
 
 pub trait IntersectsGeometryCollection<Rhs> {
     type Output;
@@ -690,7 +692,7 @@ pub trait IntersectsGeometryCollection<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for IndexedPointArray {
+impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -718,16 +720,16 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O>);
-impl_intersects!(IndexedPolygonArray<O>);
-impl_intersects!(IndexedMultiPointArray<O>);
-impl_intersects!(IndexedMultiLineStringArray<O>);
-impl_intersects!(IndexedMultiPolygonArray<O>);
-impl_intersects!(IndexedMixedGeometryArray<O>);
-impl_intersects!(IndexedGeometryCollectionArray<O>);
+impl_intersects!(IndexedLineStringArray<O, 2>);
+impl_intersects!(IndexedPolygonArray<O, 2>);
+impl_intersects!(IndexedMultiPointArray<O, 2>);
+impl_intersects!(IndexedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
 
 impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G>
-    for IndexedChunkedPointArray
+    for IndexedChunkedPointArray<2>
 {
     type Output = ChunkedArray<BooleanArray>;
 
@@ -756,10 +758,10 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O>);
-impl_intersects!(IndexedChunkedPolygonArray<O>);
-impl_intersects!(IndexedChunkedMultiPointArray<O>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O>);
+impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);

--- a/src/algorithm/geo/line_interpolate_point.rs
+++ b/src/algorithm/geo/line_interpolate_point.rs
@@ -43,8 +43,8 @@ pub trait LineInterpolatePoint<Rhs> {
     fn line_interpolate_point(&self, fraction: Rhs) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> LineInterpolatePoint<&Float64Array> for LineStringArray<O> {
-    type Output = PointArray;
+impl<O: OffsetSizeTrait> LineInterpolatePoint<&Float64Array> for LineStringArray<O, 2> {
+    type Output = PointArray<2>;
 
     fn line_interpolate_point(&self, p: &Float64Array) -> Self::Output {
         let mut output_array = PointBuilder::with_capacity(self.len());
@@ -67,7 +67,7 @@ impl<O: OffsetSizeTrait> LineInterpolatePoint<&Float64Array> for LineStringArray
 }
 
 impl LineInterpolatePoint<&Float64Array> for &dyn GeometryArrayTrait {
-    type Output = Result<PointArray>;
+    type Output = Result<PointArray<2>>;
 
     fn line_interpolate_point(&self, fraction: &Float64Array) -> Self::Output {
         use GeoDataType::*;
@@ -79,8 +79,8 @@ impl LineInterpolatePoint<&Float64Array> for &dyn GeometryArrayTrait {
     }
 }
 
-impl<O: OffsetSizeTrait> LineInterpolatePoint<&[Float64Array]> for ChunkedLineStringArray<O> {
-    type Output = ChunkedPointArray;
+impl<O: OffsetSizeTrait> LineInterpolatePoint<&[Float64Array]> for ChunkedLineStringArray<O, 2> {
+    type Output = ChunkedPointArray<2>;
 
     fn line_interpolate_point(&self, p: &[Float64Array]) -> Self::Output {
         ChunkedPointArray::new(
@@ -90,7 +90,7 @@ impl<O: OffsetSizeTrait> LineInterpolatePoint<&[Float64Array]> for ChunkedLineSt
 }
 
 impl LineInterpolatePoint<&[Float64Array]> for &dyn ChunkedGeometryArrayTrait {
-    type Output = Result<ChunkedPointArray>;
+    type Output = Result<ChunkedPointArray<2>>;
 
     fn line_interpolate_point(&self, fraction: &[Float64Array]) -> Self::Output {
         use GeoDataType::*;
@@ -102,8 +102,8 @@ impl LineInterpolatePoint<&[Float64Array]> for &dyn ChunkedGeometryArrayTrait {
     }
 }
 
-impl<O: OffsetSizeTrait> LineInterpolatePoint<f64> for LineStringArray<O> {
-    type Output = PointArray;
+impl<O: OffsetSizeTrait> LineInterpolatePoint<f64> for LineStringArray<O, 2> {
+    type Output = PointArray<2>;
 
     fn line_interpolate_point(&self, p: f64) -> Self::Output {
         let mut output_array = PointBuilder::with_capacity(self.len());
@@ -125,7 +125,7 @@ impl<O: OffsetSizeTrait> LineInterpolatePoint<f64> for LineStringArray<O> {
 }
 
 impl LineInterpolatePoint<f64> for &dyn GeometryArrayTrait {
-    type Output = Result<PointArray>;
+    type Output = Result<PointArray<2>>;
 
     fn line_interpolate_point(&self, fraction: f64) -> Self::Output {
         use GeoDataType::*;
@@ -137,8 +137,8 @@ impl LineInterpolatePoint<f64> for &dyn GeometryArrayTrait {
     }
 }
 
-impl<O: OffsetSizeTrait> LineInterpolatePoint<f64> for ChunkedLineStringArray<O> {
-    type Output = ChunkedPointArray;
+impl<O: OffsetSizeTrait> LineInterpolatePoint<f64> for ChunkedLineStringArray<O, 2> {
+    type Output = ChunkedPointArray<2>;
 
     fn line_interpolate_point(&self, fraction: f64) -> Self::Output {
         ChunkedPointArray::new(self.map(|chunk| chunk.line_interpolate_point(fraction)))
@@ -146,7 +146,7 @@ impl<O: OffsetSizeTrait> LineInterpolatePoint<f64> for ChunkedLineStringArray<O>
 }
 
 impl LineInterpolatePoint<f64> for &dyn ChunkedGeometryArrayTrait {
-    type Output = Result<ChunkedPointArray>;
+    type Output = Result<ChunkedPointArray<2>>;
 
     fn line_interpolate_point(&self, fraction: f64) -> Self::Output {
         use GeoDataType::*;

--- a/src/algorithm/geo/line_locate_point.rs
+++ b/src/algorithm/geo/line_locate_point.rs
@@ -25,10 +25,10 @@ pub trait LineLocatePoint<Rhs> {
     fn line_locate_point(&self, rhs: Rhs) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> LineLocatePoint<&PointArray> for LineStringArray<O> {
+impl<O: OffsetSizeTrait> LineLocatePoint<&PointArray<2>> for LineStringArray<O, 2> {
     type Output = Float64Array;
 
-    fn line_locate_point(&self, rhs: &PointArray) -> Float64Array {
+    fn line_locate_point(&self, rhs: &PointArray<2>) -> Float64Array {
         let mut output_array = Float64Builder::with_capacity(self.len());
 
         self.iter_geo()
@@ -65,10 +65,10 @@ impl LineLocatePoint<&dyn GeometryArrayTrait> for &dyn GeometryArrayTrait {
     }
 }
 
-impl<O: OffsetSizeTrait> LineLocatePoint<&[PointArray]> for ChunkedLineStringArray<O> {
+impl<O: OffsetSizeTrait> LineLocatePoint<&[PointArray<2>]> for ChunkedLineStringArray<O, 2> {
     type Output = ChunkedArray<Float64Array>;
 
-    fn line_locate_point(&self, rhs: &[PointArray]) -> ChunkedArray<Float64Array> {
+    fn line_locate_point(&self, rhs: &[PointArray<2>]) -> ChunkedArray<Float64Array> {
         let chunks = self.binary_map(rhs, |(left, right)| {
             LineLocatePoint::line_locate_point(left, right)
         });
@@ -102,7 +102,9 @@ pub trait LineLocatePointScalar<Rhs> {
     fn line_locate_point(&self, rhs: Rhs) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait, G: PointTrait<T = f64>> LineLocatePointScalar<G> for LineStringArray<O> {
+impl<O: OffsetSizeTrait, G: PointTrait<T = f64>> LineLocatePointScalar<G>
+    for LineStringArray<O, 2>
+{
     type Output = Float64Array;
 
     fn line_locate_point(&self, rhs: G) -> Self::Output {
@@ -142,7 +144,7 @@ impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for &dyn GeometryArrayTrai
 }
 
 impl<O: OffsetSizeTrait, G: PointTrait<T = f64>> LineLocatePointScalar<G>
-    for ChunkedLineStringArray<O>
+    for ChunkedLineStringArray<O, 2>
 {
     type Output = ChunkedArray<Float64Array>;
 

--- a/src/algorithm/geo/minimum_rotated_rect.rs
+++ b/src/algorithm/geo/minimum_rotated_rect.rs
@@ -39,8 +39,8 @@ pub trait MinimumRotatedRect<O: OffsetSizeTrait> {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for PointArray {
-    type Output = PolygonArray<O>;
+impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for PointArray<2> {
+    type Output = PolygonArray<O, 2>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         // The number of output geoms is the same as the input
@@ -72,7 +72,7 @@ macro_rules! iter_geo_impl {
         impl<OOutput: OffsetSizeTrait, OInput: OffsetSizeTrait> MinimumRotatedRect<OOutput>
             for $type
         {
-            type Output = PolygonArray<OOutput>;
+            type Output = PolygonArray<OOutput, 2>;
 
             fn minimum_rotated_rect(&self) -> Self::Output {
                 // The number of output geoms is the same as the input
@@ -100,16 +100,16 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<OInput>);
-iter_geo_impl!(PolygonArray<OInput>);
-iter_geo_impl!(MultiPointArray<OInput>);
-iter_geo_impl!(MultiLineStringArray<OInput>);
-iter_geo_impl!(MultiPolygonArray<OInput>);
-iter_geo_impl!(MixedGeometryArray<OInput>);
-iter_geo_impl!(GeometryCollectionArray<OInput>);
+iter_geo_impl!(LineStringArray<OInput, 2>);
+iter_geo_impl!(PolygonArray<OInput, 2>);
+iter_geo_impl!(MultiPointArray<OInput, 2>);
+iter_geo_impl!(MultiLineStringArray<OInput, 2>);
+iter_geo_impl!(MultiPolygonArray<OInput, 2>);
+iter_geo_impl!(MixedGeometryArray<OInput, 2>);
+iter_geo_impl!(GeometryCollectionArray<OInput, 2>);
 
 impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for &dyn GeometryArrayTrait {
-    type Output = Result<PolygonArray<O>>;
+    type Output = Result<PolygonArray<O, 2>>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         let result = match self.data_type() {
@@ -143,7 +143,7 @@ impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for &dyn GeometryArrayTrait {
 }
 
 impl<O: OffsetSizeTrait, G: GeometryArrayTrait> MinimumRotatedRect<O> for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedGeometryArray<PolygonArray<O>>>;
+    type Output = Result<ChunkedGeometryArray<PolygonArray<O, 2>>>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().minimum_rotated_rect())?
@@ -152,7 +152,7 @@ impl<O: OffsetSizeTrait, G: GeometryArrayTrait> MinimumRotatedRect<O> for Chunke
 }
 
 impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for &dyn ChunkedGeometryArrayTrait {
-    type Output = Result<ChunkedPolygonArray<O>>;
+    type Output = Result<ChunkedPolygonArray<O, 2>>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         match self.data_type() {

--- a/src/algorithm/geo/remove_repeated_points.rs
+++ b/src/algorithm/geo/remove_repeated_points.rs
@@ -27,7 +27,7 @@ pub trait RemoveRepeatedPoints {
 }
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl RemoveRepeatedPoints for PointArray {
+impl RemoveRepeatedPoints for PointArray<2> {
     type Output = Self;
 
     fn remove_repeated_points(&self) -> Self::Output {
@@ -56,21 +56,21 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, LineStringBuilder<O>, push_line_string);
-iter_geo_impl!(PolygonArray<O>, PolygonBuilder<O>, push_polygon);
-iter_geo_impl!(MultiPointArray<O>, MultiPointBuilder<O>, push_multi_point);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O>,
-    MultiLineStringBuilder<O>,
+    MultiLineStringArray<O, 2>,
+    MultiLineStringBuilder<O, 2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O>,
-    MultiPolygonBuilder<O>,
+    MultiPolygonArray<O, 2>,
+    MultiPolygonBuilder<O, 2>,
     push_multi_polygon
 );
-// iter_geo_impl!(MixedGeometryArray<O>, MixedGeometryBuilder<O>, push_geometry);
-// iter_geo_impl!(GeometryCollectionArray<O>, geo::GeometryCollection);
+// iter_geo_impl!(MixedGeometryArray<O, 2>, MixedGeometryBuilder<O, 2>, push_geometry);
+// iter_geo_impl!(GeometryCollectionArray<O, 2>, geo::GeometryCollection);
 
 impl RemoveRepeatedPoints for &dyn GeometryArrayTrait {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
@@ -114,7 +114,7 @@ impl RemoveRepeatedPoints for &dyn GeometryArrayTrait {
     }
 }
 
-impl RemoveRepeatedPoints for ChunkedPointArray {
+impl RemoveRepeatedPoints for ChunkedPointArray<2> {
     type Output = Self;
 
     fn remove_repeated_points(&self) -> Self::Output {
@@ -136,11 +136,11 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<O>);
-impl_chunked!(ChunkedPolygonArray<O>);
-impl_chunked!(ChunkedMultiPointArray<O>);
-impl_chunked!(ChunkedMultiLineStringArray<O>);
-impl_chunked!(ChunkedMultiPolygonArray<O>);
+impl_chunked!(ChunkedLineStringArray<O, 2>);
+impl_chunked!(ChunkedPolygonArray<O, 2>);
+impl_chunked!(ChunkedMultiPointArray<O, 2>);
+impl_chunked!(ChunkedMultiLineStringArray<O, 2>);
+impl_chunked!(ChunkedMultiPolygonArray<O, 2>);
 
 impl RemoveRepeatedPoints for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<Arc<dyn ChunkedGeometryArrayTrait>>;

--- a/src/algorithm/geo/rotate.rs
+++ b/src/algorithm/geo/rotate.rs
@@ -100,7 +100,7 @@ pub trait Rotate<DegreesT> {
 // └────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Rotate<Float64Array> for PointArray {
+impl Rotate<Float64Array> for PointArray<2> {
     fn rotate_around_centroid(&self, degrees: &Float64Array) -> Self {
         let centroids = self.centroid();
         let transforms: Vec<AffineTransform> = centroids
@@ -167,18 +167,18 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>);
-iter_geo_impl!(MultiPointArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
 // └─────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Rotate<f64> for PointArray {
+impl Rotate<f64> for PointArray<2> {
     fn rotate_around_centroid(&self, degrees: &f64) -> Self {
         let centroids = self.centroid();
         let transforms: Vec<AffineTransform> = centroids
@@ -233,8 +233,8 @@ macro_rules! iter_geo_impl_scalar {
     };
 }
 
-iter_geo_impl_scalar!(LineStringArray<O>);
-iter_geo_impl_scalar!(PolygonArray<O>);
-iter_geo_impl_scalar!(MultiPointArray<O>);
-iter_geo_impl_scalar!(MultiLineStringArray<O>);
-iter_geo_impl_scalar!(MultiPolygonArray<O>);
+iter_geo_impl_scalar!(LineStringArray<O, 2>);
+iter_geo_impl_scalar!(PolygonArray<O, 2>);
+iter_geo_impl_scalar!(MultiPointArray<O, 2>);
+iter_geo_impl_scalar!(MultiLineStringArray<O, 2>);
+iter_geo_impl_scalar!(MultiPolygonArray<O, 2>);

--- a/src/algorithm/geo/scale.rs
+++ b/src/algorithm/geo/scale.rs
@@ -101,7 +101,7 @@ pub trait Scale {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Scale for PointArray {
+impl Scale for PointArray<2> {
     fn scale(&self, scale_factor: BroadcastablePrimitive<Float64Type>) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
@@ -238,16 +238,16 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, LineStringBuilder<O>, push_line_string);
-iter_geo_impl!(PolygonArray<O>, PolygonBuilder<O>, push_polygon);
-iter_geo_impl!(MultiPointArray<O>, MultiPointBuilder<O>, push_multi_point);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O>,
-    MultiLineStringBuilder<O>,
+    MultiLineStringArray<O, 2>,
+    MultiLineStringBuilder<O, 2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O>,
-    MultiPolygonBuilder<O>,
+    MultiPolygonArray<O, 2>,
+    MultiPolygonBuilder<O, 2>,
     push_multi_polygon
 );

--- a/src/algorithm/geo/simplify.rs
+++ b/src/algorithm/geo/simplify.rs
@@ -39,7 +39,7 @@ pub trait Simplify {
     ///     (x: 17.3, y: 3.2),
     ///     (x: 27.8, y: 0.1),
     /// ];
-    /// let line_string_array: LineStringArray<i32> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray<i32, 2> = vec![line_string].as_slice().into();
     ///
     /// let simplified_array = line_string_array.simplify(&1.0);
     ///

--- a/src/algorithm/geo/simplify.rs
+++ b/src/algorithm/geo/simplify.rs
@@ -56,7 +56,7 @@ pub trait Simplify {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Simplify for PointArray {
+impl Simplify for PointArray<2> {
     type Output = Self;
 
     fn simplify(&self, _epsilon: &f64) -> Self {
@@ -77,7 +77,7 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(MultiPointArray<O>);
+identity_impl!(MultiPointArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -97,12 +97,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, geo::LineString);
-iter_geo_impl!(PolygonArray<O>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<O>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<O>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
+iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray<O, 2>, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray<O, 2>, geo::GeometryCollection);
 
 impl Simplify for &dyn GeometryArrayTrait {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
@@ -142,7 +142,7 @@ impl Simplify for &dyn GeometryArrayTrait {
     }
 }
 
-impl Simplify for ChunkedGeometryArray<PointArray> {
+impl Simplify for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify(&self, epsilon: &f64) -> Self::Output {
@@ -167,11 +167,11 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O, 2>>);
 
 impl Simplify for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<Arc<dyn ChunkedGeometryArrayTrait>>;
@@ -227,7 +227,7 @@ mod tests {
             (x: 17.3, y: 3.2 ),
             (x: 27.8, y: 0.1 ),
         ];
-        let input_array: LineStringArray<i64> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
         let result_array = input_array.simplify(&1.0);
 
         let expected = line_string![
@@ -250,7 +250,7 @@ mod tests {
             (x: 10., y: 0.),
             (x: 0., y: 0.),
         ];
-        let input_array: PolygonArray<i64> = vec![input_geom].as_slice().into();
+        let input_array: PolygonArray<i64, 2> = vec![input_geom].as_slice().into();
         let result_array = input_array.simplify(&2.0);
 
         let expected = polygon![

--- a/src/algorithm/geo/simplify_vw.rs
+++ b/src/algorithm/geo/simplify_vw.rs
@@ -38,7 +38,7 @@ pub trait SimplifyVw {
     ///     (x: 7.0, y: 25.0),
     ///     (x: 10.0, y: 10.0),
     /// ];
-    /// let line_string_array: LineStringArray<i32> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray<i32, 2> = vec![line_string].as_slice().into();
     ///
     /// let simplified_array = line_string_array.simplify_vw(&30.0);
     ///

--- a/src/algorithm/geo/simplify_vw.rs
+++ b/src/algorithm/geo/simplify_vw.rs
@@ -54,7 +54,7 @@ pub trait SimplifyVw {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl SimplifyVw for PointArray {
+impl SimplifyVw for PointArray<2> {
     type Output = Self;
 
     fn simplify_vw(&self, _epsilon: &f64) -> Self {
@@ -75,7 +75,7 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(MultiPointArray<O>);
+identity_impl!(MultiPointArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -95,12 +95,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, geo::LineString);
-iter_geo_impl!(PolygonArray<O>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<O>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<O>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
+iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray<O, 2>, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray<O, 2>, geo::GeometryCollection);
 
 impl SimplifyVw for &dyn GeometryArrayTrait {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
@@ -140,7 +140,7 @@ impl SimplifyVw for &dyn GeometryArrayTrait {
     }
 }
 
-impl SimplifyVw for ChunkedGeometryArray<PointArray> {
+impl SimplifyVw for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify_vw(&self, epsilon: &f64) -> Self::Output {
@@ -165,11 +165,11 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O, 2>>);
 
 impl SimplifyVw for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<Arc<dyn ChunkedGeometryArrayTrait>>;

--- a/src/algorithm/geo/simplify_vw_preserve.rs
+++ b/src/algorithm/geo/simplify_vw_preserve.rs
@@ -48,7 +48,7 @@ pub trait SimplifyVwPreserve {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl SimplifyVwPreserve for PointArray {
+impl SimplifyVwPreserve for PointArray<2> {
     type Output = Self;
 
     fn simplify_vw_preserve(&self, _epsilon: &f64) -> Self {
@@ -69,7 +69,7 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(MultiPointArray<O>);
+identity_impl!(MultiPointArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -89,12 +89,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, geo::LineString);
-iter_geo_impl!(PolygonArray<O>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<O>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<O>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
+iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray<O, 2>, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray<O, 2>, geo::GeometryCollection);
 
 impl SimplifyVwPreserve for &dyn GeometryArrayTrait {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
@@ -143,7 +143,7 @@ impl SimplifyVwPreserve for &dyn GeometryArrayTrait {
     }
 }
 
-impl SimplifyVwPreserve for ChunkedGeometryArray<PointArray> {
+impl SimplifyVwPreserve for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify_vw_preserve(&self, epsilon: &f64) -> Self::Output {
@@ -168,11 +168,11 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O, 2>>);
 
 impl SimplifyVwPreserve for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<Arc<dyn ChunkedGeometryArrayTrait>>;

--- a/src/algorithm/geo/skew.rs
+++ b/src/algorithm/geo/skew.rs
@@ -136,7 +136,7 @@ pub trait Skew {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Skew for PointArray {
+impl Skew for PointArray<2> {
     fn skew(&self, scale_factor: BroadcastablePrimitive<Float64Type>) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
@@ -273,16 +273,16 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, LineStringBuilder<O>, push_line_string);
-iter_geo_impl!(PolygonArray<O>, PolygonBuilder<O>, push_polygon);
-iter_geo_impl!(MultiPointArray<O>, MultiPointBuilder<O>, push_multi_point);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O>,
-    MultiLineStringBuilder<O>,
+    MultiLineStringArray<O, 2>,
+    MultiLineStringBuilder<O, 2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O>,
-    MultiPolygonBuilder<O>,
+    MultiPolygonArray<O, 2>,
+    MultiPolygonBuilder<O, 2>,
     push_multi_polygon
 );

--- a/src/algorithm/geo/translate.rs
+++ b/src/algorithm/geo/translate.rs
@@ -49,7 +49,7 @@ pub trait Translate {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Translate for PointArray {
+impl Translate for PointArray<2> {
     fn translate(
         &self,
         x_offset: BroadcastablePrimitive<Float64Type>,
@@ -102,16 +102,16 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, LineStringBuilder<O>, push_line_string);
-iter_geo_impl!(PolygonArray<O>, PolygonBuilder<O>, push_polygon);
-iter_geo_impl!(MultiPointArray<O>, MultiPointBuilder<O>, push_multi_point);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O>,
-    MultiLineStringBuilder<O>,
+    MultiLineStringArray<O, 2>,
+    MultiLineStringBuilder<O, 2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O>,
-    MultiPolygonBuilder<O>,
+    MultiPolygonArray<O, 2>,
+    MultiPolygonBuilder<O, 2>,
     push_multi_polygon
 );

--- a/src/algorithm/geo/vincenty_length.rs
+++ b/src/algorithm/geo/vincenty_length.rs
@@ -36,7 +36,7 @@ pub trait VincentyLength {
     ///     // Osaka
     ///     (135.5244559, 34.687455)
     /// ]);
-    /// let linestring_array: LineStringArray<i32> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray<i32, 2> = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.vincenty_length().unwrap();
     ///

--- a/src/algorithm/geo/vincenty_length.rs
+++ b/src/algorithm/geo/vincenty_length.rs
@@ -51,7 +51,7 @@ pub trait VincentyLength {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl VincentyLength for PointArray {
+impl VincentyLength for PointArray<2> {
     type Output = Result<Float64Array>;
 
     fn vincenty_length(&self) -> Self::Output {
@@ -72,7 +72,7 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(MultiPointArray<O>);
+zero_impl!(MultiPointArray<O, 2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -87,8 +87,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>);
 
 impl VincentyLength for &dyn GeometryArrayTrait {
     type Output = Result<Float64Array>;
@@ -119,7 +119,7 @@ impl VincentyLength for &dyn GeometryArrayTrait {
     }
 }
 
-impl VincentyLength for ChunkedGeometryArray<PointArray> {
+impl VincentyLength for ChunkedGeometryArray<PointArray<2>> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn vincenty_length(&self) -> Self::Output {
@@ -140,9 +140,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
 
 impl VincentyLength for &dyn ChunkedGeometryArrayTrait {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -188,7 +188,7 @@ mod tests {
             // London
             (x: -0.1278, y: 51.5074),
         ];
-        let input_array: LineStringArray<i64> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
         let result_array = input_array.vincenty_length().unwrap();
 
         // Meters

--- a/src/algorithm/geo/within.rs
+++ b/src/algorithm/geo/within.rs
@@ -50,7 +50,7 @@ pub trait Within<Other = Self> {
 // └────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl Within for PointArray {
+impl Within for PointArray<2> {
     fn is_within(&self, rhs: &Self) -> BooleanArray {
         assert_eq!(self.len(), rhs.len());
 
@@ -92,59 +92,59 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray, LineStringArray<O>);
-iter_geo_impl!(PointArray, PolygonArray<O>);
-iter_geo_impl!(PointArray, MultiPointArray<O>);
-iter_geo_impl!(PointArray, MultiLineStringArray<O>);
-iter_geo_impl!(PointArray, MultiPolygonArray<O>);
+iter_geo_impl!(PointArray<2>, LineStringArray<O, 2>);
+iter_geo_impl!(PointArray<2>, PolygonArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiPointArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(PointArray<2>, MultiPolygonArray<O, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<O>, PointArray);
-iter_geo_impl!(LineStringArray<O>, LineStringArray<O>);
-iter_geo_impl!(LineStringArray<O>, PolygonArray<O>);
-iter_geo_impl!(LineStringArray<O>, MultiPointArray<O>);
-iter_geo_impl!(LineStringArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(LineStringArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(LineStringArray<O, 2>, PointArray<2>);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<O>, PointArray);
-iter_geo_impl!(PolygonArray<O>, LineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>, PolygonArray<O>);
-iter_geo_impl!(PolygonArray<O>, MultiPointArray<O>);
-iter_geo_impl!(PolygonArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(PolygonArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(PolygonArray<O, 2>, PointArray<2>);
+iter_geo_impl!(PolygonArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(PolygonArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<O>, PointArray);
-iter_geo_impl!(MultiPointArray<O>, LineStringArray<O>);
-iter_geo_impl!(MultiPointArray<O>, PolygonArray<O>);
-iter_geo_impl!(MultiPointArray<O>, MultiPointArray<O>);
-iter_geo_impl!(MultiPointArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(MultiPointArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiPointArray<O, 2>, PointArray<2>);
+iter_geo_impl!(MultiPointArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<O>, PointArray);
-iter_geo_impl!(MultiLineStringArray<O>, LineStringArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>, PolygonArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>, MultiPointArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(MultiLineStringArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, PointArray<2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<O>, PointArray);
-iter_geo_impl!(MultiPolygonArray<O>, LineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>, PolygonArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>, MultiPointArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>, MultiLineStringArray<O>);
-iter_geo_impl!(MultiPolygonArray<O>, MultiPolygonArray<O>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, PointArray<2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, LineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, PolygonArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPointArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, MultiLineStringArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPolygonArray<O, 2>);
 
 // ┌──────────────────────────────────────────┐
 // │ Implementations for RHS geoarrow scalars │
 // └──────────────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl<'a> Within<Point<'a>> for PointArray {
-    fn is_within(&self, rhs: &Point<'a>) -> BooleanArray {
+impl<'a> Within<Point<'a, 2>> for PointArray<2> {
+    fn is_within(&self, rhs: &Point<'a, 2>) -> BooleanArray {
         let mut output_array = BooleanBuilder::with_capacity(self.len());
 
         self.iter_geo().for_each(|maybe_point| {
@@ -176,51 +176,51 @@ macro_rules! iter_geo_impl_geoarrow_scalar {
 }
 
 // Implementations on PointArray
-iter_geo_impl_geoarrow_scalar!(PointArray, LineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(PointArray, Polygon<'a, O>);
-iter_geo_impl_geoarrow_scalar!(PointArray, MultiPoint<'a, O>);
-iter_geo_impl_geoarrow_scalar!(PointArray, MultiLineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(PointArray, MultiPolygon<'a, O>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, LineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, Polygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiPoint<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiLineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O>, Point<'a>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O>, LineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O>, Polygon<'a, O>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O>, MultiPoint<'a, O>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O>, MultiLineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, LineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, Polygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, MultiPoint<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, MultiLineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O>, Point<'a>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O>, LineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O>, Polygon<'a, O>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O>, MultiPoint<'a, O>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O>, MultiLineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, LineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, Polygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, MultiPoint<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, MultiLineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O>, Point<'a>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O>, LineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O>, Polygon<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O>, MultiPoint<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O>, MultiLineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, LineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, Polygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, MultiPoint<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, MultiLineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O>, Point<'a>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O>, LineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O>, Polygon<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O>, MultiPoint<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O>, MultiLineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, LineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, Polygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, MultiPoint<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, MultiLineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O>, Point<'a>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O>, LineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O>, Polygon<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O>, MultiPoint<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O>, MultiLineString<'a, O>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O>, MultiPolygon<'a, O>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, LineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, Polygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, MultiPoint<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, MultiLineString<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, MultiPolygon<'a, O, 2>);
 
 // ┌─────────────────────────────────────┐
 // │ Implementations for RHS geo scalars │
@@ -244,12 +244,12 @@ macro_rules! non_generic_iter_geo_impl_geo_scalar {
 }
 
 // Implementations on PointArray
-non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::Point);
-non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::LineString);
-non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::Polygon);
-non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::MultiPoint);
-non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::MultiLineString);
-non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::MultiPolygon);
+non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::Point);
+non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::LineString);
+non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::Polygon);
+non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::MultiPoint);
+non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::MultiLineString);
+non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::MultiPolygon);
 
 macro_rules! iter_geo_impl_geo_scalar {
     ($first:ty, $second:ty) => {
@@ -269,41 +269,41 @@ macro_rules! iter_geo_impl_geo_scalar {
 }
 
 // Implementations on LineStringArray
-iter_geo_impl_geo_scalar!(LineStringArray<O>, geo::Point);
-iter_geo_impl_geo_scalar!(LineStringArray<O>, geo::LineString);
-iter_geo_impl_geo_scalar!(LineStringArray<O>, geo::Polygon);
-iter_geo_impl_geo_scalar!(LineStringArray<O>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(LineStringArray<O>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(LineStringArray<O>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::Point);
+iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::LineString);
+iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::MultiPolygon);
 
 // Implementations on PolygonArray
-iter_geo_impl_geo_scalar!(PolygonArray<O>, geo::Point);
-iter_geo_impl_geo_scalar!(PolygonArray<O>, geo::LineString);
-iter_geo_impl_geo_scalar!(PolygonArray<O>, geo::Polygon);
-iter_geo_impl_geo_scalar!(PolygonArray<O>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(PolygonArray<O>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(PolygonArray<O>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::Point);
+iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::LineString);
+iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::MultiPolygon);
 
 // Implementations on MultiPointArray
-iter_geo_impl_geo_scalar!(MultiPointArray<O>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiPointArray<O>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiPointArray<O>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiPointArray<O>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiPointArray<O>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiPointArray<O>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::Point);
+iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::MultiPolygon);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::Point);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::MultiPolygon);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::Point);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::MultiPolygon);

--- a/src/algorithm/geo_index/rtree.rs
+++ b/src/algorithm/geo_index/rtree.rs
@@ -24,7 +24,7 @@ pub trait RTree {
     fn create_rtree_with_node_size(&self, node_size: usize) -> Self::Output;
 }
 
-impl RTree for PointArray {
+impl RTree for PointArray<2> {
     type Output = OwnedRTree<f64>;
 
     fn create_rtree_with_node_size(&self, node_size: usize) -> Self::Output {
@@ -76,14 +76,14 @@ macro_rules! impl_rtree {
     };
 }
 
-impl_rtree!(LineStringArray<O>, bounding_rect_linestring);
-impl_rtree!(PolygonArray<O>, bounding_rect_polygon);
-impl_rtree!(MultiPointArray<O>, bounding_rect_multipoint);
-impl_rtree!(MultiLineStringArray<O>, bounding_rect_multilinestring);
-impl_rtree!(MultiPolygonArray<O>, bounding_rect_multipolygon);
-impl_rtree!(MixedGeometryArray<O>, bounding_rect_geometry);
+impl_rtree!(LineStringArray<O, 2>, bounding_rect_linestring);
+impl_rtree!(PolygonArray<O, 2>, bounding_rect_polygon);
+impl_rtree!(MultiPointArray<O, 2>, bounding_rect_multipoint);
+impl_rtree!(MultiLineStringArray<O, 2>, bounding_rect_multilinestring);
+impl_rtree!(MultiPolygonArray<O, 2>, bounding_rect_multipolygon);
+impl_rtree!(MixedGeometryArray<O, 2>, bounding_rect_geometry);
 impl_rtree!(
-    GeometryCollectionArray<O>,
+    GeometryCollectionArray<O, 2>,
     bounding_rect_geometry_collection
 );
 

--- a/src/algorithm/geodesy/mod.rs
+++ b/src/algorithm/geodesy/mod.rs
@@ -4,7 +4,8 @@
 //! [library's documentation][geodesy] for how to construct the projection string to pass into
 //! `reproject`.
 
-mod reproject;
+// TODO: reimplement not based on old GeometryArray enum
+// mod reproject;
 
-pub use geodesy::Direction;
-pub use reproject::reproject;
+// pub use geodesy::Direction;
+// pub use reproject::reproject;

--- a/src/algorithm/geos/area.rs
+++ b/src/algorithm/geos/area.rs
@@ -17,7 +17,7 @@ pub trait Area {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Area for PointArray {
+impl Area for PointArray<2> {
     type Output = Result<Float64Array>;
 
     fn area(&self) -> Self::Output {
@@ -38,9 +38,9 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(LineStringArray<O>);
-zero_impl!(MultiPointArray<O>);
-zero_impl!(MultiLineStringArray<O>);
+zero_impl!(LineStringArray<O, 2>);
+zero_impl!(MultiPointArray<O, 2>);
+zero_impl!(MultiLineStringArray<O, 2>);
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
@@ -54,10 +54,10 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(PolygonArray<O>);
-iter_geos_impl!(MultiPolygonArray<O>);
-iter_geos_impl!(MixedGeometryArray<O>);
-iter_geos_impl!(GeometryCollectionArray<O>);
+iter_geos_impl!(PolygonArray<O, 2>);
+iter_geos_impl!(MultiPolygonArray<O, 2>);
+iter_geos_impl!(MixedGeometryArray<O, 2>);
+iter_geos_impl!(GeometryCollectionArray<O, 2>);
 iter_geos_impl!(WKBArray<O>);
 
 impl Area for &dyn GeometryArrayTrait {

--- a/src/algorithm/geos/buffer.rs
+++ b/src/algorithm/geos/buffer.rs
@@ -13,8 +13,8 @@ pub trait Buffer<O: OffsetSizeTrait> {
     fn buffer_with_params(&self, width: f64, buffer_params: &BufferParams) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> Buffer<O> for PointArray {
-    type Output = Result<PolygonArray<O>>;
+impl<O: OffsetSizeTrait> Buffer<O> for PointArray<2> {
+    type Output = Result<PolygonArray<O, 2>>;
 
     fn buffer(&self, width: f64, quadsegs: i32) -> Self::Output {
         let mut builder = PolygonBuilder::new();
@@ -50,7 +50,7 @@ impl<O: OffsetSizeTrait> Buffer<O> for PointArray {
 }
 
 // // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-// impl Area for PointArray {
+// impl Area for PointArray<2> {
 //     fn area(&self) -> Result<PrimitiveArray<f64>> {
 //         Ok(zeroes(self.len(), self.nulls()))
 //     }
@@ -67,9 +67,9 @@ impl<O: OffsetSizeTrait> Buffer<O> for PointArray {
 //     };
 // }
 
-// zero_impl!(LineStringArray<O>);
-// zero_impl!(MultiPointArray<O>);
-// zero_impl!(MultiLineStringArray<O>);
+// zero_impl!(LineStringArray<O, 2>);
+// zero_impl!(MultiPointArray<O, 2>);
+// zero_impl!(MultiLineStringArray<O, 2>);
 
 // macro_rules! iter_geos_impl {
 //     ($type:ty) => {
@@ -80,11 +80,11 @@ impl<O: OffsetSizeTrait> Buffer<O> for PointArray {
 //     };
 // }
 
-// iter_geos_impl!(PolygonArray<O>);
-// iter_geos_impl!(MultiPolygonArray<O>);
+// iter_geos_impl!(PolygonArray<O, 2>);
+// iter_geos_impl!(MultiPolygonArray<O, 2>);
 // iter_geos_impl!(WKBArray<O>);
 
-// impl<O: OffsetSizeTrait> Area for GeometryArray<O> {
+// impl<O: OffsetSizeTrait> Area for GeometryArray<O, 2> {
 //     crate::geometry_array_delegate_impl! {
 //         fn area(&self) -> Result<PrimitiveArray<f64>>;
 //     }
@@ -98,7 +98,7 @@ mod test {
     #[test]
     fn point_buffer() {
         let arr = point_array();
-        let buffered: PolygonArray<i32> = arr.buffer(1., 8).unwrap();
+        let buffered: PolygonArray<i32, 2> = arr.buffer(1., 8).unwrap();
         dbg!(buffered);
     }
 }

--- a/src/algorithm/geos/is_ring.rs
+++ b/src/algorithm/geos/is_ring.rs
@@ -17,7 +17,7 @@ pub trait IsRing {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl IsRing for PointArray {
+impl IsRing for PointArray<2> {
     type Output = Result<BooleanArray>;
 
     fn is_ring(&self) -> Self::Output {
@@ -57,13 +57,13 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(LineStringArray<O>);
-iter_geos_impl!(MultiPointArray<O>);
-iter_geos_impl!(MultiLineStringArray<O>);
-iter_geos_impl!(PolygonArray<O>);
-iter_geos_impl!(MultiPolygonArray<O>);
-iter_geos_impl!(MixedGeometryArray<O>);
-iter_geos_impl!(GeometryCollectionArray<O>);
+iter_geos_impl!(LineStringArray<O, 2>);
+iter_geos_impl!(MultiPointArray<O, 2>);
+iter_geos_impl!(MultiLineStringArray<O, 2>);
+iter_geos_impl!(PolygonArray<O, 2>);
+iter_geos_impl!(MultiPolygonArray<O, 2>);
+iter_geos_impl!(MixedGeometryArray<O, 2>);
+iter_geos_impl!(GeometryCollectionArray<O, 2>);
 iter_geos_impl!(WKBArray<O>);
 
 impl IsRing for &dyn GeometryArrayTrait {

--- a/src/algorithm/geos/is_valid.rs
+++ b/src/algorithm/geos/is_valid.rs
@@ -17,7 +17,7 @@ pub trait IsValid {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl IsValid for PointArray {
+impl IsValid for PointArray<2> {
     type Output = Result<BooleanArray>;
 
     fn is_valid(&self) -> Self::Output {
@@ -57,13 +57,13 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(LineStringArray<O>);
-iter_geos_impl!(MultiPointArray<O>);
-iter_geos_impl!(MultiLineStringArray<O>);
-iter_geos_impl!(PolygonArray<O>);
-iter_geos_impl!(MultiPolygonArray<O>);
-iter_geos_impl!(MixedGeometryArray<O>);
-iter_geos_impl!(GeometryCollectionArray<O>);
+iter_geos_impl!(LineStringArray<O, 2>);
+iter_geos_impl!(MultiPointArray<O, 2>);
+iter_geos_impl!(MultiLineStringArray<O, 2>);
+iter_geos_impl!(PolygonArray<O, 2>);
+iter_geos_impl!(MultiPolygonArray<O, 2>);
+iter_geos_impl!(MixedGeometryArray<O, 2>);
+iter_geos_impl!(GeometryCollectionArray<O, 2>);
 iter_geos_impl!(WKBArray<O>);
 
 impl IsValid for &dyn GeometryArrayTrait {

--- a/src/algorithm/geos/length.rs
+++ b/src/algorithm/geos/length.rs
@@ -17,7 +17,7 @@ pub trait Length {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Length for PointArray {
+impl Length for PointArray<2> {
     type Output = Result<Float64Array>;
 
     fn length(&self) -> Self::Output {
@@ -37,13 +37,13 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(LineStringArray<O>);
-iter_geos_impl!(MultiPointArray<O>);
-iter_geos_impl!(MultiLineStringArray<O>);
-iter_geos_impl!(PolygonArray<O>);
-iter_geos_impl!(MultiPolygonArray<O>);
-iter_geos_impl!(MixedGeometryArray<O>);
-iter_geos_impl!(GeometryCollectionArray<O>);
+iter_geos_impl!(LineStringArray<O, 2>);
+iter_geos_impl!(MultiPointArray<O, 2>);
+iter_geos_impl!(MultiLineStringArray<O, 2>);
+iter_geos_impl!(PolygonArray<O, 2>);
+iter_geos_impl!(MultiPolygonArray<O, 2>);
+iter_geos_impl!(MixedGeometryArray<O, 2>);
+iter_geos_impl!(GeometryCollectionArray<O, 2>);
 iter_geos_impl!(WKBArray<O>);
 
 impl Length for &dyn GeometryArrayTrait {

--- a/src/algorithm/native/binary.rs
+++ b/src/algorithm/native/binary.rs
@@ -122,293 +122,299 @@ pub trait Binary<'a, Rhs: GeometryArrayAccessor<'a> = Self>: GeometryArrayAccess
     }
 }
 
-// Implementations on PointArray
-impl<'a> Binary<'a, PointArray> for PointArray {}
-impl<'a> Binary<'a, PointArray> for RectArray {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray> for LineStringArray<O> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray> for PolygonArray<O> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray> for MultiPointArray<O> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray> for MultiLineStringArray<O> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray> for MultiPolygonArray<O> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray> for MixedGeometryArray<O> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray> for GeometryCollectionArray<O> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray> for WKBArray<O> {}
+// Implementations on PointArray<2>
+impl<'a> Binary<'a, PointArray<2>> for PointArray<2> {}
+impl<'a> Binary<'a, PointArray<2>> for RectArray {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for LineStringArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for PolygonArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for MultiPointArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for MultiLineStringArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for MultiPolygonArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for MixedGeometryArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for GeometryCollectionArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for WKBArray<O> {}
 
 // Implementations on LineStringArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, LineStringArray<O>> for PointArray {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, LineStringArray<O>> for RectArray {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1>>
-    for LineStringArray<O2>
+impl<'a, O: OffsetSizeTrait> Binary<'a, LineStringArray<O, 2>> for PointArray<2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, LineStringArray<O, 2>> for RectArray {}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
+    for LineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1>>
-    for PolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
+    for PolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1>>
-    for MultiPointArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
+    for MultiPointArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1>>
-    for MultiLineStringArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
+    for MultiLineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1>>
-    for MultiPolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
+    for MultiPolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1>>
-    for MixedGeometryArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
+    for MixedGeometryArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1>>
-    for GeometryCollectionArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
+    for GeometryCollectionArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1>>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
     for WKBArray<O2>
 {
 }
 
 // Implementations on PolygonArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, PolygonArray<O>> for PointArray {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PolygonArray<O>> for RectArray {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1>>
-    for LineStringArray<O2>
+impl<'a, O: OffsetSizeTrait> Binary<'a, PolygonArray<O, 2>> for PointArray<2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, PolygonArray<O, 2>> for RectArray {}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
+    for LineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1>>
-    for PolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
+    for PolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1>>
-    for MultiPointArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
+    for MultiPointArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1>>
-    for MultiLineStringArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
+    for MultiLineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1>>
-    for MultiPolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
+    for MultiPolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1>>
-    for MixedGeometryArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
+    for MixedGeometryArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1>>
-    for GeometryCollectionArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
+    for GeometryCollectionArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1>> for WKBArray<O2> {}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
+    for WKBArray<O2>
+{
+}
 
 // Implementations on MultiPointArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPointArray<O>> for PointArray {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPointArray<O>> for RectArray {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1>>
-    for LineStringArray<O2>
+impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPointArray<O, 2>> for PointArray<2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPointArray<O, 2>> for RectArray {}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
+    for LineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1>>
-    for PolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
+    for PolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1>>
-    for MultiPointArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
+    for MultiPointArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1>>
-    for MultiLineStringArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
+    for MultiLineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1>>
-    for MultiPolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
+    for MultiPolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1>>
-    for MixedGeometryArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
+    for MixedGeometryArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1>>
-    for GeometryCollectionArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
+    for GeometryCollectionArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1>>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
     for WKBArray<O2>
 {
 }
 
 // Implementations on MultiLineStringArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O>> for PointArray {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O>> for RectArray {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1>>
-    for LineStringArray<O2>
+impl<'a, O: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O, 2>> for PointArray<2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O, 2>> for RectArray {}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
+    for LineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1>>
-    for PolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
+    for PolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1>>
-    for MultiPointArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
+    for MultiPointArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1>>
-    for MultiLineStringArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
+    for MultiLineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1>>
-    for MultiPolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
+    for MultiPolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1>>
-    for MixedGeometryArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
+    for MixedGeometryArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1>>
-    for GeometryCollectionArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
+    for GeometryCollectionArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1>>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
     for WKBArray<O2>
 {
 }
 
 // Implementations on MultiPolygonArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O>> for PointArray {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O>> for RectArray {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1>>
-    for LineStringArray<O2>
+impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O, 2>> for PointArray<2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O, 2>> for RectArray {}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
+    for LineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1>>
-    for PolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
+    for PolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1>>
-    for MultiPointArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
+    for MultiPointArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1>>
-    for MultiLineStringArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
+    for MultiLineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1>>
-    for MultiPolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
+    for MultiPolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1>>
-    for MixedGeometryArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
+    for MixedGeometryArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1>>
-    for GeometryCollectionArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
+    for GeometryCollectionArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1>>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
     for WKBArray<O2>
 {
 }
 
 // Implementations on MixedGeometryArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O>> for PointArray {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O>> for RectArray {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1>>
-    for LineStringArray<O2>
+impl<'a, O: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O, 2>> for PointArray<2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O, 2>> for RectArray {}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
+    for LineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1>>
-    for PolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
+    for PolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1>>
-    for MultiPointArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
+    for MultiPointArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1>>
-    for MultiLineStringArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
+    for MultiLineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1>>
-    for MultiPolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
+    for MultiPolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1>>
-    for MixedGeometryArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
+    for MixedGeometryArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1>>
-    for GeometryCollectionArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
+    for GeometryCollectionArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1>>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
     for WKBArray<O2>
 {
 }
 
 // Implementations on GeometryCollectionArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O>> for PointArray {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O>> for RectArray {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1>>
-    for LineStringArray<O2>
+impl<'a, O: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O, 2>> for PointArray<2> {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O, 2>> for RectArray {}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
+    for LineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1>>
-    for PolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
+    for PolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1>>
-    for MultiPointArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
+    for MultiPointArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1>>
-    for MultiLineStringArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
+    for MultiLineStringArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1>>
-    for MultiPolygonArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
+    for MultiPolygonArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1>>
-    for MixedGeometryArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
+    for MixedGeometryArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1>>
-    for GeometryCollectionArray<O2>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
+    for GeometryCollectionArray<O2, 2>
 {
 }
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1>>
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
     for WKBArray<O2>
 {
 }
 
 // Implementations on WKBArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, WKBArray<O>> for PointArray {}
+impl<'a, O: OffsetSizeTrait> Binary<'a, WKBArray<O>> for PointArray<2> {}
 impl<'a, O: OffsetSizeTrait> Binary<'a, WKBArray<O>> for RectArray {}
 impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>>
-    for LineStringArray<O2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>> for PolygonArray<O2> {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>>
-    for MultiPointArray<O2>
+    for LineStringArray<O2, 2>
 {
 }
 impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>>
-    for MultiLineStringArray<O2>
+    for PolygonArray<O2, 2>
 {
 }
 impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>>
-    for MultiPolygonArray<O2>
+    for MultiPointArray<O2, 2>
 {
 }
 impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>>
-    for MixedGeometryArray<O2>
+    for MultiLineStringArray<O2, 2>
 {
 }
 impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>>
-    for GeometryCollectionArray<O2>
+    for MultiPolygonArray<O2, 2>
+{
+}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>>
+    for MixedGeometryArray<O2, 2>
+{
+}
+impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>>
+    for GeometryCollectionArray<O2, 2>
 {
 }
 impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, WKBArray<O1>> for WKBArray<O2> {}

--- a/src/algorithm/native/cast.rs
+++ b/src/algorithm/native/cast.rs
@@ -74,7 +74,7 @@ impl Cast for PointArray<2> {
             MultiPoint(ct) => {
                 let capacity =
                     MultiPointCapacity::new(self.buffer_lengths(), self.buffer_lengths());
-                let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MultiPointBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -86,7 +86,7 @@ impl Cast for PointArray<2> {
             LargeMultiPoint(ct) => {
                 let capacity =
                     MultiPointCapacity::new(self.buffer_lengths(), self.buffer_lengths());
-                let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MultiPointBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -100,7 +100,7 @@ impl Cast for PointArray<2> {
                     point: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -113,7 +113,7 @@ impl Cast for PointArray<2> {
                     point: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -128,7 +128,7 @@ impl Cast for PointArray<2> {
                 };
                 let capacity =
                     GeometryCollectionCapacity::new(mixed_capacity, self.buffer_lengths());
-                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -144,7 +144,7 @@ impl Cast for PointArray<2> {
                 };
                 let capacity =
                     GeometryCollectionCapacity::new(mixed_capacity, self.buffer_lengths());
-                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -166,7 +166,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
         use GeoDataType::*;
         match to_type {
             LineString(ct) => {
-                let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
+                let mut builder = LineStringBuilder::<i32, 2>::with_capacity_and_options(
                     self.buffer_lengths(),
                     *ct,
                     self.metadata(),
@@ -176,7 +176,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
                 Ok(Arc::new(builder.finish()))
             }
             LargeLineString(ct) => {
-                let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
+                let mut builder = LineStringBuilder::<i64, 2>::with_capacity_and_options(
                     self.buffer_lengths(),
                     *ct,
                     self.metadata(),
@@ -188,7 +188,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
             MultiLineString(ct) => {
                 let mut capacity = MultiLineStringCapacity::new_empty();
                 capacity += self.buffer_lengths();
-                let mut builder = MultiLineStringBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MultiLineStringBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -200,7 +200,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
             LargeMultiLineString(ct) => {
                 let mut capacity = MultiLineStringCapacity::new_empty();
                 capacity += self.buffer_lengths();
-                let mut builder = MultiLineStringBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MultiLineStringBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -214,7 +214,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
                     line_string: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -228,7 +228,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
                     line_string: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -243,7 +243,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -258,7 +258,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -280,7 +280,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
         use GeoDataType::*;
         match to_type {
             Polygon(ct) => {
-                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
+                let mut builder = PolygonBuilder::<i32, 2>::with_capacity_and_options(
                     self.buffer_lengths(),
                     *ct,
                     self.metadata(),
@@ -290,7 +290,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
                 Ok(Arc::new(builder.finish()))
             }
             LargePolygon(ct) => {
-                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
+                let mut builder = PolygonBuilder::<i64, 2>::with_capacity_and_options(
                     self.buffer_lengths(),
                     *ct,
                     self.metadata(),
@@ -302,7 +302,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
             MultiPolygon(ct) => {
                 let mut capacity = MultiPolygonCapacity::new_empty();
                 capacity += self.buffer_lengths();
-                let mut builder = MultiPolygonBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MultiPolygonBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -314,7 +314,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
             LargeMultiPolygon(ct) => {
                 let mut capacity = MultiPolygonCapacity::new_empty();
                 capacity += self.buffer_lengths();
-                let mut builder = MultiPolygonBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MultiPolygonBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -328,7 +328,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
                     polygon: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -342,7 +342,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
                     polygon: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -357,7 +357,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -372,7 +372,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -406,7 +406,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O, 2> {
             }
             MultiPoint(ct) => {
                 let capacity = self.buffer_lengths();
-                let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MultiPointBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -417,7 +417,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O, 2> {
             }
             LargeMultiPoint(ct) => {
                 let capacity = self.buffer_lengths();
-                let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MultiPointBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -431,7 +431,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O, 2> {
                     multi_point: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -445,7 +445,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O, 2> {
                     multi_point: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -460,7 +460,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -475,7 +475,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -506,7 +506,7 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O, 2> {
                     coord_capacity: existing_capacity.coord_capacity,
                     geom_capacity: existing_capacity.ring_capacity,
                 };
-                let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
+                let mut builder = LineStringBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -526,7 +526,7 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O, 2> {
                     coord_capacity: existing_capacity.coord_capacity,
                     geom_capacity: existing_capacity.ring_capacity,
                 };
-                let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
+                let mut builder = LineStringBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -541,7 +541,7 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O, 2> {
                     multi_line_string: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -555,7 +555,7 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O, 2> {
                     multi_line_string: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -570,7 +570,7 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -585,7 +585,7 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -617,7 +617,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O, 2> {
                     ring_capacity: existing_capacity.ring_capacity,
                     geom_capacity: existing_capacity.polygon_capacity,
                 };
-                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
+                let mut builder = PolygonBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -638,7 +638,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O, 2> {
                     ring_capacity: existing_capacity.ring_capacity,
                     geom_capacity: existing_capacity.polygon_capacity,
                 };
-                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
+                let mut builder = PolygonBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -653,7 +653,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O, 2> {
                     multi_polygon: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -667,7 +667,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O, 2> {
                     multi_polygon: self.buffer_lengths(),
                     ..Default::default()
                 };
-                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -682,7 +682,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -697,7 +697,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O, 2> {
                     ..Default::default()
                 };
                 let capacity = GeometryCollectionCapacity::new(mixed_capacity, self.len());
-                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -759,7 +759,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity.geom_capacity += buffer_lengths.ring_capacity;
                 }
 
-                let mut builder = LineStringBuilder::<i32>::with_capacity_and_options(
+                let mut builder = LineStringBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -793,7 +793,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity.geom_capacity += buffer_lengths.ring_capacity;
                 }
 
-                let mut builder = LineStringBuilder::<i64>::with_capacity_and_options(
+                let mut builder = LineStringBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -828,7 +828,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity.geom_capacity += buffer_lengths.polygon_capacity;
                 }
 
-                let mut builder = PolygonBuilder::<i32>::with_capacity_and_options(
+                let mut builder = PolygonBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -863,7 +863,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity.geom_capacity += buffer_lengths.polygon_capacity;
                 }
 
-                let mut builder = PolygonBuilder::<i64>::with_capacity_and_options(
+                let mut builder = PolygonBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -892,7 +892,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity.geom_capacity += points.buffer_lengths();
                 }
 
-                let mut builder = MultiPointBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MultiPointBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -921,7 +921,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity.geom_capacity += points.buffer_lengths();
                 }
 
-                let mut builder = MultiPointBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MultiPointBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -948,7 +948,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity += line_strings.buffer_lengths();
                 }
 
-                let mut builder = MultiLineStringBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MultiLineStringBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -975,7 +975,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity += line_strings.buffer_lengths();
                 }
 
-                let mut builder = MultiLineStringBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MultiLineStringBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -1002,7 +1002,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity += polygons.buffer_lengths();
                 }
 
-                let mut builder = MultiPolygonBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MultiPolygonBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -1029,7 +1029,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                     capacity += polygons.buffer_lengths();
                 }
 
-                let mut builder = MultiPolygonBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MultiPolygonBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -1040,7 +1040,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
             }
             Mixed(ct) => {
                 let capacity = self.buffer_lengths();
-                let mut builder = MixedGeometryBuilder::<i32>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -1051,7 +1051,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
             }
             LargeMixed(ct) => {
                 let capacity = self.buffer_lengths();
-                let mut builder = MixedGeometryBuilder::<i64>::with_capacity_and_options(
+                let mut builder = MixedGeometryBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -1062,7 +1062,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
             }
             GeometryCollection(ct) => {
                 let capacity = GeometryCollectionCapacity::new(self.buffer_lengths(), self.len());
-                let mut builder = GeometryCollectionBuilder::<i32>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i32, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -1073,7 +1073,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
             }
             LargeGeometryCollection(ct) => {
                 let capacity = GeometryCollectionCapacity::new(self.buffer_lengths(), self.len());
-                let mut builder = GeometryCollectionBuilder::<i64>::with_capacity_and_options(
+                let mut builder = GeometryCollectionBuilder::<i64, 2>::with_capacity_and_options(
                     capacity,
                     *ct,
                     self.metadata(),
@@ -1209,7 +1209,7 @@ macro_rules! impl_chunked_cast_generic {
     };
 }
 
-impl_chunked_cast_non_generic!(ChunkedPointArray);
+impl_chunked_cast_non_generic!(ChunkedPointArray<2>);
 impl_chunked_cast_non_generic!(ChunkedRectArray);
 impl_chunked_cast_non_generic!(&dyn ChunkedGeometryArrayTrait);
 impl_chunked_cast_generic!(ChunkedLineStringArray<O, 2>);

--- a/src/algorithm/native/cast.rs
+++ b/src/algorithm/native/cast.rs
@@ -56,7 +56,7 @@ pub trait Cast {
     fn cast(&self, to_type: &GeoDataType) -> Self::Output;
 }
 
-impl Cast for PointArray {
+impl Cast for PointArray<2> {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
 
     fn cast(&self, to_type: &GeoDataType) -> Self::Output {
@@ -159,7 +159,7 @@ impl Cast for PointArray {
     }
 }
 
-impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
+impl<O: OffsetSizeTrait> Cast for LineStringArray<O, 2> {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
 
     fn cast(&self, to_type: &GeoDataType) -> Self::Output {
@@ -273,7 +273,7 @@ impl<O: OffsetSizeTrait> Cast for LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
+impl<O: OffsetSizeTrait> Cast for PolygonArray<O, 2> {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
 
     fn cast(&self, to_type: &GeoDataType) -> Self::Output {
@@ -387,7 +387,7 @@ impl<O: OffsetSizeTrait> Cast for PolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Cast for MultiPointArray<O> {
+impl<O: OffsetSizeTrait> Cast for MultiPointArray<O, 2> {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
 
     fn cast(&self, to_type: &GeoDataType) -> Self::Output {
@@ -490,7 +490,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O, 2> {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
 
     fn cast(&self, to_type: &GeoDataType) -> Self::Output {
@@ -600,7 +600,7 @@ impl<O: OffsetSizeTrait> Cast for MultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O> {
+impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O, 2> {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
 
     fn cast(&self, to_type: &GeoDataType) -> Self::Output {
@@ -712,7 +712,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
     type Output = Result<Arc<dyn GeometryArrayTrait>>;
 
     /// TODO: in the future, do more validation before trying to fill all geometries
@@ -1212,10 +1212,10 @@ macro_rules! impl_chunked_cast_generic {
 impl_chunked_cast_non_generic!(ChunkedPointArray);
 impl_chunked_cast_non_generic!(ChunkedRectArray);
 impl_chunked_cast_non_generic!(&dyn ChunkedGeometryArrayTrait);
-impl_chunked_cast_generic!(ChunkedLineStringArray<O>);
-impl_chunked_cast_generic!(ChunkedPolygonArray<O>);
-impl_chunked_cast_generic!(ChunkedMultiPointArray<O>);
-impl_chunked_cast_generic!(ChunkedMultiLineStringArray<O>);
-impl_chunked_cast_generic!(ChunkedMultiPolygonArray<O>);
-impl_chunked_cast_generic!(ChunkedMixedGeometryArray<O>);
-impl_chunked_cast_generic!(ChunkedGeometryCollectionArray<O>);
+impl_chunked_cast_generic!(ChunkedLineStringArray<O, 2>);
+impl_chunked_cast_generic!(ChunkedPolygonArray<O, 2>);
+impl_chunked_cast_generic!(ChunkedMultiPointArray<O, 2>);
+impl_chunked_cast_generic!(ChunkedMultiLineStringArray<O, 2>);
+impl_chunked_cast_generic!(ChunkedMultiPolygonArray<O, 2>);
+impl_chunked_cast_generic!(ChunkedMixedGeometryArray<O, 2>);
+impl_chunked_cast_generic!(ChunkedGeometryCollectionArray<O, 2>);

--- a/src/algorithm/native/concatenate.rs
+++ b/src/algorithm/native/concatenate.rs
@@ -11,8 +11,8 @@ pub trait Concatenate: Sized {
     fn concatenate(&self) -> Self::Output;
 }
 
-impl Concatenate for &[PointArray] {
-    type Output = Result<PointArray>;
+impl Concatenate for &[PointArray<2>] {
+    type Output = Result<PointArray<2>>;
 
     fn concatenate(&self) -> Self::Output {
         let output_capacity = self.iter().fold(0, |sum, val| sum + val.buffer_lengths());
@@ -45,50 +45,50 @@ macro_rules! impl_concatenate {
 }
 
 impl_concatenate!(
-    LineStringArray<O>,
+    LineStringArray<O, 2>,
     LineStringCapacity,
-    LineStringBuilder<O>,
+    LineStringBuilder<O, 2>,
     push_line_string
 );
 impl_concatenate!(
-    PolygonArray<O>,
+    PolygonArray<O, 2>,
     PolygonCapacity,
-    PolygonBuilder<O>,
+    PolygonBuilder<O, 2>,
     push_polygon
 );
 impl_concatenate!(
-    MultiPointArray<O>,
+    MultiPointArray<O, 2>,
     MultiPointCapacity,
-    MultiPointBuilder<O>,
+    MultiPointBuilder<O, 2>,
     push_multi_point
 );
 impl_concatenate!(
-    MultiLineStringArray<O>,
+    MultiLineStringArray<O, 2>,
     MultiLineStringCapacity,
-    MultiLineStringBuilder<O>,
+    MultiLineStringBuilder<O, 2>,
     push_multi_line_string
 );
 impl_concatenate!(
-    MultiPolygonArray<O>,
+    MultiPolygonArray<O, 2>,
     MultiPolygonCapacity,
-    MultiPolygonBuilder<O>,
+    MultiPolygonBuilder<O, 2>,
     push_multi_polygon
 );
 impl_concatenate!(
-    MixedGeometryArray<O>,
+    MixedGeometryArray<O, 2>,
     MixedCapacity,
-    MixedGeometryBuilder<O>,
+    MixedGeometryBuilder<O, 2>,
     push_geometry
 );
 impl_concatenate!(
-    GeometryCollectionArray<O>,
+    GeometryCollectionArray<O, 2>,
     GeometryCollectionCapacity,
-    GeometryCollectionBuilder<O>,
+    GeometryCollectionBuilder<O, 2>,
     push_geometry_collection
 );
 
-impl Concatenate for ChunkedPointArray {
-    type Output = Result<PointArray>;
+impl Concatenate for ChunkedPointArray<2> {
+    type Output = Result<PointArray<2>>;
 
     fn concatenate(&self) -> Self::Output {
         self.chunks.as_slice().concatenate()
@@ -107,13 +107,13 @@ macro_rules! impl_chunked_concatenate {
     };
 }
 
-impl_chunked_concatenate!(ChunkedLineStringArray<O>, LineStringArray<O>);
-impl_chunked_concatenate!(ChunkedPolygonArray<O>, PolygonArray<O>);
-impl_chunked_concatenate!(ChunkedMultiPointArray<O>, MultiPointArray<O>);
-impl_chunked_concatenate!(ChunkedMultiLineStringArray<O>, MultiLineStringArray<O>);
-impl_chunked_concatenate!(ChunkedMultiPolygonArray<O>, MultiPolygonArray<O>);
-impl_chunked_concatenate!(ChunkedMixedGeometryArray<O>, MixedGeometryArray<O>);
+impl_chunked_concatenate!(ChunkedLineStringArray<O, 2>, LineStringArray<O, 2>);
+impl_chunked_concatenate!(ChunkedPolygonArray<O, 2>, PolygonArray<O, 2>);
+impl_chunked_concatenate!(ChunkedMultiPointArray<O, 2>, MultiPointArray<O, 2>);
+impl_chunked_concatenate!(ChunkedMultiLineStringArray<O, 2>, MultiLineStringArray<O, 2>);
+impl_chunked_concatenate!(ChunkedMultiPolygonArray<O, 2>, MultiPolygonArray<O, 2>);
+impl_chunked_concatenate!(ChunkedMixedGeometryArray<O, 2>, MixedGeometryArray<O, 2>);
 impl_chunked_concatenate!(
-    ChunkedGeometryCollectionArray<O>,
-    GeometryCollectionArray<O>
+    ChunkedGeometryCollectionArray<O, 2>,
+    GeometryCollectionArray<O, 2>
 );

--- a/src/algorithm/native/downcast.rs
+++ b/src/algorithm/native/downcast.rs
@@ -38,7 +38,7 @@ pub trait Downcast {
     fn downcast(&self, small_offsets: bool) -> Self::Output;
 }
 
-impl Downcast for PointArray {
+impl Downcast for PointArray<2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -89,7 +89,7 @@ fn can_downcast_multi<O: OffsetSizeTrait>(buffer: &OffsetBuffer<O>) -> bool {
         .all(|slice| *slice.get(1).unwrap() - *slice.first().unwrap() <= O::one())
 }
 
-impl<O: OffsetSizeTrait> Downcast for LineStringArray<O> {
+impl<O: OffsetSizeTrait> Downcast for LineStringArray<O, 2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -118,7 +118,7 @@ impl<O: OffsetSizeTrait> Downcast for LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Downcast for PolygonArray<O> {
+impl<O: OffsetSizeTrait> Downcast for PolygonArray<O, 2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -140,7 +140,7 @@ impl<O: OffsetSizeTrait> Downcast for PolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Downcast for MultiPointArray<O> {
+impl<O: OffsetSizeTrait> Downcast for MultiPointArray<O, 2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -179,7 +179,7 @@ impl<O: OffsetSizeTrait> Downcast for MultiPointArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Downcast for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait> Downcast for MultiLineStringArray<O, 2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -220,7 +220,7 @@ impl<O: OffsetSizeTrait> Downcast for MultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Downcast for MultiPolygonArray<O> {
+impl<O: OffsetSizeTrait> Downcast for MultiPolygonArray<O, 2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -262,7 +262,7 @@ impl<O: OffsetSizeTrait> Downcast for MultiPolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Downcast for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait> Downcast for MixedGeometryArray<O, 2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -425,7 +425,7 @@ impl<O: OffsetSizeTrait> Downcast for MixedGeometryArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Downcast for GeometryCollectionArray<O> {
+impl<O: OffsetSizeTrait> Downcast for GeometryCollectionArray<O, 2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -564,7 +564,7 @@ fn resolve_types(types: &HashSet<GeoDataType>) -> GeoDataType {
     }
 }
 
-impl Downcast for ChunkedPointArray {
+impl Downcast for ChunkedPointArray<2> {
     type Output = Arc<dyn ChunkedGeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
@@ -600,13 +600,13 @@ macro_rules! impl_chunked_downcast {
     };
 }
 
-impl_chunked_downcast!(ChunkedLineStringArray<O>);
-impl_chunked_downcast!(ChunkedPolygonArray<O>);
-impl_chunked_downcast!(ChunkedMultiPointArray<O>);
-impl_chunked_downcast!(ChunkedMultiLineStringArray<O>);
-impl_chunked_downcast!(ChunkedMultiPolygonArray<O>);
-impl_chunked_downcast!(ChunkedMixedGeometryArray<O>);
-impl_chunked_downcast!(ChunkedGeometryCollectionArray<O>);
+impl_chunked_downcast!(ChunkedLineStringArray<O, 2>);
+impl_chunked_downcast!(ChunkedPolygonArray<O, 2>);
+impl_chunked_downcast!(ChunkedMultiPointArray<O, 2>);
+impl_chunked_downcast!(ChunkedMultiLineStringArray<O, 2>);
+impl_chunked_downcast!(ChunkedMultiPolygonArray<O, 2>);
+impl_chunked_downcast!(ChunkedMixedGeometryArray<O, 2>);
+impl_chunked_downcast!(ChunkedGeometryCollectionArray<O, 2>);
 
 impl Downcast for ChunkedRectArray {
     type Output = Arc<dyn ChunkedGeometryArrayTrait>;
@@ -737,7 +737,7 @@ impl DowncastTable for Table {
     }
 }
 
-// impl<O: OffsetSizeTrait> Downcast for ChunkedMultiPointArray<O> {
+// impl<O: OffsetSizeTrait> Downcast for ChunkedMultiPointArray<O, 2> {
 //     type Output = Arc<dyn ChunkedGeometryArrayTrait>;
 
 //     fn downcast(&self) -> Self::Output {

--- a/src/algorithm/native/explode.rs
+++ b/src/algorithm/native/explode.rs
@@ -22,7 +22,7 @@ pub trait Explode {
     fn explode(&self) -> Self::Output;
 }
 
-impl Explode for PointArray {
+impl Explode for PointArray<2> {
     type Output = (Self, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
@@ -30,7 +30,7 @@ impl Explode for PointArray {
     }
 }
 
-impl<O: OffsetSizeTrait> Explode for LineStringArray<O> {
+impl<O: OffsetSizeTrait> Explode for LineStringArray<O, 2> {
     type Output = (Self, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
@@ -38,7 +38,7 @@ impl<O: OffsetSizeTrait> Explode for LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Explode for PolygonArray<O> {
+impl<O: OffsetSizeTrait> Explode for PolygonArray<O, 2> {
     type Output = (Self, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
@@ -68,8 +68,8 @@ fn explode_offsets<O: OffsetSizeTrait>(offsets: &OffsetBuffer<O>) -> Int32Array 
     Int32Array::new(take_indices.into(), None)
 }
 
-impl<O: OffsetSizeTrait> Explode for MultiPointArray<O> {
-    type Output = (PointArray, Option<Int32Array>);
+impl<O: OffsetSizeTrait> Explode for MultiPointArray<O, 2> {
+    type Output = (PointArray<2>, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
         assert_eq!(
@@ -84,8 +84,8 @@ impl<O: OffsetSizeTrait> Explode for MultiPointArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Explode for MultiLineStringArray<O> {
-    type Output = (LineStringArray<O>, Option<Int32Array>);
+impl<O: OffsetSizeTrait> Explode for MultiLineStringArray<O, 2> {
+    type Output = (LineStringArray<O, 2>, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
         assert_eq!(
@@ -105,8 +105,8 @@ impl<O: OffsetSizeTrait> Explode for MultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Explode for MultiPolygonArray<O> {
-    type Output = (PolygonArray<O>, Option<Int32Array>);
+impl<O: OffsetSizeTrait> Explode for MultiPolygonArray<O, 2> {
+    type Output = (PolygonArray<O, 2>, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
         assert_eq!(

--- a/src/algorithm/native/map_coords.rs
+++ b/src/algorithm/native/map_coords.rs
@@ -44,7 +44,7 @@ impl MapCoords for Coord<'_, 2> {
     }
 }
 
-impl MapCoords for Point<'_> {
+impl MapCoords for Point<'_, 2> {
     type Output = geo::Point;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -56,7 +56,7 @@ impl MapCoords for Point<'_> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for LineString<'_, O> {
+impl<O: OffsetSizeTrait> MapCoords for LineString<'_, O, 2> {
     type Output = geo::LineString;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -72,7 +72,7 @@ impl<O: OffsetSizeTrait> MapCoords for LineString<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for Polygon<'_, O> {
+impl<O: OffsetSizeTrait> MapCoords for Polygon<'_, O, 2> {
     type Output = geo::Polygon;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -94,7 +94,7 @@ impl<O: OffsetSizeTrait> MapCoords for Polygon<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiPoint<'_, O> {
+impl<O: OffsetSizeTrait> MapCoords for MultiPoint<'_, O, 2> {
     type Output = geo::MultiPoint;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -110,7 +110,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPoint<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiLineString<'_, O> {
+impl<O: OffsetSizeTrait> MapCoords for MultiLineString<'_, O, 2> {
     type Output = geo::MultiLineString;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -126,7 +126,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiLineString<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiPolygon<'_, O> {
+impl<O: OffsetSizeTrait> MapCoords for MultiPolygon<'_, O, 2> {
     // TODO: support empty polygons within a multi polygon
     type Output = geo::MultiPolygon;
 
@@ -143,7 +143,7 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPolygon<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for Geometry<'_, O> {
+impl<O: OffsetSizeTrait> MapCoords for Geometry<'_, O, 2> {
     type Output = geo::Geometry;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -176,7 +176,7 @@ impl<O: OffsetSizeTrait> MapCoords for Geometry<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for GeometryCollection<'_, O> {
+impl<O: OffsetSizeTrait> MapCoords for GeometryCollection<'_, O, 2> {
     type Output = geo::GeometryCollection;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -213,8 +213,8 @@ impl MapCoords for Rect<'_> {
     }
 }
 
-impl MapCoords for PointArray {
-    type Output = PointArray;
+impl MapCoords for PointArray<2> {
+    type Output = PointArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -238,8 +238,8 @@ impl MapCoords for PointArray {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for LineStringArray<O> {
-    type Output = LineStringArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for LineStringArray<O, 2> {
+    type Output = LineStringArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -263,8 +263,8 @@ impl<O: OffsetSizeTrait> MapCoords for LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for PolygonArray<O> {
-    type Output = PolygonArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for PolygonArray<O, 2> {
+    type Output = PolygonArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -288,8 +288,8 @@ impl<O: OffsetSizeTrait> MapCoords for PolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiPointArray<O> {
-    type Output = MultiPointArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for MultiPointArray<O, 2> {
+    type Output = MultiPointArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -313,8 +313,8 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPointArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiLineStringArray<O> {
-    type Output = MultiLineStringArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for MultiLineStringArray<O, 2> {
+    type Output = MultiLineStringArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -338,8 +338,8 @@ impl<O: OffsetSizeTrait> MapCoords for MultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiPolygonArray<O> {
-    type Output = MultiPolygonArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for MultiPolygonArray<O, 2> {
+    type Output = MultiPolygonArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -363,8 +363,8 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MixedGeometryArray<O> {
-    type Output = MixedGeometryArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for MixedGeometryArray<O, 2> {
+    type Output = MixedGeometryArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -388,8 +388,8 @@ impl<O: OffsetSizeTrait> MapCoords for MixedGeometryArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for GeometryCollectionArray<O> {
-    type Output = GeometryCollectionArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for GeometryCollectionArray<O, 2> {
+    type Output = GeometryCollectionArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -483,8 +483,8 @@ impl MapCoords for &dyn GeometryArrayTrait {
     }
 }
 
-impl MapCoords for ChunkedPointArray {
-    type Output = ChunkedPointArray;
+impl MapCoords for ChunkedPointArray<2> {
+    type Output = ChunkedPointArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -497,8 +497,8 @@ impl MapCoords for ChunkedPointArray {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedLineStringArray<O> {
-    type Output = ChunkedLineStringArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for ChunkedLineStringArray<O, 2> {
+    type Output = ChunkedLineStringArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -511,8 +511,8 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedPolygonArray<O> {
-    type Output = ChunkedPolygonArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for ChunkedPolygonArray<O, 2> {
+    type Output = ChunkedPolygonArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -525,8 +525,8 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedPolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPointArray<O> {
-    type Output = ChunkedMultiPointArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPointArray<O, 2> {
+    type Output = ChunkedMultiPointArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -539,8 +539,8 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPointArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiLineStringArray<O> {
-    type Output = ChunkedMultiLineStringArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiLineStringArray<O, 2> {
+    type Output = ChunkedMultiLineStringArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -553,8 +553,8 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPolygonArray<O> {
-    type Output = ChunkedMultiPolygonArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPolygonArray<O, 2> {
+    type Output = ChunkedMultiPolygonArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -567,8 +567,8 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedMixedGeometryArray<O> {
-    type Output = ChunkedMixedGeometryArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for ChunkedMixedGeometryArray<O, 2> {
+    type Output = ChunkedMixedGeometryArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -581,8 +581,8 @@ impl<O: OffsetSizeTrait> MapCoords for ChunkedMixedGeometryArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedGeometryCollectionArray<O> {
-    type Output = ChunkedGeometryCollectionArray<O>;
+impl<O: OffsetSizeTrait> MapCoords for ChunkedGeometryCollectionArray<O, 2> {
+    type Output = ChunkedGeometryCollectionArray<O, 2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where

--- a/src/algorithm/native/rechunk.rs
+++ b/src/algorithm/native/rechunk.rs
@@ -18,8 +18,8 @@ pub trait Rechunk {
     // }
 }
 
-impl Rechunk for PointArray {
-    type Output = ChunkedGeometryArray<PointArray>;
+impl Rechunk for PointArray<2> {
+    type Output = ChunkedGeometryArray<PointArray<2>>;
 
     fn rechunk(&self, ranges: &[Range<usize>]) -> Self::Output {
         let mut output_arrays = Vec::with_capacity(ranges.len());
@@ -58,15 +58,15 @@ macro_rules! rechunk_impl {
     };
 }
 
-rechunk_impl!(LineStringArray<O>);
-rechunk_impl!(PolygonArray<O>);
-rechunk_impl!(MultiPointArray<O>);
-rechunk_impl!(MultiLineStringArray<O>);
-rechunk_impl!(MultiPolygonArray<O>);
-rechunk_impl!(MixedGeometryArray<O>);
-rechunk_impl!(GeometryCollectionArray<O>);
+rechunk_impl!(LineStringArray<O, 2>);
+rechunk_impl!(PolygonArray<O, 2>);
+rechunk_impl!(MultiPointArray<O, 2>);
+rechunk_impl!(MultiLineStringArray<O, 2>);
+rechunk_impl!(MultiPolygonArray<O, 2>);
+rechunk_impl!(MixedGeometryArray<O, 2>);
+rechunk_impl!(GeometryCollectionArray<O, 2>);
 
-// impl<O: OffsetSizeTrait> Rechunk for LineStringArray<O> {
+// impl<O: OffsetSizeTrait> Rechunk for LineStringArray<O, 2> {
 //     type Output = Result<ChunkedGeometryArray<Self>>;
 
 //     fn rechunk(&self, ranges: &[Range<usize>]) -> Self::Output {

--- a/src/algorithm/native/take.rs
+++ b/src/algorithm/native/take.rs
@@ -19,7 +19,7 @@ pub trait Take {
     fn take_range(&self, range: &Range<usize>) -> Self::Output;
 }
 
-impl Take for PointArray {
+impl Take for PointArray<2> {
     type Output = Self;
 
     fn take(&self, indices: &UInt32Array) -> Self::Output {
@@ -107,37 +107,37 @@ macro_rules! take_impl {
 }
 
 take_impl!(
-    LineStringArray<O>,
+    LineStringArray<O, 2>,
     LineStringCapacity,
-    LineStringBuilder<O>,
+    LineStringBuilder<O, 2>,
     add_line_string,
     push_line_string
 );
 take_impl!(
-    PolygonArray<O>,
+    PolygonArray<O, 2>,
     PolygonCapacity,
-    PolygonBuilder<O>,
+    PolygonBuilder<O, 2>,
     add_polygon,
     push_polygon
 );
 take_impl!(
-    MultiPointArray<O>,
+    MultiPointArray<O, 2>,
     MultiPointCapacity,
-    MultiPointBuilder<O>,
+    MultiPointBuilder<O, 2>,
     add_multi_point,
     push_multi_point
 );
 take_impl!(
-    MultiLineStringArray<O>,
+    MultiLineStringArray<O, 2>,
     MultiLineStringCapacity,
-    MultiLineStringBuilder<O>,
+    MultiLineStringBuilder<O, 2>,
     add_multi_line_string,
     push_multi_line_string
 );
 take_impl!(
-    MultiPolygonArray<O>,
+    MultiPolygonArray<O, 2>,
     MultiPolygonCapacity,
-    MultiPolygonBuilder<O>,
+    MultiPolygonBuilder<O, 2>,
     add_multi_polygon,
     push_multi_polygon
 );
@@ -195,16 +195,16 @@ macro_rules! take_impl_fallible {
 }
 
 take_impl_fallible!(
-    MixedGeometryArray<O>,
+    MixedGeometryArray<O, 2>,
     MixedCapacity,
-    MixedGeometryBuilder<O>,
+    MixedGeometryBuilder<O, 2>,
     add_geometry,
     push_geometry
 );
 take_impl_fallible!(
-    GeometryCollectionArray<O>,
+    GeometryCollectionArray<O, 2>,
     GeometryCollectionCapacity,
-    GeometryCollectionBuilder<O>,
+    GeometryCollectionBuilder<O, 2>,
     add_geometry_collection,
     push_geometry_collection
 );
@@ -279,8 +279,8 @@ impl Take for &dyn GeometryArrayTrait {
     }
 }
 
-impl Take for ChunkedGeometryArray<PointArray> {
-    type Output = Result<ChunkedGeometryArray<PointArray>>;
+impl Take for ChunkedGeometryArray<PointArray<2>> {
+    type Output = Result<ChunkedGeometryArray<PointArray<2>>>;
 
     fn take(&self, indices: &UInt32Array) -> Self::Output {
         let mut output_chunks = Vec::with_capacity(self.chunks.len());
@@ -328,10 +328,10 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O>>);
-chunked_impl!(ChunkedGeometryArray<MixedGeometryArray<O>>);
-chunked_impl!(ChunkedGeometryArray<GeometryCollectionArray<O>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<MixedGeometryArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<GeometryCollectionArray<O, 2>>);

--- a/src/algorithm/native/total_bounds.rs
+++ b/src/algorithm/native/total_bounds.rs
@@ -12,7 +12,7 @@ pub trait TotalBounds {
     fn total_bounds(&self) -> BoundingRect;
 }
 
-impl TotalBounds for PointArray {
+impl TotalBounds for PointArray<2> {
     fn total_bounds(&self) -> BoundingRect {
         let mut bounds = BoundingRect::new();
         for geom in self.iter().flatten() {
@@ -46,13 +46,13 @@ macro_rules! impl_array {
     };
 }
 
-impl_array!(LineStringArray<O>, add_line_string);
-impl_array!(PolygonArray<O>, add_polygon);
-impl_array!(MultiPointArray<O>, add_multi_point);
-impl_array!(MultiLineStringArray<O>, add_multi_line_string);
-impl_array!(MultiPolygonArray<O>, add_multi_polygon);
-impl_array!(MixedGeometryArray<O>, add_geometry);
-impl_array!(GeometryCollectionArray<O>, add_geometry_collection);
+impl_array!(LineStringArray<O, 2>, add_line_string);
+impl_array!(PolygonArray<O, 2>, add_polygon);
+impl_array!(MultiPointArray<O, 2>, add_multi_point);
+impl_array!(MultiLineStringArray<O, 2>, add_multi_line_string);
+impl_array!(MultiPolygonArray<O, 2>, add_multi_polygon);
+impl_array!(MixedGeometryArray<O, 2>, add_geometry);
+impl_array!(GeometryCollectionArray<O, 2>, add_geometry_collection);
 
 impl<O: OffsetSizeTrait> TotalBounds for WKBArray<O> {
     fn total_bounds(&self) -> BoundingRect {

--- a/src/algorithm/native/type_id.rs
+++ b/src/algorithm/native/type_id.rs
@@ -39,7 +39,7 @@ pub trait TypeIds {
     fn get_unique_type_ids(&self) -> HashSet<i8>;
 }
 
-impl TypeIds for PointArray {
+impl TypeIds for PointArray<2> {
     fn get_type_ids(&self) -> Int8Array {
         let values = vec![0i8; self.len()];
         Int8Array::new(values.into(), self.nulls().cloned())
@@ -69,13 +69,13 @@ macro_rules! constant_impl {
     };
 }
 
-constant_impl!(LineStringArray<O>, 1);
-constant_impl!(PolygonArray<O>, 3);
-constant_impl!(MultiPointArray<O>, 4);
-constant_impl!(MultiLineStringArray<O>, 5);
-constant_impl!(MultiPolygonArray<O>, 6);
+constant_impl!(LineStringArray<O, 2>, 1);
+constant_impl!(PolygonArray<O, 2>, 3);
+constant_impl!(MultiPointArray<O, 2>, 4);
+constant_impl!(MultiLineStringArray<O, 2>, 5);
+constant_impl!(MultiPolygonArray<O, 2>, 6);
 
-impl<O: OffsetSizeTrait> TypeIds for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait> TypeIds for MixedGeometryArray<O, 2> {
     fn get_type_ids(&self) -> Int8Array {
         use crate::scalar::Geometry::*;
 

--- a/src/algorithm/native/unary.rs
+++ b/src/algorithm/native/unary.rs
@@ -85,7 +85,7 @@ pub trait Unary<'a>: GeometryArrayAccessor<'a> {
         Ok(BooleanArray::new(buffer.finish(), nulls))
     }
 
-    fn unary_point<F, G>(&'a self, op: F) -> PointArray
+    fn unary_point<F, G>(&'a self, op: F) -> PointArray<2>
     where
         G: PointTrait<T = f64> + 'a,
         F: Fn(Self::Item) -> &'a G,
@@ -99,7 +99,7 @@ pub trait Unary<'a>: GeometryArrayAccessor<'a> {
         result
     }
 
-    fn try_unary_point<F, G, E>(&'a self, op: F) -> std::result::Result<PointArray, E>
+    fn try_unary_point<F, G, E>(&'a self, op: F) -> std::result::Result<PointArray<2>, E>
     where
         G: PointTrait<T = f64> + 'a,
         F: Fn(Self::Item) -> std::result::Result<G, E>,
@@ -119,13 +119,13 @@ pub trait Unary<'a>: GeometryArrayAccessor<'a> {
     }
 }
 
-impl<'a> Unary<'a> for PointArray {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for LineStringArray<O> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for PolygonArray<O> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiPointArray<O> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiLineStringArray<O> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiPolygonArray<O> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for MixedGeometryArray<O> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for GeometryCollectionArray<O> {}
+impl<'a> Unary<'a> for PointArray<2> {}
+impl<'a, O: OffsetSizeTrait> Unary<'a> for LineStringArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Unary<'a> for PolygonArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiPointArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiLineStringArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiPolygonArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Unary<'a> for MixedGeometryArray<O, 2> {}
+impl<'a, O: OffsetSizeTrait> Unary<'a> for GeometryCollectionArray<O, 2> {}
 impl<'a> Unary<'a> for RectArray {}
 impl<'a, O: OffsetSizeTrait> Unary<'a> for WKBArray<O> {}

--- a/src/algorithm/polylabel.rs
+++ b/src/algorithm/polylabel.rs
@@ -26,8 +26,8 @@ pub trait Polylabel {
     fn polylabel(&self, tolerance: f64) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> Polylabel for PolygonArray<O> {
-    type Output = Result<PointArray>;
+impl<O: OffsetSizeTrait> Polylabel for PolygonArray<O, 2> {
+    type Output = Result<PointArray<2>>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         Ok(self.try_unary_point(|geom| polylabel(&geom.to_geo(), &tolerance))?)
@@ -35,7 +35,7 @@ impl<O: OffsetSizeTrait> Polylabel for PolygonArray<O> {
 }
 
 impl Polylabel for &dyn GeometryArrayTrait {
-    type Output = Result<PointArray>;
+    type Output = Result<PointArray<2>>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         match self.data_type() {
@@ -46,8 +46,8 @@ impl Polylabel for &dyn GeometryArrayTrait {
     }
 }
 
-impl<O: OffsetSizeTrait> Polylabel for ChunkedPolygonArray<O> {
-    type Output = Result<ChunkedPointArray>;
+impl<O: OffsetSizeTrait> Polylabel for ChunkedPolygonArray<O, 2> {
+    type Output = Result<ChunkedPointArray<2>>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         let chunks = self.try_map(|chunk| chunk.polylabel(tolerance))?;
@@ -56,7 +56,7 @@ impl<O: OffsetSizeTrait> Polylabel for ChunkedPolygonArray<O> {
 }
 
 impl Polylabel for &dyn ChunkedGeometryArrayTrait {
-    type Output = Result<ChunkedPointArray>;
+    type Output = Result<ChunkedPointArray<2>>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         match self.data_type() {

--- a/src/algorithm/proj.rs
+++ b/src/algorithm/proj.rs
@@ -14,7 +14,7 @@ pub trait Reproject {
         Self: Sized;
 }
 
-impl Reproject for PointArray {
+impl Reproject for PointArray<2> {
     fn reproject(&self, proj: &Proj) -> Result<Self> {
         let mut output_array = PointBuilder::with_capacity(self.len());
 
@@ -52,17 +52,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O>, LineStringBuilder<O>, push_line_string);
-iter_geo_impl!(PolygonArray<O>, PolygonBuilder<O>, push_polygon);
-iter_geo_impl!(MultiPointArray<O>, MultiPointBuilder<O>, push_multi_point);
+iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
+iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
+iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O>,
-    MultiLineStringBuilder<O>,
+    MultiLineStringArray<O, 2>,
+    MultiLineStringBuilder<O, 2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O>,
-    MultiPolygonBuilder<O>,
+    MultiPolygonArray<O, 2>,
+    MultiPolygonBuilder<O, 2>,
     push_multi_polygon
 );
 
@@ -76,7 +76,7 @@ mod test {
 
     #[test]
     fn point_round_trip() {
-        let point_array: PointArray = vec![Some(p0()), Some(p1()), Some(p2())].into();
+        let point_array: PointArray<2> = vec![Some(p0()), Some(p1()), Some(p2())].into();
         let proj = Proj::new_known_crs("EPSG:4326", "EPSG:3857", None).unwrap();
 
         // You can verify this with PROJ on the command line:

--- a/src/algorithm/rstar.rs
+++ b/src/algorithm/rstar.rs
@@ -14,8 +14,8 @@ pub trait RTree<'a> {
     fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject>;
 }
 
-impl<'a> RTree<'a> for PointArray {
-    type RTreeObject = crate::scalar::Point<'a>;
+impl<'a> RTree<'a> for PointArray<2> {
+    type RTreeObject = crate::scalar::Point<'a, 2>;
 
     fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject> {
         // Note: for points we don't memoize with CachedEnvelope
@@ -44,17 +44,17 @@ macro_rules! iter_cached_impl {
     };
 }
 
-iter_cached_impl!(LineStringArray<O>, crate::scalar::LineString<'a, O>);
-iter_cached_impl!(PolygonArray<O>, crate::scalar::Polygon<'a, O>);
-iter_cached_impl!(MultiPointArray<O>, crate::scalar::MultiPoint<'a, O>);
+iter_cached_impl!(LineStringArray<O, 2>, crate::scalar::LineString<'a, O, 2>);
+iter_cached_impl!(PolygonArray<O, 2>, crate::scalar::Polygon<'a, O, 2>);
+iter_cached_impl!(MultiPointArray<O, 2>, crate::scalar::MultiPoint<'a, O, 2>);
 iter_cached_impl!(
-    MultiLineStringArray<O>,
-    crate::scalar::MultiLineString<'a, O>
+    MultiLineStringArray<O, 2>,
+    crate::scalar::MultiLineString<'a, O, 2>
 );
-iter_cached_impl!(MultiPolygonArray<O>, crate::scalar::MultiPolygon<'a, O>);
+iter_cached_impl!(MultiPolygonArray<O, 2>, crate::scalar::MultiPolygon<'a, O, 2>);
 iter_cached_impl!(WKBArray<O>, crate::scalar::WKB<'a, O>);
-iter_cached_impl!(MixedGeometryArray<O>, crate::scalar::Geometry<'a, O>);
+iter_cached_impl!(MixedGeometryArray<O, 2>, crate::scalar::Geometry<'a, O, 2>);
 iter_cached_impl!(
-    GeometryCollectionArray<O>,
-    crate::scalar::GeometryCollection<'a, O>
+    GeometryCollectionArray<O, 2>,
+    crate::scalar::GeometryCollection<'a, O, 2>
 );

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -155,7 +155,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for WKBArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for WKBArray<O> {
+impl<O: OffsetSizeTrait> GeometryArraySelfMethods<2> for WKBArray<O> {
     fn with_coords(self, _coords: crate::array::CoordBuffer<2>) -> Self {
         unimplemented!()
     }

--- a/src/array/cast.rs
+++ b/src/array/cast.rs
@@ -4,145 +4,145 @@ use crate::chunked_array::*;
 /// Helpers for downcasting a [`GeometryArrayTrait`] to a concrete implementation.
 pub trait AsGeometryArray {
     /// Downcast this to a [`PointArray`] returning `None` if not possible
-    fn as_point_opt(&self) -> Option<&PointArray>;
+    fn as_point_opt(&self) -> Option<&PointArray<2>>;
 
     /// Downcast this to a [`PointArray`] panicking if not possible
     #[inline]
-    fn as_point(&self) -> &PointArray {
+    fn as_point(&self) -> &PointArray<2> {
         self.as_point_opt().unwrap()
     }
 
     /// Downcast this to a [`LineStringArray`] with `i32` offsets returning `None` if not possible
-    fn as_line_string_opt(&self) -> Option<&LineStringArray<i32>>;
+    fn as_line_string_opt(&self) -> Option<&LineStringArray<i32, 2>>;
 
     /// Downcast this to a [`LineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_line_string(&self) -> &LineStringArray<i32> {
+    fn as_line_string(&self) -> &LineStringArray<i32, 2> {
         self.as_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`LineStringArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_line_string_opt(&self) -> Option<&LineStringArray<i64>>;
+    fn as_large_line_string_opt(&self) -> Option<&LineStringArray<i64, 2>>;
 
     /// Downcast this to a [`LineStringArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_line_string(&self) -> &LineStringArray<i64> {
+    fn as_large_line_string(&self) -> &LineStringArray<i64, 2> {
         self.as_large_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`PolygonArray`] with `i32` offsets returning `None` if not possible
-    fn as_polygon_opt(&self) -> Option<&PolygonArray<i32>>;
+    fn as_polygon_opt(&self) -> Option<&PolygonArray<i32, 2>>;
 
     /// Downcast this to a [`PolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_polygon(&self) -> &PolygonArray<i32> {
+    fn as_polygon(&self) -> &PolygonArray<i32, 2> {
         self.as_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`PolygonArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_polygon_opt(&self) -> Option<&PolygonArray<i64>>;
+    fn as_large_polygon_opt(&self) -> Option<&PolygonArray<i64, 2>>;
 
     /// Downcast this to a [`PolygonArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_polygon(&self) -> &PolygonArray<i64> {
+    fn as_large_polygon(&self) -> &PolygonArray<i64, 2> {
         self.as_large_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiPointArray`] with `i32` offsets returning `None` if not possible
-    fn as_multi_point_opt(&self) -> Option<&MultiPointArray<i32>>;
+    fn as_multi_point_opt(&self) -> Option<&MultiPointArray<i32, 2>>;
 
     /// Downcast this to a [`MultiPointArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_point(&self) -> &MultiPointArray<i32> {
+    fn as_multi_point(&self) -> &MultiPointArray<i32, 2> {
         self.as_multi_point_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiPointArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_multi_point_opt(&self) -> Option<&MultiPointArray<i64>>;
+    fn as_large_multi_point_opt(&self) -> Option<&MultiPointArray<i64, 2>>;
 
     /// Downcast this to a [`MultiPointArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_multi_point(&self) -> &MultiPointArray<i64> {
+    fn as_large_multi_point(&self) -> &MultiPointArray<i64, 2> {
         self.as_large_multi_point_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiLineStringArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_line_string_opt(&self) -> Option<&MultiLineStringArray<i32>>;
+    fn as_multi_line_string_opt(&self) -> Option<&MultiLineStringArray<i32, 2>>;
 
     /// Downcast this to a [`MultiLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_line_string(&self) -> &MultiLineStringArray<i32> {
+    fn as_multi_line_string(&self) -> &MultiLineStringArray<i32, 2> {
         self.as_multi_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiLineStringArray`] with `i64` offsets returning `None` if not
     /// possible
-    fn as_large_multi_line_string_opt(&self) -> Option<&MultiLineStringArray<i64>>;
+    fn as_large_multi_line_string_opt(&self) -> Option<&MultiLineStringArray<i64, 2>>;
 
     /// Downcast this to a [`MultiLineStringArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_multi_line_string(&self) -> &MultiLineStringArray<i64> {
+    fn as_large_multi_line_string(&self) -> &MultiLineStringArray<i64, 2> {
         self.as_large_multi_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiPolygonArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_polygon_opt(&self) -> Option<&MultiPolygonArray<i32>>;
+    fn as_multi_polygon_opt(&self) -> Option<&MultiPolygonArray<i32, 2>>;
 
     /// Downcast this to a [`MultiPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_polygon(&self) -> &MultiPolygonArray<i32> {
+    fn as_multi_polygon(&self) -> &MultiPolygonArray<i32, 2> {
         self.as_multi_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiPolygonArray`] with `i64` offsets returning `None` if not
     /// possible
-    fn as_large_multi_polygon_opt(&self) -> Option<&MultiPolygonArray<i64>>;
+    fn as_large_multi_polygon_opt(&self) -> Option<&MultiPolygonArray<i64, 2>>;
 
     /// Downcast this to a [`MultiPolygonArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_multi_polygon(&self) -> &MultiPolygonArray<i64> {
+    fn as_large_multi_polygon(&self) -> &MultiPolygonArray<i64, 2> {
         self.as_large_multi_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`MixedGeometryArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_mixed_opt(&self) -> Option<&MixedGeometryArray<i32>>;
+    fn as_mixed_opt(&self) -> Option<&MixedGeometryArray<i32, 2>>;
 
     /// Downcast this to a [`MixedGeometryArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_mixed(&self) -> &MixedGeometryArray<i32> {
+    fn as_mixed(&self) -> &MixedGeometryArray<i32, 2> {
         self.as_mixed_opt().unwrap()
     }
 
     /// Downcast this to a [`MixedGeometryArray`] with `i64` offsets returning `None` if not
     /// possible
-    fn as_large_mixed_opt(&self) -> Option<&MixedGeometryArray<i64>>;
+    fn as_large_mixed_opt(&self) -> Option<&MixedGeometryArray<i64, 2>>;
 
     /// Downcast this to a [`MixedGeometryArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_mixed(&self) -> &MixedGeometryArray<i64> {
+    fn as_large_mixed(&self) -> &MixedGeometryArray<i64, 2> {
         self.as_large_mixed_opt().unwrap()
     }
 
     /// Downcast this to a [`GeometryCollectionArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray<i32>>;
+    fn as_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray<i32, 2>>;
 
     /// Downcast this to a [`GeometryCollectionArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_geometry_collection(&self) -> &GeometryCollectionArray<i32> {
+    fn as_geometry_collection(&self) -> &GeometryCollectionArray<i32, 2> {
         self.as_geometry_collection_opt().unwrap()
     }
 
     /// Downcast this to a [`GeometryCollectionArray`] with `i64` offsets returning `None` if not
     /// possible
-    fn as_large_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray<i64>>;
+    fn as_large_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray<i64, 2>>;
 
     /// Downcast this to a [`GeometryCollectionArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_geometry_collection(&self) -> &GeometryCollectionArray<i64> {
+    fn as_large_geometry_collection(&self) -> &GeometryCollectionArray<i64, 2> {
         self.as_large_geometry_collection_opt().unwrap()
     }
 
@@ -176,78 +176,80 @@ pub trait AsGeometryArray {
 
 impl AsGeometryArray for &dyn GeometryArrayTrait {
     #[inline]
-    fn as_point_opt(&self) -> Option<&PointArray> {
-        self.as_any().downcast_ref::<PointArray>()
+    fn as_point_opt(&self) -> Option<&PointArray<2>> {
+        self.as_any().downcast_ref::<PointArray<2>>()
     }
 
     #[inline]
-    fn as_line_string_opt(&self) -> Option<&LineStringArray<i32>> {
-        self.as_any().downcast_ref::<LineStringArray<i32>>()
+    fn as_line_string_opt(&self) -> Option<&LineStringArray<i32, 2>> {
+        self.as_any().downcast_ref::<LineStringArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_line_string_opt(&self) -> Option<&LineStringArray<i64>> {
-        self.as_any().downcast_ref::<LineStringArray<i64>>()
+    fn as_large_line_string_opt(&self) -> Option<&LineStringArray<i64, 2>> {
+        self.as_any().downcast_ref::<LineStringArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_polygon_opt(&self) -> Option<&PolygonArray<i32>> {
-        self.as_any().downcast_ref::<PolygonArray<i32>>()
+    fn as_polygon_opt(&self) -> Option<&PolygonArray<i32, 2>> {
+        self.as_any().downcast_ref::<PolygonArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_polygon_opt(&self) -> Option<&PolygonArray<i64>> {
-        self.as_any().downcast_ref::<PolygonArray<i64>>()
+    fn as_large_polygon_opt(&self) -> Option<&PolygonArray<i64, 2>> {
+        self.as_any().downcast_ref::<PolygonArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_multi_point_opt(&self) -> Option<&MultiPointArray<i32>> {
-        self.as_any().downcast_ref::<MultiPointArray<i32>>()
+    fn as_multi_point_opt(&self) -> Option<&MultiPointArray<i32, 2>> {
+        self.as_any().downcast_ref::<MultiPointArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_multi_point_opt(&self) -> Option<&MultiPointArray<i64>> {
-        self.as_any().downcast_ref::<MultiPointArray<i64>>()
+    fn as_large_multi_point_opt(&self) -> Option<&MultiPointArray<i64, 2>> {
+        self.as_any().downcast_ref::<MultiPointArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_multi_line_string_opt(&self) -> Option<&MultiLineStringArray<i32>> {
-        self.as_any().downcast_ref::<MultiLineStringArray<i32>>()
+    fn as_multi_line_string_opt(&self) -> Option<&MultiLineStringArray<i32, 2>> {
+        self.as_any().downcast_ref::<MultiLineStringArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_multi_line_string_opt(&self) -> Option<&MultiLineStringArray<i64>> {
-        self.as_any().downcast_ref::<MultiLineStringArray<i64>>()
+    fn as_large_multi_line_string_opt(&self) -> Option<&MultiLineStringArray<i64, 2>> {
+        self.as_any().downcast_ref::<MultiLineStringArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_multi_polygon_opt(&self) -> Option<&MultiPolygonArray<i32>> {
-        self.as_any().downcast_ref::<MultiPolygonArray<i32>>()
+    fn as_multi_polygon_opt(&self) -> Option<&MultiPolygonArray<i32, 2>> {
+        self.as_any().downcast_ref::<MultiPolygonArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_multi_polygon_opt(&self) -> Option<&MultiPolygonArray<i64>> {
-        self.as_any().downcast_ref::<MultiPolygonArray<i64>>()
+    fn as_large_multi_polygon_opt(&self) -> Option<&MultiPolygonArray<i64, 2>> {
+        self.as_any().downcast_ref::<MultiPolygonArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_mixed_opt(&self) -> Option<&MixedGeometryArray<i32>> {
-        self.as_any().downcast_ref::<MixedGeometryArray<i32>>()
+    fn as_mixed_opt(&self) -> Option<&MixedGeometryArray<i32, 2>> {
+        self.as_any().downcast_ref::<MixedGeometryArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_mixed_opt(&self) -> Option<&MixedGeometryArray<i64>> {
-        self.as_any().downcast_ref::<MixedGeometryArray<i64>>()
+    fn as_large_mixed_opt(&self) -> Option<&MixedGeometryArray<i64, 2>> {
+        self.as_any().downcast_ref::<MixedGeometryArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray<i32>> {
-        self.as_any().downcast_ref::<GeometryCollectionArray<i32>>()
+    fn as_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray<i32, 2>> {
+        self.as_any()
+            .downcast_ref::<GeometryCollectionArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray<i64>> {
-        self.as_any().downcast_ref::<GeometryCollectionArray<i64>>()
+    fn as_large_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray<i64, 2>> {
+        self.as_any()
+            .downcast_ref::<GeometryCollectionArray<i64, 2>>()
     }
 
     #[inline]
@@ -269,145 +271,145 @@ impl AsGeometryArray for &dyn GeometryArrayTrait {
 /// Helpers for downcasting a [`ChunkedGeometryArrayTrait`] to a concrete implementation.
 pub trait AsChunkedGeometryArray {
     /// Downcast this to a [`ChunkedPointArray`] returning `None` if not possible
-    fn as_point_opt(&self) -> Option<&ChunkedPointArray>;
+    fn as_point_opt(&self) -> Option<&ChunkedPointArray<2>>;
 
     /// Downcast this to a [`ChunkedPointArray`] panicking if not possible
     #[inline]
-    fn as_point(&self) -> &ChunkedPointArray {
+    fn as_point(&self) -> &ChunkedPointArray<2> {
         self.as_point_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedLineStringArray`] with `i32` offsets returning `None` if not possible
-    fn as_line_string_opt(&self) -> Option<&ChunkedLineStringArray<i32>>;
+    fn as_line_string_opt(&self) -> Option<&ChunkedLineStringArray<i32, 2>>;
 
     /// Downcast this to a [`ChunkedLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_line_string(&self) -> &ChunkedLineStringArray<i32> {
+    fn as_line_string(&self) -> &ChunkedLineStringArray<i32, 2> {
         self.as_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedLineStringArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_line_string_opt(&self) -> Option<&ChunkedLineStringArray<i64>>;
+    fn as_large_line_string_opt(&self) -> Option<&ChunkedLineStringArray<i64, 2>>;
 
     /// Downcast this to a [`ChunkedLineStringArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_line_string(&self) -> &ChunkedLineStringArray<i64> {
+    fn as_large_line_string(&self) -> &ChunkedLineStringArray<i64, 2> {
         self.as_large_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedPolygonArray`] with `i32` offsets returning `None` if not possible
-    fn as_polygon_opt(&self) -> Option<&ChunkedPolygonArray<i32>>;
+    fn as_polygon_opt(&self) -> Option<&ChunkedPolygonArray<i32, 2>>;
 
     /// Downcast this to a [`ChunkedPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_polygon(&self) -> &ChunkedPolygonArray<i32> {
+    fn as_polygon(&self) -> &ChunkedPolygonArray<i32, 2> {
         self.as_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedPolygonArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_polygon_opt(&self) -> Option<&ChunkedPolygonArray<i64>>;
+    fn as_large_polygon_opt(&self) -> Option<&ChunkedPolygonArray<i64, 2>>;
 
     /// Downcast this to a [`ChunkedPolygonArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_polygon(&self) -> &ChunkedPolygonArray<i64> {
+    fn as_large_polygon(&self) -> &ChunkedPolygonArray<i64, 2> {
         self.as_large_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiPointArray`] with `i32` offsets returning `None` if not possible
-    fn as_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray<i32>>;
+    fn as_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray<i32, 2>>;
 
     /// Downcast this to a [`ChunkedMultiPointArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_point(&self) -> &ChunkedMultiPointArray<i32> {
+    fn as_multi_point(&self) -> &ChunkedMultiPointArray<i32, 2> {
         self.as_multi_point_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiPointArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray<i64>>;
+    fn as_large_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray<i64, 2>>;
 
     /// Downcast this to a [`ChunkedMultiPointArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_multi_point(&self) -> &ChunkedMultiPointArray<i64> {
+    fn as_large_multi_point(&self) -> &ChunkedMultiPointArray<i64, 2> {
         self.as_large_multi_point_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray<i32>>;
+    fn as_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray<i32, 2>>;
 
     /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_line_string(&self) -> &ChunkedMultiLineStringArray<i32> {
+    fn as_multi_line_string(&self) -> &ChunkedMultiLineStringArray<i32, 2> {
         self.as_multi_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i64` offsets returning `None` if not
     /// possible
-    fn as_large_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray<i64>>;
+    fn as_large_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray<i64, 2>>;
 
     /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_multi_line_string(&self) -> &ChunkedMultiLineStringArray<i64> {
+    fn as_large_multi_line_string(&self) -> &ChunkedMultiLineStringArray<i64, 2> {
         self.as_large_multi_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray<i32>>;
+    fn as_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray<i32, 2>>;
 
     /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_polygon(&self) -> &ChunkedMultiPolygonArray<i32> {
+    fn as_multi_polygon(&self) -> &ChunkedMultiPolygonArray<i32, 2> {
         self.as_multi_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i64` offsets returning `None` if not
     /// possible
-    fn as_large_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray<i64>>;
+    fn as_large_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray<i64, 2>>;
 
     /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_multi_polygon(&self) -> &ChunkedMultiPolygonArray<i64> {
+    fn as_large_multi_polygon(&self) -> &ChunkedMultiPolygonArray<i64, 2> {
         self.as_large_multi_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray<i32>>;
+    fn as_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray<i32, 2>>;
 
     /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_mixed(&self) -> &ChunkedMixedGeometryArray<i32> {
+    fn as_mixed(&self) -> &ChunkedMixedGeometryArray<i32, 2> {
         self.as_mixed_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i64` offsets returning `None` if not
     /// possible
-    fn as_large_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray<i64>>;
+    fn as_large_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray<i64, 2>>;
 
     /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_mixed(&self) -> &ChunkedMixedGeometryArray<i64> {
+    fn as_large_mixed(&self) -> &ChunkedMixedGeometryArray<i64, 2> {
         self.as_large_mixed_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray<i32>>;
+    fn as_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray<i32, 2>>;
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_geometry_collection(&self) -> &ChunkedGeometryCollectionArray<i32> {
+    fn as_geometry_collection(&self) -> &ChunkedGeometryCollectionArray<i32, 2> {
         self.as_geometry_collection_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i64` offsets returning `None` if not
     /// possible
-    fn as_large_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray<i64>>;
+    fn as_large_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray<i64, 2>>;
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i64` offsets panicking if not possible
     #[inline]
-    fn as_large_geometry_collection(&self) -> &ChunkedGeometryCollectionArray<i64> {
+    fn as_large_geometry_collection(&self) -> &ChunkedGeometryCollectionArray<i64, 2> {
         self.as_large_geometry_collection_opt().unwrap()
     }
 
@@ -441,86 +443,90 @@ pub trait AsChunkedGeometryArray {
 
 impl AsChunkedGeometryArray for &dyn ChunkedGeometryArrayTrait {
     #[inline]
-    fn as_point_opt(&self) -> Option<&ChunkedPointArray> {
-        self.as_any().downcast_ref::<ChunkedPointArray>()
+    fn as_point_opt(&self) -> Option<&ChunkedPointArray<2>> {
+        self.as_any().downcast_ref::<ChunkedPointArray<2>>()
     }
 
     #[inline]
-    fn as_line_string_opt(&self) -> Option<&ChunkedLineStringArray<i32>> {
-        self.as_any().downcast_ref::<ChunkedLineStringArray<i32>>()
-    }
-
-    #[inline]
-    fn as_large_line_string_opt(&self) -> Option<&ChunkedLineStringArray<i64>> {
-        self.as_any().downcast_ref::<ChunkedLineStringArray<i64>>()
-    }
-
-    #[inline]
-    fn as_polygon_opt(&self) -> Option<&ChunkedPolygonArray<i32>> {
-        self.as_any().downcast_ref::<ChunkedPolygonArray<i32>>()
-    }
-
-    #[inline]
-    fn as_large_polygon_opt(&self) -> Option<&ChunkedPolygonArray<i64>> {
-        self.as_any().downcast_ref::<ChunkedPolygonArray<i64>>()
-    }
-
-    #[inline]
-    fn as_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray<i32>> {
-        self.as_any().downcast_ref::<ChunkedMultiPointArray<i32>>()
-    }
-
-    #[inline]
-    fn as_large_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray<i64>> {
-        self.as_any().downcast_ref::<ChunkedMultiPointArray<i64>>()
-    }
-
-    #[inline]
-    fn as_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray<i32>> {
+    fn as_line_string_opt(&self) -> Option<&ChunkedLineStringArray<i32, 2>> {
         self.as_any()
-            .downcast_ref::<ChunkedMultiLineStringArray<i32>>()
+            .downcast_ref::<ChunkedLineStringArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray<i64>> {
+    fn as_large_line_string_opt(&self) -> Option<&ChunkedLineStringArray<i64, 2>> {
         self.as_any()
-            .downcast_ref::<ChunkedMultiLineStringArray<i64>>()
+            .downcast_ref::<ChunkedLineStringArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray<i32>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMultiPolygonArray<i32>>()
+    fn as_polygon_opt(&self) -> Option<&ChunkedPolygonArray<i32, 2>> {
+        self.as_any().downcast_ref::<ChunkedPolygonArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray<i64>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMultiPolygonArray<i64>>()
+    fn as_large_polygon_opt(&self) -> Option<&ChunkedPolygonArray<i64, 2>> {
+        self.as_any().downcast_ref::<ChunkedPolygonArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray<i32>> {
+    fn as_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray<i32, 2>> {
         self.as_any()
-            .downcast_ref::<ChunkedMixedGeometryArray<i32>>()
+            .downcast_ref::<ChunkedMultiPointArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray<i64>> {
+    fn as_large_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray<i64, 2>> {
         self.as_any()
-            .downcast_ref::<ChunkedMixedGeometryArray<i64>>()
+            .downcast_ref::<ChunkedMultiPointArray<i64, 2>>()
     }
 
     #[inline]
-    fn as_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray<i32>> {
+    fn as_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray<i32, 2>> {
         self.as_any()
-            .downcast_ref::<ChunkedGeometryCollectionArray<i32>>()
+            .downcast_ref::<ChunkedMultiLineStringArray<i32, 2>>()
     }
 
     #[inline]
-    fn as_large_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray<i64>> {
+    fn as_large_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray<i64, 2>> {
         self.as_any()
-            .downcast_ref::<ChunkedGeometryCollectionArray<i64>>()
+            .downcast_ref::<ChunkedMultiLineStringArray<i64, 2>>()
+    }
+
+    #[inline]
+    fn as_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray<i32, 2>> {
+        self.as_any()
+            .downcast_ref::<ChunkedMultiPolygonArray<i32, 2>>()
+    }
+
+    #[inline]
+    fn as_large_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray<i64, 2>> {
+        self.as_any()
+            .downcast_ref::<ChunkedMultiPolygonArray<i64, 2>>()
+    }
+
+    #[inline]
+    fn as_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray<i32, 2>> {
+        self.as_any()
+            .downcast_ref::<ChunkedMixedGeometryArray<i32, 2>>()
+    }
+
+    #[inline]
+    fn as_large_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray<i64, 2>> {
+        self.as_any()
+            .downcast_ref::<ChunkedMixedGeometryArray<i64, 2>>()
+    }
+
+    #[inline]
+    fn as_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray<i32, 2>> {
+        self.as_any()
+            .downcast_ref::<ChunkedGeometryCollectionArray<i32, 2>>()
+    }
+
+    #[inline]
+    fn as_large_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray<i64, 2>> {
+        self.as_any()
+            .downcast_ref::<ChunkedGeometryCollectionArray<i64, 2>>()
     }
 
     #[inline]

--- a/src/array/coord/combined/array.rs
+++ b/src/array/coord/combined/array.rs
@@ -196,7 +196,7 @@ impl<const D: usize> TryFrom<&dyn Array> for CoordBuffer<D> {
     }
 }
 
-impl PartialEq for CoordBuffer<2> {
+impl<const D: usize> PartialEq for CoordBuffer<D> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (CoordBuffer::Interleaved(a), CoordBuffer::Interleaved(b)) => PartialEq::eq(a, b),
@@ -258,7 +258,7 @@ mod test {
     #[test]
     fn test_eq_both_interleaved() -> Result<()> {
         let coords1 = vec![0., 3., 1., 4., 2., 5.];
-        let buf1 = CoordBuffer::Interleaved(coords1.try_into()?);
+        let buf1 = CoordBuffer::<2>::Interleaved(coords1.try_into()?);
 
         let coords2 = vec![0., 3., 1., 4., 2., 5.];
         let buf2 = CoordBuffer::Interleaved(coords2.try_into()?);

--- a/src/array/coord/combined/array.rs
+++ b/src/array/coord/combined/array.rs
@@ -11,7 +11,6 @@ use crate::GeometryArrayTrait;
 use arrow_array::{Array, FixedSizeListArray, StructArray};
 use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field};
-use itertools::Itertools;
 
 /// An Arrow representation of an array of coordinates.
 ///
@@ -31,15 +30,19 @@ pub enum CoordBuffer<const D: usize> {
     Separated(SeparatedCoordBuffer<D>),
 }
 
-impl CoordBuffer<2> {
+impl<const D: usize> CoordBuffer<D> {
     pub fn get_x(&self, i: usize) -> f64 {
-        let geo_coord: geo::Coord = self.value(i).into();
-        geo_coord.x
+        match self {
+            CoordBuffer::Interleaved(c) => c.get_x(i),
+            CoordBuffer::Separated(c) => c.get_x(i),
+        }
     }
 
     pub fn get_y(&self, i: usize) -> f64 {
-        let geo_coord: geo::Coord = self.value(i).into();
-        geo_coord.y
+        match self {
+            CoordBuffer::Interleaved(c) => c.get_y(i),
+            CoordBuffer::Separated(c) => c.get_y(i),
+        }
     }
 }
 
@@ -106,8 +109,8 @@ impl<const D: usize> GeometryArrayTrait for CoordBuffer<D> {
     }
 }
 
-impl GeometryArraySelfMethods for CoordBuffer<2> {
-    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
+impl<const D: usize> GeometryArraySelfMethods<D> for CoordBuffer<D> {
+    fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.len());
         coords
     }
@@ -117,19 +120,18 @@ impl GeometryArraySelfMethods for CoordBuffer<2> {
             (CoordBuffer::Interleaved(cb), CoordType::Interleaved) => CoordBuffer::Interleaved(cb),
             (CoordBuffer::Interleaved(cb), CoordType::Separated) => {
                 let mut new_buffer = SeparatedCoordBufferBuilder::with_capacity(cb.len());
-                cb.coords
-                    .into_iter()
-                    .tuples()
-                    .for_each(|(x, y)| new_buffer.push_xy(*x, *y));
+                let coords = cb.coords;
+                for row_start_idx in (0..coords.len()).step_by(D) {
+                    new_buffer.push(core::array::from_fn(|i| coords[row_start_idx + i]));
+                }
                 CoordBuffer::Separated(new_buffer.into())
             }
             (CoordBuffer::Separated(cb), CoordType::Separated) => CoordBuffer::Separated(cb),
             (CoordBuffer::Separated(cb), CoordType::Interleaved) => {
                 let mut new_buffer = InterleavedCoordBufferBuilder::with_capacity(cb.len());
-                cb.buffers[0]
-                    .into_iter()
-                    .zip(cb.buffers[1].iter())
-                    .for_each(|(x, y)| new_buffer.push_xy(*x, *y));
+                for row_idx in 0..cb.len() {
+                    new_buffer.push(core::array::from_fn(|i| cb.buffers[i][row_idx]));
+                }
                 CoordBuffer::Interleaved(new_buffer.into())
             }
         }
@@ -152,8 +154,8 @@ impl GeometryArraySelfMethods for CoordBuffer<2> {
     }
 }
 
-impl<'a> GeometryArrayAccessor<'a> for CoordBuffer<2> {
-    type Item = Coord<'a, 2>;
+impl<'a, const D: usize> GeometryArrayAccessor<'a> for CoordBuffer<D> {
+    type Item = Coord<'a, D>;
     type ItemGeo = geo::Coord;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/coord/combined/builder.rs
+++ b/src/array/coord/combined/builder.rs
@@ -70,6 +70,13 @@ impl<const D: usize> CoordBufferBuilder<D> {
         self.len() == 0
     }
 
+    pub fn push(&mut self, c: [f64; D]) {
+        match self {
+            CoordBufferBuilder::Interleaved(cb) => cb.push(c),
+            CoordBufferBuilder::Separated(cb) => cb.push(c),
+        }
+    }
+
     pub fn coord_type(&self) -> CoordType {
         match self {
             CoordBufferBuilder::Interleaved(_) => CoordType::Interleaved,

--- a/src/array/coord/interleaved/array.rs
+++ b/src/array/coord/interleaved/array.rs
@@ -55,6 +55,16 @@ impl<const D: usize> InterleavedCoordBuffer<D> {
     pub fn values_field(&self) -> Field {
         Field::new("xy", DataType::Float64, false)
     }
+
+    pub fn get_x(&self, i: usize) -> f64 {
+        let c = self.value(i);
+        c.x()
+    }
+
+    pub fn get_y(&self, i: usize) -> f64 {
+        let c = self.value(i);
+        c.y()
+    }
 }
 
 impl<const D: usize> GeometryArrayTrait for InterleavedCoordBuffer<D> {
@@ -111,8 +121,8 @@ impl<const D: usize> GeometryArrayTrait for InterleavedCoordBuffer<D> {
     }
 }
 
-impl<const D: usize> GeometryArraySelfMethods for InterleavedCoordBuffer<D> {
-    fn with_coords(self, _coords: crate::array::CoordBuffer<2>) -> Self {
+impl<const D: usize> GeometryArraySelfMethods<D> for InterleavedCoordBuffer<D> {
+    fn with_coords(self, _coords: crate::array::CoordBuffer<D>) -> Self {
         unimplemented!();
     }
 
@@ -136,8 +146,8 @@ impl<const D: usize> GeometryArraySelfMethods for InterleavedCoordBuffer<D> {
     }
 }
 
-impl<'a> GeometryArrayAccessor<'a> for InterleavedCoordBuffer<2> {
-    type Item = InterleavedCoord<'a, 2>;
+impl<'a, const D: usize> GeometryArrayAccessor<'a> for InterleavedCoordBuffer<D> {
+    type Item = InterleavedCoord<'a, D>;
     type ItemGeo = geo::Coord;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/coord/interleaved/builder.rs
+++ b/src/array/coord/interleaved/builder.rs
@@ -66,6 +66,10 @@ impl<const D: usize> InterleavedCoordBufferBuilder<D> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    pub fn push(&mut self, c: [f64; D]) {
+        self.coords.extend_from_slice(&c);
+    }
 }
 
 impl InterleavedCoordBufferBuilder<2> {

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -76,6 +76,16 @@ impl<const D: usize> SeparatedCoordBuffer<D> {
             _ => todo!("only supports xy and xyz right now."),
         }
     }
+
+    pub fn get_x(&self, i: usize) -> f64 {
+        let c = self.value(i);
+        c.x()
+    }
+
+    pub fn get_y(&self, i: usize) -> f64 {
+        let c = self.value(i);
+        c.y()
+    }
 }
 
 impl<const D: usize> GeometryArrayTrait for SeparatedCoordBuffer<D> {
@@ -132,8 +142,8 @@ impl<const D: usize> GeometryArrayTrait for SeparatedCoordBuffer<D> {
     }
 }
 
-impl<const D: usize> GeometryArraySelfMethods for SeparatedCoordBuffer<D> {
-    fn with_coords(self, _coords: crate::array::CoordBuffer<2>) -> Self {
+impl<const D: usize> GeometryArraySelfMethods<D> for SeparatedCoordBuffer<D> {
+    fn with_coords(self, _coords: crate::array::CoordBuffer<D>) -> Self {
         unimplemented!();
     }
 
@@ -176,8 +186,8 @@ impl<const D: usize> GeometryArraySelfMethods for SeparatedCoordBuffer<D> {
     }
 }
 
-impl<'a> GeometryArrayAccessor<'a> for SeparatedCoordBuffer<2> {
-    type Item = SeparatedCoord<'a, 2>;
+impl<'a, const D: usize> GeometryArrayAccessor<'a> for SeparatedCoordBuffer<D> {
+    type Item = SeparatedCoord<'a, D>;
     type ItemGeo = geo::Coord;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/coord/separated/builder.rs
+++ b/src/array/coord/separated/builder.rs
@@ -75,6 +75,12 @@ impl<const D: usize> SeparatedCoordBufferBuilder<D> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    pub fn push(&mut self, c: [f64; D]) {
+        for i in 0..D {
+            self.buffers[i].push(c[i]);
+        }
+    }
 }
 
 impl SeparatedCoordBufferBuilder<2> {

--- a/src/array/coord/separated/builder.rs
+++ b/src/array/coord/separated/builder.rs
@@ -77,8 +77,8 @@ impl<const D: usize> SeparatedCoordBufferBuilder<D> {
     }
 
     pub fn push(&mut self, c: [f64; D]) {
-        for i in 0..D {
-            self.buffers[i].push(c[i]);
+        for (i, value) in c.iter().enumerate().take(D) {
+            self.buffers[i].push(*value);
         }
     }
 }

--- a/src/array/geometry/mod.rs
+++ b/src/array/geometry/mod.rs
@@ -1,8 +1,8 @@
 //! Contains the [`GeometryArray`], which is an enum over all geometry array types.
 
-#[allow(deprecated)]
-pub use array::GeometryArray;
+// #[allow(deprecated)]
+// pub use array::GeometryArray;
 
-mod array;
-mod iterator;
+// mod array;
+// mod iterator;
 // mod mutable;

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -159,8 +159,10 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for GeometryCollecti
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for GeometryCollectionArray<O, 2> {
-    fn with_coords(self, _coords: CoordBuffer<2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D>
+    for GeometryCollectionArray<O, D>
+{
+    fn with_coords(self, _coords: CoordBuffer<D>) -> Self {
         todo!()
     }
 
@@ -207,8 +209,10 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for GeometryCollectionArray<O,
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for GeometryCollectionArray<O, 2> {
-    type Item = GeometryCollection<'a, O, 2>;
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a>
+    for GeometryCollectionArray<O, D>
+{
+    type Item = GeometryCollection<'a, O, D>;
     type ItemGeo = geo::GeometryCollection;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -309,7 +309,7 @@ impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<&[G]>
     for GeometryCollectionArray<O, 2>
 {
     fn from(other: &[G]) -> Self {
-        let mut_arr: GeometryCollectionBuilder<O> = other.into();
+        let mut_arr: GeometryCollectionBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
@@ -318,7 +318,7 @@ impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<Vec<Option<G>
     for GeometryCollectionArray<O, 2>
 {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: GeometryCollectionBuilder<O> = other.into();
+        let mut_arr: GeometryCollectionBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
@@ -327,7 +327,7 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for GeometryCollectionArray<O, 2> 
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
-        let mut_arr: GeometryCollectionBuilder<O> = value.try_into()?;
+        let mut_arr: GeometryCollectionBuilder<O, 2> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -101,7 +101,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionBuilder<O, D> {
         (self.geoms, self.geom_offsets, self.validity)
     }
 
-    pub fn finish(self) -> GeometryCollectionArray<O> {
+    pub fn finish(self) -> GeometryCollectionArray<O, D> {
         self.into()
     }
 }

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -21,17 +21,17 @@ use crate::trait_::{GeometryArrayAccessor, GeometryArrayBuilder, IntoArrow};
 ///
 /// Converting an [`GeometryCollectionBuilder`] into a [`GeometryCollectionArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct GeometryCollectionBuilder<O: OffsetSizeTrait> {
+pub struct GeometryCollectionBuilder<O: OffsetSizeTrait, const D: usize> {
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) geoms: MixedGeometryBuilder<O>,
+    pub(crate) geoms: MixedGeometryBuilder<O, D>,
 
     pub(crate) geom_offsets: OffsetsBuilder<O>,
 
     pub(crate) validity: NullBufferBuilder,
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionBuilder<O, D> {
     /// Creates a new empty [`GeometryCollectionBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -61,41 +61,6 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
             validity: NullBufferBuilder::new(capacity.geom_capacity),
             metadata,
         }
-    }
-
-    pub fn with_capacity_from_iter(
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
-    ) -> Result<Self> {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
-    }
-
-    pub fn with_capacity_and_options_from_iter(
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self> {
-        let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
-        Ok(Self::with_capacity_and_options(
-            counter, coord_type, metadata,
-        ))
-    }
-
-    pub fn reserve_from_iter(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
-    ) -> Result<()> {
-        let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
-        self.reserve(counter);
-        Ok(())
-    }
-
-    pub fn reserve_exact_from_iter(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
-    ) -> Result<()> {
-        let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
-        self.reserve_exact(counter);
-        Ok(())
     }
 
     /// Reserves capacity for at least `additional` more LineStrings to be inserted
@@ -129,11 +94,52 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
     pub fn into_inner(
         self,
     ) -> (
-        MixedGeometryBuilder<O>,
+        MixedGeometryBuilder<O, D>,
         OffsetsBuilder<O>,
         NullBufferBuilder,
     ) {
         (self.geoms, self.geom_offsets, self.validity)
+    }
+
+    pub fn finish(self) -> GeometryCollectionArray<O> {
+        self.into()
+    }
+}
+
+impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O, 2> {
+    pub fn with_capacity_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+    ) -> Result<Self> {
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
+    }
+
+    pub fn with_capacity_and_options_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
+        let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
+        Ok(Self::with_capacity_and_options(
+            counter, coord_type, metadata,
+        ))
+    }
+
+    pub fn reserve_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+    ) -> Result<()> {
+        let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
+        self.reserve(counter);
+        Ok(())
+    }
+
+    pub fn reserve_exact_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+    ) -> Result<()> {
+        let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
+        self.reserve_exact(counter);
+        Ok(())
     }
 
     /// Push a Point onto the end of this builder
@@ -403,13 +409,9 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O> {
             .collect();
         Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata, prefer_multi)
     }
-
-    pub fn finish(self) -> GeometryCollectionArray<O> {
-        self.into()
-    }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayBuilder for GeometryCollectionBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for GeometryCollectionBuilder<O, D> {
     fn new() -> Self {
         Self::new()
     }
@@ -452,23 +454,25 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for GeometryCollectionBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for GeometryCollectionBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for GeometryCollectionBuilder<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let linestring_arr: GeometryCollectionArray<O> = self.into();
+        let linestring_arr: GeometryCollectionArray<O, D> = self.into();
         linestring_arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait> Default for GeometryCollectionBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for GeometryCollectionBuilder<O, D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: OffsetSizeTrait> From<GeometryCollectionBuilder<O>> for GeometryCollectionArray<O> {
-    fn from(other: GeometryCollectionBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<GeometryCollectionBuilder<O, D>>
+    for GeometryCollectionArray<O, D>
+{
+    fn from(other: GeometryCollectionBuilder<O, D>) -> Self {
         let validity = other.validity.finish_cloned();
         Self::new(
             other.geoms.into(),
@@ -479,14 +483,16 @@ impl<O: OffsetSizeTrait> From<GeometryCollectionBuilder<O>> for GeometryCollecti
     }
 }
 
-impl<O: OffsetSizeTrait> From<GeometryCollectionBuilder<O>> for GenericListArray<O> {
-    fn from(arr: GeometryCollectionBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<GeometryCollectionBuilder<O, D>>
+    for GenericListArray<O>
+{
+    fn from(arr: GeometryCollectionBuilder<O, D>) -> Self {
         arr.into_arrow()
     }
 }
 
 impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<&[G]>
-    for GeometryCollectionBuilder<O>
+    for GeometryCollectionBuilder<O, 2>
 {
     fn from(geoms: &[G]) -> Self {
         Self::from_geometry_collections(geoms, Default::default(), Default::default(), true)
@@ -495,7 +501,7 @@ impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<&[G]>
 }
 
 impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<Vec<Option<G>>>
-    for GeometryCollectionBuilder<O>
+    for GeometryCollectionBuilder<O, 2>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_geometry_collections(
@@ -508,30 +514,7 @@ impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<Vec<Option<G>
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>>
-    for GeometryCollectionBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_geometry_collections(&geoms, Default::default(), Default::default(), true)
-            .unwrap()
-    }
-}
-
-impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>>
-    From<bumpalo::collections::Vec<'_, Option<G>>> for GeometryCollectionBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_geometry_collections(
-            &geoms,
-            Default::default(),
-            Default::default(),
-            true,
-        )
-        .unwrap()
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for GeometryCollectionBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for GeometryCollectionBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -31,7 +31,7 @@ pub struct GeometryCollectionBuilder<O: OffsetSizeTrait, const D: usize> {
     pub(crate) validity: NullBufferBuilder,
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionBuilder<O, D> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionBuilder<O, D> {
     /// Creates a new empty [`GeometryCollectionBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -283,7 +283,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for LineStringArray<O, 2> {
 }
 
 impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for LineStringArray<O, 2> {
-    type Item = LineString<'a, O>;
+    type Item = LineString<'a, O, 2>;
     type ItemGeo = geo::LineString;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -330,7 +330,7 @@ impl<const D: usize> TryFrom<&dyn Array> for LineStringArray<i32, D> {
             }
             DataType::LargeList(_) => {
                 let downcasted = value.as_any().downcast_ref::<LargeListArray>().unwrap();
-                let geom_array: LineStringArray<i64, 2> = downcasted.try_into()?;
+                let geom_array: LineStringArray<i64, D> = downcasted.try_into()?;
                 geom_array.try_into()
             }
             _ => Err(GeoArrowError::General(format!(
@@ -348,7 +348,7 @@ impl<const D: usize> TryFrom<&dyn Array> for LineStringArray<i64, D> {
         match value.data_type() {
             DataType::List(_) => {
                 let downcasted = value.as_any().downcast_ref::<ListArray>().unwrap();
-                let geom_array: LineStringArray<i32, 2> = downcasted.try_into()?;
+                let geom_array: LineStringArray<i32, D> = downcasted.try_into()?;
                 Ok(geom_array.into())
             }
             DataType::LargeList(_) => {

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -210,8 +210,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for LineStringArray<
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for LineStringArray<O, 2> {
-    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D> for LineStringArray<O, D> {
+    fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(coords, self.geom_offsets, self.validity, self.metadata)
     }
@@ -282,8 +282,8 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for LineStringArray<O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for LineStringArray<O, 2> {
-    type Item = LineString<'a, O, 2>;
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a> for LineStringArray<O, D> {
+    type Item = LineString<'a, O, D>;
     type ItemGeo = geo::LineString;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -24,13 +24,13 @@ use super::LineStringBuilder;
 /// This is semantically equivalent to `Vec<Option<LineString>>` due to the internal validity
 /// bitmap.
 #[derive(Debug, Clone)]
-pub struct LineStringArray<O: OffsetSizeTrait> {
+pub struct LineStringArray<O: OffsetSizeTrait, const D: usize> {
     // Always GeoDataType::LineString or GeoDataType::LargeLineString
     data_type: GeoDataType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBuffer<2>,
+    pub(crate) coords: CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -39,8 +39,8 @@ pub struct LineStringArray<O: OffsetSizeTrait> {
     pub(crate) validity: Option<NullBuffer>,
 }
 
-pub(super) fn check<O: OffsetSizeTrait>(
-    coords: &CoordBuffer<2>,
+pub(super) fn check<O: OffsetSizeTrait, const D: usize>(
+    coords: &CoordBuffer<D>,
     validity_len: Option<usize>,
     geom_offsets: &OffsetBuffer<O>,
 ) -> Result<()> {
@@ -59,7 +59,7 @@ pub(super) fn check<O: OffsetSizeTrait>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> LineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> LineStringArray<O, D> {
     /// Create a new LineStringArray from parts
     ///
     /// # Implementation
@@ -71,7 +71,7 @@ impl<O: OffsetSizeTrait> LineStringArray<O> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     pub fn new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
@@ -90,7 +90,7 @@ impl<O: OffsetSizeTrait> LineStringArray<O> {
     /// - if the validity buffer does not have the same length as the number of geometries
     /// - if the geometry offsets do not match the number of coordinates
     pub fn try_new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
@@ -123,7 +123,7 @@ impl<O: OffsetSizeTrait> LineStringArray<O> {
         }
     }
 
-    pub fn coords(&self) -> &CoordBuffer<2> {
+    pub fn coords(&self) -> &CoordBuffer<D> {
         &self.coords
     }
 
@@ -143,7 +143,7 @@ impl<O: OffsetSizeTrait> LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayTrait for LineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for LineStringArray<O, D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -210,7 +210,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for LineStringArray<O> {
+impl<O: OffsetSizeTrait> GeometryArraySelfMethods for LineStringArray<O, 2> {
     fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(coords, self.geom_offsets, self.validity, self.metadata)
@@ -282,7 +282,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for LineStringArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for LineStringArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for LineStringArray<O, 2> {
     type Item = LineString<'a, O>;
     type ItemGeo = geo::LineString;
 
@@ -291,7 +291,7 @@ impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for LineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for LineStringArray<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -302,11 +302,11 @@ impl<O: OffsetSizeTrait> IntoArrow for LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for LineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>> for LineStringArray<O, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &GenericListArray<O>) -> Result<Self> {
-        let coords: CoordBuffer<2> = value.values().as_ref().try_into()?;
+        let coords: CoordBuffer<D> = value.values().as_ref().try_into()?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
@@ -319,7 +319,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for LineStringArray<O> {
     }
 }
 
-impl TryFrom<&dyn Array> for LineStringArray<i32> {
+impl<const D: usize> TryFrom<&dyn Array> for LineStringArray<i32, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
@@ -330,7 +330,7 @@ impl TryFrom<&dyn Array> for LineStringArray<i32> {
             }
             DataType::LargeList(_) => {
                 let downcasted = value.as_any().downcast_ref::<LargeListArray>().unwrap();
-                let geom_array: LineStringArray<i64> = downcasted.try_into()?;
+                let geom_array: LineStringArray<i64, 2> = downcasted.try_into()?;
                 geom_array.try_into()
             }
             _ => Err(GeoArrowError::General(format!(
@@ -341,14 +341,14 @@ impl TryFrom<&dyn Array> for LineStringArray<i32> {
     }
 }
 
-impl TryFrom<&dyn Array> for LineStringArray<i64> {
+impl<const D: usize> TryFrom<&dyn Array> for LineStringArray<i64, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
         match value.data_type() {
             DataType::List(_) => {
                 let downcasted = value.as_any().downcast_ref::<ListArray>().unwrap();
-                let geom_array: LineStringArray<i32> = downcasted.try_into()?;
+                let geom_array: LineStringArray<i32, 2> = downcasted.try_into()?;
                 Ok(geom_array.into())
             }
             DataType::LargeList(_) => {
@@ -363,42 +363,26 @@ impl TryFrom<&dyn Array> for LineStringArray<i64> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<Vec<Option<G>>> for LineStringArray<O> {
+impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<Vec<Option<G>>>
+    for LineStringArray<O, 2>
+{
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: LineStringBuilder<O> = other.into();
+        let mut_arr: LineStringBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<&[G]> for LineStringArray<O> {
+impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<&[G]> for LineStringArray<O, 2> {
     fn from(other: &[G]) -> Self {
-        let mut_arr: LineStringBuilder<O> = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<bumpalo::collections::Vec<'_, Option<G>>>
-    for LineStringArray<O>
-{
-    fn from(other: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        let mut_arr: LineStringBuilder<O> = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>>
-    for LineStringArray<O>
-{
-    fn from(other: bumpalo::collections::Vec<'_, G>) -> Self {
-        let mut_arr: LineStringBuilder<O> = other.into();
+        let mut_arr: LineStringBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<O: OffsetSizeTrait> From<LineStringArray<O>> for MultiPointArray<O> {
-    fn from(value: LineStringArray<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<LineStringArray<O, D>> for MultiPointArray<O, D> {
+    fn from(value: LineStringArray<O, D>) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -408,17 +392,17 @@ impl<O: OffsetSizeTrait> From<LineStringArray<O>> for MultiPointArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
-        let mut_arr: LineStringBuilder<O> = value.try_into()?;
+        let mut_arr: LineStringBuilder<O, 2> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }
 
-impl From<LineStringArray<i32>> for LineStringArray<i64> {
-    fn from(value: LineStringArray<i32>) -> Self {
+impl<const D: usize> From<LineStringArray<i32, D>> for LineStringArray<i64, D> {
+    fn from(value: LineStringArray<i32, D>) -> Self {
         Self::new(
             value.coords,
             offsets_buffer_i32_to_i64(&value.geom_offsets),
@@ -428,10 +412,10 @@ impl From<LineStringArray<i32>> for LineStringArray<i64> {
     }
 }
 
-impl TryFrom<LineStringArray<i64>> for LineStringArray<i32> {
+impl<const D: usize> TryFrom<LineStringArray<i64, D>> for LineStringArray<i32, D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: LineStringArray<i64>) -> Result<Self> {
+    fn try_from(value: LineStringArray<i64, D>) -> Result<Self> {
         Ok(Self::new(
             value.coords,
             offsets_buffer_i64_to_i32(&value.geom_offsets)?,
@@ -442,13 +426,13 @@ impl TryFrom<LineStringArray<i64>> for LineStringArray<i32> {
 }
 
 /// Default to an empty array
-impl<O: OffsetSizeTrait> Default for LineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for LineStringArray<O, D> {
     fn default() -> Self {
         LineStringBuilder::default().into()
     }
 }
 
-impl<O: OffsetSizeTrait> PartialEq for LineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> PartialEq for LineStringArray<O, D> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;
@@ -477,14 +461,14 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: LineStringArray<i64> = vec![ls0(), ls1()].as_slice().into();
+        let arr: LineStringArray<i64, 2> = vec![ls0(), ls1()].as_slice().into();
         assert_eq!(arr.value_as_geo(0), ls0());
         assert_eq!(arr.value_as_geo(1), ls1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: LineStringArray<i64> = vec![Some(ls0()), Some(ls1()), None].into();
+        let arr: LineStringArray<i64, 2> = vec![Some(ls0()), Some(ls1()), None].into();
         assert_eq!(arr.get_as_geo(0), Some(ls0()));
         assert_eq!(arr.get_as_geo(1), Some(ls1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -508,7 +492,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: LineStringArray<i64> = vec![ls0(), ls1()].as_slice().into();
+        let arr: LineStringArray<i64, 2> = vec![ls0(), ls1()].as_slice().into();
         let sliced = arr.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(ls1()));
@@ -516,7 +500,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: LineStringArray<i64> = vec![ls0(), ls1()].as_slice().into();
+        let arr: LineStringArray<i64, 2> = vec![ls0(), ls1()].as_slice().into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -533,7 +517,7 @@ mod test {
         let linestring_arr = example_linestring_interleaved();
 
         let wkb_arr = example_linestring_wkb();
-        let parsed_linestring_arr: LineStringArray<i64> = wkb_arr.try_into().unwrap();
+        let parsed_linestring_arr: LineStringArray<i64, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(linestring_arr, parsed_linestring_arr);
     }
@@ -543,7 +527,7 @@ mod test {
         let linestring_arr = example_linestring_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_linestring_wkb();
-        let parsed_linestring_arr: LineStringArray<i64> = wkb_arr.try_into().unwrap();
+        let parsed_linestring_arr: LineStringArray<i64, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(linestring_arr, parsed_linestring_arr);
     }

--- a/src/array/linestring/builder.rs
+++ b/src/array/linestring/builder.rs
@@ -20,10 +20,10 @@ use std::sync::Arc;
 ///
 /// Converting an [`LineStringBuilder`] into a [`LineStringArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct LineStringBuilder<O: OffsetSizeTrait> {
+pub struct LineStringBuilder<O: OffsetSizeTrait, const D: usize> {
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBufferBuilder<2>,
+    pub(crate) coords: CoordBufferBuilder<D>,
 
     /// Offsets into the coordinate array where each geometry starts
     pub(crate) geom_offsets: OffsetsBuilder<O>,
@@ -32,7 +32,7 @@ pub struct LineStringBuilder<O: OffsetSizeTrait> {
     pub(crate) validity: NullBufferBuilder,
 }
 
-impl<O: OffsetSizeTrait> LineStringBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> LineStringBuilder<O, D> {
     /// Creates a new empty [`LineStringBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -66,37 +66,6 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
             validity: NullBufferBuilder::new(capacity.geom_capacity()),
             metadata,
         }
-    }
-
-    pub fn with_capacity_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
-    ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
-    }
-
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let counter = LineStringCapacity::from_line_strings(geoms);
-        Self::with_capacity_and_options(counter, coord_type, metadata)
-    }
-
-    pub fn reserve_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
-    ) {
-        let counter = LineStringCapacity::from_line_strings(geoms);
-        self.reserve(counter)
-    }
-
-    pub fn reserve_exact_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
-    ) {
-        let counter = LineStringCapacity::from_line_strings(geoms);
-        self.reserve_exact(counter)
     }
 
     /// Reserves capacity for at least `additional` more LineStrings to be inserted
@@ -139,7 +108,7 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
     /// - The validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     pub fn try_new(
-        coords: CoordBufferBuilder<2>,
+        coords: CoordBufferBuilder<D>,
         geom_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
         metadata: Arc<ArrayMetadata>,
@@ -158,8 +127,92 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
     }
 
     /// Extract the low-level APIs from the [`LineStringBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder<2>, OffsetsBuilder<O>, NullBufferBuilder) {
+    pub fn into_inner(self) -> (CoordBufferBuilder<D>, OffsetsBuilder<O>, NullBufferBuilder) {
         (self.coords, self.geom_offsets, self.validity)
+    }
+
+    /// Needs to be called when a valid value was extended to this array.
+    /// This is a relatively low level function, prefer `try_push` when you can.
+    #[inline]
+    pub(crate) fn try_push_length(&mut self, geom_offsets_length: usize) -> Result<()> {
+        self.geom_offsets.try_push_usize(geom_offsets_length)?;
+        self.validity.append(true);
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn push_null(&mut self) {
+        self.geom_offsets.extend_constant(1);
+        self.validity.append(false);
+    }
+
+    pub fn into_array_ref(self) -> Arc<dyn Array> {
+        Arc::new(self.into_arrow())
+    }
+
+    pub fn finish(self) -> LineStringArray<O, D> {
+        self.into()
+    }
+}
+
+impl<O: OffsetSizeTrait> LineStringBuilder<O, 2> {
+    pub fn with_capacity_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
+    ) -> Self {
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
+    }
+
+    pub fn with_capacity_and_options_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let counter = LineStringCapacity::from_line_strings(geoms);
+        Self::with_capacity_and_options(counter, coord_type, metadata)
+    }
+
+    pub fn reserve_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
+    ) {
+        let counter = LineStringCapacity::from_line_strings(geoms);
+        self.reserve(counter)
+    }
+
+    pub fn reserve_exact_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
+    ) {
+        let counter = LineStringCapacity::from_line_strings(geoms);
+        self.reserve_exact(counter)
+    }
+
+    pub fn from_line_strings(
+        geoms: &[impl LineStringTrait<T = f64>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
+        array.extend_from_iter(geoms.iter().map(Some));
+        array
+    }
+
+    pub fn from_nullable_line_strings(
+        geoms: &[Option<impl LineStringTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(|x| x.as_ref()),
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
+        array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
+        array
     }
 
     /// Add a new LineString to the end of this array.
@@ -205,21 +258,6 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
         self.coords.push_xy(x, y);
     }
 
-    /// Needs to be called when a valid value was extended to this array.
-    /// This is a relatively low level function, prefer `try_push` when you can.
-    #[inline]
-    pub(crate) fn try_push_length(&mut self, geom_offsets_length: usize) -> Result<()> {
-        self.geom_offsets.try_push_usize(geom_offsets_length)?;
-        self.validity.append(true);
-        Ok(())
-    }
-
-    #[inline]
-    pub(crate) fn push_null(&mut self) {
-        self.geom_offsets.extend_constant(1);
-        self.validity.append(false);
-    }
-
     #[inline]
     pub fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
         if let Some(value) = value {
@@ -238,38 +276,6 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
             self.push_null();
         };
         Ok(())
-    }
-
-    pub fn into_array_ref(self) -> Arc<dyn Array> {
-        Arc::new(self.into_arrow())
-    }
-
-    pub fn from_line_strings(
-        geoms: &[impl LineStringTrait<T = f64>],
-        coord_type: Option<CoordType>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(Some),
-            coord_type.unwrap_or_default(),
-            metadata,
-        );
-        array.extend_from_iter(geoms.iter().map(Some));
-        array
-    }
-
-    pub fn from_nullable_line_strings(
-        geoms: &[Option<impl LineStringTrait<T = f64>>],
-        coord_type: Option<CoordType>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(|x| x.as_ref()),
-            coord_type.unwrap_or_default(),
-            metadata,
-        );
-        array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
-        array
     }
 
     pub(crate) fn from_wkb<W: OffsetSizeTrait>(
@@ -291,13 +297,9 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O> {
             metadata,
         ))
     }
-
-    pub fn finish(self) -> LineStringArray<O> {
-        self.into()
-    }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayBuilder for LineStringBuilder<O> {
+impl<O: OffsetSizeTrait> GeometryArrayBuilder for LineStringBuilder<O, 2> {
     fn new() -> Self {
         Self::new()
     }
@@ -340,23 +342,23 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for LineStringBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for LineStringBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for LineStringBuilder<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let linestring_arr: LineStringArray<O> = self.into();
+        let linestring_arr: LineStringArray<O, D> = self.into();
         linestring_arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait> Default for LineStringBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for LineStringBuilder<O, D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: OffsetSizeTrait> From<LineStringBuilder<O>> for LineStringArray<O> {
-    fn from(other: LineStringBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<LineStringBuilder<O, D>> for LineStringArray<O, D> {
+    fn from(other: LineStringBuilder<O, D>) -> Self {
         let validity = other.validity.finish_cloned();
         Self::new(
             other.coords.into(),
@@ -367,43 +369,27 @@ impl<O: OffsetSizeTrait> From<LineStringBuilder<O>> for LineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<LineStringBuilder<O>> for GenericListArray<O> {
-    fn from(arr: LineStringBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<LineStringBuilder<O, D>> for GenericListArray<O> {
+    fn from(arr: LineStringBuilder<O, D>) -> Self {
         arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<&[G]> for LineStringBuilder<O> {
+impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<&[G]> for LineStringBuilder<O, 2> {
     fn from(geoms: &[G]) -> Self {
         Self::from_line_strings(geoms, Default::default(), Default::default())
     }
 }
 
 impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<Vec<Option<G>>>
-    for LineStringBuilder<O>
+    for LineStringBuilder<O, 2>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_line_strings(&geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>>
-    for LineStringBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_line_strings(&geoms, Default::default(), Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> From<bumpalo::collections::Vec<'_, Option<G>>>
-    for LineStringBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_line_strings(&geoms, Default::default(), Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -415,8 +401,8 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringBuilder<O> {
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<O: OffsetSizeTrait> From<LineStringBuilder<O>> for MultiPointBuilder<O> {
-    fn from(value: LineStringBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<LineStringBuilder<O, D>> for MultiPointBuilder<O, D> {
+    fn from(value: LineStringBuilder<O, D>) -> Self {
         Self::try_new(
             value.coords,
             value.geom_offsets,

--- a/src/array/linestring/builder.rs
+++ b/src/array/linestring/builder.rs
@@ -299,7 +299,7 @@ impl<O: OffsetSizeTrait> LineStringBuilder<O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayBuilder for LineStringBuilder<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for LineStringBuilder<O, D> {
     fn new() -> Self {
         Self::new()
     }

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -435,7 +435,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O, 2> {
 }
 
 impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MixedGeometryArray<O, 2> {
-    type Item = Geometry<'a, O>;
+    type Item = Geometry<'a, O, 2>;
     type ItemGeo = geo::Geometry;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -700,7 +700,7 @@ impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[G]> for MixedGeome
     type Error = GeoArrowError;
 
     fn try_from(geoms: &[G]) -> Result<Self> {
-        let mut_arr: MixedGeometryBuilder<O> = geoms.try_into()?;
+        let mut_arr: MixedGeometryBuilder<O, 2> = geoms.try_into()?;
         Ok(mut_arr.into())
     }
 }
@@ -711,7 +711,7 @@ impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[Option<G>]>
     type Error = GeoArrowError;
 
     fn try_from(geoms: &[Option<G>]) -> Result<Self> {
-        let mut_arr: MixedGeometryBuilder<O> = geoms.try_into()?;
+        let mut_arr: MixedGeometryBuilder<O, 2> = geoms.try_into()?;
         Ok(mut_arr.into())
     }
 }
@@ -720,7 +720,7 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MixedGeometryArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
-        let mut_arr: MixedGeometryBuilder<O> = value.try_into()?;
+        let mut_arr: MixedGeometryBuilder<O, 2> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -24,7 +24,7 @@ use crate::GeometryArrayTrait;
 /// - All arrays must have the same dimension
 /// - All arrays must have the same coordinate layout (interleaved or separated)
 #[derive(Debug, Clone, PartialEq)]
-pub struct MixedGeometryArray<O: OffsetSizeTrait> {
+pub struct MixedGeometryArray<O: OffsetSizeTrait, const D: usize> {
     /// Always GeoDataType::Mixed or GeoDataType::LargeMixed
     data_type: GeoDataType,
 
@@ -67,12 +67,12 @@ pub struct MixedGeometryArray<O: OffsetSizeTrait> {
     pub(crate) map: [Option<GeometryType>; 7],
 
     /// Invariant: Any of these arrays that are `Some()` must have length >0
-    pub(crate) points: Option<PointArray>,
-    pub(crate) line_strings: Option<LineStringArray<O>>,
-    pub(crate) polygons: Option<PolygonArray<O>>,
-    pub(crate) multi_points: Option<MultiPointArray<O>>,
-    pub(crate) multi_line_strings: Option<MultiLineStringArray<O>>,
-    pub(crate) multi_polygons: Option<MultiPolygonArray<O>>,
+    pub(crate) points: Option<PointArray<D>>,
+    pub(crate) line_strings: Option<LineStringArray<O, D>>,
+    pub(crate) polygons: Option<PolygonArray<O, D>>,
+    pub(crate) multi_points: Option<MultiPointArray<O, D>>,
+    pub(crate) multi_line_strings: Option<MultiLineStringArray<O, D>>,
+    pub(crate) multi_polygons: Option<MultiPolygonArray<O, D>>,
 
     /// An offset used for slicing into this array. The offset will be 0 if the array has not been
     /// sliced.
@@ -134,7 +134,7 @@ impl From<&String> for GeometryType {
     }
 }
 
-impl<O: OffsetSizeTrait> MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> MixedGeometryArray<O, D> {
     /// Create a new MixedGeometryArray from parts
     ///
     /// # Implementation
@@ -149,12 +149,12 @@ impl<O: OffsetSizeTrait> MixedGeometryArray<O> {
     pub fn new(
         type_ids: ScalarBuffer<i8>,
         offsets: ScalarBuffer<i32>,
-        points: Option<PointArray>,
-        line_strings: Option<LineStringArray<O>>,
-        polygons: Option<PolygonArray<O>>,
-        multi_points: Option<MultiPointArray<O>>,
-        multi_line_strings: Option<MultiLineStringArray<O>>,
-        multi_polygons: Option<MultiPolygonArray<O>>,
+        points: Option<PointArray<D>>,
+        line_strings: Option<LineStringArray<O, D>>,
+        polygons: Option<PolygonArray<O, D>>,
+        multi_points: Option<MultiPointArray<O, D>>,
+        multi_line_strings: Option<MultiLineStringArray<O, D>>,
+        multi_polygons: Option<MultiPolygonArray<O, D>>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let default_ordering = [
@@ -269,7 +269,7 @@ impl<O: OffsetSizeTrait> MixedGeometryArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayTrait for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MixedGeometryArray<O, D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -389,7 +389,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MixedGeometryArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O, 2> {
     fn with_coords(self, _coords: crate::array::CoordBuffer<2>) -> Self {
         todo!();
     }
@@ -434,7 +434,7 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MixedGeometryArray<O> {
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MixedGeometryArray<O, 2> {
     type Item = Geometry<'a, O>;
     type ItemGeo = geo::Geometry;
 
@@ -469,7 +469,7 @@ impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MixedGeometryArray<O>
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MixedGeometryArray<O, D> {
     type ArrowArray = UnionArray;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -518,16 +518,16 @@ impl<O: OffsetSizeTrait> IntoArrow for MixedGeometryArray<O> {
     }
 }
 
-impl TryFrom<&UnionArray> for MixedGeometryArray<i32> {
+impl<const D: usize> TryFrom<&UnionArray> for MixedGeometryArray<i32, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &UnionArray) -> std::result::Result<Self, Self::Error> {
-        let mut points: Option<PointArray> = None;
-        let mut line_strings: Option<LineStringArray<i32>> = None;
-        let mut polygons: Option<PolygonArray<i32>> = None;
-        let mut multi_points: Option<MultiPointArray<i32>> = None;
-        let mut multi_line_strings: Option<MultiLineStringArray<i32>> = None;
-        let mut multi_polygons: Option<MultiPolygonArray<i32>> = None;
+        let mut points: Option<PointArray<D>> = None;
+        let mut line_strings: Option<LineStringArray<i32, D>> = None;
+        let mut polygons: Option<PolygonArray<i32, D>> = None;
+        let mut multi_points: Option<MultiPointArray<i32, D>> = None;
+        let mut multi_line_strings: Option<MultiLineStringArray<i32, D>> = None;
+        let mut multi_polygons: Option<MultiPolygonArray<i32, D>> = None;
         match value.data_type() {
             DataType::Union(fields, mode) => {
                 if !matches!(mode, UnionMode::Dense) {
@@ -590,16 +590,16 @@ impl TryFrom<&UnionArray> for MixedGeometryArray<i32> {
     }
 }
 
-impl TryFrom<&UnionArray> for MixedGeometryArray<i64> {
+impl<const D: usize> TryFrom<&UnionArray> for MixedGeometryArray<i64, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &UnionArray) -> std::result::Result<Self, Self::Error> {
-        let mut points: Option<PointArray> = None;
-        let mut line_strings: Option<LineStringArray<i64>> = None;
-        let mut polygons: Option<PolygonArray<i64>> = None;
-        let mut multi_points: Option<MultiPointArray<i64>> = None;
-        let mut multi_line_strings: Option<MultiLineStringArray<i64>> = None;
-        let mut multi_polygons: Option<MultiPolygonArray<i64>> = None;
+        let mut points: Option<PointArray<D>> = None;
+        let mut line_strings: Option<LineStringArray<i64, D>> = None;
+        let mut polygons: Option<PolygonArray<i64, D>> = None;
+        let mut multi_points: Option<MultiPointArray<i64, D>> = None;
+        let mut multi_line_strings: Option<MultiLineStringArray<i64, D>> = None;
+        let mut multi_polygons: Option<MultiPolygonArray<i64, D>> = None;
         match value.data_type() {
             DataType::Union(fields, mode) => {
                 if !matches!(mode, UnionMode::Dense) {
@@ -662,7 +662,7 @@ impl TryFrom<&UnionArray> for MixedGeometryArray<i64> {
     }
 }
 
-impl TryFrom<&dyn Array> for MixedGeometryArray<i32> {
+impl<const D: usize> TryFrom<&dyn Array> for MixedGeometryArray<i32, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
@@ -679,7 +679,7 @@ impl TryFrom<&dyn Array> for MixedGeometryArray<i32> {
     }
 }
 
-impl TryFrom<&dyn Array> for MixedGeometryArray<i64> {
+impl<const D: usize> TryFrom<&dyn Array> for MixedGeometryArray<i64, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
@@ -696,7 +696,7 @@ impl TryFrom<&dyn Array> for MixedGeometryArray<i64> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[G]> for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[G]> for MixedGeometryArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(geoms: &[G]) -> Result<Self> {
@@ -706,7 +706,7 @@ impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[G]> for MixedGeome
 }
 
 impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[Option<G>]>
-    for MixedGeometryArray<O>
+    for MixedGeometryArray<O, 2>
 {
     type Error = GeoArrowError;
 
@@ -716,7 +716,7 @@ impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[Option<G>]>
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MixedGeometryArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -725,8 +725,8 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MixedGeometryArray<O> {
     }
 }
 
-impl From<MixedGeometryArray<i32>> for MixedGeometryArray<i64> {
-    fn from(value: MixedGeometryArray<i32>) -> Self {
+impl<const D: usize> From<MixedGeometryArray<i32, D>> for MixedGeometryArray<i64, D> {
+    fn from(value: MixedGeometryArray<i32, D>) -> Self {
         Self::new(
             value.type_ids,
             value.offsets,
@@ -741,10 +741,10 @@ impl From<MixedGeometryArray<i32>> for MixedGeometryArray<i64> {
     }
 }
 
-impl TryFrom<MixedGeometryArray<i64>> for MixedGeometryArray<i32> {
+impl<const D: usize> TryFrom<MixedGeometryArray<i64, D>> for MixedGeometryArray<i32, D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: MixedGeometryArray<i64>) -> Result<Self> {
+    fn try_from(value: MixedGeometryArray<i64, D>) -> Result<Self> {
         Ok(Self::new(
             value.type_ids,
             value.offsets,
@@ -763,7 +763,7 @@ impl TryFrom<MixedGeometryArray<i64>> for MixedGeometryArray<i32> {
 }
 
 /// Default to an empty array
-impl<O: OffsetSizeTrait> Default for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for MixedGeometryArray<O, D> {
     fn default() -> Self {
         MixedGeometryBuilder::default().into()
     }
@@ -782,7 +782,7 @@ mod test {
             geo::Geometry::Point(point::p1()),
             geo::Geometry::Point(point::p2()),
         ];
-        let arr: MixedGeometryArray<i32> = geoms.as_slice().try_into().unwrap();
+        let arr: MixedGeometryArray<i32, 2> = geoms.as_slice().try_into().unwrap();
 
         assert_eq!(
             arr.value_as_geo(0),
@@ -808,7 +808,7 @@ mod test {
             geo::Geometry::MultiLineString(multilinestring::ml0()),
             geo::Geometry::MultiPolygon(multipolygon::mp0()),
         ];
-        let arr: MixedGeometryArray<i32> = geoms.as_slice().try_into().unwrap();
+        let arr: MixedGeometryArray<i32, 2> = geoms.as_slice().try_into().unwrap();
 
         assert_eq!(
             arr.value_as_geo(0),
@@ -837,11 +837,11 @@ mod test {
             geo::Geometry::MultiLineString(multilinestring::ml0()),
             geo::Geometry::MultiPolygon(multipolygon::mp0()),
         ];
-        let arr: MixedGeometryArray<i32> = geoms.as_slice().try_into().unwrap();
+        let arr: MixedGeometryArray<i32, 2> = geoms.as_slice().try_into().unwrap();
 
         // Round trip to/from arrow-rs
         let arrow_array = arr.into_arrow();
-        let round_trip_arr: MixedGeometryArray<i32> = (&arrow_array).try_into().unwrap();
+        let round_trip_arr: MixedGeometryArray<i32, 2> = (&arrow_array).try_into().unwrap();
 
         assert_eq!(
             round_trip_arr.value_as_geo(0),
@@ -867,11 +867,11 @@ mod test {
             geo::Geometry::MultiLineString(multilinestring::ml0()),
             geo::Geometry::MultiPolygon(multipolygon::mp0()),
         ];
-        let arr: MixedGeometryArray<i32> = geoms.as_slice().try_into().unwrap();
+        let arr: MixedGeometryArray<i32, 2> = geoms.as_slice().try_into().unwrap();
 
         // Round trip to/from arrow-rs
         let arrow_array = arr.into_arrow();
-        let round_trip_arr: MixedGeometryArray<i32> = (&arrow_array).try_into().unwrap();
+        let round_trip_arr: MixedGeometryArray<i32, 2> = (&arrow_array).try_into().unwrap();
 
         assert_eq!(round_trip_arr.value_as_geo(0), geoms[0]);
         assert_eq!(round_trip_arr.value_as_geo(1), geoms[1]);
@@ -884,11 +884,11 @@ mod test {
             geo::Geometry::MultiPoint(multipoint::mp0()),
             geo::Geometry::MultiPolygon(multipolygon::mp0()),
         ];
-        let arr: MixedGeometryArray<i32> = geoms.as_slice().try_into().unwrap();
+        let arr: MixedGeometryArray<i32, 2> = geoms.as_slice().try_into().unwrap();
 
         // Round trip to/from arrow-rs
         let arrow_array = arr.into_arrow();
-        let round_trip_arr: MixedGeometryArray<i32> = (&arrow_array).try_into().unwrap();
+        let round_trip_arr: MixedGeometryArray<i32, 2> = (&arrow_array).try_into().unwrap();
 
         assert_eq!(round_trip_arr.value_as_geo(0), geoms[0]);
         assert_eq!(round_trip_arr.value_as_geo(1), geoms[1]);

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -389,8 +389,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MixedGeometryArr
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O, 2> {
-    fn with_coords(self, _coords: crate::array::CoordBuffer<2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D> for MixedGeometryArray<O, D> {
+    fn with_coords(self, _coords: crate::array::CoordBuffer<D>) -> Self {
         todo!();
     }
 
@@ -434,8 +434,10 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MixedGeometryArray<O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MixedGeometryArray<O, 2> {
-    type Item = Geometry<'a, O, 2>;
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a>
+    for MixedGeometryArray<O, D>
+{
+    type Item = Geometry<'a, O, D>;
     type ItemGeo = geo::Geometry;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -44,7 +44,7 @@ pub struct MixedGeometryBuilder<O: OffsetSizeTrait, const D: usize> {
     offsets: Vec<i32>,
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> MixedGeometryBuilder<O, D> {
+impl<O: OffsetSizeTrait, const D: usize> MixedGeometryBuilder<O, D> {
     /// Creates a new empty [`MixedGeometryBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -27,24 +27,24 @@ use arrow_array::{OffsetSizeTrait, UnionArray};
 /// - All arrays must have the same dimension
 /// - All arrays must have the same coordinate layout (interleaved or separated)
 #[derive(Debug)]
-pub struct MixedGeometryBuilder<O: OffsetSizeTrait> {
+pub struct MixedGeometryBuilder<O: OffsetSizeTrait, const D: usize> {
     metadata: Arc<ArrayMetadata>,
 
     // Invariant: every item in `types` is `> 0 && < fields.len()`
     types: Vec<i8>,
 
-    pub(crate) points: PointBuilder,
-    pub(crate) line_strings: LineStringBuilder<O>,
-    pub(crate) polygons: PolygonBuilder<O>,
-    pub(crate) multi_points: MultiPointBuilder<O>,
-    pub(crate) multi_line_strings: MultiLineStringBuilder<O>,
-    pub(crate) multi_polygons: MultiPolygonBuilder<O>,
+    pub(crate) points: PointBuilder<D>,
+    pub(crate) line_strings: LineStringBuilder<O, D>,
+    pub(crate) polygons: PolygonBuilder<O, D>,
+    pub(crate) multi_points: MultiPointBuilder<O, D>,
+    pub(crate) multi_line_strings: MultiLineStringBuilder<O, D>,
+    pub(crate) multi_polygons: MultiPolygonBuilder<O, D>,
 
     // Invariant: `offsets.len() == types.len()`
     offsets: Vec<i32>,
 }
 
-impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MixedGeometryBuilder<O, D> {
     /// Creates a new empty [`MixedGeometryBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -102,23 +102,6 @@ impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O> {
         }
     }
 
-    pub fn with_capacity_from_iter(
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
-    ) -> Result<Self> {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
-    }
-
-    pub fn with_capacity_and_options_from_iter(
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self> {
-        let counter = MixedCapacity::from_geometries(geoms)?;
-        Ok(Self::with_capacity_and_options(
-            counter, coord_type, metadata,
-        ))
-    }
-
     pub fn reserve(&mut self, capacity: MixedCapacity) {
         let total_num_geoms = capacity.total_num_geoms();
         self.types.reserve(total_num_geoms);
@@ -142,24 +125,6 @@ impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O> {
         self.multi_line_strings
             .reserve_exact(capacity.multi_line_string);
         self.multi_polygons.reserve_exact(capacity.multi_polygon);
-    }
-
-    pub fn reserve_from_iter(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
-    ) -> Result<()> {
-        let counter = MixedCapacity::from_geometries(geoms)?;
-        self.reserve(counter);
-        Ok(())
-    }
-
-    pub fn reserve_exact_from_iter(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
-    ) -> Result<()> {
-        let counter = MixedCapacity::from_geometries(geoms)?;
-        self.reserve_exact(counter);
-        Ok(())
     }
 
     // /// The canonical method to create a [`MixedGeometryBuilder`] out of its internal
@@ -190,6 +155,47 @@ impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O> {
     //         validity,
     //     })
     // }
+
+    pub fn finish(self) -> MixedGeometryArray<O, D> {
+        self.into()
+    }
+}
+
+impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O, 2> {
+    pub fn with_capacity_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<Self> {
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
+    }
+
+    pub fn with_capacity_and_options_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
+        let counter = MixedCapacity::from_geometries(geoms)?;
+        Ok(Self::with_capacity_and_options(
+            counter, coord_type, metadata,
+        ))
+    }
+
+    pub fn reserve_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<()> {
+        let counter = MixedCapacity::from_geometries(geoms)?;
+        self.reserve(counter);
+        Ok(())
+    }
+
+    pub fn reserve_exact_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<()> {
+        let counter = MixedCapacity::from_geometries(geoms)?;
+        self.reserve_exact(counter);
+        Ok(())
+    }
 
     /// Add a new Point to the end of this array, storing it in the PointBuilder child array.
     #[inline]
@@ -482,19 +488,15 @@ impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O> {
             .collect();
         Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata, prefer_multi)
     }
-
-    pub fn finish(self) -> MixedGeometryArray<O> {
-        self.into()
-    }
 }
 
-impl<O: OffsetSizeTrait> Default for MixedGeometryBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for MixedGeometryBuilder<O, D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for MixedGeometryBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MixedGeometryBuilder<O, D> {
     type ArrowArray = UnionArray;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -502,8 +504,10 @@ impl<O: OffsetSizeTrait> IntoArrow for MixedGeometryBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<MixedGeometryBuilder<O>> for MixedGeometryArray<O> {
-    fn from(other: MixedGeometryBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MixedGeometryBuilder<O, D>>
+    for MixedGeometryArray<O, D>
+{
+    fn from(other: MixedGeometryBuilder<O, D>) -> Self {
         Self::new(
             other.types.into(),
             other.offsets.into(),
@@ -542,7 +546,7 @@ impl<O: OffsetSizeTrait> From<MixedGeometryBuilder<O>> for MixedGeometryArray<O>
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[G]> for MixedGeometryBuilder<O> {
+impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[G]> for MixedGeometryBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(geoms: &[G]) -> Result<Self> {
@@ -551,7 +555,7 @@ impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[G]> for MixedGeome
 }
 
 impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[Option<G>]>
-    for MixedGeometryBuilder<O>
+    for MixedGeometryBuilder<O, 2>
 {
     type Error = GeoArrowError;
 
@@ -560,7 +564,7 @@ impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[Option<G>]>
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MixedGeometryBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MixedGeometryBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> std::result::Result<Self, Self::Error> {
@@ -576,7 +580,7 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MixedGeometryBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayBuilder for MixedGeometryBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MixedGeometryBuilder<O, D> {
     fn len(&self) -> usize {
         self.types.len()
     }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -43,43 +43,49 @@ use arrow_schema::{DataType, Field};
 use crate::error::{GeoArrowError, Result};
 use crate::GeometryArrayTrait;
 
+// TODO: support 3d coords here.
+
 /// Convert an Arrow [Array] to a geoarrow GeometryArray
 pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeometryArrayTrait>> {
     if let Some(extension_name) = field.metadata().get("ARROW:extension:name") {
         let geom_arr: Arc<dyn GeometryArrayTrait> = match extension_name.as_str() {
             "geoarrow.point" => Arc::new(PointArray::try_from(array).unwrap()),
             "geoarrow.linestring" => match field.data_type() {
-                DataType::List(_) => Arc::new(LineStringArray::<i32>::try_from(array).unwrap()),
+                DataType::List(_) => Arc::new(LineStringArray::<i32, 2>::try_from(array).unwrap()),
                 DataType::LargeList(_) => {
-                    Arc::new(LineStringArray::<i64>::try_from(array).unwrap())
+                    Arc::new(LineStringArray::<i64, 2>::try_from(array).unwrap())
                 }
                 _ => panic!("Unexpected data type"),
             },
             "geoarrow.polygon" => match field.data_type() {
-                DataType::List(_) => Arc::new(PolygonArray::<i32>::try_from(array).unwrap()),
-                DataType::LargeList(_) => Arc::new(PolygonArray::<i64>::try_from(array).unwrap()),
+                DataType::List(_) => Arc::new(PolygonArray::<i32, 2>::try_from(array).unwrap()),
+                DataType::LargeList(_) => {
+                    Arc::new(PolygonArray::<i64, 2>::try_from(array).unwrap())
+                }
                 _ => panic!("Unexpected data type"),
             },
             "geoarrow.multipoint" => match field.data_type() {
-                DataType::List(_) => Arc::new(MultiPointArray::<i32>::try_from(array).unwrap()),
+                DataType::List(_) => Arc::new(MultiPointArray::<i32, 2>::try_from(array).unwrap()),
                 DataType::LargeList(_) => {
-                    Arc::new(MultiPointArray::<i64>::try_from(array).unwrap())
+                    Arc::new(MultiPointArray::<i64, 2>::try_from(array).unwrap())
                 }
                 _ => panic!("Unexpected data type"),
             },
             "geoarrow.multilinestring" => match field.data_type() {
                 DataType::List(_) => {
-                    Arc::new(MultiLineStringArray::<i32>::try_from(array).unwrap())
+                    Arc::new(MultiLineStringArray::<i32, 2>::try_from(array).unwrap())
                 }
                 DataType::LargeList(_) => {
-                    Arc::new(MultiLineStringArray::<i64>::try_from(array).unwrap())
+                    Arc::new(MultiLineStringArray::<i64, 2>::try_from(array).unwrap())
                 }
                 _ => panic!("Unexpected data type"),
             },
             "geoarrow.multipolygon" => match field.data_type() {
-                DataType::List(_) => Arc::new(MultiPolygonArray::<i32>::try_from(array).unwrap()),
+                DataType::List(_) => {
+                    Arc::new(MultiPolygonArray::<i32, 2>::try_from(array).unwrap())
+                }
                 DataType::LargeList(_) => {
-                    Arc::new(MultiPolygonArray::<i64>::try_from(array).unwrap())
+                    Arc::new(MultiPolygonArray::<i64, 2>::try_from(array).unwrap())
                 }
                 _ => panic!("Unexpected data type"),
             },
@@ -97,13 +103,13 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn Geom
 
                     if large_offsets.is_empty() {
                         // Only contains a point array, we can cast to i32
-                        Arc::new(MixedGeometryArray::<i32>::try_from(array).unwrap())
+                        Arc::new(MixedGeometryArray::<i32, 2>::try_from(array).unwrap())
                     } else if large_offsets.iter().all(|x| *x) {
                         // All large offsets, cast to i64
-                        Arc::new(MixedGeometryArray::<i64>::try_from(array).unwrap())
+                        Arc::new(MixedGeometryArray::<i64, 2>::try_from(array).unwrap())
                     } else if large_offsets.iter().all(|x| !x) {
                         // All small offsets, cast to i32
-                        Arc::new(MixedGeometryArray::<i32>::try_from(array).unwrap())
+                        Arc::new(MixedGeometryArray::<i32, 2>::try_from(array).unwrap())
                     } else {
                         panic!("Mix of offset types");
                     }
@@ -112,10 +118,10 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn Geom
             },
             "geoarrow.geometrycollection" => match field.data_type() {
                 DataType::List(_) => {
-                    Arc::new(GeometryCollectionArray::<i32>::try_from(array).unwrap())
+                    Arc::new(GeometryCollectionArray::<i32, 2>::try_from(array).unwrap())
                 }
                 DataType::LargeList(_) => {
-                    Arc::new(GeometryCollectionArray::<i64>::try_from(array).unwrap())
+                    Arc::new(GeometryCollectionArray::<i64, 2>::try_from(array).unwrap())
                 }
                 _ => panic!("Unexpected data type"),
             },
@@ -144,10 +150,10 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn Geom
                 Ok(Arc::new(WKBArray::<i64>::try_from(array).unwrap()))
             }
             DataType::Struct(_) => {
-                Ok(Arc::new(PointArray::try_from(array).unwrap()))
+                Ok(Arc::new(PointArray::<2>::try_from(array).unwrap()))
             }
             DataType::FixedSizeList(_, _) => {
-                Ok(Arc::new(PointArray::try_from(array).unwrap()))
+                Ok(Arc::new(PointArray::<2>::try_from(array).unwrap()))
             }
             _ => Err(GeoArrowError::General("Only Binary, LargeBinary, FixedSizeList, and Struct arrays are unambigously typed and can be used without extension metadata.".to_string()))
         }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -49,7 +49,7 @@ use crate::GeometryArrayTrait;
 pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeometryArrayTrait>> {
     if let Some(extension_name) = field.metadata().get("ARROW:extension:name") {
         let geom_arr: Arc<dyn GeometryArrayTrait> = match extension_name.as_str() {
-            "geoarrow.point" => Arc::new(PointArray::try_from(array).unwrap()),
+            "geoarrow.point" => Arc::new(PointArray::<2>::try_from(array).unwrap()),
             "geoarrow.linestring" => match field.data_type() {
                 DataType::List(_) => Arc::new(LineStringArray::<i32, 2>::try_from(array).unwrap()),
                 DataType::LargeList(_) => {

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -247,8 +247,10 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiLineStringA
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiLineStringArray<O, 2> {
-    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D>
+    for MultiLineStringArray<O, D>
+{
+    fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
             coords,
@@ -329,8 +331,10 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiLineStringArray<O, 2>
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiLineStringArray<O, 2> {
-    type Item = MultiLineString<'a, O, 2>;
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a>
+    for MultiLineStringArray<O, D>
+{
+    type Item = MultiLineString<'a, O, D>;
     type ItemGeo = geo::MultiLineString;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -26,13 +26,13 @@ use super::MultiLineStringBuilder;
 /// bitmap.
 #[derive(Debug, Clone)]
 // #[derive(Debug, Clone, PartialEq)]
-pub struct MultiLineStringArray<O: OffsetSizeTrait> {
+pub struct MultiLineStringArray<O: OffsetSizeTrait, const D: usize> {
     // Always GeoDataType::MultiLineString or GeoDataType::LargeMultiLineString
     data_type: GeoDataType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBuffer<2>,
+    pub(crate) coords: CoordBuffer<D>,
 
     /// Offsets into the ring array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -44,8 +44,8 @@ pub struct MultiLineStringArray<O: OffsetSizeTrait> {
     pub(crate) validity: Option<NullBuffer>,
 }
 
-pub(super) fn check<O: OffsetSizeTrait>(
-    coords: &CoordBuffer<2>,
+pub(super) fn check<O: OffsetSizeTrait, const D: usize>(
+    coords: &CoordBuffer<D>,
     geom_offsets: &OffsetBuffer<O>,
     ring_offsets: &OffsetBuffer<O>,
     validity_len: Option<usize>,
@@ -71,7 +71,7 @@ pub(super) fn check<O: OffsetSizeTrait>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
     /// Create a new MultiLineStringArray from parts
     ///
     /// # Implementation
@@ -84,7 +84,7 @@ impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
@@ -105,7 +105,7 @@ impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn try_new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
@@ -152,7 +152,7 @@ impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
         }
     }
 
-    pub fn coords(&self) -> &CoordBuffer<2> {
+    pub fn coords(&self) -> &CoordBuffer<D> {
         &self.coords
     }
 
@@ -180,7 +180,7 @@ impl<O: OffsetSizeTrait> MultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiLineStringArray<O, D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -247,7 +247,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for MultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiLineStringArray<O, 2> {
     fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
@@ -329,8 +329,8 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiLineStringArray<O> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiLineStringArray<O> {
-    type Item = MultiLineString<'a, O>;
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiLineStringArray<O, 2> {
+    type Item = MultiLineString<'a, O, 2>;
     type ItemGeo = geo::MultiLineString;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -338,7 +338,7 @@ impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiLineStringArray<
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiLineStringArray<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -356,7 +356,9 @@ impl<O: OffsetSizeTrait> IntoArrow for MultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>>
+    for MultiLineStringArray<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(geom_array: &GenericListArray<O>) -> Result<Self, Self::Error> {
@@ -370,7 +372,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for MultiLineStringArray<
             .unwrap();
 
         let ring_offsets = rings_array.offsets();
-        let coords: CoordBuffer<2> = rings_array.values().as_ref().try_into()?;
+        let coords: CoordBuffer<D> = rings_array.values().as_ref().try_into()?;
 
         Ok(Self::new(
             coords,
@@ -382,7 +384,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for MultiLineStringArray<
     }
 }
 
-impl TryFrom<&dyn Array> for MultiLineStringArray<i32> {
+impl<const D: usize> TryFrom<&dyn Array> for MultiLineStringArray<i32, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self, Self::Error> {
@@ -393,7 +395,7 @@ impl TryFrom<&dyn Array> for MultiLineStringArray<i32> {
             }
             DataType::LargeList(_) => {
                 let downcasted = value.as_any().downcast_ref::<LargeListArray>().unwrap();
-                let geom_array: MultiLineStringArray<i64> = downcasted.try_into()?;
+                let geom_array: MultiLineStringArray<i64, D> = downcasted.try_into()?;
                 geom_array.try_into()
             }
             _ => Err(GeoArrowError::General(format!(
@@ -404,14 +406,14 @@ impl TryFrom<&dyn Array> for MultiLineStringArray<i32> {
     }
 }
 
-impl TryFrom<&dyn Array> for MultiLineStringArray<i64> {
+impl<const D: usize> TryFrom<&dyn Array> for MultiLineStringArray<i64, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self, Self::Error> {
         match value.data_type() {
             DataType::List(_) => {
                 let downcasted = value.as_any().downcast_ref::<ListArray>().unwrap();
-                let geom_array: MultiLineStringArray<i32> = downcasted.try_into()?;
+                let geom_array: MultiLineStringArray<i32, D> = downcasted.try_into()?;
                 Ok(geom_array.into())
             }
             DataType::LargeList(_) => {
@@ -427,7 +429,7 @@ impl TryFrom<&dyn Array> for MultiLineStringArray<i64> {
 }
 
 impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<Vec<Option<G>>>
-    for MultiLineStringArray<O>
+    for MultiLineStringArray<O, 2>
 {
     fn from(other: Vec<Option<G>>) -> Self {
         let mut_arr: MultiLineStringBuilder<O> = other.into();
@@ -435,34 +437,19 @@ impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<Vec<Option<G>>>
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<&[G]> for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<&[G]>
+    for MultiLineStringArray<O, 2>
+{
     fn from(other: &[G]) -> Self {
         let mut_arr: MultiLineStringBuilder<O> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>>
-    From<bumpalo::collections::Vec<'_, Option<G>>> for MultiLineStringArray<O>
-{
-    fn from(other: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        let mut_arr: MultiLineStringBuilder<O> = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>>
-    for MultiLineStringArray<O>
-{
-    fn from(other: bumpalo::collections::Vec<'_, G>) -> Self {
-        let mut_arr: MultiLineStringBuilder<O> = other.into();
-        mut_arr.into()
-    }
-}
 /// Polygon and MultiLineString have the same layout, so enable conversions between the two to
 /// change the semantic type
-impl<O: OffsetSizeTrait> From<MultiLineStringArray<O>> for PolygonArray<O> {
-    fn from(value: MultiLineStringArray<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiLineStringArray<O, D>> for PolygonArray<O, D> {
+    fn from(value: MultiLineStringArray<O, D>) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -473,7 +460,7 @@ impl<O: OffsetSizeTrait> From<MultiLineStringArray<O>> for PolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self, Self::Error> {
@@ -482,10 +469,12 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<LineStringArray<O>> for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<LineStringArray<O, D>>
+    for MultiLineStringArray<O, D>
+{
     type Error = GeoArrowError;
 
-    fn try_from(value: LineStringArray<O>) -> Result<Self, Self::Error> {
+    fn try_from(value: LineStringArray<O, D>) -> Result<Self, Self::Error> {
         let geom_length = value.len();
 
         let coords = value.coords;
@@ -508,8 +497,8 @@ impl<O: OffsetSizeTrait> TryFrom<LineStringArray<O>> for MultiLineStringArray<O>
     }
 }
 
-impl From<MultiLineStringArray<i32>> for MultiLineStringArray<i64> {
-    fn from(value: MultiLineStringArray<i32>) -> Self {
+impl<const D: usize> From<MultiLineStringArray<i32, D>> for MultiLineStringArray<i64, D> {
+    fn from(value: MultiLineStringArray<i32, D>) -> Self {
         Self::new(
             value.coords,
             offsets_buffer_i32_to_i64(&value.geom_offsets),
@@ -520,10 +509,10 @@ impl From<MultiLineStringArray<i32>> for MultiLineStringArray<i64> {
     }
 }
 
-impl TryFrom<MultiLineStringArray<i64>> for MultiLineStringArray<i32> {
+impl<const D: usize> TryFrom<MultiLineStringArray<i64, D>> for MultiLineStringArray<i32, D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: MultiLineStringArray<i64>) -> Result<Self, Self::Error> {
+    fn try_from(value: MultiLineStringArray<i64, D>) -> Result<Self, Self::Error> {
         Ok(Self::new(
             value.coords,
             offsets_buffer_i64_to_i32(&value.geom_offsets)?,
@@ -535,13 +524,13 @@ impl TryFrom<MultiLineStringArray<i64>> for MultiLineStringArray<i32> {
 }
 
 /// Default to an empty array
-impl<O: OffsetSizeTrait> Default for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for MultiLineStringArray<O, D> {
     fn default() -> Self {
         MultiLineStringBuilder::default().into()
     }
 }
 
-impl<O: OffsetSizeTrait> PartialEq for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> PartialEq for MultiLineStringArray<O, D> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;
@@ -575,14 +564,14 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: MultiLineStringArray<i64> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray<i64, 2> = vec![ml0(), ml1()].as_slice().into();
         assert_eq!(arr.value_as_geo(0), ml0());
         assert_eq!(arr.value_as_geo(1), ml1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: MultiLineStringArray<i64> = vec![Some(ml0()), Some(ml1()), None].into();
+        let arr: MultiLineStringArray<i64, 2> = vec![Some(ml0()), Some(ml1()), None].into();
         assert_eq!(arr.get_as_geo(0), Some(ml0()));
         assert_eq!(arr.get_as_geo(1), Some(ml1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -590,7 +579,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiLineStringArray<i64> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray<i64, 2> = vec![ml0(), ml1()].as_slice().into();
         let sliced = arr.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(ml1()));
@@ -598,7 +587,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: MultiLineStringArray<i64> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray<i64, 2> = vec![ml0(), ml1()].as_slice().into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -619,7 +608,7 @@ mod test {
         let geom_arr = example_multilinestring_interleaved();
 
         let wkb_arr = example_multilinestring_wkb();
-        let parsed_geom_arr: MultiLineStringArray<i64> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiLineStringArray<i64, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }
@@ -629,7 +618,7 @@ mod test {
         let geom_arr = example_multilinestring_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_multilinestring_wkb();
-        let parsed_geom_arr: MultiLineStringArray<i64> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiLineStringArray<i64, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -432,7 +432,7 @@ impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<Vec<Option<G>>>
     for MultiLineStringArray<O, 2>
 {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: MultiLineStringBuilder<O> = other.into();
+        let mut_arr: MultiLineStringBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
@@ -441,7 +441,7 @@ impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<&[G]>
     for MultiLineStringArray<O, 2>
 {
     fn from(other: &[G]) -> Self {
-        let mut_arr: MultiLineStringBuilder<O> = other.into();
+        let mut_arr: MultiLineStringBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
@@ -464,7 +464,7 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self, Self::Error> {
-        let mut_arr: MultiLineStringBuilder<O> = value.try_into()?;
+        let mut_arr: MultiLineStringBuilder<O, 2> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -432,7 +432,7 @@ impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiLineStringBuilder<O,
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let arr: MultiLineStringArray<O> = self.into();
+        let arr: MultiLineStringArray<O, D> = self.into();
         arr.into_arrow()
     }
 }

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -21,10 +21,10 @@ use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 ///
 /// Converting an [`MultiLineStringBuilder`] into a [`MultiLineStringArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct MultiLineStringBuilder<O: OffsetSizeTrait> {
+pub struct MultiLineStringBuilder<O: OffsetSizeTrait, const D: usize> {
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBufferBuilder<2>,
+    pub(crate) coords: CoordBufferBuilder<D>,
 
     /// OffsetsBuilder into the ring array where each geometry starts
     pub(crate) geom_offsets: OffsetsBuilder<O>,
@@ -36,14 +36,14 @@ pub struct MultiLineStringBuilder<O: OffsetSizeTrait> {
     pub(crate) validity: NullBufferBuilder,
 }
 
-pub type MultiLineStringInner<O> = (
-    CoordBufferBuilder<2>,
+pub type MultiLineStringInner<O, const D: usize> = (
+    CoordBufferBuilder<D>,
     OffsetsBuilder<O>,
     OffsetsBuilder<O>,
     NullBufferBuilder,
 );
 
-impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> MultiLineStringBuilder<O, D> {
     /// Creates a new empty [`MultiLineStringBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -80,21 +80,6 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
         }
     }
 
-    pub fn with_capacity_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
-    ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
-    }
-
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
-        Self::with_capacity_and_options(counter, coord_type, metadata)
-    }
-
     /// Reserves capacity for at least `additional` more LineStrings to be inserted
     /// in the given `Vec<T>`. The collection may reserve more space to
     /// speculatively avoid frequent reallocations. After calling `reserve`,
@@ -124,22 +109,6 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
         self.geom_offsets.reserve_exact(additional.geom_capacity);
     }
 
-    pub fn reserve_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
-    ) {
-        let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
-        self.reserve(counter)
-    }
-
-    pub fn reserve_exact_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
-    ) {
-        let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
-        self.reserve_exact(counter)
-    }
-
     /// The canonical method to create a [`MultiLineStringBuilder`] out of its internal
     /// components.
     ///
@@ -153,7 +122,7 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn try_new(
-        coords: CoordBufferBuilder<2>,
+        coords: CoordBufferBuilder<D>,
         geom_offsets: OffsetsBuilder<O>,
         ring_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
@@ -175,7 +144,7 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
     }
 
     /// Extract the low-level APIs from the [`MultiLineStringBuilder`].
-    pub fn into_inner(self) -> MultiLineStringInner<O> {
+    pub fn into_inner(self) -> MultiLineStringInner<O, D> {
         (
             self.coords,
             self.geom_offsets,
@@ -186,6 +155,68 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
 
     pub fn into_array_ref(self) -> Arc<dyn Array> {
         Arc::new(self.into_arrow())
+    }
+
+    /// Push a raw offset to the underlying geometry offsets buffer.
+    ///
+    /// # Safety
+    ///
+    /// This is marked as unsafe because care must be taken to ensure that pushing raw offsets
+    /// upholds the necessary invariants of the array.
+    #[inline]
+    pub unsafe fn try_push_geom_offset(&mut self, offsets_length: usize) -> Result<()> {
+        self.geom_offsets.try_push_usize(offsets_length)?;
+        self.validity.append(true);
+        Ok(())
+    }
+
+    /// Push a raw offset to the underlying ring offsets buffer.
+    ///
+    /// # Safety
+    ///
+    /// This is marked as unsafe because care must be taken to ensure that pushing raw offsets
+    /// upholds the necessary invariants of the array.
+    #[inline]
+    pub unsafe fn try_push_ring_offset(&mut self, offsets_length: usize) -> Result<()> {
+        self.ring_offsets.try_push_usize(offsets_length)?;
+        Ok(())
+    }
+
+    pub fn finish(self) -> MultiLineStringArray<O, D> {
+        self.into()
+    }
+}
+
+impl<O: OffsetSizeTrait> MultiLineStringBuilder<O, 2> {
+    pub fn with_capacity_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) -> Self {
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
+    }
+
+    pub fn with_capacity_and_options_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
+        Self::with_capacity_and_options(counter, coord_type, metadata)
+    }
+
+    pub fn reserve_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) {
+        let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
+        self.reserve(counter)
+    }
+
+    pub fn reserve_exact_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) {
+        let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
+        self.reserve_exact(counter)
     }
 
     /// Add a new LineString to the end of this array.
@@ -285,31 +316,6 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
             .unwrap();
     }
 
-    /// Push a raw offset to the underlying geometry offsets buffer.
-    ///
-    /// # Safety
-    ///
-    /// This is marked as unsafe because care must be taken to ensure that pushing raw offsets
-    /// upholds the necessary invariants of the array.
-    #[inline]
-    pub unsafe fn try_push_geom_offset(&mut self, offsets_length: usize) -> Result<()> {
-        self.geom_offsets.try_push_usize(offsets_length)?;
-        self.validity.append(true);
-        Ok(())
-    }
-
-    /// Push a raw offset to the underlying ring offsets buffer.
-    ///
-    /// # Safety
-    ///
-    /// This is marked as unsafe because care must be taken to ensure that pushing raw offsets
-    /// upholds the necessary invariants of the array.
-    #[inline]
-    pub unsafe fn try_push_ring_offset(&mut self, offsets_length: usize) -> Result<()> {
-        self.ring_offsets.try_push_usize(offsets_length)?;
-        Ok(())
-    }
-
     /// Push a raw coordinate to the underlying coordinate array.
     ///
     /// # Safety
@@ -377,13 +383,9 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O> {
             metadata,
         ))
     }
-
-    pub fn finish(self) -> MultiLineStringArray<O> {
-        self.into()
-    }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiLineStringBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MultiLineStringBuilder<O, D> {
     fn new() -> Self {
         Self::new()
     }
@@ -426,7 +428,7 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiLineStringBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for MultiLineStringBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiLineStringBuilder<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -435,14 +437,16 @@ impl<O: OffsetSizeTrait> IntoArrow for MultiLineStringBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> Default for MultiLineStringBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for MultiLineStringBuilder<O, D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiLineStringBuilder<O>> for MultiLineStringArray<O> {
-    fn from(other: MultiLineStringBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiLineStringBuilder<O, D>>
+    for MultiLineStringArray<O, D>
+{
+    fn from(other: MultiLineStringBuilder<O, D>) -> Self {
         let validity = other.validity.finish_cloned();
 
         let geom_offsets: OffsetBuffer<O> = other.geom_offsets.into();
@@ -459,7 +463,7 @@ impl<O: OffsetSizeTrait> From<MultiLineStringBuilder<O>> for MultiLineStringArra
 }
 
 impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<&[G]>
-    for MultiLineStringBuilder<O>
+    for MultiLineStringBuilder<O, 2>
 {
     fn from(geoms: &[G]) -> Self {
         Self::from_multi_line_strings(geoms, Default::default(), Default::default())
@@ -467,30 +471,14 @@ impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<&[G]>
 }
 
 impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<Vec<Option<G>>>
-    for MultiLineStringBuilder<O>
+    for MultiLineStringBuilder<O, 2>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_multi_line_strings(&geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>>
-    for MultiLineStringBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_multi_line_strings(&geoms, Default::default(), Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>>
-    From<bumpalo::collections::Vec<'_, Option<G>>> for MultiLineStringBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_multi_line_strings(&geoms, Default::default(), Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -502,8 +490,10 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringBuilder<O> {
 
 /// Polygon and MultiLineString have the same layout, so enable conversions between the two to
 /// change the semantic type
-impl<O: OffsetSizeTrait> From<MultiLineStringBuilder<O>> for PolygonBuilder<O> {
-    fn from(value: MultiLineStringBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiLineStringBuilder<O, D>>
+    for PolygonBuilder<O, D>
+{
+    fn from(value: MultiLineStringBuilder<O, D>) -> Self {
         Self::try_new(
             value.coords,
             value.geom_offsets,

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -210,8 +210,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiPointArray<
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPointArray<O, 2> {
-    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D> for MultiPointArray<O, D> {
+    fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(coords, self.geom_offsets, self.validity, self.metadata)
     }
@@ -282,8 +282,8 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPointArray<O, 2> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiPointArray<O, 2> {
-    type Item = MultiPoint<'a, O, 2>;
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a> for MultiPointArray<O, D> {
+    type Item = MultiPoint<'a, O, D>;
     type ItemGeo = geo::MultiPoint;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/multipoint/builder.rs
+++ b/src/array/multipoint/builder.rs
@@ -379,7 +379,7 @@ impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiPointBuilder<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let arr: MultiPointArray<O> = self.into();
+        let arr: MultiPointArray<O, D> = self.into();
         arr.into_arrow()
     }
 }

--- a/src/array/multipoint/builder.rs
+++ b/src/array/multipoint/builder.rs
@@ -20,10 +20,10 @@ use arrow_buffer::NullBufferBuilder;
 ///
 /// Converting an [`MultiPointBuilder`] into a [`MultiPointArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct MultiPointBuilder<O: OffsetSizeTrait> {
+pub struct MultiPointBuilder<O: OffsetSizeTrait, const D: usize> {
     metadata: Arc<ArrayMetadata>,
 
-    coords: CoordBufferBuilder<2>,
+    coords: CoordBufferBuilder<D>,
 
     geom_offsets: OffsetsBuilder<O>,
 
@@ -31,7 +31,7 @@ pub struct MultiPointBuilder<O: OffsetSizeTrait> {
     validity: NullBufferBuilder,
 }
 
-impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> MultiPointBuilder<O, D> {
     /// Creates a new empty [`MultiPointBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -68,21 +68,6 @@ impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
         }
     }
 
-    pub fn with_capacity_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-    ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
-    }
-
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let counter = MultiPointCapacity::from_multi_points(geoms);
-        Self::with_capacity_and_options(counter, coord_type, metadata)
-    }
-
     /// Reserves capacity for at least `additional` more MultiPoints to be inserted
     /// in the given `Vec<T>`. The collection may reserve more space to
     /// speculatively avoid frequent reallocations. After calling `reserve`,
@@ -110,22 +95,6 @@ impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
         self.geom_offsets.reserve_exact(capacity.geom_capacity);
     }
 
-    pub fn reserve_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-    ) {
-        let counter = MultiPointCapacity::from_multi_points(geoms);
-        self.reserve(counter)
-    }
-
-    pub fn reserve_exact_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-    ) {
-        let counter = MultiPointCapacity::from_multi_points(geoms);
-        self.reserve_exact(counter)
-    }
-
     /// The canonical method to create a [`MultiPointBuilder`] out of its internal components.
     ///
     /// # Implementation
@@ -139,7 +108,7 @@ impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     pub fn try_new(
-        coords: CoordBufferBuilder<2>,
+        coords: CoordBufferBuilder<D>,
         geom_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
         metadata: Arc<ArrayMetadata>,
@@ -158,7 +127,7 @@ impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
     }
 
     /// Extract the low-level APIs from the [`MultiPointBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder<2>, OffsetsBuilder<O>, NullBufferBuilder) {
+    pub fn into_inner(self) -> (CoordBufferBuilder<D>, OffsetsBuilder<O>, NullBufferBuilder) {
         (self.coords, self.geom_offsets, self.validity)
     }
 
@@ -166,6 +135,42 @@ impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
         Arc::new(self.into_arrow())
     }
 
+    pub fn finish(self) -> MultiPointArray<O, D> {
+        self.into()
+    }
+}
+
+impl<O: OffsetSizeTrait> MultiPointBuilder<O, 2> {
+    pub fn with_capacity_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+    ) -> Self {
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
+    }
+
+    pub fn with_capacity_and_options_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let counter = MultiPointCapacity::from_multi_points(geoms);
+        Self::with_capacity_and_options(counter, coord_type, metadata)
+    }
+
+    pub fn reserve_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+    ) {
+        let counter = MultiPointCapacity::from_multi_points(geoms);
+        self.reserve(counter)
+    }
+
+    pub fn reserve_exact_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+    ) {
+        let counter = MultiPointCapacity::from_multi_points(geoms);
+        self.reserve_exact(counter)
+    }
     pub fn extend_from_iter<'a>(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait<T = f64> + 'a)>>,
@@ -319,19 +324,15 @@ impl<O: OffsetSizeTrait> MultiPointBuilder<O> {
             metadata,
         ))
     }
-
-    pub fn finish(self) -> MultiPointArray<O> {
-        self.into()
-    }
 }
 
-impl<O: OffsetSizeTrait> Default for MultiPointBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for MultiPointBuilder<O, D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiPointBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MultiPointBuilder<O, D> {
     fn new() -> Self {
         Self::new()
     }
@@ -374,7 +375,7 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiPointBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for MultiPointBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiPointBuilder<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -383,8 +384,8 @@ impl<O: OffsetSizeTrait> IntoArrow for MultiPointBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPointBuilder<O>> for MultiPointArray<O> {
-    fn from(mut other: MultiPointBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPointBuilder<O, D>> for MultiPointArray<O, D> {
+    fn from(mut other: MultiPointBuilder<O, D>) -> Self {
         let validity = other.validity.finish_cloned();
 
         // TODO: impl shrink_to_fit for all mutable -> * impls
@@ -400,43 +401,27 @@ impl<O: OffsetSizeTrait> From<MultiPointBuilder<O>> for MultiPointArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPointBuilder<O>> for GenericListArray<O> {
-    fn from(arr: MultiPointBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPointBuilder<O, D>> for GenericListArray<O> {
+    fn from(arr: MultiPointBuilder<O, D>) -> Self {
         arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> From<&[G]> for MultiPointBuilder<O> {
+impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> From<&[G]> for MultiPointBuilder<O, 2> {
     fn from(geoms: &[G]) -> Self {
         Self::from_multi_points(geoms, Default::default(), Default::default())
     }
 }
 
 impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> From<Vec<Option<G>>>
-    for MultiPointBuilder<O>
+    for MultiPointBuilder<O, 2>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_multi_points(&geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>>
-    for MultiPointBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_multi_points(&geoms, Default::default(), Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> From<bumpalo::collections::Vec<'_, Option<G>>>
-    for MultiPointBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_multi_points(&geoms, Default::default(), Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPointBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPointBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -448,8 +433,8 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPointBuilder<O> {
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<O: OffsetSizeTrait> From<MultiPointBuilder<O>> for LineStringBuilder<O> {
-    fn from(value: MultiPointBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPointBuilder<O, D>> for LineStringBuilder<O, D> {
+    fn from(value: MultiPointBuilder<O, D>) -> Self {
         Self::try_new(
             value.coords,
             value.geom_offsets,

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -502,14 +502,14 @@ impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<Vec<Option<G>>>
     for MultiPolygonArray<O, 2>
 {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: MultiPolygonBuilder<O> = other.into();
+        let mut_arr: MultiPolygonBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
 
 impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<&[G]> for MultiPolygonArray<O, 2> {
     fn from(other: &[G]) -> Self {
-        let mut_arr: MultiPolygonBuilder<O> = other.into();
+        let mut_arr: MultiPolygonBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
@@ -518,7 +518,7 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPolygonArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self, Self::Error> {
-        let mut_arr: MultiPolygonBuilder<O> = value.try_into()?;
+        let mut_arr: MultiPolygonBuilder<O, 2> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -284,8 +284,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiPolygonArra
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPolygonArray<O, 2> {
-    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D> for MultiPolygonArray<O, D> {
+    fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
             coords,
@@ -379,8 +379,8 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for MultiPolygonArray<O, 2> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for MultiPolygonArray<O, 2> {
-    type Item = MultiPolygon<'a, O, 2>;
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a> for MultiPolygonArray<O, D> {
+    type Item = MultiPolygon<'a, O, D>;
     type ItemGeo = geo::MultiPolygon;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {

--- a/src/array/multipolygon/builder.rs
+++ b/src/array/multipolygon/builder.rs
@@ -18,8 +18,8 @@ use crate::trait_::{GeometryArrayAccessor, GeometryArrayBuilder, IntoArrow};
 use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 
-pub type MutableMultiPolygonParts<O> = (
-    CoordBufferBuilder<2>,
+pub type MutableMultiPolygonParts<O, const D: usize> = (
+    CoordBufferBuilder<D>,
     OffsetsBuilder<O>,
     OffsetsBuilder<O>,
     OffsetsBuilder<O>,
@@ -30,10 +30,10 @@ pub type MutableMultiPolygonParts<O> = (
 ///
 /// Converting an [`MultiPolygonBuilder`] into a [`MultiPolygonArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct MultiPolygonBuilder<O: OffsetSizeTrait> {
+pub struct MultiPolygonBuilder<O: OffsetSizeTrait, const D: usize> {
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBufferBuilder<2>,
+    pub(crate) coords: CoordBufferBuilder<D>,
 
     /// OffsetsBuilder into the polygon array where each geometry starts
     pub(crate) geom_offsets: OffsetsBuilder<O>,
@@ -48,7 +48,7 @@ pub struct MultiPolygonBuilder<O: OffsetSizeTrait> {
     pub(crate) validity: NullBufferBuilder,
 }
 
-impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> MultiPolygonBuilder<O, D> {
     /// Creates a new empty [`MultiPolygonBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -87,21 +87,6 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
         }
     }
 
-    pub fn with_capacity_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
-    ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
-    }
-
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let counter = MultiPolygonCapacity::from_multi_polygons(geoms);
-        Self::with_capacity_and_options(counter, coord_type, metadata)
-    }
-
     /// Reserves capacity for at least `additional` more LineStrings to be inserted
     /// in the given `Vec<T>`. The collection may reserve more space to
     /// speculatively avoid frequent reallocations. After calling `reserve`,
@@ -134,22 +119,6 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
         self.geom_offsets.reserve_exact(additional.geom_capacity);
     }
 
-    pub fn reserve_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
-    ) {
-        let counter = MultiPolygonCapacity::from_multi_polygons(geoms);
-        self.reserve(counter)
-    }
-
-    pub fn reserve_exact_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
-    ) {
-        let counter = MultiPolygonCapacity::from_multi_polygons(geoms);
-        self.reserve_exact(counter)
-    }
-
     /// The canonical method to create a [`MultiPolygonBuilder`] out of its internal
     /// components.
     ///
@@ -164,7 +133,7 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
     /// - if the largest polygon offset does not match the size of ring offsets
     /// - if the largest geometry offset does not match the size of polygon offsets
     pub fn try_new(
-        coords: CoordBufferBuilder<2>,
+        coords: CoordBufferBuilder<D>,
         geom_offsets: OffsetsBuilder<O>,
         polygon_offsets: OffsetsBuilder<O>,
         ring_offsets: OffsetsBuilder<O>,
@@ -189,7 +158,7 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
     }
 
     /// Extract the low-level APIs from the [`MultiPolygonBuilder`].
-    pub fn into_inner(self) -> MutableMultiPolygonParts<O> {
+    pub fn into_inner(self) -> MutableMultiPolygonParts<O, D> {
         (
             self.coords,
             self.geom_offsets,
@@ -203,6 +172,42 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
         Arc::new(self.into_arrow())
     }
 
+    pub fn finish(self) -> MultiPolygonArray<O, D> {
+        self.into()
+    }
+}
+
+impl<O: OffsetSizeTrait> MultiPolygonBuilder<O, 2> {
+    pub fn with_capacity_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
+    ) -> Self {
+        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
+    }
+
+    pub fn with_capacity_and_options_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let counter = MultiPolygonCapacity::from_multi_polygons(geoms);
+        Self::with_capacity_and_options(counter, coord_type, metadata)
+    }
+
+    pub fn reserve_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
+    ) {
+        let counter = MultiPolygonCapacity::from_multi_polygons(geoms);
+        self.reserve(counter)
+    }
+
+    pub fn reserve_exact_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
+    ) {
+        let counter = MultiPolygonCapacity::from_multi_polygons(geoms);
+        self.reserve_exact(counter)
+    }
     /// Add a new Polygon to the end of this array.
     ///
     /// # Errors
@@ -438,19 +443,15 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O> {
             metadata,
         ))
     }
-
-    pub fn finish(self) -> MultiPolygonArray<O> {
-        self.into()
-    }
 }
 
-impl<O: OffsetSizeTrait> Default for MultiPolygonBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for MultiPolygonBuilder<O, D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiPolygonBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MultiPolygonBuilder<O, D> {
     fn new() -> Self {
         Self::new()
     }
@@ -498,17 +499,19 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MultiPolygonBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for MultiPolygonBuilder<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiPolygonBuilder<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let arr: MultiPolygonArray<O> = self.into();
+        let arr: MultiPolygonArray<O, D> = self.into();
         arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPolygonBuilder<O>> for MultiPolygonArray<O> {
-    fn from(other: MultiPolygonBuilder<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygonBuilder<O, D>>
+    for MultiPolygonArray<O, D>
+{
+    fn from(other: MultiPolygonBuilder<O, D>) -> Self {
         let validity = other.validity.finish_cloned();
 
         let geom_offsets: OffsetBuffer<O> = other.geom_offsets.into();
@@ -526,37 +529,21 @@ impl<O: OffsetSizeTrait> From<MultiPolygonBuilder<O>> for MultiPolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<&[G]> for MultiPolygonBuilder<O> {
+impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<&[G]> for MultiPolygonBuilder<O, 2> {
     fn from(geoms: &[G]) -> Self {
         Self::from_multi_polygons(geoms, Default::default(), Default::default())
     }
 }
 
 impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<Vec<Option<G>>>
-    for MultiPolygonBuilder<O>
+    for MultiPolygonBuilder<O, 2>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_multi_polygons(&geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>>
-    for MultiPolygonBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, G>) -> Self {
-        Self::from_multi_polygons(&geoms, Default::default(), Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>>
-    From<bumpalo::collections::Vec<'_, Option<G>>> for MultiPolygonBuilder<O>
-{
-    fn from(geoms: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        Self::from_nullable_multi_polygons(&geoms, Default::default(), Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPolygonBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPolygonBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -172,8 +172,8 @@ impl<const D: usize> GeometryArrayTrait for PointArray<D> {
     }
 }
 
-impl GeometryArraySelfMethods for PointArray<2> {
-    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
+impl<const D: usize> GeometryArraySelfMethods<D> for PointArray<D> {
+    fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(coords, self.validity, self.metadata)
     }
@@ -219,8 +219,8 @@ impl GeometryArraySelfMethods for PointArray<2> {
 }
 
 // Implement geometry accessors
-impl<'a> GeometryArrayAccessor<'a> for PointArray<2> {
-    type Item = Point<'a, 2>;
+impl<'a, const D: usize> GeometryArrayAccessor<'a> for PointArray<D> {
+    type Item = Point<'a, D>;
     type ItemGeo = geo::Point;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -328,7 +328,7 @@ impl<const D: usize> Default for PointArray<D> {
 
 // Implement a custom PartialEq for PointArray to allow Point(EMPTY) comparisons, which is stored
 // as (NaN, NaN). By default, these resolve to false
-impl PartialEq for PointArray<2> {
+impl<const D: usize> PartialEq for PointArray<D> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -22,16 +22,16 @@ use arrow_schema::{DataType, Field};
 ///
 /// This is semantically equivalent to `Vec<Option<Point>>` due to the internal validity bitmap.
 #[derive(Debug, Clone)]
-pub struct PointArray {
+pub struct PointArray<const D: usize> {
     // Always GeoDataType::Point
     data_type: GeoDataType,
     pub(crate) metadata: Arc<ArrayMetadata>,
-    pub(crate) coords: CoordBuffer<2>,
+    pub(crate) coords: CoordBuffer<D>,
     pub(crate) validity: Option<NullBuffer>,
 }
 
 pub(super) fn check(
-    coords: &CoordBuffer<2>,
+    coords: &CoordBuffer<D>,
     validity_len: Option<usize>,
 ) -> Result<(), GeoArrowError> {
     if validity_len.map_or(false, |len| len != coords.len()) {
@@ -43,7 +43,7 @@ pub(super) fn check(
     Ok(())
 }
 
-impl PointArray {
+impl<const D: usize> PointArray<D> {
     /// Create a new PointArray from parts
     ///
     /// # Implementation
@@ -54,7 +54,7 @@ impl PointArray {
     ///
     /// - if the validity is not `None` and its length is different from the number of geometries
     pub fn new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
@@ -71,7 +71,7 @@ impl PointArray {
     ///
     /// - if the validity is not `None` and its length is different from the number of geometries
     pub fn try_new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self, GeoArrowError> {
@@ -85,11 +85,11 @@ impl PointArray {
         })
     }
 
-    pub fn coords(&self) -> &CoordBuffer<2> {
+    pub fn coords(&self) -> &CoordBuffer<D> {
         &self.coords
     }
 
-    pub fn into_inner(self) -> (CoordBuffer<2>, Option<NullBuffer>) {
+    pub fn into_inner(self) -> (CoordBuffer<D>, Option<NullBuffer>) {
         (self.coords, self.validity)
     }
 
@@ -101,11 +101,11 @@ impl PointArray {
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
         let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
-        validity_len + self.buffer_lengths() * 2 * 8
+        validity_len + self.buffer_lengths() * D * 8
     }
 }
 
-impl GeometryArrayTrait for PointArray {
+impl<const D: usize> GeometryArrayTrait for PointArray<D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -172,7 +172,7 @@ impl GeometryArrayTrait for PointArray {
     }
 }
 
-impl GeometryArraySelfMethods for PointArray {
+impl GeometryArraySelfMethods for PointArray<2> {
     fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(coords, self.validity, self.metadata)
@@ -219,8 +219,8 @@ impl GeometryArraySelfMethods for PointArray {
 }
 
 // Implement geometry accessors
-impl<'a> GeometryArrayAccessor<'a> for PointArray {
-    type Item = Point<'a>;
+impl<'a> GeometryArrayAccessor<'a> for PointArray<2> {
+    type Item = Point<'a, 2>;
     type ItemGeo = geo::Point;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -228,7 +228,7 @@ impl<'a> GeometryArrayAccessor<'a> for PointArray {
     }
 }
 
-impl IntoArrow for PointArray {
+impl<const D: usize> IntoArrow for PointArray<D> {
     type ArrowArray = Arc<dyn Array>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -236,7 +236,7 @@ impl IntoArrow for PointArray {
         match self.coords {
             CoordBuffer::Interleaved(c) => Arc::new(FixedSizeListArray::new(
                 c.values_field().into(),
-                2,
+                D as i32,
                 Arc::new(c.values_array()),
                 validity,
             )),
@@ -248,7 +248,7 @@ impl IntoArrow for PointArray {
     }
 }
 
-impl TryFrom<&FixedSizeListArray> for PointArray {
+impl<const D: usize> TryFrom<&FixedSizeListArray> for PointArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &FixedSizeListArray) -> Result<Self, Self::Error> {
@@ -262,7 +262,7 @@ impl TryFrom<&FixedSizeListArray> for PointArray {
     }
 }
 
-impl TryFrom<&StructArray> for PointArray {
+impl<const D: usize> TryFrom<&StructArray> for PointArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &StructArray) -> Result<Self, Self::Error> {
@@ -276,7 +276,7 @@ impl TryFrom<&StructArray> for PointArray {
     }
 }
 
-impl TryFrom<&dyn Array> for PointArray {
+impl<const D: usize> TryFrom<&dyn Array> for PointArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self, Self::Error> {
@@ -296,35 +296,21 @@ impl TryFrom<&dyn Array> for PointArray {
     }
 }
 
-impl<G: PointTrait<T = f64>> From<Vec<Option<G>>> for PointArray {
+impl<G: PointTrait<T = f64>> From<Vec<Option<G>>> for PointArray<2> {
     fn from(other: Vec<Option<G>>) -> Self {
         let mut_arr: PointBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: PointTrait<T = f64>> From<&[G]> for PointArray {
+impl<G: PointTrait<T = f64>> From<&[G]> for PointArray<2> {
     fn from(other: &[G]) -> Self {
         let mut_arr: PointBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: PointTrait<T = f64>> From<bumpalo::collections::Vec<'_, Option<G>>> for PointArray {
-    fn from(other: bumpalo::collections::Vec<'_, Option<G>>) -> Self {
-        let mut_arr: PointBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<G: PointTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>> for PointArray {
-    fn from(other: bumpalo::collections::Vec<'_, G>) -> Self {
-        let mut_arr: PointBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PointArray {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PointArray<2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self, Self::Error> {
@@ -334,7 +320,7 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PointArray {
 }
 
 /// Default to an empty array
-impl Default for PointArray {
+impl<const D: usize> Default for PointArray<D> {
     fn default() -> Self {
         PointBuilder::default().into()
     }
@@ -342,7 +328,7 @@ impl Default for PointArray {
 
 // Implement a custom PartialEq for PointArray to allow Point(EMPTY) comparisons, which is stored
 // as (NaN, NaN). By default, these resolve to false
-impl PartialEq for PointArray {
+impl<const D: usize> PartialEq for PointArray<D> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;
@@ -382,7 +368,7 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: PointArray = vec![p0(), p1(), p2()].as_slice().into();
+        let arr: PointArray<2> = vec![p0(), p1(), p2()].as_slice().into();
         assert_eq!(arr.value_as_geo(0), p0());
         assert_eq!(arr.value_as_geo(1), p1());
         assert_eq!(arr.value_as_geo(2), p2());
@@ -390,7 +376,7 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: PointArray = vec![Some(p0()), Some(p1()), Some(p2()), None].into();
+        let arr: PointArray<2> = vec![Some(p0()), Some(p1()), Some(p2()), None].into();
         assert_eq!(arr.get_as_geo(0), Some(p0()));
         assert_eq!(arr.get_as_geo(1), Some(p1()));
         assert_eq!(arr.get_as_geo(2), Some(p2()));
@@ -400,7 +386,7 @@ mod test {
     #[test]
     fn slice() {
         let points: Vec<Point> = vec![p0(), p1(), p2()];
-        let point_array: PointArray = points.as_slice().into();
+        let point_array: PointArray<2> = points.as_slice().into();
         let sliced = point_array.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(p1()));
@@ -409,7 +395,7 @@ mod test {
     #[test]
     fn owned_slice() {
         let points: Vec<Point> = vec![p0(), p1(), p2()];
-        let point_array: PointArray = points.as_slice().into();
+        let point_array: PointArray<2> = points.as_slice().into();
         let sliced = point_array.owned_slice(1, 1);
 
         assert_eq!(point_array.len(), 3);
@@ -423,7 +409,7 @@ mod test {
         let geom_arr = example_point_interleaved();
 
         let wkb_arr = example_point_wkb();
-        let parsed_geom_arr: PointArray = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: PointArray<2> = wkb_arr.try_into().unwrap();
 
         // Comparisons on the point array directly currently fail because of NaN values in
         // coordinate 1.
@@ -436,7 +422,7 @@ mod test {
         let geom_arr = example_point_separated();
 
         let wkb_arr = example_point_wkb();
-        let parsed_geom_arr: PointArray = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: PointArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -248,7 +248,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for PolygonArray<O, 
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods for PolygonArray<O, D> {
+impl<O: OffsetSizeTrait> GeometryArraySelfMethods for PolygonArray<O, 2> {
     fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
@@ -371,7 +371,7 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>> for Polyg
             .unwrap();
 
         let ring_offsets = rings_array.offsets();
-        let coords: CoordBuffer<2> = rings_array.values().as_ref().try_into()?;
+        let coords: CoordBuffer<D> = rings_array.values().as_ref().try_into()?;
 
         Ok(Self::new(
             coords,
@@ -394,7 +394,7 @@ impl<const D: usize> TryFrom<&dyn Array> for PolygonArray<i32, D> {
             }
             DataType::LargeList(_) => {
                 let downcasted = value.as_any().downcast_ref::<LargeListArray>().unwrap();
-                let geom_array: PolygonArray<i64> = downcasted.try_into()?;
+                let geom_array: PolygonArray<i64, D> = downcasted.try_into()?;
                 geom_array.try_into()
             }
             _ => Err(GeoArrowError::General(format!(
@@ -412,7 +412,7 @@ impl<const D: usize> TryFrom<&dyn Array> for PolygonArray<i64, D> {
         match value.data_type() {
             DataType::List(_) => {
                 let downcasted = value.as_any().downcast_ref::<ListArray>().unwrap();
-                let geom_array: PolygonArray<i32> = downcasted.try_into()?;
+                let geom_array: PolygonArray<i32, D> = downcasted.try_into()?;
                 Ok(geom_array.into())
             }
             DataType::LargeList(_) => {
@@ -428,14 +428,14 @@ impl<const D: usize> TryFrom<&dyn Array> for PolygonArray<i64, D> {
 }
 impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<Vec<Option<G>>> for PolygonArray<O, 2> {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: PolygonBuilder<O> = other.into();
+        let mut_arr: PolygonBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
 
 impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<&[G]> for PolygonArray<O, 2> {
     fn from(other: &[G]) -> Self {
-        let mut_arr: PolygonBuilder<O> = other.into();
+        let mut_arr: PolygonBuilder<O, 2> = other.into();
         mut_arr.into()
     }
 }
@@ -444,7 +444,7 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PolygonArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self, Self::Error> {
-        let mut_arr: PolygonBuilder<O> = value.try_into()?;
+        let mut_arr: PolygonBuilder<O, 2> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -26,13 +26,13 @@ use super::PolygonBuilder;
 /// This is semantically equivalent to `Vec<Option<Polygon>>` due to the internal validity bitmap.
 #[derive(Debug, Clone)]
 // #[derive(Debug, Clone, PartialEq)]
-pub struct PolygonArray<O: OffsetSizeTrait> {
+pub struct PolygonArray<O: OffsetSizeTrait, const D: usize> {
     // Always GeoDataType::Polygon or GeoDataType::LargePolygon
     data_type: GeoDataType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,
 
-    pub(crate) coords: CoordBuffer<2>,
+    pub(crate) coords: CoordBuffer<D>,
 
     /// Offsets into the ring array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -44,8 +44,8 @@ pub struct PolygonArray<O: OffsetSizeTrait> {
     pub(crate) validity: Option<NullBuffer>,
 }
 
-pub(super) fn check<O: OffsetSizeTrait>(
-    coords: &CoordBuffer<2>,
+pub(super) fn check<O: OffsetSizeTrait, const D: usize>(
+    coords: &CoordBuffer<D>,
     geom_offsets: &OffsetBuffer<O>,
     ring_offsets: &OffsetBuffer<O>,
     validity_len: Option<usize>,
@@ -71,7 +71,7 @@ pub(super) fn check<O: OffsetSizeTrait>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> PolygonArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> PolygonArray<O, D> {
     /// Create a new PolygonArray from parts
     ///
     /// # Implementation
@@ -84,7 +84,7 @@ impl<O: OffsetSizeTrait> PolygonArray<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
@@ -105,7 +105,7 @@ impl<O: OffsetSizeTrait> PolygonArray<O> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn try_new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
@@ -153,7 +153,7 @@ impl<O: OffsetSizeTrait> PolygonArray<O> {
         }
     }
 
-    pub fn coords(&self) -> &CoordBuffer<2> {
+    pub fn coords(&self) -> &CoordBuffer<D> {
         &self.coords
     }
 
@@ -181,7 +181,7 @@ impl<O: OffsetSizeTrait> PolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArrayTrait for PolygonArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for PolygonArray<O, D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -248,7 +248,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for PolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for PolygonArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods for PolygonArray<O, D> {
     fn with_coords(self, coords: CoordBuffer<2>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
@@ -330,8 +330,8 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for PolygonArray<O> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for PolygonArray<O> {
-    type Item = Polygon<'a, O>;
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for PolygonArray<O, 2> {
+    type Item = Polygon<'a, O, 2>;
     type ItemGeo = geo::Polygon;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -339,7 +339,7 @@ impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for PolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for PolygonArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> IntoArrow for PolygonArray<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -357,7 +357,7 @@ impl<O: OffsetSizeTrait> IntoArrow for PolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for PolygonArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>> for PolygonArray<O, D> {
     type Error = GeoArrowError;
 
     fn try_from(geom_array: &GenericListArray<O>) -> Result<Self, Self::Error> {
@@ -383,7 +383,7 @@ impl<O: OffsetSizeTrait> TryFrom<&GenericListArray<O>> for PolygonArray<O> {
     }
 }
 
-impl TryFrom<&dyn Array> for PolygonArray<i32> {
+impl<const D: usize> TryFrom<&dyn Array> for PolygonArray<i32, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self, Self::Error> {
@@ -405,7 +405,7 @@ impl TryFrom<&dyn Array> for PolygonArray<i32> {
     }
 }
 
-impl TryFrom<&dyn Array> for PolygonArray<i64> {
+impl<const D: usize> TryFrom<&dyn Array> for PolygonArray<i64, D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self, Self::Error> {
@@ -426,39 +426,21 @@ impl TryFrom<&dyn Array> for PolygonArray<i64> {
         }
     }
 }
-impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<Vec<Option<G>>> for PolygonArray<O> {
+impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<Vec<Option<G>>> for PolygonArray<O, 2> {
     fn from(other: Vec<Option<G>>) -> Self {
         let mut_arr: PolygonBuilder<O> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<&[G]> for PolygonArray<O> {
+impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<&[G]> for PolygonArray<O, 2> {
     fn from(other: &[G]) -> Self {
         let mut_arr: PolygonBuilder<O> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<bumpalo::collections::Vec<'_, G>>
-    for PolygonArray<O>
-{
-    fn from(value: bumpalo::collections::Vec<G>) -> Self {
-        let mut_arr: PolygonBuilder<O> = value.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> From<bumpalo::collections::Vec<'_, Option<G>>>
-    for PolygonArray<O>
-{
-    fn from(value: bumpalo::collections::Vec<Option<G>>) -> Self {
-        let mut_arr: PolygonBuilder<O> = value.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PolygonArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PolygonArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self, Self::Error> {
@@ -469,8 +451,8 @@ impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PolygonArray<O> {
 
 /// Polygon and MultiLineString have the same layout, so enable conversions between the two to
 /// change the semantic type
-impl<O: OffsetSizeTrait> From<PolygonArray<O>> for MultiLineStringArray<O> {
-    fn from(value: PolygonArray<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<PolygonArray<O, D>> for MultiLineStringArray<O, D> {
+    fn from(value: PolygonArray<O, D>) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -481,8 +463,8 @@ impl<O: OffsetSizeTrait> From<PolygonArray<O>> for MultiLineStringArray<O> {
     }
 }
 
-impl From<PolygonArray<i32>> for PolygonArray<i64> {
-    fn from(value: PolygonArray<i32>) -> Self {
+impl<const D: usize> From<PolygonArray<i32, D>> for PolygonArray<i64, D> {
+    fn from(value: PolygonArray<i32, D>) -> Self {
         Self::new(
             value.coords,
             offsets_buffer_i32_to_i64(&value.geom_offsets),
@@ -493,10 +475,10 @@ impl From<PolygonArray<i32>> for PolygonArray<i64> {
     }
 }
 
-impl TryFrom<PolygonArray<i64>> for PolygonArray<i32> {
+impl<const D: usize> TryFrom<PolygonArray<i64, D>> for PolygonArray<i32, D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: PolygonArray<i64>) -> Result<Self, Self::Error> {
+    fn try_from(value: PolygonArray<i64, D>) -> Result<Self, Self::Error> {
         Ok(Self::new(
             value.coords,
             offsets_buffer_i64_to_i32(&value.geom_offsets)?,
@@ -507,7 +489,7 @@ impl TryFrom<PolygonArray<i64>> for PolygonArray<i32> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<RectArray> for PolygonArray<O> {
+impl<O: OffsetSizeTrait> From<RectArray> for PolygonArray<O, 2> {
     fn from(value: RectArray) -> Self {
         // The number of output geoms is the same as the input
         let geom_capacity = value.len();
@@ -533,13 +515,13 @@ impl<O: OffsetSizeTrait> From<RectArray> for PolygonArray<O> {
 }
 
 /// Default to an empty array
-impl<O: OffsetSizeTrait> Default for PolygonArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> Default for PolygonArray<O, D> {
     fn default() -> Self {
         PolygonBuilder::default().into()
     }
 }
 
-impl<O: OffsetSizeTrait> PartialEq for PolygonArray<O> {
+impl<O: OffsetSizeTrait, const D: usize> PartialEq for PolygonArray<O, D> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -248,8 +248,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for PolygonArray<O, 
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryArraySelfMethods for PolygonArray<O, 2> {
-    fn with_coords(self, coords: CoordBuffer<2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D> for PolygonArray<O, D> {
+    fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
             coords,
@@ -330,8 +330,8 @@ impl<O: OffsetSizeTrait> GeometryArraySelfMethods for PolygonArray<O, 2> {
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for PolygonArray<O, 2> {
-    type Item = Polygon<'a, O, 2>;
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a> for PolygonArray<O, D> {
+    type Item = Polygon<'a, O, D>;
     type ItemGeo = geo::Polygon;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -554,14 +554,14 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: PolygonArray<i64> = vec![p0(), p1()].as_slice().into();
+        let arr: PolygonArray<i64, 2> = vec![p0(), p1()].as_slice().into();
         assert_eq!(arr.value_as_geo(0), p0());
         assert_eq!(arr.value_as_geo(1), p1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: PolygonArray<i64> = vec![Some(p0()), Some(p1()), None].into();
+        let arr: PolygonArray<i64, 2> = vec![Some(p0()), Some(p1()), None].into();
         assert_eq!(arr.get_as_geo(0), Some(p0()));
         assert_eq!(arr.get_as_geo(1), Some(p1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -569,7 +569,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: PolygonArray<i64> = vec![p0(), p1()].as_slice().into();
+        let arr: PolygonArray<i64, 2> = vec![p0(), p1()].as_slice().into();
         let sliced = arr.slice(1, 1);
 
         assert_eq!(sliced.len(), 1);
@@ -581,7 +581,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: PolygonArray<i64> = vec![p0(), p1()].as_slice().into();
+        let arr: PolygonArray<i64, 2> = vec![p0(), p1()].as_slice().into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -602,7 +602,7 @@ mod test {
         let geom_arr = example_polygon_interleaved();
 
         let wkb_arr = example_polygon_wkb();
-        let parsed_geom_arr: PolygonArray<i64> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: PolygonArray<i64, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }
@@ -613,7 +613,7 @@ mod test {
         let geom_arr = example_polygon_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_polygon_wkb();
-        let parsed_geom_arr: PolygonArray<i64> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: PolygonArray<i64, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }

--- a/src/array/polygon/builder.rs
+++ b/src/array/polygon/builder.rs
@@ -139,7 +139,7 @@ impl<O: OffsetSizeTrait, const D: usize> PolygonBuilder<O, D> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
     pub fn try_new(
-        coords: CoordBufferBuilder<2>,
+        coords: CoordBufferBuilder<D>,
         geom_offsets: OffsetsBuilder<O>,
         ring_offsets: OffsetsBuilder<O>,
         validity: NullBufferBuilder,
@@ -449,7 +449,7 @@ impl<O: OffsetSizeTrait, const D: usize> IntoArrow for PolygonBuilder<O, D> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let polygon_array: PolygonArray<O> = self.into();
+        let polygon_array: PolygonArray<O, D> = self.into();
         polygon_array.into_arrow()
     }
 }

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -125,7 +125,7 @@ impl GeometryArrayTrait for RectArray {
     }
 }
 
-impl GeometryArraySelfMethods for RectArray {
+impl GeometryArraySelfMethods<2> for RectArray {
     fn with_coords(self, _coords: CoordBuffer<2>) -> Self {
         unimplemented!()
     }

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -21,8 +21,6 @@ pub enum GeoDataType {
     /// [ChunkedPointArray][crate::chunked_array::ChunkedPointArray].
     Point(CoordType),
 
-    PointZ(CoordType),
-
     /// Represents a [LineStringArray][crate::array::LineStringArray] or
     /// [ChunkedLineStringArray][crate::chunked_array::ChunkedLineStringArray] with `i32` offsets.
     LineString(CoordType),

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -21,6 +21,8 @@ pub enum GeoDataType {
     /// [ChunkedPointArray][crate::chunked_array::ChunkedPointArray].
     Point(CoordType),
 
+    PointZ(CoordType),
+
     /// Represents a [LineStringArray][crate::array::LineStringArray] or
     /// [ChunkedLineStringArray][crate::chunked_array::ChunkedLineStringArray] with `i32` offsets.
     LineString(CoordType),

--- a/src/indexed/array.rs
+++ b/src/indexed/array.rs
@@ -126,14 +126,18 @@ impl<'a, G: GeometryArrayTrait + GeometryArrayAccessor<'a>> IndexedGeometryArray
     }
 }
 
-pub type IndexedPointArray = IndexedGeometryArray<PointArray>;
-pub type IndexedLineStringArray<O> = IndexedGeometryArray<LineStringArray<O>>;
-pub type IndexedPolygonArray<O> = IndexedGeometryArray<PolygonArray<O>>;
-pub type IndexedMultiPointArray<O> = IndexedGeometryArray<MultiPointArray<O>>;
-pub type IndexedMultiLineStringArray<O> = IndexedGeometryArray<MultiLineStringArray<O>>;
-pub type IndexedMultiPolygonArray<O> = IndexedGeometryArray<MultiPolygonArray<O>>;
-pub type IndexedMixedGeometryArray<O> = IndexedGeometryArray<MixedGeometryArray<O>>;
-pub type IndexedGeometryCollectionArray<O> = IndexedGeometryArray<GeometryCollectionArray<O>>;
+pub type IndexedPointArray<const D: usize> = IndexedGeometryArray<PointArray<D>>;
+pub type IndexedLineStringArray<O, const D: usize> = IndexedGeometryArray<LineStringArray<O, D>>;
+pub type IndexedPolygonArray<O, const D: usize> = IndexedGeometryArray<PolygonArray<O, D>>;
+pub type IndexedMultiPointArray<O, const D: usize> = IndexedGeometryArray<MultiPointArray<O, D>>;
+pub type IndexedMultiLineStringArray<O, const D: usize> =
+    IndexedGeometryArray<MultiLineStringArray<O, D>>;
+pub type IndexedMultiPolygonArray<O, const D: usize> =
+    IndexedGeometryArray<MultiPolygonArray<O, D>>;
+pub type IndexedMixedGeometryArray<O, const D: usize> =
+    IndexedGeometryArray<MixedGeometryArray<O, D>>;
+pub type IndexedGeometryCollectionArray<O, const D: usize> =
+    IndexedGeometryArray<GeometryCollectionArray<O, D>>;
 pub type IndexedWKBArray<O> = IndexedGeometryArray<WKBArray<O>>;
 pub type IndexedRectArray = IndexedGeometryArray<RectArray>;
 pub type IndexedUnknownGeometryArray = IndexedGeometryArray<Arc<dyn GeometryArrayTrait>>;

--- a/src/indexed/chunked.rs
+++ b/src/indexed/chunked.rs
@@ -41,16 +41,21 @@ impl<G: GeometryArrayTrait> IndexedChunkedGeometryArray<G> {
     }
 }
 
-pub type IndexedChunkedPointArray = IndexedChunkedGeometryArray<PointArray>;
-pub type IndexedChunkedLineStringArray<O> = IndexedChunkedGeometryArray<LineStringArray<O>>;
-pub type IndexedChunkedPolygonArray<O> = IndexedChunkedGeometryArray<PolygonArray<O>>;
-pub type IndexedChunkedMultiPointArray<O> = IndexedChunkedGeometryArray<MultiPointArray<O>>;
-pub type IndexedChunkedMultiLineStringArray<O> =
-    IndexedChunkedGeometryArray<MultiLineStringArray<O>>;
-pub type IndexedChunkedMultiPolygonArray<O> = IndexedChunkedGeometryArray<MultiPolygonArray<O>>;
-pub type IndexedChunkedMixedGeometryArray<O> = IndexedChunkedGeometryArray<MixedGeometryArray<O>>;
-pub type IndexedChunkedGeometryCollectionArray<O> =
-    IndexedChunkedGeometryArray<GeometryCollectionArray<O>>;
+pub type IndexedChunkedPointArray<const D: usize> = IndexedChunkedGeometryArray<PointArray<D>>;
+pub type IndexedChunkedLineStringArray<O, const D: usize> =
+    IndexedChunkedGeometryArray<LineStringArray<O, D>>;
+pub type IndexedChunkedPolygonArray<O, const D: usize> =
+    IndexedChunkedGeometryArray<PolygonArray<O, D>>;
+pub type IndexedChunkedMultiPointArray<O, const D: usize> =
+    IndexedChunkedGeometryArray<MultiPointArray<O, D>>;
+pub type IndexedChunkedMultiLineStringArray<O, const D: usize> =
+    IndexedChunkedGeometryArray<MultiLineStringArray<O, D>>;
+pub type IndexedChunkedMultiPolygonArray<O, const D: usize> =
+    IndexedChunkedGeometryArray<MultiPolygonArray<O, D>>;
+pub type IndexedChunkedMixedGeometryArray<O, const D: usize> =
+    IndexedChunkedGeometryArray<MixedGeometryArray<O, D>>;
+pub type IndexedChunkedGeometryCollectionArray<O, const D: usize> =
+    IndexedChunkedGeometryArray<GeometryCollectionArray<O, D>>;
 pub type IndexedChunkedWKBArray<O> = IndexedChunkedGeometryArray<WKBArray<O>>;
 pub type IndexedChunkedRectArray = IndexedChunkedGeometryArray<RectArray>;
 pub type IndexedChunkedUnknownGeometryArray =

--- a/src/io/display/array.rs
+++ b/src/io/display/array.rs
@@ -81,7 +81,7 @@ macro_rules! impl_fmt_non_generic {
     };
 }
 
-impl_fmt_non_generic!(PointArray, "PointArray");
+impl_fmt_non_generic!(PointArray<2>, "PointArray");
 impl_fmt_non_generic!(RectArray, "RectArray");
 
 macro_rules! impl_fmt_generic {
@@ -126,16 +126,16 @@ macro_rules! impl_fmt_generic {
     };
 }
 
-impl_fmt_generic!(LineStringArray<O>, "LineStringArray");
-impl_fmt_generic!(PolygonArray<O>, "PolygonArray");
-impl_fmt_generic!(MultiPointArray<O>, "MultiPointArray");
-impl_fmt_generic!(MultiLineStringArray<O>, "MultiLineStringArray");
-impl_fmt_generic!(MultiPolygonArray<O>, "MultiPolygonArray");
-impl_fmt_generic!(MixedGeometryArray<O>, "MixedGeometryArray");
-impl_fmt_generic!(GeometryCollectionArray<O>, "GeometryCollectionArray");
+impl_fmt_generic!(LineStringArray<O, 2>, "LineStringArray");
+impl_fmt_generic!(PolygonArray<O, 2>, "PolygonArray");
+impl_fmt_generic!(MultiPointArray<O, 2>, "MultiPointArray");
+impl_fmt_generic!(MultiLineStringArray<O, 2>, "MultiLineStringArray");
+impl_fmt_generic!(MultiPolygonArray<O, 2>, "MultiPolygonArray");
+impl_fmt_generic!(MixedGeometryArray<O, 2>, "MixedGeometryArray");
+impl_fmt_generic!(GeometryCollectionArray<O, 2>, "GeometryCollectionArray");
 impl_fmt_generic!(WKBArray<O>, "WKBArray");
 
-impl fmt::Display for PointArray {
+impl fmt::Display for PointArray<2> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.write(f, 0)
     }
@@ -157,13 +157,13 @@ macro_rules! impl_fmt {
     };
 }
 
-impl_fmt!(LineStringArray<O>, "LineStringArray");
-impl_fmt!(PolygonArray<O>, "PolygonArray");
-impl_fmt!(MultiPointArray<O>, "MultiPointArray");
-impl_fmt!(MultiLineStringArray<O>, "MultiLineStringArray");
-impl_fmt!(MultiPolygonArray<O>, "MultiPolygonArray");
-impl_fmt!(MixedGeometryArray<O>, "MixedGeometryArray");
-impl_fmt!(GeometryCollectionArray<O>, "GeometryCollectionArray");
+impl_fmt!(LineStringArray<O, 2>, "LineStringArray");
+impl_fmt!(PolygonArray<O, 2>, "PolygonArray");
+impl_fmt!(MultiPointArray<O, 2>, "MultiPointArray");
+impl_fmt!(MultiLineStringArray<O, 2>, "MultiLineStringArray");
+impl_fmt!(MultiPolygonArray<O, 2>, "MultiPolygonArray");
+impl_fmt!(MixedGeometryArray<O, 2>, "MixedGeometryArray");
+impl_fmt!(GeometryCollectionArray<O, 2>, "GeometryCollectionArray");
 impl_fmt!(WKBArray<O>, "WKBArray");
 
 #[cfg(test)]

--- a/src/io/display/chunked_array.rs
+++ b/src/io/display/chunked_array.rs
@@ -5,7 +5,7 @@ use arrow_array::OffsetSizeTrait;
 use crate::chunked_array::*;
 use crate::io::display::array::{write_indented_ellipsis, WriteArray};
 
-impl fmt::Display for ChunkedPointArray {
+impl fmt::Display for ChunkedPointArray<2> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("ChunkedPointArray")?;
         writeln!(f, "([")?;
@@ -88,17 +88,17 @@ macro_rules! impl_fmt_generic {
     };
 }
 
-impl_fmt_generic!(ChunkedLineStringArray<O>, "ChunkedLineStringArray");
-impl_fmt_generic!(ChunkedPolygonArray<O>, "ChunkedPolygonArray");
-impl_fmt_generic!(ChunkedMultiPointArray<O>, "ChunkedMultiPointArray");
+impl_fmt_generic!(ChunkedLineStringArray<O, 2>, "ChunkedLineStringArray");
+impl_fmt_generic!(ChunkedPolygonArray<O, 2>, "ChunkedPolygonArray");
+impl_fmt_generic!(ChunkedMultiPointArray<O, 2>, "ChunkedMultiPointArray");
 impl_fmt_generic!(
-    ChunkedMultiLineStringArray<O>,
+    ChunkedMultiLineStringArray<O, 2>,
     "ChunkedMultiLineStringArray"
 );
-impl_fmt_generic!(ChunkedMultiPolygonArray<O>, "ChunkedMultiPolygonArray");
-impl_fmt_generic!(ChunkedMixedGeometryArray<O>, "ChunkedMixedGeometryArray");
+impl_fmt_generic!(ChunkedMultiPolygonArray<O, 2>, "ChunkedMultiPolygonArray");
+impl_fmt_generic!(ChunkedMixedGeometryArray<O, 2>, "ChunkedMixedGeometryArray");
 impl_fmt_generic!(
-    ChunkedGeometryCollectionArray<O>,
+    ChunkedGeometryCollectionArray<O, 2>,
     "ChunkedGeometryCollectionArray"
 );
 impl_fmt_generic!(ChunkedWKBArray<O>, "ChunkedWKBArray");

--- a/src/io/display/scalar.rs
+++ b/src/io/display/scalar.rs
@@ -37,7 +37,7 @@ pub(crate) fn write_geometry(
     Ok(())
 }
 
-impl fmt::Display for Point<'_> {
+impl fmt::Display for Point<'_, 2> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_geometry(f, self.to_geo_geometry(), 80)
     }
@@ -59,14 +59,14 @@ macro_rules! impl_fmt {
     };
 }
 
-impl_fmt!(LineString<'_, O>);
-impl_fmt!(Polygon<'_, O>);
-impl_fmt!(MultiPoint<'_, O>);
-impl_fmt!(MultiLineString<'_, O>);
-impl_fmt!(MultiPolygon<'_, O>);
-impl_fmt!(GeometryCollection<'_, O>);
+impl_fmt!(LineString<'_, O, 2>);
+impl_fmt!(Polygon<'_, O, 2>);
+impl_fmt!(MultiPoint<'_, O, 2>);
+impl_fmt!(MultiLineString<'_, O, 2>);
+impl_fmt!(MultiPolygon<'_, O, 2>);
+impl_fmt!(GeometryCollection<'_, O, 2>);
 
-impl<O: OffsetSizeTrait> fmt::Display for Geometry<'_, O> {
+impl<O: OffsetSizeTrait> fmt::Display for Geometry<'_, O, 2> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_geometry(f, self.to_geo_geometry(), 80)
     }
@@ -100,7 +100,7 @@ mod test {
     #[test]
     fn test_display_point_5_decimals() {
         let point = geo::Point::from((0.12345, 1.23456));
-        let point_array: PointArray = vec![point].as_slice().into();
+        let point_array: PointArray<2> = vec![point].as_slice().into();
         let result = point_array.value(0).to_string();
         let expected = "<POINT(0.123 1.234)>";
         assert_eq!(result, expected);

--- a/src/io/flatgeobuf/reader/async.rs
+++ b/src/io/flatgeobuf/reader/async.rs
@@ -60,34 +60,36 @@ pub async fn read_flatgeobuf_async<T: ObjectStore>(
 
     match geometry_type {
         GeometryType::Point => {
-            let mut builder = GeoTableBuilder::<PointBuilder>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<PointBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::LineString => {
-            let mut builder = GeoTableBuilder::<LineStringBuilder<i32>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<LineStringBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::Polygon => {
-            let mut builder = GeoTableBuilder::<PolygonBuilder<i32>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<PolygonBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::MultiPoint => {
-            let mut builder = GeoTableBuilder::<MultiPointBuilder<i32>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MultiPointBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::MultiLineString => {
             let mut builder =
-                GeoTableBuilder::<MultiLineStringBuilder<i32>>::new_with_options(options);
+                GeoTableBuilder::<MultiLineStringBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::MultiPolygon => {
             let mut builder =
-                GeoTableBuilder::<MultiPolygonBuilder<i32>>::new_with_options(options);
+                GeoTableBuilder::<MultiPolygonBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }

--- a/src/io/flatgeobuf/reader/sync.rs
+++ b/src/io/flatgeobuf/reader/sync.rs
@@ -67,34 +67,36 @@ pub fn read_flatgeobuf<R: Read + Seek>(
 
     match geometry_type {
         GeometryType::Point => {
-            let mut builder = GeoTableBuilder::<PointBuilder>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<PointBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder)?;
             builder.finish()
         }
         GeometryType::LineString => {
-            let mut builder = GeoTableBuilder::<LineStringBuilder<i32>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<LineStringBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder)?;
             builder.finish()
         }
         GeometryType::Polygon => {
-            let mut builder = GeoTableBuilder::<PolygonBuilder<i32>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<PolygonBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder)?;
             builder.finish()
         }
         GeometryType::MultiPoint => {
-            let mut builder = GeoTableBuilder::<MultiPointBuilder<i32>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MultiPointBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder)?;
             builder.finish()
         }
         GeometryType::MultiLineString => {
             let mut builder =
-                GeoTableBuilder::<MultiLineStringBuilder<i32>>::new_with_options(options);
+                GeoTableBuilder::<MultiLineStringBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder)?;
             builder.finish()
         }
         GeometryType::MultiPolygon => {
             let mut builder =
-                GeoTableBuilder::<MultiPolygonBuilder<i32>>::new_with_options(options);
+                GeoTableBuilder::<MultiPolygonBuilder<i32, 2>>::new_with_options(options);
             selection.process_features(&mut builder)?;
             builder.finish()
         }

--- a/src/io/geos/array/linestring.rs
+++ b/src/io/geos/array/linestring.rs
@@ -21,7 +21,7 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringArra
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: LineStringBuilder<O> = value.try_into()?;
+        let mutable_arr: LineStringBuilder<O, 2> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/linestring.rs
+++ b/src/io/geos/array/linestring.rs
@@ -4,7 +4,7 @@ use crate::array::{LineStringArray, LineStringBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSLineString;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -17,7 +17,7 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringBuil
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {

--- a/src/io/geos/array/multilinestring.rs
+++ b/src/io/geos/array/multilinestring.rs
@@ -4,7 +4,7 @@ use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSMultiLineString;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -17,7 +17,7 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStrin
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {

--- a/src/io/geos/array/multilinestring.rs
+++ b/src/io/geos/array/multilinestring.rs
@@ -21,7 +21,7 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStrin
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: MultiLineStringBuilder<O> = value.try_into()?;
+        let mutable_arr: MultiLineStringBuilder<O, 2> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/multipoint.rs
+++ b/src/io/geos/array/multipoint.rs
@@ -4,7 +4,7 @@ use crate::array::{MultiPointArray, MultiPointBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSMultiPoint;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
@@ -17,11 +17,11 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointBuil
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: MultiPointBuilder<O> = value.try_into()?;
+        let mutable_arr: MultiPointBuilder<O, 2> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/multipolygon.rs
+++ b/src/io/geos/array/multipolygon.rs
@@ -4,7 +4,7 @@ use crate::array::{MultiPolygonArray, MultiPolygonBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSMultiPolygon;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -17,11 +17,11 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonBu
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: MultiPolygonBuilder<O> = value.try_into()?;
+        let mutable_arr: MultiPolygonBuilder<O, 2> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/point.rs
+++ b/src/io/geos/array/point.rs
@@ -2,7 +2,7 @@ use crate::array::{PointArray, PointBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSPoint;
 
-impl TryFrom<Vec<Option<geos::Geometry>>> for PointBuilder {
+impl TryFrom<Vec<Option<geos::Geometry>>> for PointBuilder<2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
@@ -15,7 +15,7 @@ impl TryFrom<Vec<Option<geos::Geometry>>> for PointBuilder {
     }
 }
 
-impl TryFrom<Vec<Option<geos::Geometry>>> for PointArray {
+impl TryFrom<Vec<Option<geos::Geometry>>> for PointArray<2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {

--- a/src/io/geos/array/point.rs
+++ b/src/io/geos/array/point.rs
@@ -19,7 +19,7 @@ impl TryFrom<Vec<Option<geos::Geometry>>> for PointArray<2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: PointBuilder = value.try_into()?;
+        let mutable_arr: PointBuilder<2> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }
@@ -37,7 +37,7 @@ mod test {
             .iter()
             .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
             .collect();
-        let round_trip: PointArray = geos_geoms.try_into().unwrap();
+        let round_trip: PointArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/polygon.rs
+++ b/src/io/geos/array/polygon.rs
@@ -1,11 +1,10 @@
 use arrow_array::OffsetSizeTrait;
-use bumpalo::collections::CollectIn;
 
 use crate::array::{PolygonArray, PolygonBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSPolygon;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for PolygonBuilder<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for PolygonBuilder<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -19,41 +18,11 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for PolygonBuilder
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for PolygonArray<O> {
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for PolygonArray<O, 2> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: PolygonBuilder<O> = value.try_into()?;
-        Ok(mutable_arr.into())
-    }
-}
-
-impl<'a, O: OffsetSizeTrait> TryFrom<bumpalo::collections::Vec<'a, Option<geos::Geometry>>>
-    for PolygonBuilder<O>
-{
-    type Error = GeoArrowError;
-
-    fn try_from(value: bumpalo::collections::Vec<'a, Option<geos::Geometry>>) -> Result<Self> {
-        let bump = bumpalo::Bump::new();
-
-        // TODO: avoid creating GEOSPolygon objects at all?
-        // TODO: don't use new_unchecked
-        let geos_objects: bumpalo::collections::Vec<'_, Option<GEOSPolygon>> = value
-            .into_iter()
-            .map(|geom| geom.map(GEOSPolygon::new_unchecked))
-            .collect_in(&bump);
-
-        Ok(geos_objects.into())
-    }
-}
-
-impl<'a, O: OffsetSizeTrait> TryFrom<bumpalo::collections::Vec<'a, Option<geos::Geometry>>>
-    for PolygonArray<O>
-{
-    type Error = GeoArrowError;
-
-    fn try_from(value: bumpalo::collections::Vec<'a, Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: PolygonBuilder<O> = value.try_into()?;
+        let mutable_arr: PolygonBuilder<O, 2> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/scalar/coord/combined.rs
+++ b/src/io/geos/scalar/coord/combined.rs
@@ -1,10 +1,10 @@
 use crate::array::CoordBuffer;
 use geos::CoordSeq;
 
-impl TryFrom<CoordBuffer<2>> for CoordSeq {
+impl<const D: usize> TryFrom<CoordBuffer<D>> for CoordSeq {
     type Error = geos::Error;
 
-    fn try_from(value: CoordBuffer<2>) -> std::result::Result<Self, geos::Error> {
+    fn try_from(value: CoordBuffer<D>) -> std::result::Result<Self, geos::Error> {
         match value {
             CoordBuffer::Separated(cb) => cb.try_into(),
             CoordBuffer::Interleaved(cb) => cb.try_into(),

--- a/src/io/geos/scalar/coord/interleaved.rs
+++ b/src/io/geos/scalar/coord/interleaved.rs
@@ -2,10 +2,10 @@ use crate::array::InterleavedCoordBuffer;
 use crate::GeometryArrayTrait;
 use geos::CoordSeq;
 
-impl TryFrom<InterleavedCoordBuffer<2>> for CoordSeq {
+impl<const D: usize> TryFrom<InterleavedCoordBuffer<D>> for CoordSeq {
     type Error = geos::Error;
 
-    fn try_from(value: InterleavedCoordBuffer<2>) -> std::result::Result<Self, geos::Error> {
+    fn try_from(value: InterleavedCoordBuffer<D>) -> std::result::Result<Self, geos::Error> {
         CoordSeq::new_from_buffer(&value.coords, value.len(), false, false)
     }
 }

--- a/src/io/geos/scalar/coord/separated.rs
+++ b/src/io/geos/scalar/coord/separated.rs
@@ -1,10 +1,10 @@
 use crate::array::SeparatedCoordBuffer;
 use geos::CoordSeq;
 
-impl TryFrom<SeparatedCoordBuffer<2>> for CoordSeq {
+impl<const D: usize> TryFrom<SeparatedCoordBuffer<D>> for CoordSeq {
     type Error = geos::Error;
 
-    fn try_from(value: SeparatedCoordBuffer<2>) -> std::result::Result<Self, geos::Error> {
+    fn try_from(value: SeparatedCoordBuffer<D>) -> std::result::Result<Self, geos::Error> {
         CoordSeq::new_from_arrays(&value.buffers[0], &value.buffers[1], None, None)
     }
 }

--- a/src/io/geos/scalar/geometry.rs
+++ b/src/io/geos/scalar/geometry.rs
@@ -1,18 +1,18 @@
 use crate::scalar::Geometry;
 use arrow_array::OffsetSizeTrait;
 
-impl<O: OffsetSizeTrait> TryFrom<Geometry<'_, O, 2>> for geos::Geometry {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Geometry<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: Geometry<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: Geometry<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a Geometry<'_, O, 2>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a Geometry<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Geometry<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Geometry<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         match value {
             Geometry::Point(g) => g.try_into(),
             Geometry::LineString(g) => g.try_into(),

--- a/src/io/geos/scalar/geometry.rs
+++ b/src/io/geos/scalar/geometry.rs
@@ -1,18 +1,18 @@
 use crate::scalar::Geometry;
 use arrow_array::OffsetSizeTrait;
 
-impl<O: OffsetSizeTrait> TryFrom<Geometry<'_, O>> for geos::Geometry {
+impl<O: OffsetSizeTrait> TryFrom<Geometry<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: Geometry<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: Geometry<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a Geometry<'_, O>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait> TryFrom<&'a Geometry<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Geometry<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Geometry<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         match value {
             Geometry::Point(g) => g.try_into(),
             Geometry::LineString(g) => g.try_into(),

--- a/src/io/geos/scalar/geometrycollection.rs
+++ b/src/io/geos/scalar/geometrycollection.rs
@@ -2,21 +2,23 @@ use crate::geo_traits::GeometryCollectionTrait;
 use crate::scalar::GeometryCollection;
 use arrow_array::OffsetSizeTrait;
 
-impl<O: OffsetSizeTrait> TryFrom<GeometryCollection<'_, O, 2>> for geos::Geometry {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollection<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: GeometryCollection<'_, O, 2>,
+        value: GeometryCollection<'_, O, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a GeometryCollection<'_, O, 2>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a GeometryCollection<'_, O, D>>
+    for geos::Geometry
+{
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a GeometryCollection<'_, O, 2>,
+        value: &'a GeometryCollection<'_, O, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_geometry_collection(
             value

--- a/src/io/geos/scalar/geometrycollection.rs
+++ b/src/io/geos/scalar/geometrycollection.rs
@@ -2,21 +2,21 @@ use crate::geo_traits::GeometryCollectionTrait;
 use crate::scalar::GeometryCollection;
 use arrow_array::OffsetSizeTrait;
 
-impl<O: OffsetSizeTrait> TryFrom<GeometryCollection<'_, O>> for geos::Geometry {
+impl<O: OffsetSizeTrait> TryFrom<GeometryCollection<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: GeometryCollection<'_, O>,
+        value: GeometryCollection<'_, O, 2>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a GeometryCollection<'_, O>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait> TryFrom<&'a GeometryCollection<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a GeometryCollection<'_, O>,
+        value: &'a GeometryCollection<'_, O, 2>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_geometry_collection(
             value

--- a/src/io/geos/scalar/linestring.rs
+++ b/src/io/geos/scalar/linestring.rs
@@ -7,20 +7,20 @@ use crate::trait_::GeometryArraySelfMethods;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<LineString<'_, O, 2>> for geos::Geometry {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<LineString<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: LineString<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: LineString<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
 // TODO: maybe this should use traits instead of a manual approach via coordbuffer?
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a LineString<'_, O, 2>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a LineString<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a LineString<'_, O, 2>,
+        value: &'a LineString<'_, O, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = value.geom_offsets.start_end(value.geom_index);
 
@@ -30,7 +30,7 @@ impl<'a, O: OffsetSizeTrait> TryFrom<&'a LineString<'_, O, 2>> for geos::Geometr
     }
 }
 
-impl<O: OffsetSizeTrait> LineString<'_, O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> LineString<'_, O, D> {
     pub fn to_geos_linear_ring(&self) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
 

--- a/src/io/geos/scalar/linestring.rs
+++ b/src/io/geos/scalar/linestring.rs
@@ -7,19 +7,21 @@ use crate::trait_::GeometryArraySelfMethods;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<LineString<'_, O>> for geos::Geometry {
+impl<O: OffsetSizeTrait> TryFrom<LineString<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: LineString<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: LineString<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
 // TODO: maybe this should use traits instead of a manual approach via coordbuffer?
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a LineString<'_, O>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait> TryFrom<&'a LineString<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a LineString<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(
+        value: &'a LineString<'_, O, 2>,
+    ) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = value.geom_offsets.start_end(value.geom_index);
 
         let sliced_coords = value.coords.clone().to_mut().slice(start, end - start);
@@ -28,7 +30,7 @@ impl<'a, O: OffsetSizeTrait> TryFrom<&'a LineString<'_, O>> for geos::Geometry {
     }
 }
 
-impl<O: OffsetSizeTrait> LineString<'_, O> {
+impl<O: OffsetSizeTrait> LineString<'_, O, 2> {
     pub fn to_geos_linear_ring(&self) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
 

--- a/src/io/geos/scalar/multilinestring.rs
+++ b/src/io/geos/scalar/multilinestring.rs
@@ -5,19 +5,21 @@ use crate::scalar::MultiLineString;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<MultiLineString<'_, O>> for geos::Geometry {
+impl<O: OffsetSizeTrait> TryFrom<MultiLineString<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: MultiLineString<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(
+        value: MultiLineString<'_, O, 2>,
+    ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiLineString<'_, O>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiLineString<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiLineString<'_, O>,
+        value: &'a MultiLineString<'_, O, 2>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multiline_string(
             value

--- a/src/io/geos/scalar/multilinestring.rs
+++ b/src/io/geos/scalar/multilinestring.rs
@@ -5,21 +5,23 @@ use crate::scalar::MultiLineString;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<MultiLineString<'_, O, 2>> for geos::Geometry {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<MultiLineString<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: MultiLineString<'_, O, 2>,
+        value: MultiLineString<'_, O, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiLineString<'_, O, 2>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiLineString<'_, O, D>>
+    for geos::Geometry
+{
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiLineString<'_, O, 2>,
+        value: &'a MultiLineString<'_, O, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multiline_string(
             value

--- a/src/io/geos/scalar/multipoint.rs
+++ b/src/io/geos/scalar/multipoint.rs
@@ -5,18 +5,20 @@ use crate::scalar::MultiPoint;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<MultiPoint<'_, O>> for geos::Geometry {
+impl<O: OffsetSizeTrait> TryFrom<MultiPoint<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: MultiPoint<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: MultiPoint<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiPoint<'_, O>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiPoint<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a MultiPoint<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(
+        value: &'a MultiPoint<'_, O, 2>,
+    ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipoint(
             value
                 .points()

--- a/src/io/geos/scalar/multipoint.rs
+++ b/src/io/geos/scalar/multipoint.rs
@@ -5,19 +5,19 @@ use crate::scalar::MultiPoint;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<MultiPoint<'_, O, 2>> for geos::Geometry {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<MultiPoint<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: MultiPoint<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: MultiPoint<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiPoint<'_, O, 2>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiPoint<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiPoint<'_, O, 2>,
+        value: &'a MultiPoint<'_, O, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipoint(
             value

--- a/src/io/geos/scalar/multipolygon.rs
+++ b/src/io/geos/scalar/multipolygon.rs
@@ -5,19 +5,19 @@ use crate::scalar::MultiPolygon;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<MultiPolygon<'_, O>> for geos::Geometry {
+impl<O: OffsetSizeTrait> TryFrom<MultiPolygon<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: MultiPolygon<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: MultiPolygon<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiPolygon<'_, O>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiPolygon<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiPolygon<'_, O>,
+        value: &'a MultiPolygon<'_, O, 2>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipolygon(
             value

--- a/src/io/geos/scalar/multipolygon.rs
+++ b/src/io/geos/scalar/multipolygon.rs
@@ -5,19 +5,21 @@ use crate::scalar::MultiPolygon;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<MultiPolygon<'_, O, 2>> for geos::Geometry {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<MultiPolygon<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: MultiPolygon<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: MultiPolygon<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a MultiPolygon<'_, O, 2>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiPolygon<'_, O, D>>
+    for geos::Geometry
+{
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiPolygon<'_, O, 2>,
+        value: &'a MultiPolygon<'_, O, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipolygon(
             value

--- a/src/io/geos/scalar/point.rs
+++ b/src/io/geos/scalar/point.rs
@@ -3,18 +3,18 @@ use crate::geo_traits::{CoordTrait, PointTrait};
 use crate::scalar::Point;
 use geos::{CoordDimensions, CoordSeq, Geom, GeometryTypes};
 
-impl TryFrom<Point<'_, 2>> for geos::Geometry {
+impl<const D: usize> TryFrom<Point<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: Point<'_, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: Point<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a> TryFrom<&'a Point<'_, 2>> for geos::Geometry {
+impl<'a, const D: usize> TryFrom<&'a Point<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Point<'_, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Point<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         let mut coord_seq = CoordSeq::new(1, CoordDimensions::TwoD)?;
         coord_seq.set_x(0, PointTrait::x(&value))?;
         coord_seq.set_y(0, PointTrait::y(&value))?;

--- a/src/io/geos/scalar/point.rs
+++ b/src/io/geos/scalar/point.rs
@@ -3,18 +3,18 @@ use crate::geo_traits::{CoordTrait, PointTrait};
 use crate::scalar::Point;
 use geos::{CoordDimensions, CoordSeq, Geom, GeometryTypes};
 
-impl TryFrom<Point<'_>> for geos::Geometry {
+impl TryFrom<Point<'_, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: Point<'_>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: Point<'_, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a> TryFrom<&'a Point<'_>> for geos::Geometry {
+impl<'a> TryFrom<&'a Point<'_, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Point<'_>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Point<'_, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         let mut coord_seq = CoordSeq::new(1, CoordDimensions::TwoD)?;
         coord_seq.set_x(0, PointTrait::x(&value))?;
         coord_seq.set_y(0, PointTrait::y(&value))?;

--- a/src/io/geos/scalar/polygon.rs
+++ b/src/io/geos/scalar/polygon.rs
@@ -5,18 +5,18 @@ use crate::scalar::Polygon;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<Polygon<'_, O, 2>> for geos::Geometry {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Polygon<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: Polygon<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: Polygon<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a Polygon<'_, O, 2>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a Polygon<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Polygon<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Polygon<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         if let Some(exterior) = value.exterior() {
             let exterior = exterior.to_geos_linear_ring()?;
             let interiors = value

--- a/src/io/geos/scalar/polygon.rs
+++ b/src/io/geos/scalar/polygon.rs
@@ -5,18 +5,18 @@ use crate::scalar::Polygon;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait> TryFrom<Polygon<'_, O>> for geos::Geometry {
+impl<O: OffsetSizeTrait> TryFrom<Polygon<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: Polygon<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: Polygon<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::try_from(&value)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> TryFrom<&'a Polygon<'_, O>> for geos::Geometry {
+impl<'a, O: OffsetSizeTrait> TryFrom<&'a Polygon<'_, O, 2>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Polygon<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Polygon<'_, O, 2>) -> std::result::Result<geos::Geometry, geos::Error> {
         if let Some(exterior) = value.exterior() {
             let exterior = exterior.to_geos_linear_ring()?;
             let interiors = value

--- a/src/io/geozero/api/ewkb.rs
+++ b/src/io/geozero/api/ewkb.rs
@@ -89,12 +89,12 @@ impl FromEWKB for Arc<dyn GeometryArrayTrait> {
         prefer_multi: bool,
     ) -> Result<Self> {
         let geom_arr =
-            GeometryCollectionArray::<i64>::from_ewkb(arr, coord_type, metadata, prefer_multi)?;
+            GeometryCollectionArray::<i64, 2>::from_ewkb(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedMixedGeometryArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedMixedGeometryArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
     fn from_ewkb<O: OffsetSizeTrait>(
@@ -108,7 +108,7 @@ impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedMixedGeometryArray<OOutput> {
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedGeometryCollectionArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedGeometryCollectionArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
     fn from_ewkb<O: OffsetSizeTrait>(
@@ -131,7 +131,7 @@ impl FromEWKB for Arc<dyn ChunkedGeometryArrayTrait> {
         metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        let geom_arr = ChunkedGeometryCollectionArray::<i64>::from_ewkb(
+        let geom_arr = ChunkedGeometryCollectionArray::<i64, 2>::from_ewkb(
             arr,
             coord_type,
             metadata,

--- a/src/io/geozero/api/ewkb.rs
+++ b/src/io/geozero/api/ewkb.rs
@@ -27,7 +27,7 @@ pub trait FromEWKB: Sized {
     ) -> Result<Self>;
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for MixedGeometryArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromEWKB for MixedGeometryArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
     fn from_ewkb<O: OffsetSizeTrait>(
@@ -51,7 +51,7 @@ impl<OOutput: OffsetSizeTrait> FromEWKB for MixedGeometryArray<OOutput> {
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for GeometryCollectionArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromEWKB for GeometryCollectionArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
     fn from_ewkb<O: OffsetSizeTrait>(

--- a/src/io/geozero/api/wkt.rs
+++ b/src/io/geozero/api/wkt.rs
@@ -84,12 +84,12 @@ impl FromWKT for Arc<dyn GeometryArrayTrait> {
         prefer_multi: bool,
     ) -> Result<Self> {
         let geom_arr =
-            GeometryCollectionArray::<i64>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
+            GeometryCollectionArray::<i64, 2>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedMixedGeometryArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedMixedGeometryArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = ChunkedArray<GenericStringArray<O>>;
 
     fn from_wkt<O: OffsetSizeTrait>(
@@ -103,7 +103,7 @@ impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedMixedGeometryArray<OOutput> {
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedGeometryCollectionArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedGeometryCollectionArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = ChunkedArray<GenericStringArray<O>>;
 
     fn from_wkt<O: OffsetSizeTrait>(
@@ -126,7 +126,7 @@ impl FromWKT for Arc<dyn ChunkedGeometryArrayTrait> {
         metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        let geom_arr = ChunkedGeometryCollectionArray::<i64>::from_wkt(
+        let geom_arr = ChunkedGeometryCollectionArray::<i64, 2>::from_wkt(
             arr,
             coord_type,
             metadata,
@@ -155,7 +155,7 @@ mod test {
         wkt_geoms.iter().for_each(|s| builder.append_value(s));
         let arr = builder.finish();
         // dbg!(arr);
-        let geom_arr = MixedGeometryArray::<i32>::from_wkt(
+        let geom_arr = MixedGeometryArray::<i32, 2>::from_wkt(
             &arr,
             Default::default(),
             Default::default(),
@@ -174,9 +174,13 @@ mod test {
         wkt_geoms.iter().for_each(|s| builder.append_value(s));
         let arr = builder.finish();
         // dbg!(arr);
-        let geom_arr =
-            MixedGeometryArray::<i32>::from_wkt(&arr, Default::default(), Default::default(), true)
-                .unwrap();
+        let geom_arr = MixedGeometryArray::<i32, 2>::from_wkt(
+            &arr,
+            Default::default(),
+            Default::default(),
+            true,
+        )
+        .unwrap();
         let geom_arr = geom_arr.downcast(true);
         assert!(matches!(geom_arr.data_type(), GeoDataType::Point(_)));
     }

--- a/src/io/geozero/api/wkt.rs
+++ b/src/io/geozero/api/wkt.rs
@@ -25,7 +25,7 @@ pub trait FromWKT: Sized {
     ) -> Result<Self>;
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKT for MixedGeometryArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromWKT for MixedGeometryArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
 
     fn from_wkt<O: OffsetSizeTrait>(
@@ -49,7 +49,7 @@ impl<OOutput: OffsetSizeTrait> FromWKT for MixedGeometryArray<OOutput> {
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKT for GeometryCollectionArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromWKT for GeometryCollectionArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
 
     fn from_wkt<O: OffsetSizeTrait>(

--- a/src/io/geozero/array/geometrycollection.rs
+++ b/src/io/geozero/array/geometrycollection.rs
@@ -5,7 +5,7 @@ use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for GeometryCollectionArray<O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for GeometryCollectionArray<O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/array/linestring.rs
+++ b/src/io/geozero/array/linestring.rs
@@ -7,7 +7,7 @@ use crate::io::geozero::scalar::process_line_string;
 use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for LineStringArray<O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for LineStringArray<O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -27,26 +27,26 @@ impl<O: OffsetSizeTrait> GeozeroGeometry for LineStringArray<O> {
 /// GeoZero trait to convert to GeoArrow LineStringArray.
 pub trait ToLineStringArray<O: OffsetSizeTrait> {
     /// Convert to GeoArrow LineStringArray
-    fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<O>>;
+    fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<O, 2>>;
 
     /// Convert to a GeoArrow LineStringBuilder
-    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<O>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<O, 2>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToLineStringArray<O> for T {
-    fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<O>> {
+    fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<O, 2>> {
         Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<O>> {
-        let mut mutable_array = LineStringBuilder::<O>::new();
+    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<O, 2>> {
+        let mut mutable_array = LineStringBuilder::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
     }
 }
 
 #[allow(unused_variables)]
-impl<O: OffsetSizeTrait> GeomProcessor for LineStringBuilder<O> {
+impl<O: OffsetSizeTrait> GeomProcessor for LineStringBuilder<O, 2> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         let capacity = LineStringCapacity::new(0, size);
         self.reserve(capacity);
@@ -94,7 +94,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> geozero::error::Result<()> {
-        let arr: LineStringArray<i64> = vec![ls0(), ls1()].as_slice().into();
+        let arr: LineStringArray<i64, 2> = vec![ls0(), ls1()].as_slice().into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(LINESTRING(0 1,1 2),LINESTRING(3 4,5 6))";
         assert_eq!(wkt, expected);
@@ -109,7 +109,7 @@ mod test {
                 .map(Geometry::LineString)
                 .collect(),
         );
-        let multi_point_array: LineStringArray<i32> = geo.to_line_string_array().unwrap();
+        let multi_point_array: LineStringArray<i32, 2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), ls0());
         assert_eq!(multi_point_array.value_as_geo(1), ls1());
         Ok(())

--- a/src/io/geozero/array/mixed.rs
+++ b/src/io/geozero/array/mixed.rs
@@ -9,7 +9,7 @@ use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for MixedGeometryArray<O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for MixedGeometryArray<O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -30,18 +30,18 @@ impl<O: OffsetSizeTrait> GeozeroGeometry for MixedGeometryArray<O> {
 /// GeoZero trait to convert to GeoArrow MixedArray.
 pub trait ToMixedArray<O: OffsetSizeTrait> {
     /// Convert to GeoArrow MixedArray
-    fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<O>>;
+    fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<O, 2>>;
 
     /// Convert to a GeoArrow MixedArrayBuilder
-    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<O>>;
+    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<O, 2>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToMixedArray<O> for T {
-    fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<O>> {
+    fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<O, 2>> {
         Ok(self.to_mixed_geometry_builder()?.into())
     }
 
-    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<O>> {
+    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<O, 2>> {
         let mut stream_builder = MixedGeometryStreamBuilder::new();
         self.process_geom(&mut stream_builder)?;
         Ok(stream_builder.builder)
@@ -56,7 +56,7 @@ impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToMixedArray<O> for T {
 /// Converting an [`MixedGeometryStreamBuilder`] into a [`MixedGeometryArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct MixedGeometryStreamBuilder<O: OffsetSizeTrait> {
-    builder: MixedGeometryBuilder<O>,
+    builder: MixedGeometryBuilder<O, 2>,
     // Note: we don't know if, when `linestring_end` is called, that means a ring of a polygon has
     // finished or if a tagged line string has finished. This means we can't have an "unknown" enum
     // type, because we'll never be able to set it to unknown after a line string is done, meaning
@@ -69,7 +69,7 @@ pub struct MixedGeometryStreamBuilder<O: OffsetSizeTrait> {
 impl<O: OffsetSizeTrait> MixedGeometryStreamBuilder<O> {
     pub fn new() -> Self {
         Self {
-            builder: MixedGeometryBuilder::<O>::new(),
+            builder: MixedGeometryBuilder::new(),
             current_geom_type: GeometryType::Point,
             prefer_multi: true,
         }
@@ -81,7 +81,7 @@ impl<O: OffsetSizeTrait> MixedGeometryStreamBuilder<O> {
         prefer_multi: bool,
     ) -> Self {
         Self {
-            builder: MixedGeometryBuilder::<O>::new_with_options(coord_type, metadata),
+            builder: MixedGeometryBuilder::new_with_options(coord_type, metadata),
             current_geom_type: GeometryType::Point,
             prefer_multi,
         }
@@ -91,7 +91,7 @@ impl<O: OffsetSizeTrait> MixedGeometryStreamBuilder<O> {
         self.builder.push_null()
     }
 
-    pub fn finish(self) -> MixedGeometryArray<O> {
+    pub fn finish(self) -> MixedGeometryArray<O, 2> {
         self.builder.finish()
     }
 }

--- a/src/io/geozero/array/multilinestring.rs
+++ b/src/io/geozero/array/multilinestring.rs
@@ -7,7 +7,7 @@ use crate::io::geozero::scalar::process_multi_line_string;
 use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for MultiLineStringArray<O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for MultiLineStringArray<O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -27,26 +27,26 @@ impl<O: OffsetSizeTrait> GeozeroGeometry for MultiLineStringArray<O> {
 /// GeoZero trait to convert to GeoArrow MultiLineStringArray.
 pub trait ToMultiLineStringArray<O: OffsetSizeTrait> {
     /// Convert to GeoArrow MultiLineStringArray
-    fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<O>>;
+    fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<O, 2>>;
 
     /// Convert to a GeoArrow MultiLineStringBuilder
-    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<O>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<O, 2>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToMultiLineStringArray<O> for T {
-    fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<O>> {
+    fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<O, 2>> {
         Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<O>> {
-        let mut mutable_array = MultiLineStringBuilder::<O>::new();
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<O, 2>> {
+        let mut mutable_array = MultiLineStringBuilder::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
     }
 }
 
 #[allow(unused_variables)]
-impl<O: OffsetSizeTrait> GeomProcessor for MultiLineStringBuilder<O> {
+impl<O: OffsetSizeTrait> GeomProcessor for MultiLineStringBuilder<O, 2> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         let capacity = MultiLineStringCapacity::new(0, 0, size);
@@ -122,7 +122,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> geozero::error::Result<()> {
-        let arr: MultiLineStringArray<i64> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray<i64, 2> = vec![ml0(), ml1()].as_slice().into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(MULTILINESTRING((-111 45,-111 41,-104 41,-104 45)),MULTILINESTRING((-111 45,-111 41,-104 41,-104 45),(-110 44,-110 42,-105 42,-105 44)))";
         assert_eq!(wkt, expected);
@@ -137,7 +137,7 @@ mod test {
                 .map(Geometry::MultiLineString)
                 .collect(),
         );
-        let multi_point_array: MultiLineStringArray<i32> = geo.to_line_string_array().unwrap();
+        let multi_point_array: MultiLineStringArray<i32, 2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), ml0());
         assert_eq!(multi_point_array.value_as_geo(1), ml1());
         Ok(())

--- a/src/io/geozero/array/multipolygon.rs
+++ b/src/io/geozero/array/multipolygon.rs
@@ -7,7 +7,7 @@ use crate::io::geozero::scalar::process_multi_polygon;
 use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for MultiPolygonArray<O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for MultiPolygonArray<O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -27,26 +27,26 @@ impl<O: OffsetSizeTrait> GeozeroGeometry for MultiPolygonArray<O> {
 /// GeoZero trait to convert to GeoArrow MultiPolygonArray.
 pub trait ToMultiPolygonArray<O: OffsetSizeTrait> {
     /// Convert to GeoArrow MultiPolygonArray
-    fn to_line_string_array(&self) -> geozero::error::Result<MultiPolygonArray<O>>;
+    fn to_line_string_array(&self) -> geozero::error::Result<MultiPolygonArray<O, 2>>;
 
     /// Convert to a GeoArrow MultiPolygonBuilder
-    fn to_line_string_builder(&self) -> geozero::error::Result<MultiPolygonBuilder<O>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiPolygonBuilder<O, 2>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToMultiPolygonArray<O> for T {
-    fn to_line_string_array(&self) -> geozero::error::Result<MultiPolygonArray<O>> {
+    fn to_line_string_array(&self) -> geozero::error::Result<MultiPolygonArray<O, 2>> {
         Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_line_string_builder(&self) -> geozero::error::Result<MultiPolygonBuilder<O>> {
-        let mut mutable_array = MultiPolygonBuilder::<O>::new();
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiPolygonBuilder<O, 2>> {
+        let mut mutable_array = MultiPolygonBuilder::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
     }
 }
 
 #[allow(unused_variables)]
-impl<O: OffsetSizeTrait> GeomProcessor for MultiPolygonBuilder<O> {
+impl<O: OffsetSizeTrait> GeomProcessor for MultiPolygonBuilder<O, 2> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         let capacity = MultiPolygonCapacity::new(0, 0, 0, size);
@@ -139,7 +139,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> geozero::error::Result<()> {
-        let arr: MultiPolygonArray<i64> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPolygonArray<i64, 2> = vec![mp0(), mp1()].as_slice().into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(MULTIPOLYGON(((-111 45,-111 41,-104 41,-104 45,-111 45)),((-111 45,-111 41,-104 41,-104 45,-111 45),(-110 44,-110 42,-105 42,-105 44,-110 44))),MULTIPOLYGON(((-111 45,-111 41,-104 41,-104 45,-111 45)),((-110 44,-110 42,-105 42,-105 44,-110 44))))";
         assert_eq!(wkt, expected);
@@ -154,7 +154,7 @@ mod test {
                 .map(Geometry::MultiPolygon)
                 .collect(),
         );
-        let multi_point_array: MultiPolygonArray<i32> = geo.to_line_string_array().unwrap();
+        let multi_point_array: MultiPolygonArray<i32, 2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), mp0());
         assert_eq!(multi_point_array.value_as_geo(1), mp1());
         Ok(())

--- a/src/io/geozero/array/point.rs
+++ b/src/io/geozero/array/point.rs
@@ -4,7 +4,7 @@ use crate::trait_::GeometryArrayAccessor;
 use crate::GeometryArrayTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl GeozeroGeometry for PointArray {
+impl GeozeroGeometry for PointArray<2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -24,18 +24,18 @@ impl GeozeroGeometry for PointArray {
 /// GeoZero trait to convert to GeoArrow PointArray.
 pub trait ToPointArray {
     /// Convert to GeoArrow PointArray
-    fn to_point_array(&self) -> geozero::error::Result<PointArray>;
+    fn to_point_array(&self) -> geozero::error::Result<PointArray<2>>;
 
     /// Convert to a GeoArrow PointBuilder
-    fn to_point_builder(&self) -> geozero::error::Result<PointBuilder>;
+    fn to_point_builder(&self) -> geozero::error::Result<PointBuilder<2>>;
 }
 
 impl<T: GeozeroGeometry> ToPointArray for T {
-    fn to_point_array(&self) -> geozero::error::Result<PointArray> {
+    fn to_point_array(&self) -> geozero::error::Result<PointArray<2>> {
         Ok(self.to_point_builder()?.into())
     }
 
-    fn to_point_builder(&self) -> geozero::error::Result<PointBuilder> {
+    fn to_point_builder(&self) -> geozero::error::Result<PointBuilder<2>> {
         let mut mutable_point_array = PointBuilder::new();
         self.process_geom(&mut mutable_point_array)?;
         Ok(mutable_point_array)
@@ -43,7 +43,7 @@ impl<T: GeozeroGeometry> ToPointArray for T {
 }
 
 #[allow(unused_variables)]
-impl GeomProcessor for PointBuilder {
+impl GeomProcessor for PointBuilder<2> {
     fn empty_point(&mut self, idx: usize) -> geozero::error::Result<()> {
         self.push_empty();
         Ok(())

--- a/src/io/geozero/array/polygon.rs
+++ b/src/io/geozero/array/polygon.rs
@@ -6,7 +6,7 @@ use crate::GeometryArrayTrait;
 use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for PolygonArray<O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for PolygonArray<O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -26,26 +26,26 @@ impl<O: OffsetSizeTrait> GeozeroGeometry for PolygonArray<O> {
 /// GeoZero trait to convert to GeoArrow PolygonArray.
 pub trait ToPolygonArray<O: OffsetSizeTrait> {
     /// Convert to GeoArrow PolygonArray
-    fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<O>>;
+    fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<O, 2>>;
 
     /// Convert to a GeoArrow PolygonBuilder
-    fn to_line_string_builder(&self) -> geozero::error::Result<PolygonBuilder<O>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<PolygonBuilder<O, 2>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToPolygonArray<O> for T {
-    fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<O>> {
+    fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<O, 2>> {
         Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_line_string_builder(&self) -> geozero::error::Result<PolygonBuilder<O>> {
-        let mut mutable_array = PolygonBuilder::<O>::new();
+    fn to_line_string_builder(&self) -> geozero::error::Result<PolygonBuilder<O, 2>> {
+        let mut mutable_array = PolygonBuilder::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
     }
 }
 
 #[allow(unused_variables)]
-impl<O: OffsetSizeTrait> GeomProcessor for PolygonBuilder<O> {
+impl<O: OffsetSizeTrait> GeomProcessor for PolygonBuilder<O, 2> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         let capacity = PolygonCapacity::new(0, 0, size);
@@ -113,7 +113,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> geozero::error::Result<()> {
-        let arr: PolygonArray<i64> = vec![p0(), p1()].as_slice().into();
+        let arr: PolygonArray<i64, 2> = vec![p0(), p1()].as_slice().into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(POLYGON((-111 45,-111 41,-104 41,-104 45,-111 45)),POLYGON((-111 45,-111 41,-104 41,-104 45,-111 45),(-110 44,-110 42,-105 42,-105 44,-110 44)))";
         assert_eq!(wkt, expected);
@@ -128,7 +128,7 @@ mod test {
                 .map(Geometry::Polygon)
                 .collect(),
         );
-        let multi_point_array: PolygonArray<i32> = geo.to_line_string_array().unwrap();
+        let multi_point_array: PolygonArray<i32, 2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), p0());
         assert_eq!(multi_point_array.value_as_geo(1), p1());
         Ok(())

--- a/src/io/geozero/scalar/geometry.rs
+++ b/src/io/geozero/scalar/geometry.rs
@@ -32,7 +32,7 @@ pub(crate) fn process_geometry<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for Geometry<'_, O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for Geometry<'_, O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -42,11 +42,11 @@ impl<O: OffsetSizeTrait> GeozeroGeometry for Geometry<'_, O> {
 }
 
 pub trait ToGeometry<O: OffsetSizeTrait> {
-    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<O>>;
+    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<O, 2>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToGeometry<O> for T {
-    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<O>> {
+    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<O, 2>> {
         let arr = self.to_mixed_geometry_array()?;
         assert_eq!(arr.len(), 1);
         Ok(OwnedGeometry::from(arr.value(0)))

--- a/src/io/geozero/scalar/geometry_collection.rs
+++ b/src/io/geozero/scalar/geometry_collection.rs
@@ -19,7 +19,7 @@ pub(crate) fn process_geometry_collection<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for GeometryCollection<'_, O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for GeometryCollection<'_, O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/linestring.rs
+++ b/src/io/geozero/scalar/linestring.rs
@@ -18,7 +18,7 @@ pub(crate) fn process_line_string<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for LineString<'_, O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for LineString<'_, O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multilinestring.rs
+++ b/src/io/geozero/scalar/multilinestring.rs
@@ -24,7 +24,7 @@ pub(crate) fn process_multi_line_string<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for MultiLineString<'_, O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for MultiLineString<'_, O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multipoint.rs
+++ b/src/io/geozero/scalar/multipoint.rs
@@ -18,7 +18,7 @@ pub(crate) fn process_multi_point<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for MultiPoint<'_, O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for MultiPoint<'_, O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multipolygon.rs
+++ b/src/io/geozero/scalar/multipolygon.rs
@@ -19,7 +19,7 @@ pub(crate) fn process_multi_polygon<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for MultiPolygon<'_, O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for MultiPolygon<'_, O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/point.rs
+++ b/src/io/geozero/scalar/point.rs
@@ -13,7 +13,7 @@ pub(crate) fn process_point<P: GeomProcessor>(
     Ok(())
 }
 
-impl GeozeroGeometry for Point<'_> {
+impl GeozeroGeometry for Point<'_, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/polygon.rs
+++ b/src/io/geozero/scalar/polygon.rs
@@ -39,7 +39,7 @@ pub(crate) fn process_polygon<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for Polygon<'_, O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for Polygon<'_, O, 2> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/parquet/reader/async.rs
+++ b/src/io/parquet/reader/async.rs
@@ -142,7 +142,7 @@ impl<R: AsyncFileReader + Unpin + Send + 'static> ParquetFile<R> {
     ///
     /// As of GeoParquet 1.1 you won't need to pass in these column names, as they'll be specified
     /// in the metadata.
-    pub fn row_groups_bounds(&self, paths: &ParquetBboxPaths) -> Result<PolygonArray<i32>> {
+    pub fn row_groups_bounds(&self, paths: &ParquetBboxPaths) -> Result<PolygonArray<i32, 2>> {
         let geo_statistics = ParquetBboxStatistics::try_new(self.meta.parquet_schema(), paths)?;
         let rects = self
             .meta

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -103,7 +103,7 @@ impl FromWKB for Arc<dyn GeometryArrayTrait> {
     }
 }
 
-impl FromWKB for ChunkedPointArray {
+impl FromWKB for ChunkedPointArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self> {
@@ -128,13 +128,13 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<OOutput>);
-impl_chunked!(ChunkedPolygonArray<OOutput>);
-impl_chunked!(ChunkedMultiPointArray<OOutput>);
-impl_chunked!(ChunkedMultiLineStringArray<OOutput>);
-impl_chunked!(ChunkedMultiPolygonArray<OOutput>);
-impl_chunked!(ChunkedMixedGeometryArray<OOutput>);
-impl_chunked!(ChunkedGeometryCollectionArray<OOutput>);
+impl_chunked!(ChunkedLineStringArray<OOutput, 2>);
+impl_chunked!(ChunkedPolygonArray<OOutput, 2>);
+impl_chunked!(ChunkedMultiPointArray<OOutput, 2>);
+impl_chunked!(ChunkedMultiLineStringArray<OOutput, 2>);
+impl_chunked!(ChunkedMultiPolygonArray<OOutput, 2>);
+impl_chunked!(ChunkedMixedGeometryArray<OOutput, 2>);
+impl_chunked!(ChunkedGeometryCollectionArray<OOutput, 2>);
 
 /// Parse an ISO [WKBArray] to a GeometryArray with GeoArrow native encoding.
 ///

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -22,7 +22,7 @@ pub trait FromWKB: Sized {
     fn from_wkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self>;
 }
 
-impl FromWKB for PointArray {
+impl FromWKB for PointArray<2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
@@ -49,21 +49,21 @@ macro_rules! impl_from_wkb {
     };
 }
 
-impl_from_wkb!(LineStringArray<OOutput>, LineStringBuilder<OOutput>);
-impl_from_wkb!(PolygonArray<OOutput>, PolygonBuilder<OOutput>);
-impl_from_wkb!(MultiPointArray<OOutput>, MultiPointBuilder<OOutput>);
+impl_from_wkb!(LineStringArray<OOutput, 2>, LineStringBuilder<OOutput, 2>);
+impl_from_wkb!(PolygonArray<OOutput, 2>, PolygonBuilder<OOutput, 2>);
+impl_from_wkb!(MultiPointArray<OOutput, 2>, MultiPointBuilder<OOutput, 2>);
 impl_from_wkb!(
-    MultiLineStringArray<OOutput>,
-    MultiLineStringBuilder<OOutput>
+    MultiLineStringArray<OOutput, 2>,
+    MultiLineStringBuilder<OOutput, 2>
 );
-impl_from_wkb!(MultiPolygonArray<OOutput>, MultiPolygonBuilder<OOutput>);
+impl_from_wkb!(MultiPolygonArray<OOutput, 2>, MultiPolygonBuilder<OOutput, 2>);
 
-impl<OOutput: OffsetSizeTrait> FromWKB for MixedGeometryArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromWKB for MixedGeometryArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = MixedGeometryBuilder::<OOutput>::from_wkb(
+        let builder = MixedGeometryBuilder::<OOutput, 2>::from_wkb(
             &wkb_objects,
             Some(coord_type),
             arr.metadata(),
@@ -73,12 +73,12 @@ impl<OOutput: OffsetSizeTrait> FromWKB for MixedGeometryArray<OOutput> {
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKB for GeometryCollectionArray<OOutput> {
+impl<OOutput: OffsetSizeTrait> FromWKB for GeometryCollectionArray<OOutput, 2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = GeometryCollectionBuilder::<OOutput>::from_wkb(
+        let builder = GeometryCollectionBuilder::<OOutput, 2>::from_wkb(
             &wkb_objects,
             Some(coord_type),
             arr.metadata(),
@@ -93,7 +93,7 @@ impl FromWKB for Arc<dyn GeometryArrayTrait> {
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = GeometryCollectionBuilder::<i64>::from_wkb(
+        let builder = GeometryCollectionBuilder::<i64, 2>::from_wkb(
             &wkb_objects,
             Some(coord_type),
             arr.metadata(),
@@ -153,37 +153,49 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             Ok(Arc::new(builder.finish()))
         }
         LineString(coord_type) => {
-            let builder =
-                LineStringBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder = LineStringBuilder::<i32, 2>::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+            )?;
             Ok(Arc::new(builder.finish()))
         }
         LargeLineString(coord_type) => {
-            let builder =
-                LineStringBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder = LineStringBuilder::<i64, 2>::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+            )?;
             Ok(Arc::new(builder.finish()))
         }
         Polygon(coord_type) => {
             let builder =
-                PolygonBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+                PolygonBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         LargePolygon(coord_type) => {
             let builder =
-                PolygonBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+                PolygonBuilder::<i64, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiPoint(coord_type) => {
-            let builder =
-                MultiPointBuilder::<i32>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder = MultiPointBuilder::<i32, 2>::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+            )?;
             Ok(Arc::new(builder.finish()))
         }
         LargeMultiPoint(coord_type) => {
-            let builder =
-                MultiPointBuilder::<i64>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder = MultiPointBuilder::<i64, 2>::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+            )?;
             Ok(Arc::new(builder.finish()))
         }
         MultiLineString(coord_type) => {
-            let builder = MultiLineStringBuilder::<i32>::from_wkb(
+            let builder = MultiLineStringBuilder::<i32, 2>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
                 arr.metadata(),
@@ -191,7 +203,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             Ok(Arc::new(builder.finish()))
         }
         LargeMultiLineString(coord_type) => {
-            let builder = MultiLineStringBuilder::<i64>::from_wkb(
+            let builder = MultiLineStringBuilder::<i64, 2>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
                 arr.metadata(),
@@ -199,7 +211,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             Ok(Arc::new(builder.finish()))
         }
         MultiPolygon(coord_type) => {
-            let builder = MultiPolygonBuilder::<i32>::from_wkb(
+            let builder = MultiPolygonBuilder::<i32, 2>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
                 arr.metadata(),
@@ -207,7 +219,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             Ok(Arc::new(builder.finish()))
         }
         LargeMultiPolygon(coord_type) => {
-            let builder = MultiPolygonBuilder::<i64>::from_wkb(
+            let builder = MultiPolygonBuilder::<i64, 2>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
                 arr.metadata(),
@@ -215,7 +227,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             Ok(Arc::new(builder.finish()))
         }
         Mixed(coord_type) => {
-            let builder = MixedGeometryBuilder::<i32>::from_wkb(
+            let builder = MixedGeometryBuilder::<i32, 2>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
                 arr.metadata(),
@@ -224,7 +236,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             Ok(Arc::new(builder.finish()))
         }
         LargeMixed(coord_type) => {
-            let builder = MixedGeometryBuilder::<i64>::from_wkb(
+            let builder = MixedGeometryBuilder::<i64, 2>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
                 arr.metadata(),
@@ -233,7 +245,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             Ok(Arc::new(builder.finish()))
         }
         GeometryCollection(coord_type) => {
-            let builder = GeometryCollectionBuilder::<i32>::from_wkb(
+            let builder = GeometryCollectionBuilder::<i32, 2>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
                 arr.metadata(),
@@ -242,7 +254,7 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             Ok(Arc::new(builder.finish()))
         }
         LargeGeometryCollection(coord_type) => {
-            let builder = GeometryCollectionBuilder::<i64>::from_wkb(
+            let builder = GeometryCollectionBuilder::<i64, 2>::from_wkb(
                 &wkb_objects,
                 Some(coord_type),
                 arr.metadata(),

--- a/src/io/wkb/writer/geometry.rs
+++ b/src/io/wkb/writer/geometry.rs
@@ -53,8 +53,8 @@ pub fn write_geometry_as_wkb<W: Write>(
     }
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MixedGeometryArray<A>> for WKBArray<B> {
-    fn from(value: &MixedGeometryArray<A>) -> Self {
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MixedGeometryArray<A, 2>> for WKBArray<B> {
+    fn from(value: &MixedGeometryArray<A, 2>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets

--- a/src/io/wkb/writer/geometrycollection.rs
+++ b/src/io/wkb/writer/geometrycollection.rs
@@ -44,8 +44,8 @@ pub fn write_geometry_collection_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&GeometryCollectionArray<A>> for WKBArray<B> {
-    fn from(value: &GeometryCollectionArray<A>) -> Self {
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&GeometryCollectionArray<A, 2>> for WKBArray<B> {
+    fn from(value: &GeometryCollectionArray<A, 2>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -38,8 +38,8 @@ pub fn write_line_string_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&LineStringArray<A>> for WKBArray<B> {
-    fn from(value: &LineStringArray<A>) -> Self {
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&LineStringArray<A, 2>> for WKBArray<B> {
+    fn from(value: &LineStringArray<A, 2>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -75,9 +75,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: LineStringArray<i32> = vec![Some(ls0()), Some(ls1()), None].into();
+        let orig_arr: LineStringArray<i32, 2> = vec![Some(ls0()), Some(ls1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: LineStringArray<i32> = wkb_arr.try_into().unwrap();
+        let new_arr: LineStringArray<i32, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/src/io/wkb/writer/multilinestring.rs
+++ b/src/io/wkb/writer/multilinestring.rs
@@ -43,8 +43,8 @@ pub fn write_multi_line_string_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiLineStringArray<A>> for WKBArray<B> {
-    fn from(value: &MultiLineStringArray<A>) -> Self {
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiLineStringArray<A, 2>> for WKBArray<B> {
+    fn from(value: &MultiLineStringArray<A, 2>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -82,9 +82,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiLineStringArray<i32> = vec![Some(ml0()), Some(ml1()), None].into();
+        let orig_arr: MultiLineStringArray<i32, 2> = vec![Some(ml0()), Some(ml1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiLineStringArray<i32> = wkb_arr.try_into().unwrap();
+        let new_arr: MultiLineStringArray<i32, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/src/io/wkb/writer/multipoint.rs
+++ b/src/io/wkb/writer/multipoint.rs
@@ -38,8 +38,8 @@ pub fn write_multi_point_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiPointArray<A>> for WKBArray<B> {
-    fn from(value: &MultiPointArray<A>) -> Self {
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiPointArray<A, 2>> for WKBArray<B> {
+    fn from(value: &MultiPointArray<A, 2>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -75,9 +75,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiPointArray<i32> = vec![Some(mp0()), Some(mp1()), None].into();
+        let orig_arr: MultiPointArray<i32, 2> = vec![Some(mp0()), Some(mp1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiPointArray<i32> = wkb_arr.try_into().unwrap();
+        let new_arr: MultiPointArray<i32, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/src/io/wkb/writer/multipolygon.rs
+++ b/src/io/wkb/writer/multipolygon.rs
@@ -43,8 +43,8 @@ pub fn write_multi_polygon_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiPolygonArray<A>> for WKBArray<B> {
-    fn from(value: &MultiPolygonArray<A>) -> Self {
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&MultiPolygonArray<A, 2>> for WKBArray<B> {
+    fn from(value: &MultiPolygonArray<A, 2>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -82,9 +82,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiPolygonArray<i32> = vec![Some(mp0()), Some(mp1()), None].into();
+        let orig_arr: MultiPolygonArray<i32, 2> = vec![Some(mp0()), Some(mp1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiPolygonArray<i32> = wkb_arr.try_into().unwrap();
+        let new_arr: MultiPolygonArray<i32, 2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/src/io/wkb/writer/point.rs
+++ b/src/io/wkb/writer/point.rs
@@ -26,8 +26,8 @@ pub fn write_point_as_wkb<W: Write>(mut writer: W, geom: &impl PointTrait<T = f6
     Ok(())
 }
 
-impl<O: OffsetSizeTrait> From<&PointArray> for WKBArray<O> {
-    fn from(value: &PointArray) -> Self {
+impl<O: OffsetSizeTrait> From<&PointArray<2>> for WKBArray<O> {
+    fn from(value: &PointArray<2>) -> Self {
         let non_null_count = value
             .nulls()
             .map_or(value.len(), |validity| value.len() - validity.null_count());
@@ -66,18 +66,18 @@ mod test {
     #[test]
     fn round_trip() {
         // TODO: test with nulls
-        let orig_arr: PointArray = vec![Some(p0()), Some(p1()), Some(p2())].into();
+        let orig_arr: PointArray<2> = vec![Some(p0()), Some(p1()), Some(p2())].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: PointArray = wkb_arr.try_into().unwrap();
+        let new_arr: PointArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }
 
     #[test]
     fn round_trip_with_null() {
-        let orig_arr: PointArray = vec![Some(p0()), None, Some(p1()), None, Some(p2())].into();
+        let orig_arr: PointArray<2> = vec![Some(p0()), None, Some(p1()), None, Some(p2())].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: PointArray = wkb_arr.try_into().unwrap();
+        let new_arr: PointArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/src/io/wkb/writer/polygon.rs
+++ b/src/io/wkb/writer/polygon.rs
@@ -66,8 +66,8 @@ pub fn write_polygon_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&PolygonArray<A>> for WKBArray<B> {
-    fn from(value: &PolygonArray<A>) -> Self {
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait> From<&PolygonArray<A, 2>> for WKBArray<B> {
+    fn from(value: &PolygonArray<A, 2>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -105,9 +105,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: PolygonArray<i32> = vec![Some(p0()), Some(p1()), None].into();
+        let orig_arr: PolygonArray<i32, 2> = vec![Some(p0()), Some(p1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: PolygonArray<i32> = wkb_arr.clone().try_into().unwrap();
+        let new_arr: PolygonArray<i32, 2> = wkb_arr.clone().try_into().unwrap();
 
         let wkb0 = geo::Geometry::Polygon(p0())
             .to_wkb(CoordDimensions::xy())

--- a/src/scalar/coord/interleaved/scalar.rs
+++ b/src/scalar/coord/interleaved/scalar.rs
@@ -109,7 +109,7 @@ mod test {
     #[test]
     fn test_eq_other_index_false() {
         let coords1 = vec![0., 3., 1., 4., 2., 5.];
-        let buf1 = InterleavedCoordBuffer::new(coords1.into());
+        let buf1 = InterleavedCoordBuffer::<2>::new(coords1.into());
         let coord1 = buf1.value(0);
 
         let coords2 = vec![0., 3., 100., 400., 200., 500.];

--- a/src/scalar/geometry/owned.rs
+++ b/src/scalar/geometry/owned.rs
@@ -7,19 +7,19 @@ use crate::scalar::*;
 #[derive(Clone, Debug)]
 // TODO: come back to this in #449
 #[allow(clippy::large_enum_variant)]
-pub enum OwnedGeometry<O: OffsetSizeTrait> {
-    Point(crate::scalar::OwnedPoint),
-    LineString(crate::scalar::OwnedLineString<O>),
-    Polygon(crate::scalar::OwnedPolygon<O>),
-    MultiPoint(crate::scalar::OwnedMultiPoint<O>),
-    MultiLineString(crate::scalar::OwnedMultiLineString<O>),
-    MultiPolygon(crate::scalar::OwnedMultiPolygon<O>),
-    GeometryCollection(crate::scalar::OwnedGeometryCollection<O>),
+pub enum OwnedGeometry<O: OffsetSizeTrait, const D: usize> {
+    Point(crate::scalar::OwnedPoint<D>),
+    LineString(crate::scalar::OwnedLineString<O, D>),
+    Polygon(crate::scalar::OwnedPolygon<O, D>),
+    MultiPoint(crate::scalar::OwnedMultiPoint<O, D>),
+    MultiLineString(crate::scalar::OwnedMultiLineString<O, D>),
+    MultiPolygon(crate::scalar::OwnedMultiPolygon<O, D>),
+    GeometryCollection(crate::scalar::OwnedGeometryCollection<O, D>),
     Rect(crate::scalar::OwnedRect),
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometry<O>> for Geometry<'a, O> {
-    fn from(value: &'a OwnedGeometry<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedGeometry<O, D>> for Geometry<'a, O, D> {
+    fn from(value: &'a OwnedGeometry<O, D>) -> Self {
         use OwnedGeometry::*;
         match value {
             Point(geom) => Geometry::Point(geom.into()),
@@ -34,15 +34,15 @@ impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometry<O>> for Geometry<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometry<O>> for geo::Geometry {
-    fn from(value: &'a OwnedGeometry<O>) -> Self {
+impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometry<O, 2>> for geo::Geometry {
+    fn from(value: &'a OwnedGeometry<O, 2>) -> Self {
         let geom = Geometry::from(value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<Geometry<'a, O>> for OwnedGeometry<O> {
-    fn from(value: Geometry<'a, O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<Geometry<'a, O, D>> for OwnedGeometry<O, D> {
+    fn from(value: Geometry<'a, O, D>) -> Self {
         use OwnedGeometry::*;
         match value {
             Geometry::Point(geom) => Point(geom.into()),
@@ -64,28 +64,28 @@ impl<'a, O: OffsetSizeTrait> From<Geometry<'a, O>> for OwnedGeometry<O> {
 //     }
 // }
 
-impl<O: OffsetSizeTrait> GeometryTrait for OwnedGeometry<O> {
+impl<O: OffsetSizeTrait> GeometryTrait for OwnedGeometry<O, 2> {
     type T = f64;
-    type Point<'b> = OwnedPoint where Self: 'b;
-    type LineString<'b> = OwnedLineString< O> where Self: 'b;
-    type Polygon<'b> = OwnedPolygon< O> where Self: 'b;
-    type MultiPoint<'b> = OwnedMultiPoint< O> where Self: 'b;
-    type MultiLineString<'b> = OwnedMultiLineString< O> where Self: 'b;
-    type MultiPolygon<'b> = OwnedMultiPolygon< O> where Self: 'b;
-    type GeometryCollection<'b> = OwnedGeometryCollection< O> where Self: 'b;
+    type Point<'b> = OwnedPoint<2> where Self: 'b;
+    type LineString<'b> = OwnedLineString<O, 2> where Self: 'b;
+    type Polygon<'b> = OwnedPolygon<O, 2> where Self: 'b;
+    type MultiPoint<'b> = OwnedMultiPoint<O, 2> where Self: 'b;
+    type MultiLineString<'b> = OwnedMultiLineString<O, 2> where Self: 'b;
+    type MultiPolygon<'b> = OwnedMultiPolygon<O, 2> where Self: 'b;
+    type GeometryCollection<'b> = OwnedGeometryCollection<O, 2> where Self: 'b;
     type Rect<'b> = OwnedRect where Self: 'b;
 
     fn as_type(
         &self,
     ) -> crate::geo_traits::GeometryType<
         '_,
-        OwnedPoint,
-        OwnedLineString<O>,
-        OwnedPolygon<O>,
-        OwnedMultiPoint<O>,
-        OwnedMultiLineString<O>,
-        OwnedMultiPolygon<O>,
-        OwnedGeometryCollection<O>,
+        OwnedPoint<2>,
+        OwnedLineString<O, 2>,
+        OwnedPolygon<O, 2>,
+        OwnedMultiPoint<O, 2>,
+        OwnedMultiLineString<O, 2>,
+        OwnedMultiPolygon<O, 2>,
+        OwnedGeometryCollection<O, 2>,
         OwnedRect,
     > {
         match self {
@@ -101,7 +101,7 @@ impl<O: OffsetSizeTrait> GeometryTrait for OwnedGeometry<O> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> PartialEq<G> for OwnedGeometry<O> {
+impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> PartialEq<G> for OwnedGeometry<O, 2> {
     fn eq(&self, other: &G) -> bool {
         geometry_eq(self, other)
     }

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -10,18 +10,18 @@ use rstar::{RTreeObject, AABB};
 ///
 /// Notably this does _not_ include [`WKB`] as a variant, because that is not zero-copy to parse.
 #[derive(Debug)]
-pub enum Geometry<'a, O: OffsetSizeTrait> {
-    Point(crate::scalar::Point<'a>),
-    LineString(crate::scalar::LineString<'a, O>),
-    Polygon(crate::scalar::Polygon<'a, O>),
-    MultiPoint(crate::scalar::MultiPoint<'a, O>),
-    MultiLineString(crate::scalar::MultiLineString<'a, O>),
-    MultiPolygon(crate::scalar::MultiPolygon<'a, O>),
-    GeometryCollection(crate::scalar::GeometryCollection<'a, O>),
+pub enum Geometry<'a, O: OffsetSizeTrait, const D: usize> {
+    Point(crate::scalar::Point<'a, D>),
+    LineString(crate::scalar::LineString<'a, O, D>),
+    Polygon(crate::scalar::Polygon<'a, O, D>),
+    MultiPoint(crate::scalar::MultiPoint<'a, O, D>),
+    MultiLineString(crate::scalar::MultiLineString<'a, O, D>),
+    MultiPolygon(crate::scalar::MultiPolygon<'a, O, D>),
+    GeometryCollection(crate::scalar::GeometryCollection<'a, O, D>),
     Rect(crate::scalar::Rect<'a>),
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for Geometry<'a, O> {
+impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for Geometry<'a, O, 2> {
     type ScalarGeo = geo::Geometry;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -47,28 +47,28 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for Geometry<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryTrait for Geometry<'a, O> {
+impl<'a, O: OffsetSizeTrait> GeometryTrait for Geometry<'a, O, 2> {
     type T = f64;
-    type Point<'b> = Point<'b> where Self: 'b;
-    type LineString<'b> = LineString<'b, O> where Self: 'b;
-    type Polygon<'b> = Polygon<'b, O> where Self: 'b;
-    type MultiPoint<'b> = MultiPoint<'b, O> where Self: 'b;
-    type MultiLineString<'b> = MultiLineString<'b, O> where Self: 'b;
-    type MultiPolygon<'b> = MultiPolygon<'b, O> where Self: 'b;
-    type GeometryCollection<'b> = GeometryCollection<'b, O> where Self: 'b;
+    type Point<'b> = Point<'b, 2> where Self: 'b;
+    type LineString<'b> = LineString<'b, O, 2> where Self: 'b;
+    type Polygon<'b> = Polygon<'b, O, 2> where Self: 'b;
+    type MultiPoint<'b> = MultiPoint<'b, O, 2> where Self: 'b;
+    type MultiLineString<'b> = MultiLineString<'b, O, 2> where Self: 'b;
+    type MultiPolygon<'b> = MultiPolygon<'b, O, 2> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<'b, O, 2> where Self: 'b;
     type Rect<'b> = Rect<'b> where Self: 'b;
 
     fn as_type(
         &self,
     ) -> crate::geo_traits::GeometryType<
         '_,
-        Point<'_>,
-        LineString<'_, O>,
-        Polygon<'_, O>,
-        MultiPoint<'_, O>,
-        MultiLineString<'_, O>,
-        MultiPolygon<'_, O>,
-        GeometryCollection<'_, O>,
+        Point<'_, 2>,
+        LineString<'_, O, 2>,
+        Polygon<'_, O, 2>,
+        MultiPoint<'_, O, 2>,
+        MultiLineString<'_, O, 2>,
+        MultiPolygon<'_, O, 2>,
+        GeometryCollection<'_, O, 2>,
         Rect<'_>,
     > {
         match self {
@@ -84,28 +84,28 @@ impl<'a, O: OffsetSizeTrait> GeometryTrait for Geometry<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryTrait for &'a Geometry<'a, O> {
+impl<'a, O: OffsetSizeTrait> GeometryTrait for &'a Geometry<'a, O, 2> {
     type T = f64;
-    type Point<'b> = Point<'a> where Self: 'b;
-    type LineString<'b> = LineString<'a, O> where Self: 'b;
-    type Polygon<'b> = Polygon<'a, O> where Self: 'b;
-    type MultiPoint<'b> = MultiPoint<'a, O> where Self: 'b;
-    type MultiLineString<'b> = MultiLineString<'a, O> where Self: 'b;
-    type MultiPolygon<'b> = MultiPolygon<'a, O> where Self: 'b;
-    type GeometryCollection<'b> = GeometryCollection<'a, O> where Self: 'b;
+    type Point<'b> = Point<'a, 2> where Self: 'b;
+    type LineString<'b> = LineString<'a, O, 2> where Self: 'b;
+    type Polygon<'b> = Polygon<'a, O, 2> where Self: 'b;
+    type MultiPoint<'b> = MultiPoint<'a, O, 2> where Self: 'b;
+    type MultiLineString<'b> = MultiLineString<'a, O, 2> where Self: 'b;
+    type MultiPolygon<'b> = MultiPolygon<'a, O, 2> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<'a, O, 2> where Self: 'b;
     type Rect<'b> = Rect<'a> where Self: 'b;
 
     fn as_type(
         &self,
     ) -> crate::geo_traits::GeometryType<
         'a,
-        Point<'a>,
-        LineString<'a, O>,
-        Polygon<'a, O>,
-        MultiPoint<'a, O>,
-        MultiLineString<'a, O>,
-        MultiPolygon<'a, O>,
-        GeometryCollection<'a, O>,
+        Point<'a, 2>,
+        LineString<'a, O, 2>,
+        Polygon<'a, O, 2>,
+        MultiPoint<'a, O, 2>,
+        MultiLineString<'a, O, 2>,
+        MultiPolygon<'a, O, 2>,
+        GeometryCollection<'a, O, 2>,
         Rect<'a>,
     > {
         match self {
@@ -121,7 +121,7 @@ impl<'a, O: OffsetSizeTrait> GeometryTrait for &'a Geometry<'a, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> RTreeObject for Geometry<'_, O> {
+impl<O: OffsetSizeTrait> RTreeObject for Geometry<'_, O, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -138,19 +138,19 @@ impl<O: OffsetSizeTrait> RTreeObject for Geometry<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<Geometry<'_, O>> for geo::Geometry {
-    fn from(value: Geometry<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<Geometry<'_, O, 2>> for geo::Geometry {
+    fn from(value: Geometry<'_, O, 2>) -> Self {
         geometry_to_geo(&value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<&Geometry<'_, O>> for geo::Geometry {
-    fn from(value: &Geometry<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<&Geometry<'_, O, 2>> for geo::Geometry {
+    fn from(value: &Geometry<'_, O, 2>) -> Self {
         geometry_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> PartialEq<G> for Geometry<'_, O> {
+impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> PartialEq<G> for Geometry<'_, O, 2> {
     fn eq(&self, other: &G) -> bool {
         geometry_eq(self, other)
     }

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -21,7 +21,7 @@ pub enum Geometry<'a, O: OffsetSizeTrait, const D: usize> {
     Rect(crate::scalar::Rect<'a>),
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for Geometry<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for Geometry<'a, O, D> {
     type ScalarGeo = geo::Geometry;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -47,28 +47,28 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for Geometry<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryTrait for Geometry<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for Geometry<'a, O, D> {
     type T = f64;
-    type Point<'b> = Point<'b, 2> where Self: 'b;
-    type LineString<'b> = LineString<'b, O, 2> where Self: 'b;
-    type Polygon<'b> = Polygon<'b, O, 2> where Self: 'b;
-    type MultiPoint<'b> = MultiPoint<'b, O, 2> where Self: 'b;
-    type MultiLineString<'b> = MultiLineString<'b, O, 2> where Self: 'b;
-    type MultiPolygon<'b> = MultiPolygon<'b, O, 2> where Self: 'b;
-    type GeometryCollection<'b> = GeometryCollection<'b, O, 2> where Self: 'b;
+    type Point<'b> = Point<'b, D> where Self: 'b;
+    type LineString<'b> = LineString<'b, O, D> where Self: 'b;
+    type Polygon<'b> = Polygon<'b, O, D> where Self: 'b;
+    type MultiPoint<'b> = MultiPoint<'b, O, D> where Self: 'b;
+    type MultiLineString<'b> = MultiLineString<'b, O, D> where Self: 'b;
+    type MultiPolygon<'b> = MultiPolygon<'b, O, D> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<'b, O, D> where Self: 'b;
     type Rect<'b> = Rect<'b> where Self: 'b;
 
     fn as_type(
         &self,
     ) -> crate::geo_traits::GeometryType<
         '_,
-        Point<'_, 2>,
-        LineString<'_, O, 2>,
-        Polygon<'_, O, 2>,
-        MultiPoint<'_, O, 2>,
-        MultiLineString<'_, O, 2>,
-        MultiPolygon<'_, O, 2>,
-        GeometryCollection<'_, O, 2>,
+        Point<'_, D>,
+        LineString<'_, O, D>,
+        Polygon<'_, O, D>,
+        MultiPoint<'_, O, D>,
+        MultiLineString<'_, O, D>,
+        MultiPolygon<'_, O, D>,
+        GeometryCollection<'_, O, D>,
         Rect<'_>,
     > {
         match self {
@@ -84,28 +84,28 @@ impl<'a, O: OffsetSizeTrait> GeometryTrait for Geometry<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryTrait for &'a Geometry<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for &'a Geometry<'a, O, D> {
     type T = f64;
-    type Point<'b> = Point<'a, 2> where Self: 'b;
-    type LineString<'b> = LineString<'a, O, 2> where Self: 'b;
-    type Polygon<'b> = Polygon<'a, O, 2> where Self: 'b;
-    type MultiPoint<'b> = MultiPoint<'a, O, 2> where Self: 'b;
-    type MultiLineString<'b> = MultiLineString<'a, O, 2> where Self: 'b;
-    type MultiPolygon<'b> = MultiPolygon<'a, O, 2> where Self: 'b;
-    type GeometryCollection<'b> = GeometryCollection<'a, O, 2> where Self: 'b;
+    type Point<'b> = Point<'a, D> where Self: 'b;
+    type LineString<'b> = LineString<'a, O, D> where Self: 'b;
+    type Polygon<'b> = Polygon<'a, O, D> where Self: 'b;
+    type MultiPoint<'b> = MultiPoint<'a, O, D> where Self: 'b;
+    type MultiLineString<'b> = MultiLineString<'a, O, D> where Self: 'b;
+    type MultiPolygon<'b> = MultiPolygon<'a, O, D> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<'a, O, D> where Self: 'b;
     type Rect<'b> = Rect<'a> where Self: 'b;
 
     fn as_type(
         &self,
     ) -> crate::geo_traits::GeometryType<
         'a,
-        Point<'a, 2>,
-        LineString<'a, O, 2>,
-        Polygon<'a, O, 2>,
-        MultiPoint<'a, O, 2>,
-        MultiLineString<'a, O, 2>,
-        MultiPolygon<'a, O, 2>,
-        GeometryCollection<'a, O, 2>,
+        Point<'a, D>,
+        LineString<'a, O, D>,
+        Polygon<'a, O, D>,
+        MultiPoint<'a, O, D>,
+        MultiLineString<'a, O, D>,
+        MultiPolygon<'a, O, D>,
+        GeometryCollection<'a, O, D>,
         Rect<'a>,
     > {
         match self {
@@ -138,19 +138,21 @@ impl<O: OffsetSizeTrait> RTreeObject for Geometry<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<Geometry<'_, O, 2>> for geo::Geometry {
-    fn from(value: Geometry<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<Geometry<'_, O, D>> for geo::Geometry {
+    fn from(value: Geometry<'_, O, D>) -> Self {
         geometry_to_geo(&value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<&Geometry<'_, O, 2>> for geo::Geometry {
-    fn from(value: &Geometry<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<&Geometry<'_, O, D>> for geo::Geometry {
+    fn from(value: &Geometry<'_, O, D>) -> Self {
         geometry_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> PartialEq<G> for Geometry<'_, O, 2> {
+impl<O: OffsetSizeTrait, const D: usize, G: GeometryTrait<T = f64>> PartialEq<G>
+    for Geometry<'_, O, D>
+{
     fn eq(&self, other: &G) -> bool {
         geometry_eq(self, other)
     }

--- a/src/scalar/geometrycollection/owned.rs
+++ b/src/scalar/geometrycollection/owned.rs
@@ -6,8 +6,8 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedGeometryCollection<O: OffsetSizeTrait> {
-    array: MixedGeometryArray<O>,
+pub struct OwnedGeometryCollection<O: OffsetSizeTrait, const D: usize> {
+    array: MixedGeometryArray<O, D>,
 
     /// Offsets into the geometry array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -15,9 +15,9 @@ pub struct OwnedGeometryCollection<O: OffsetSizeTrait> {
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait> OwnedGeometryCollection<O> {
+impl<O: OffsetSizeTrait, const D: usize> OwnedGeometryCollection<O, D> {
     pub fn new(
-        array: MixedGeometryArray<O>,
+        array: MixedGeometryArray<O, D>,
         geom_offsets: OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
@@ -29,35 +29,41 @@ impl<O: OffsetSizeTrait> OwnedGeometryCollection<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometryCollection<O>> for GeometryCollection<'a, O> {
-    fn from(value: &'a OwnedGeometryCollection<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedGeometryCollection<O, D>>
+    for GeometryCollection<'a, O, D>
+{
+    fn from(value: &'a OwnedGeometryCollection<O, D>) -> Self {
         Self::new(&value.array, &value.geom_offsets, value.geom_index)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometryCollection<O>> for geo::GeometryCollection {
-    fn from(value: &'a OwnedGeometryCollection<O>) -> Self {
+impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometryCollection<O, 2>> for geo::GeometryCollection {
+    fn from(value: &'a OwnedGeometryCollection<O, 2>) -> Self {
         let geom = GeometryCollection::from(value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<GeometryCollection<'a, O>> for OwnedGeometryCollection<O> {
-    fn from(value: GeometryCollection<'a, O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<GeometryCollection<'a, O, D>>
+    for OwnedGeometryCollection<O, D>
+{
+    fn from(value: GeometryCollection<'a, O, D>) -> Self {
         let (array, geom_offsets, geom_index) = value.into_inner();
         Self::new(array.clone(), geom_offsets.clone(), geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedGeometryCollection<O>> for GeometryCollectionArray<O> {
-    fn from(value: OwnedGeometryCollection<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<OwnedGeometryCollection<O, D>>
+    for GeometryCollectionArray<O, D>
+{
+    fn from(value: OwnedGeometryCollection<O, D>) -> Self {
         Self::new(value.array, value.geom_offsets, None, Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait> GeometryCollectionTrait for OwnedGeometryCollection<O> {
+impl<O: OffsetSizeTrait> GeometryCollectionTrait for OwnedGeometryCollection<O, 2> {
     type T = f64;
-    type ItemType<'b> = Geometry<'b, O> where Self: 'b;
+    type ItemType<'b> = Geometry<'b, O, 2> where Self: 'b;
 
     fn num_geometries(&self) -> usize {
         GeometryCollection::from(self).num_geometries()
@@ -69,7 +75,7 @@ impl<O: OffsetSizeTrait> GeometryCollectionTrait for OwnedGeometryCollection<O> 
 }
 
 impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
-    for OwnedGeometryCollection<O>
+    for OwnedGeometryCollection<O, 2>
 {
     fn eq(&self, other: &G) -> bool {
         geometry_collection_eq(self, other)

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -43,7 +43,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollection<'a, O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for GeometryCollection<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for GeometryCollection<'a, O, D> {
     type ScalarGeo = geo::GeometryCollection;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -60,9 +60,11 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for GeometryCollection<'a, O, 2
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryCollectionTrait for GeometryCollection<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
+    for GeometryCollection<'a, O, D>
+{
     type T = f64;
-    type ItemType<'b> = Geometry<'a, O, 2> where Self: 'b;
+    type ItemType<'b> = Geometry<'a, O, D> where Self: 'b;
 
     fn num_geometries(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -74,9 +76,11 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionTrait for GeometryCollection<'a, 
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryCollectionTrait for &'a GeometryCollection<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
+    for &'a GeometryCollection<'a, O, D>
+{
     type T = f64;
-    type ItemType<'b> = Geometry<'a, O, 2> where Self: 'b;
+    type ItemType<'b> = Geometry<'a, O, D> where Self: 'b;
 
     fn num_geometries(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -94,14 +98,16 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionTrait for &'a GeometryCollection<
 //     }
 // }
 
-impl<O: OffsetSizeTrait> From<&GeometryCollection<'_, O, 2>> for geo::GeometryCollection {
-    fn from(value: &GeometryCollection<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<&GeometryCollection<'_, O, D>>
+    for geo::GeometryCollection
+{
+    fn from(value: &GeometryCollection<'_, O, D>) -> Self {
         geometry_collection_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<GeometryCollection<'_, O, 2>> for geo::Geometry {
-    fn from(value: GeometryCollection<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<GeometryCollection<'_, O, D>> for geo::Geometry {
+    fn from(value: GeometryCollection<'_, O, D>) -> Self {
         geo::Geometry::GeometryCollection(value.into())
     }
 }
@@ -116,8 +122,8 @@ impl<O: OffsetSizeTrait> RTreeObject for GeometryCollection<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
-    for GeometryCollection<'_, O, 2>
+impl<O: OffsetSizeTrait, const D: usize, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
+    for GeometryCollection<'_, O, D>
 {
     fn eq(&self, other: &G) -> bool {
         geometry_collection_eq(self, other)

--- a/src/scalar/linestring/owned.rs
+++ b/src/scalar/linestring/owned.rs
@@ -6,8 +6,8 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedLineString<O: OffsetSizeTrait> {
-    coords: CoordBuffer<2>,
+pub struct OwnedLineString<O: OffsetSizeTrait, const D: usize> {
+    coords: CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -15,8 +15,8 @@ pub struct OwnedLineString<O: OffsetSizeTrait> {
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait> OwnedLineString<O> {
-    pub fn new(coords: CoordBuffer<2>, geom_offsets: OffsetBuffer<O>, geom_index: usize) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> OwnedLineString<O, D> {
+    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<O>, geom_index: usize) -> Self {
         Self {
             coords,
             geom_offsets,
@@ -25,41 +25,43 @@ impl<O: OffsetSizeTrait> OwnedLineString<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<OwnedLineString<O>> for LineString<'a, O> {
-    fn from(value: OwnedLineString<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedLineString<O, D>> for LineString<'a, O, D> {
+    fn from(value: OwnedLineString<O, D>) -> Self {
         Self::new_owned(value.coords, value.geom_offsets, value.geom_index)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedLineString<O>> for LineString<'a, O> {
-    fn from(value: &'a OwnedLineString<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedLineString<O, D>>
+    for LineString<'a, O, D>
+{
+    fn from(value: &'a OwnedLineString<O, D>) -> Self {
         Self::new_borrowed(&value.coords, &value.geom_offsets, value.geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedLineString<O>> for geo::LineString {
-    fn from(value: OwnedLineString<O>) -> Self {
+impl<O: OffsetSizeTrait> From<OwnedLineString<O, 2>> for geo::LineString {
+    fn from(value: OwnedLineString<O, 2>) -> Self {
         let geom = LineString::from(value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<LineString<'a, O>> for OwnedLineString<O> {
-    fn from(value: LineString<'a, O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<LineString<'a, O, D>> for OwnedLineString<O, D> {
+    fn from(value: LineString<'a, O, D>) -> Self {
         let (coords, geom_offsets, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_offsets, geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedLineString<O>> for LineStringArray<O> {
-    fn from(value: OwnedLineString<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<OwnedLineString<O, D>> for LineStringArray<O, D> {
+    fn from(value: OwnedLineString<O, D>) -> Self {
         Self::new(value.coords, value.geom_offsets, None, Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait> LineStringTrait for OwnedLineString<O> {
+impl<O: OffsetSizeTrait> LineStringTrait for OwnedLineString<O, 2> {
     type T = f64;
-    type ItemType<'b> = Point<'b> where Self: 'b;
+    type ItemType<'b> = Point<'b, 2> where Self: 'b;
 
     fn num_coords(&self) -> usize {
         LineString::from(self).num_coords()
@@ -70,7 +72,7 @@ impl<O: OffsetSizeTrait> LineStringTrait for OwnedLineString<O> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> PartialEq<G> for OwnedLineString<O> {
+impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> PartialEq<G> for OwnedLineString<O, 2> {
     fn eq(&self, other: &G) -> bool {
         line_string_eq(self, other)
     }

--- a/src/scalar/linestring/scalar.rs
+++ b/src/scalar/linestring/scalar.rs
@@ -100,9 +100,9 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for LineString<
     }
 }
 
-impl<'a, O: OffsetSizeTrait> LineStringTrait for LineString<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> LineStringTrait for LineString<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = Point<'a, 2> where Self: 'b;
+    type ItemType<'b> = Point<'a, D> where Self: 'b;
 
     fn num_coords(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -114,9 +114,9 @@ impl<'a, O: OffsetSizeTrait> LineStringTrait for LineString<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> LineStringTrait for &'a LineString<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> LineStringTrait for &'a LineString<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = Point<'a, 2> where Self: 'b;
+    type ItemType<'b> = Point<'a, D> where Self: 'b;
 
     fn num_coords(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -128,20 +128,20 @@ impl<'a, O: OffsetSizeTrait> LineStringTrait for &'a LineString<'a, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<LineString<'_, O, 2>> for geo::LineString {
-    fn from(value: LineString<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<LineString<'_, O, D>> for geo::LineString {
+    fn from(value: LineString<'_, O, D>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait> From<&LineString<'_, O, 2>> for geo::LineString {
-    fn from(value: &LineString<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<&LineString<'_, O, D>> for geo::LineString {
+    fn from(value: &LineString<'_, O, D>) -> Self {
         line_string_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<LineString<'_, O, 2>> for geo::Geometry {
-    fn from(value: LineString<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<LineString<'_, O, D>> for geo::Geometry {
+    fn from(value: LineString<'_, O, D>) -> Self {
         geo::Geometry::LineString(value.into())
     }
 }

--- a/src/scalar/multilinestring/owned.rs
+++ b/src/scalar/multilinestring/owned.rs
@@ -6,8 +6,8 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedMultiLineString<O: OffsetSizeTrait> {
-    coords: CoordBuffer<2>,
+pub struct OwnedMultiLineString<O: OffsetSizeTrait, const D: usize> {
+    coords: CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -17,9 +17,9 @@ pub struct OwnedMultiLineString<O: OffsetSizeTrait> {
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait> OwnedMultiLineString<O> {
+impl<O: OffsetSizeTrait, const D: usize> OwnedMultiLineString<O, D> {
     pub fn new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         geom_index: usize,
@@ -33,8 +33,10 @@ impl<O: OffsetSizeTrait> OwnedMultiLineString<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<OwnedMultiLineString<O>> for MultiLineString<'a, O> {
-    fn from(value: OwnedMultiLineString<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedMultiLineString<O, D>>
+    for MultiLineString<'a, O, D>
+{
+    fn from(value: OwnedMultiLineString<O, D>) -> Self {
         Self::new_owned(
             value.coords,
             value.geom_offsets,
@@ -44,8 +46,10 @@ impl<'a, O: OffsetSizeTrait> From<OwnedMultiLineString<O>> for MultiLineString<'
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedMultiLineString<O>> for MultiLineString<'a, O> {
-    fn from(value: &'a OwnedMultiLineString<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiLineString<O, D>>
+    for MultiLineString<'a, O, D>
+{
+    fn from(value: &'a OwnedMultiLineString<O, D>) -> Self {
         Self::new_borrowed(
             &value.coords,
             &value.geom_offsets,
@@ -55,22 +59,26 @@ impl<'a, O: OffsetSizeTrait> From<&'a OwnedMultiLineString<O>> for MultiLineStri
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedMultiLineString<O>> for geo::MultiLineString {
-    fn from(value: OwnedMultiLineString<O>) -> Self {
+impl<O: OffsetSizeTrait> From<OwnedMultiLineString<O, 2>> for geo::MultiLineString {
+    fn from(value: OwnedMultiLineString<O, 2>) -> Self {
         let geom = MultiLineString::from(value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<MultiLineString<'a, O>> for OwnedMultiLineString<O> {
-    fn from(value: MultiLineString<'a, O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<MultiLineString<'a, O, D>>
+    for OwnedMultiLineString<O, D>
+{
+    fn from(value: MultiLineString<'a, O, D>) -> Self {
         let (coords, geom_offsets, ring_offsets, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_offsets, ring_offsets, geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedMultiLineString<O>> for MultiLineStringArray<O> {
-    fn from(value: OwnedMultiLineString<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<OwnedMultiLineString<O, D>>
+    for MultiLineStringArray<O, D>
+{
+    fn from(value: OwnedMultiLineString<O, D>) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -81,9 +89,9 @@ impl<O: OffsetSizeTrait> From<OwnedMultiLineString<O>> for MultiLineStringArray<
     }
 }
 
-impl<O: OffsetSizeTrait> MultiLineStringTrait for OwnedMultiLineString<O> {
+impl<O: OffsetSizeTrait> MultiLineStringTrait for OwnedMultiLineString<O, 2> {
     type T = f64;
-    type ItemType<'b> = LineString<'b, O> where Self: 'b;
+    type ItemType<'b> = LineString<'b, O, 2> where Self: 'b;
 
     fn num_lines(&self) -> usize {
         MultiLineString::from(self).num_lines()
@@ -95,7 +103,7 @@ impl<O: OffsetSizeTrait> MultiLineStringTrait for OwnedMultiLineString<O> {
 }
 
 impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> PartialEq<G>
-    for OwnedMultiLineString<O>
+    for OwnedMultiLineString<O, 2>
 {
     fn eq(&self, other: &G) -> bool {
         multi_line_string_eq(self, other)

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -104,7 +104,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineString<'a, O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiLineString<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for MultiLineString<'a, O, D> {
     type ScalarGeo = geo::MultiLineString;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -121,9 +121,9 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiLineString<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for MultiLineString<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineStringTrait for MultiLineString<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = LineString<'a, O> where Self: 'b;
+    type ItemType<'b> = LineString<'a, O, D> where Self: 'b;
 
     fn num_lines(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -139,9 +139,11 @@ impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for MultiLineString<'a, O, 2> 
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for &'a MultiLineString<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineStringTrait
+    for &'a MultiLineString<'a, O, D>
+{
     type T = f64;
-    type ItemType<'b> = LineString<'a, O> where Self: 'b;
+    type ItemType<'b> = LineString<'a, O, D> where Self: 'b;
 
     fn num_lines(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -157,20 +159,20 @@ impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for &'a MultiLineString<'a, O,
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiLineString<'_, O, 2>> for geo::MultiLineString {
-    fn from(value: MultiLineString<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiLineString<'_, O, D>> for geo::MultiLineString {
+    fn from(value: MultiLineString<'_, O, D>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait> From<&MultiLineString<'_, O, 2>> for geo::MultiLineString {
-    fn from(value: &MultiLineString<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<&MultiLineString<'_, O, D>> for geo::MultiLineString {
+    fn from(value: &MultiLineString<'_, O, D>) -> Self {
         multi_line_string_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiLineString<'_, O, 2>> for geo::Geometry {
-    fn from(value: MultiLineString<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiLineString<'_, O, D>> for geo::Geometry {
+    fn from(value: MultiLineString<'_, O, D>) -> Self {
         geo::Geometry::MultiLineString(value.into())
     }
 }

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -14,8 +14,8 @@ use std::borrow::Cow;
 
 /// An Arrow equivalent of a MultiLineString
 #[derive(Debug, Clone)]
-pub struct MultiLineString<'a, O: OffsetSizeTrait> {
-    pub(crate) coords: Cow<'a, CoordBuffer<2>>,
+pub struct MultiLineString<'a, O: OffsetSizeTrait, const D: usize> {
+    pub(crate) coords: Cow<'a, CoordBuffer<D>>,
 
     /// Offsets into the ring array where each geometry starts
     pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -28,9 +28,9 @@ pub struct MultiLineString<'a, O: OffsetSizeTrait> {
     start_offset: usize,
 }
 
-impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineString<'a, O, D> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer<2>>,
+        coords: Cow<'a, CoordBuffer<D>>,
         geom_offsets: Cow<'a, OffsetBuffer<O>>,
         ring_offsets: Cow<'a, OffsetBuffer<O>>,
         geom_index: usize,
@@ -46,7 +46,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
     }
 
     pub fn new_borrowed(
-        coords: &'a CoordBuffer<2>,
+        coords: &'a CoordBuffer<D>,
         geom_offsets: &'a OffsetBuffer<O>,
         ring_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
@@ -60,7 +60,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
     }
 
     pub fn new_owned(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
         geom_index: usize,
@@ -93,7 +93,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
         )
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer<2>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
         let owned = self.into_owned();
         (
             owned.coords.into_owned(),
@@ -104,7 +104,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineString<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiLineString<'a, O> {
+impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiLineString<'a, O, 2> {
     type ScalarGeo = geo::MultiLineString;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -121,7 +121,7 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiLineString<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for MultiLineString<'a, O> {
+impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for MultiLineString<'a, O, 2> {
     type T = f64;
     type ItemType<'b> = LineString<'a, O> where Self: 'b;
 
@@ -139,7 +139,7 @@ impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for MultiLineString<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for &'a MultiLineString<'a, O> {
+impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for &'a MultiLineString<'a, O, 2> {
     type T = f64;
     type ItemType<'b> = LineString<'a, O> where Self: 'b;
 
@@ -157,25 +157,25 @@ impl<'a, O: OffsetSizeTrait> MultiLineStringTrait for &'a MultiLineString<'a, O>
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiLineString<'_, O>> for geo::MultiLineString {
-    fn from(value: MultiLineString<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<MultiLineString<'_, O, 2>> for geo::MultiLineString {
+    fn from(value: MultiLineString<'_, O, 2>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait> From<&MultiLineString<'_, O>> for geo::MultiLineString {
-    fn from(value: &MultiLineString<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<&MultiLineString<'_, O, 2>> for geo::MultiLineString {
+    fn from(value: &MultiLineString<'_, O, 2>) -> Self {
         multi_line_string_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiLineString<'_, O>> for geo::Geometry {
-    fn from(value: MultiLineString<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<MultiLineString<'_, O, 2>> for geo::Geometry {
+    fn from(value: MultiLineString<'_, O, 2>) -> Self {
         geo::Geometry::MultiLineString(value.into())
     }
 }
 
-impl<O: OffsetSizeTrait> RTreeObject for MultiLineString<'_, O> {
+impl<O: OffsetSizeTrait> RTreeObject for MultiLineString<'_, O, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -184,7 +184,9 @@ impl<O: OffsetSizeTrait> RTreeObject for MultiLineString<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> PartialEq<G> for MultiLineString<'_, O> {
+impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> PartialEq<G>
+    for MultiLineString<'_, O, 2>
+{
     fn eq(&self, other: &G) -> bool {
         multi_line_string_eq(self, other)
     }
@@ -199,8 +201,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiLineStringArray<i32> = vec![ml0(), ml1()].as_slice().into();
-        let arr2: MultiLineStringArray<i32> = vec![ml0(), ml0()].as_slice().into();
+        let arr1: MultiLineStringArray<i32, 2> = vec![ml0(), ml1()].as_slice().into();
+        let arr2: MultiLineStringArray<i32, 2> = vec![ml0(), ml0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/src/scalar/multipoint/owned.rs
+++ b/src/scalar/multipoint/owned.rs
@@ -6,8 +6,8 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedMultiPoint<O: OffsetSizeTrait> {
-    coords: CoordBuffer<2>,
+pub struct OwnedMultiPoint<O: OffsetSizeTrait, const D: usize> {
+    coords: CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -15,8 +15,8 @@ pub struct OwnedMultiPoint<O: OffsetSizeTrait> {
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait> OwnedMultiPoint<O> {
-    pub fn new(coords: CoordBuffer<2>, geom_offsets: OffsetBuffer<O>, geom_index: usize) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> OwnedMultiPoint<O, D> {
+    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<O>, geom_index: usize) -> Self {
         Self {
             coords,
             geom_offsets,
@@ -25,41 +25,43 @@ impl<O: OffsetSizeTrait> OwnedMultiPoint<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<OwnedMultiPoint<O>> for MultiPoint<'a, O> {
-    fn from(value: OwnedMultiPoint<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedMultiPoint<O, D>> for MultiPoint<'a, O, D> {
+    fn from(value: OwnedMultiPoint<O, D>) -> Self {
         Self::new_owned(value.coords, value.geom_offsets, value.geom_index)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedMultiPoint<O>> for MultiPoint<'a, O> {
-    fn from(value: &'a OwnedMultiPoint<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiPoint<O, D>>
+    for MultiPoint<'a, O, D>
+{
+    fn from(value: &'a OwnedMultiPoint<O, D>) -> Self {
         Self::new_borrowed(&value.coords, &value.geom_offsets, value.geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedMultiPoint<O>> for geo::MultiPoint {
-    fn from(value: OwnedMultiPoint<O>) -> Self {
+impl<O: OffsetSizeTrait> From<OwnedMultiPoint<O, 2>> for geo::MultiPoint {
+    fn from(value: OwnedMultiPoint<O, 2>) -> Self {
         let geom = MultiPoint::from(value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<MultiPoint<'a, O>> for OwnedMultiPoint<O> {
-    fn from(value: MultiPoint<'a, O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<MultiPoint<'a, O, D>> for OwnedMultiPoint<O, D> {
+    fn from(value: MultiPoint<'a, O, D>) -> Self {
         let (coords, geom_offsets, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_offsets, geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedMultiPoint<O>> for MultiPointArray<O> {
-    fn from(value: OwnedMultiPoint<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<OwnedMultiPoint<O, D>> for MultiPointArray<O, D> {
+    fn from(value: OwnedMultiPoint<O, D>) -> Self {
         Self::new(value.coords, value.geom_offsets, None, Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait> MultiPointTrait for OwnedMultiPoint<O> {
+impl<O: OffsetSizeTrait> MultiPointTrait for OwnedMultiPoint<O, 2> {
     type T = f64;
-    type ItemType<'b> = Point<'b> where Self: 'b;
+    type ItemType<'b> = Point<'b, 2> where Self: 'b;
 
     fn num_points(&self) -> usize {
         MultiPoint::from(self).num_points()
@@ -70,7 +72,7 @@ impl<O: OffsetSizeTrait> MultiPointTrait for OwnedMultiPoint<O> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> PartialEq<G> for OwnedMultiPoint<O> {
+impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> PartialEq<G> for OwnedMultiPoint<O, 2> {
     fn eq(&self, other: &G) -> bool {
         multi_point_eq(self, other)
     }

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -85,7 +85,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPoint<'a, O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPoint<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for MultiPoint<'a, O, D> {
     type ScalarGeo = geo::MultiPoint;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -102,9 +102,9 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPoint<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPointTrait for MultiPoint<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiPointTrait for MultiPoint<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = Point<'a, 2> where Self: 'b;
+    type ItemType<'b> = Point<'a, D> where Self: 'b;
 
     fn num_points(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -116,9 +116,9 @@ impl<'a, O: OffsetSizeTrait> MultiPointTrait for MultiPoint<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPointTrait for &'a MultiPoint<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiPointTrait for &'a MultiPoint<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = Point<'a, 2> where Self: 'b;
+    type ItemType<'b> = Point<'a, D> where Self: 'b;
 
     fn num_points(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -130,20 +130,20 @@ impl<'a, O: OffsetSizeTrait> MultiPointTrait for &'a MultiPoint<'a, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPoint<'_, O, 2>> for geo::MultiPoint {
-    fn from(value: MultiPoint<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPoint<'_, O, D>> for geo::MultiPoint {
+    fn from(value: MultiPoint<'_, O, D>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait> From<&MultiPoint<'_, O, 2>> for geo::MultiPoint {
-    fn from(value: &MultiPoint<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<&MultiPoint<'_, O, D>> for geo::MultiPoint {
+    fn from(value: &MultiPoint<'_, O, D>) -> Self {
         multi_point_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPoint<'_, O, 2>> for geo::Geometry {
-    fn from(value: MultiPoint<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPoint<'_, O, D>> for geo::Geometry {
+    fn from(value: MultiPoint<'_, O, D>) -> Self {
         geo::Geometry::MultiPoint(value.into())
     }
 }
@@ -157,7 +157,9 @@ impl<O: OffsetSizeTrait> RTreeObject for MultiPoint<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> PartialEq<G> for MultiPoint<'_, O, 2> {
+impl<O: OffsetSizeTrait, const D: usize, G: MultiPointTrait<T = f64>> PartialEq<G>
+    for MultiPoint<'_, O, D>
+{
     fn eq(&self, other: &G) -> bool {
         multi_point_eq(self, other)
     }
@@ -172,8 +174,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiPointArray<i32> = vec![mp0(), mp1()].as_slice().into();
-        let arr2: MultiPointArray<i32> = vec![mp0(), mp0()].as_slice().into();
+        let arr1: MultiPointArray<i32, 2> = vec![mp0(), mp1()].as_slice().into();
+        let arr2: MultiPointArray<i32, 2> = vec![mp0(), mp0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -14,9 +14,9 @@ use std::borrow::Cow;
 
 /// An Arrow equivalent of a MultiPoint
 #[derive(Debug, Clone)]
-pub struct MultiPoint<'a, O: OffsetSizeTrait> {
+pub struct MultiPoint<'a, O: OffsetSizeTrait, const D: usize> {
     /// Buffer of coordinates
-    pub(crate) coords: Cow<'a, CoordBuffer<2>>,
+    pub(crate) coords: Cow<'a, CoordBuffer<D>>,
 
     /// Offsets into the coordinate array where each geometry starts
     pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -26,9 +26,9 @@ pub struct MultiPoint<'a, O: OffsetSizeTrait> {
     start_offset: usize,
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPoint<'a, O> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiPoint<'a, O, D> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer<2>>,
+        coords: Cow<'a, CoordBuffer<D>>,
         geom_offsets: Cow<'a, OffsetBuffer<O>>,
         geom_index: usize,
     ) -> Self {
@@ -42,7 +42,7 @@ impl<'a, O: OffsetSizeTrait> MultiPoint<'a, O> {
     }
 
     pub fn new_borrowed(
-        coords: &'a CoordBuffer<2>,
+        coords: &'a CoordBuffer<D>,
         geom_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
@@ -85,7 +85,7 @@ impl<'a, O: OffsetSizeTrait> MultiPoint<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPoint<'a, O> {
+impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPoint<'a, O, 2> {
     type ScalarGeo = geo::MultiPoint;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -102,9 +102,9 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPoint<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPointTrait for MultiPoint<'a, O> {
+impl<'a, O: OffsetSizeTrait> MultiPointTrait for MultiPoint<'a, O, 2> {
     type T = f64;
-    type ItemType<'b> = Point<'a> where Self: 'b;
+    type ItemType<'b> = Point<'a, 2> where Self: 'b;
 
     fn num_points(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -116,9 +116,9 @@ impl<'a, O: OffsetSizeTrait> MultiPointTrait for MultiPoint<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPointTrait for &'a MultiPoint<'a, O> {
+impl<'a, O: OffsetSizeTrait> MultiPointTrait for &'a MultiPoint<'a, O, 2> {
     type T = f64;
-    type ItemType<'b> = Point<'a> where Self: 'b;
+    type ItemType<'b> = Point<'a, 2> where Self: 'b;
 
     fn num_points(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -130,25 +130,25 @@ impl<'a, O: OffsetSizeTrait> MultiPointTrait for &'a MultiPoint<'a, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPoint<'_, O>> for geo::MultiPoint {
-    fn from(value: MultiPoint<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<MultiPoint<'_, O, 2>> for geo::MultiPoint {
+    fn from(value: MultiPoint<'_, O, 2>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait> From<&MultiPoint<'_, O>> for geo::MultiPoint {
-    fn from(value: &MultiPoint<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<&MultiPoint<'_, O, 2>> for geo::MultiPoint {
+    fn from(value: &MultiPoint<'_, O, 2>) -> Self {
         multi_point_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPoint<'_, O>> for geo::Geometry {
-    fn from(value: MultiPoint<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<MultiPoint<'_, O, 2>> for geo::Geometry {
+    fn from(value: MultiPoint<'_, O, 2>) -> Self {
         geo::Geometry::MultiPoint(value.into())
     }
 }
 
-impl<O: OffsetSizeTrait> RTreeObject for MultiPoint<'_, O> {
+impl<O: OffsetSizeTrait> RTreeObject for MultiPoint<'_, O, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -157,7 +157,7 @@ impl<O: OffsetSizeTrait> RTreeObject for MultiPoint<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> PartialEq<G> for MultiPoint<'_, O> {
+impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> PartialEq<G> for MultiPoint<'_, O, 2> {
     fn eq(&self, other: &G) -> bool {
         multi_point_eq(self, other)
     }

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -54,7 +54,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPoint<'a, O, D> {
     }
 
     pub fn new_owned(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
@@ -75,7 +75,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPoint<'a, O, D> {
         Self::new_owned(sliced_arr.coords, sliced_arr.geom_offsets, 0)
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer<2>, OffsetBuffer<O>, usize) {
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, usize) {
         let owned = self.into_owned();
         (
             owned.coords.into_owned(),

--- a/src/scalar/multipolygon/owned.rs
+++ b/src/scalar/multipolygon/owned.rs
@@ -6,8 +6,8 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedMultiPolygon<O: OffsetSizeTrait> {
-    coords: CoordBuffer<2>,
+pub struct OwnedMultiPolygon<O: OffsetSizeTrait, const D: usize> {
+    coords: CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
     geom_offsets: OffsetBuffer<O>,
@@ -19,9 +19,9 @@ pub struct OwnedMultiPolygon<O: OffsetSizeTrait> {
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait> OwnedMultiPolygon<O> {
+impl<O: OffsetSizeTrait, const D: usize> OwnedMultiPolygon<O, D> {
     pub fn new(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         polygon_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
@@ -37,8 +37,10 @@ impl<O: OffsetSizeTrait> OwnedMultiPolygon<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<OwnedMultiPolygon<O>> for MultiPolygon<'a, O> {
-    fn from(value: OwnedMultiPolygon<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedMultiPolygon<O, D>>
+    for MultiPolygon<'a, O, D>
+{
+    fn from(value: OwnedMultiPolygon<O, D>) -> Self {
         Self::new_owned(
             value.coords,
             value.geom_offsets,
@@ -49,8 +51,10 @@ impl<'a, O: OffsetSizeTrait> From<OwnedMultiPolygon<O>> for MultiPolygon<'a, O> 
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedMultiPolygon<O>> for MultiPolygon<'a, O> {
-    fn from(value: &'a OwnedMultiPolygon<O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiPolygon<O, D>>
+    for MultiPolygon<'a, O, D>
+{
+    fn from(value: &'a OwnedMultiPolygon<O, D>) -> Self {
         Self::new_borrowed(
             &value.coords,
             &value.geom_offsets,
@@ -61,15 +65,17 @@ impl<'a, O: OffsetSizeTrait> From<&'a OwnedMultiPolygon<O>> for MultiPolygon<'a,
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedMultiPolygon<O>> for geo::MultiPolygon {
-    fn from(value: OwnedMultiPolygon<O>) -> Self {
+impl<O: OffsetSizeTrait> From<OwnedMultiPolygon<O, 2>> for geo::MultiPolygon {
+    fn from(value: OwnedMultiPolygon<O, 2>) -> Self {
         let geom = MultiPolygon::from(value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<MultiPolygon<'a, O>> for OwnedMultiPolygon<O> {
-    fn from(value: MultiPolygon<'a, O>) -> Self {
+impl<'a, O: OffsetSizeTrait, const D: usize> From<MultiPolygon<'a, O, D>>
+    for OwnedMultiPolygon<O, D>
+{
+    fn from(value: MultiPolygon<'a, O, D>) -> Self {
         let (coords, geom_offsets, polygon_offsets, ring_offsets, geom_index) =
             value.into_owned_inner();
         Self::new(
@@ -82,8 +88,8 @@ impl<'a, O: OffsetSizeTrait> From<MultiPolygon<'a, O>> for OwnedMultiPolygon<O> 
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedMultiPolygon<O>> for MultiPolygonArray<O> {
-    fn from(value: OwnedMultiPolygon<O>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<OwnedMultiPolygon<O, D>> for MultiPolygonArray<O, D> {
+    fn from(value: OwnedMultiPolygon<O, D>) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -95,9 +101,9 @@ impl<O: OffsetSizeTrait> From<OwnedMultiPolygon<O>> for MultiPolygonArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> MultiPolygonTrait for OwnedMultiPolygon<O> {
+impl<O: OffsetSizeTrait> MultiPolygonTrait for OwnedMultiPolygon<O, 2> {
     type T = f64;
-    type ItemType<'b> = Polygon<'b, O> where Self: 'b;
+    type ItemType<'b> = Polygon<'b, O, 2> where Self: 'b;
 
     fn num_polygons(&self) -> usize {
         MultiPolygon::from(self).num_polygons()
@@ -108,7 +114,7 @@ impl<O: OffsetSizeTrait> MultiPolygonTrait for OwnedMultiPolygon<O> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> PartialEq<G> for OwnedMultiPolygon<O> {
+impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> PartialEq<G> for OwnedMultiPolygon<O, 2> {
     fn eq(&self, other: &G) -> bool {
         multi_polygon_eq(self, other)
     }

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -123,7 +123,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygon<'a, O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPolygon<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for MultiPolygon<'a, O, D> {
     type ScalarGeo = geo::MultiPolygon;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -140,9 +140,9 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPolygon<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for MultiPolygon<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygonTrait for MultiPolygon<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = Polygon<'a, O> where Self: 'b;
+    type ItemType<'b> = Polygon<'a, O, D> where Self: 'b;
 
     fn num_polygons(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -159,9 +159,9 @@ impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for MultiPolygon<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for &'a MultiPolygon<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygonTrait for &'a MultiPolygon<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = Polygon<'a, O> where Self: 'b;
+    type ItemType<'b> = Polygon<'a, O, D> where Self: 'b;
 
     fn num_polygons(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -178,20 +178,20 @@ impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for &'a MultiPolygon<'a, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPolygon<'_, O, 2>> for geo::MultiPolygon {
-    fn from(value: MultiPolygon<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygon<'_, O, D>> for geo::MultiPolygon {
+    fn from(value: MultiPolygon<'_, O, D>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait> From<&MultiPolygon<'_, O, 2>> for geo::MultiPolygon {
-    fn from(value: &MultiPolygon<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<&MultiPolygon<'_, O, D>> for geo::MultiPolygon {
+    fn from(value: &MultiPolygon<'_, O, D>) -> Self {
         multi_polygon_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPolygon<'_, O, 2>> for geo::Geometry {
-    fn from(value: MultiPolygon<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygon<'_, O, D>> for geo::Geometry {
+    fn from(value: MultiPolygon<'_, O, D>) -> Self {
         geo::Geometry::MultiPolygon(value.into())
     }
 }
@@ -205,7 +205,9 @@ impl<O: OffsetSizeTrait> RTreeObject for MultiPolygon<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> PartialEq<G> for MultiPolygon<'_, O, 2> {
+impl<O: OffsetSizeTrait, const D: usize, G: MultiPolygonTrait<T = f64>> PartialEq<G>
+    for MultiPolygon<'_, O, D>
+{
     fn eq(&self, other: &G) -> bool {
         multi_polygon_eq(self, other)
     }

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -13,8 +13,8 @@ use std::borrow::Cow;
 
 /// An Arrow equivalent of a MultiPolygon
 #[derive(Debug, Clone)]
-pub struct MultiPolygon<'a, O: OffsetSizeTrait> {
-    pub(crate) coords: Cow<'a, CoordBuffer<2>>,
+pub struct MultiPolygon<'a, O: OffsetSizeTrait, const D: usize> {
+    pub(crate) coords: Cow<'a, CoordBuffer<D>>,
 
     /// Offsets into the polygon array where each geometry starts
     pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -30,9 +30,9 @@ pub struct MultiPolygon<'a, O: OffsetSizeTrait> {
     start_offset: usize,
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygon<'a, O, D> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer<2>>,
+        coords: Cow<'a, CoordBuffer<D>>,
         geom_offsets: Cow<'a, OffsetBuffer<O>>,
         polygon_offsets: Cow<'a, OffsetBuffer<O>>,
         ring_offsets: Cow<'a, OffsetBuffer<O>>,
@@ -50,7 +50,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
     }
 
     pub fn new_borrowed(
-        coords: &'a CoordBuffer<2>,
+        coords: &'a CoordBuffer<D>,
         geom_offsets: &'a OffsetBuffer<O>,
         polygon_offsets: &'a OffsetBuffer<O>,
         ring_offsets: &'a OffsetBuffer<O>,
@@ -66,7 +66,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
     }
 
     pub fn new_owned(
-        coords: CoordBuffer<2>,
+        coords: CoordBuffer<D>,
         geom_offsets: OffsetBuffer<O>,
         polygon_offsets: OffsetBuffer<O>,
         ring_offsets: OffsetBuffer<O>,
@@ -106,7 +106,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
     pub fn into_owned_inner(
         self,
     ) -> (
-        CoordBuffer<2>,
+        CoordBuffer<D>,
         OffsetBuffer<O>,
         OffsetBuffer<O>,
         OffsetBuffer<O>,
@@ -123,7 +123,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygon<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPolygon<'a, O> {
+impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPolygon<'a, O, 2> {
     type ScalarGeo = geo::MultiPolygon;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -140,7 +140,7 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for MultiPolygon<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for MultiPolygon<'a, O> {
+impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for MultiPolygon<'a, O, 2> {
     type T = f64;
     type ItemType<'b> = Polygon<'a, O> where Self: 'b;
 
@@ -159,7 +159,7 @@ impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for MultiPolygon<'a, O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for &'a MultiPolygon<'a, O> {
+impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for &'a MultiPolygon<'a, O, 2> {
     type T = f64;
     type ItemType<'b> = Polygon<'a, O> where Self: 'b;
 
@@ -178,25 +178,25 @@ impl<'a, O: OffsetSizeTrait> MultiPolygonTrait for &'a MultiPolygon<'a, O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPolygon<'_, O>> for geo::MultiPolygon {
-    fn from(value: MultiPolygon<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<MultiPolygon<'_, O, 2>> for geo::MultiPolygon {
+    fn from(value: MultiPolygon<'_, O, 2>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait> From<&MultiPolygon<'_, O>> for geo::MultiPolygon {
-    fn from(value: &MultiPolygon<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<&MultiPolygon<'_, O, 2>> for geo::MultiPolygon {
+    fn from(value: &MultiPolygon<'_, O, 2>) -> Self {
         multi_polygon_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<MultiPolygon<'_, O>> for geo::Geometry {
-    fn from(value: MultiPolygon<'_, O>) -> Self {
+impl<O: OffsetSizeTrait> From<MultiPolygon<'_, O, 2>> for geo::Geometry {
+    fn from(value: MultiPolygon<'_, O, 2>) -> Self {
         geo::Geometry::MultiPolygon(value.into())
     }
 }
 
-impl<O: OffsetSizeTrait> RTreeObject for MultiPolygon<'_, O> {
+impl<O: OffsetSizeTrait> RTreeObject for MultiPolygon<'_, O, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -205,7 +205,7 @@ impl<O: OffsetSizeTrait> RTreeObject for MultiPolygon<'_, O> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> PartialEq<G> for MultiPolygon<'_, O> {
+impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> PartialEq<G> for MultiPolygon<'_, O, 2> {
     fn eq(&self, other: &G) -> bool {
         multi_polygon_eq(self, other)
     }
@@ -220,8 +220,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiPolygonArray<i32> = vec![mp0(), mp1()].as_slice().into();
-        let arr2: MultiPolygonArray<i32> = vec![mp0(), mp0()].as_slice().into();
+        let arr1: MultiPolygonArray<i32, 2> = vec![mp0(), mp1()].as_slice().into();
+        let arr2: MultiPolygonArray<i32, 2> = vec![mp0(), mp0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/src/scalar/point/owned.rs
+++ b/src/scalar/point/owned.rs
@@ -6,47 +6,47 @@ use crate::scalar::{Coord, Point};
 use crate::trait_::GeometryArrayAccessor;
 
 #[derive(Clone, Debug)]
-pub struct OwnedPoint {
-    coords: CoordBuffer<2>,
+pub struct OwnedPoint<const D: usize> {
+    coords: CoordBuffer<D>,
     geom_index: usize,
 }
 
-impl OwnedPoint {
-    pub fn new(coords: CoordBuffer<2>, geom_index: usize) -> Self {
+impl<const D: usize> OwnedPoint<D> {
+    pub fn new(coords: CoordBuffer<D>, geom_index: usize) -> Self {
         Self { coords, geom_index }
     }
 
-    pub fn coord(&self) -> Coord<2> {
+    pub fn coord(&self) -> Coord<D> {
         self.coords.value(self.geom_index)
     }
 }
 
-impl<'a> From<OwnedPoint> for Point<'a> {
-    fn from(value: OwnedPoint) -> Self {
+impl<'a, const D: usize> From<OwnedPoint<D>> for Point<'a, D> {
+    fn from(value: OwnedPoint<D>) -> Self {
         Self::new_owned(value.coords, value.geom_index)
     }
 }
 
-impl<'a> From<&'a OwnedPoint> for Point<'a> {
-    fn from(value: &'a OwnedPoint) -> Self {
+impl<'a, const D: usize> From<&'a OwnedPoint<D>> for Point<'a, D> {
+    fn from(value: &'a OwnedPoint<D>) -> Self {
         Self::new_borrowed(&value.coords, value.geom_index)
     }
 }
 
-impl<'a> From<Point<'a>> for OwnedPoint {
-    fn from(value: Point<'a>) -> Self {
+impl<'a, const D: usize> From<Point<'a, D>> for OwnedPoint<D> {
+    fn from(value: Point<'a, D>) -> Self {
         let (coords, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_index)
     }
 }
 
-impl From<OwnedPoint> for PointArray {
-    fn from(value: OwnedPoint) -> Self {
+impl<const D: usize> From<OwnedPoint<D>> for PointArray<D> {
+    fn from(value: OwnedPoint<D>) -> Self {
         Self::new(value.coords, None, Default::default())
     }
 }
 
-impl PointTrait for OwnedPoint {
+impl PointTrait for OwnedPoint<2> {
     type T = f64;
 
     fn x(&self) -> f64 {
@@ -58,7 +58,7 @@ impl PointTrait for OwnedPoint {
     }
 }
 
-impl CoordTrait for OwnedPoint {
+impl CoordTrait for OwnedPoint<2> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -70,19 +70,19 @@ impl CoordTrait for OwnedPoint {
     }
 }
 
-impl From<OwnedPoint> for geo::Point {
-    fn from(value: OwnedPoint) -> Self {
+impl From<OwnedPoint<2>> for geo::Point {
+    fn from(value: OwnedPoint<2>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&OwnedPoint> for geo::Point {
-    fn from(value: &OwnedPoint) -> Self {
+impl From<&OwnedPoint<2>> for geo::Point {
+    fn from(value: &OwnedPoint<2>) -> Self {
         point_to_geo(value)
     }
 }
 
-impl PartialEq for OwnedPoint {
+impl PartialEq for OwnedPoint<2> {
     fn eq(&self, other: &Self) -> bool {
         point_eq(self, other, true)
     }

--- a/src/scalar/point/scalar.rs
+++ b/src/scalar/point/scalar.rs
@@ -69,7 +69,7 @@ impl<'a, const D: usize> Point<'a, D> {
         }
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer<2>, usize) {
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, usize) {
         let owned = self.into_owned();
         (owned.coords.into_owned(), owned.geom_index)
     }

--- a/src/scalar/point/scalar.rs
+++ b/src/scalar/point/scalar.rs
@@ -10,8 +10,8 @@ use std::borrow::Cow;
 
 /// An Arrow equivalent of a Point
 #[derive(Debug, Clone)]
-pub struct Point<'a> {
-    coords: Cow<'a, CoordBuffer<2>>,
+pub struct Point<'a, const D: usize> {
+    coords: Cow<'a, CoordBuffer<D>>,
     geom_index: usize,
 }
 
@@ -31,26 +31,26 @@ pub struct Point<'a> {
 //     }
 // }
 
-impl<'a> Point<'a> {
-    pub fn new(coords: Cow<'a, CoordBuffer<2>>, geom_index: usize) -> Self {
+impl<'a, const D: usize> Point<'a, D> {
+    pub fn new(coords: Cow<'a, CoordBuffer<D>>, geom_index: usize) -> Self {
         Point { coords, geom_index }
     }
 
-    pub fn new_borrowed(coords: &'a CoordBuffer<2>, geom_index: usize) -> Self {
+    pub fn new_borrowed(coords: &'a CoordBuffer<D>, geom_index: usize) -> Self {
         Point {
             coords: Cow::Borrowed(coords),
             geom_index,
         }
     }
 
-    pub fn new_owned(coords: CoordBuffer<2>, geom_index: usize) -> Self {
+    pub fn new_owned(coords: CoordBuffer<D>, geom_index: usize) -> Self {
         Point {
             coords: Cow::Owned(coords),
             geom_index,
         }
     }
 
-    pub fn coord(&self) -> Coord<2> {
+    pub fn coord(&self) -> Coord<D> {
         self.coords.value(self.geom_index)
     }
 
@@ -75,7 +75,7 @@ impl<'a> Point<'a> {
     }
 }
 
-impl<'a> GeometryScalarTrait for Point<'a> {
+impl<'a, const D: usize> GeometryScalarTrait for Point<'a, D> {
     type ScalarGeo = geo::Point;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -92,7 +92,7 @@ impl<'a> GeometryScalarTrait for Point<'a> {
     }
 }
 
-impl PointTrait for Point<'_> {
+impl PointTrait for Point<'_, 2> {
     type T = f64;
 
     fn x(&self) -> f64 {
@@ -104,7 +104,7 @@ impl PointTrait for Point<'_> {
     }
 }
 
-impl PointTrait for &Point<'_> {
+impl PointTrait for &Point<'_, 2> {
     type T = f64;
 
     fn x(&self) -> f64 {
@@ -116,7 +116,7 @@ impl PointTrait for &Point<'_> {
     }
 }
 
-impl CoordTrait for Point<'_> {
+impl CoordTrait for Point<'_, 2> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -128,37 +128,37 @@ impl CoordTrait for Point<'_> {
     }
 }
 
-impl From<Point<'_>> for geo::Point {
-    fn from(value: Point<'_>) -> Self {
+impl From<Point<'_, 2>> for geo::Point {
+    fn from(value: Point<'_, 2>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&Point<'_>> for geo::Point {
-    fn from(value: &Point<'_>) -> Self {
+impl From<&Point<'_, 2>> for geo::Point {
+    fn from(value: &Point<'_, 2>) -> Self {
         point_to_geo(value)
     }
 }
 
-impl From<Point<'_>> for geo::Coord {
-    fn from(value: Point<'_>) -> Self {
+impl From<Point<'_, 2>> for geo::Coord {
+    fn from(value: Point<'_, 2>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&Point<'_>> for geo::Coord {
-    fn from(value: &Point<'_>) -> Self {
+impl From<&Point<'_, 2>> for geo::Coord {
+    fn from(value: &Point<'_, 2>) -> Self {
         coord_to_geo(value)
     }
 }
 
-impl From<Point<'_>> for geo::Geometry {
-    fn from(value: Point<'_>) -> Self {
+impl From<Point<'_, 2>> for geo::Geometry {
+    fn from(value: Point<'_, 2>) -> Self {
         geo::Geometry::Point(value.into())
     }
 }
 
-impl RTreeObject for Point<'_> {
+impl RTreeObject for Point<'_, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -167,7 +167,7 @@ impl RTreeObject for Point<'_> {
     }
 }
 
-impl<G: PointTrait<T = f64>> PartialEq<G> for Point<'_> {
+impl<G: PointTrait<T = f64>> PartialEq<G> for Point<'_, 2> {
     fn eq(&self, other: &G) -> bool {
         point_eq(self, other, true)
     }

--- a/src/scalar/point/scalar.rs
+++ b/src/scalar/point/scalar.rs
@@ -92,7 +92,7 @@ impl<'a, const D: usize> GeometryScalarTrait for Point<'a, D> {
     }
 }
 
-impl PointTrait for Point<'_, 2> {
+impl<const D: usize> PointTrait for Point<'_, D> {
     type T = f64;
 
     fn x(&self) -> f64 {
@@ -104,7 +104,7 @@ impl PointTrait for Point<'_, 2> {
     }
 }
 
-impl PointTrait for &Point<'_, 2> {
+impl<const D: usize> PointTrait for &Point<'_, D> {
     type T = f64;
 
     fn x(&self) -> f64 {
@@ -116,7 +116,7 @@ impl PointTrait for &Point<'_, 2> {
     }
 }
 
-impl CoordTrait for Point<'_, 2> {
+impl<const D: usize> CoordTrait for Point<'_, D> {
     type T = f64;
 
     fn x(&self) -> Self::T {
@@ -128,37 +128,37 @@ impl CoordTrait for Point<'_, 2> {
     }
 }
 
-impl From<Point<'_, 2>> for geo::Point {
-    fn from(value: Point<'_, 2>) -> Self {
+impl<const D: usize> From<Point<'_, D>> for geo::Point {
+    fn from(value: Point<'_, D>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&Point<'_, 2>> for geo::Point {
-    fn from(value: &Point<'_, 2>) -> Self {
+impl<const D: usize> From<&Point<'_, D>> for geo::Point {
+    fn from(value: &Point<'_, D>) -> Self {
         point_to_geo(value)
     }
 }
 
-impl From<Point<'_, 2>> for geo::Coord {
-    fn from(value: Point<'_, 2>) -> Self {
+impl<const D: usize> From<Point<'_, D>> for geo::Coord {
+    fn from(value: Point<'_, D>) -> Self {
         (&value).into()
     }
 }
 
-impl From<&Point<'_, 2>> for geo::Coord {
-    fn from(value: &Point<'_, 2>) -> Self {
+impl<const D: usize> From<&Point<'_, D>> for geo::Coord {
+    fn from(value: &Point<'_, D>) -> Self {
         coord_to_geo(value)
     }
 }
 
-impl From<Point<'_, 2>> for geo::Geometry {
-    fn from(value: Point<'_, 2>) -> Self {
+impl<const D: usize> From<Point<'_, D>> for geo::Geometry {
+    fn from(value: Point<'_, D>) -> Self {
         geo::Geometry::Point(value.into())
     }
 }
 
-impl RTreeObject for Point<'_, 2> {
+impl<const D: usize> RTreeObject for Point<'_, D> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -103,7 +103,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> Polygon<'a, O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for Polygon<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for Polygon<'a, O, D> {
     type ScalarGeo = geo::Polygon;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -120,9 +120,9 @@ impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for Polygon<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> PolygonTrait for Polygon<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> PolygonTrait for Polygon<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = LineString<'a, O, 2> where Self: 'b;
+    type ItemType<'b> = LineString<'a, O, D> where Self: 'b;
 
     fn exterior(&self) -> Option<Self::ItemType<'_>> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -151,9 +151,9 @@ impl<'a, O: OffsetSizeTrait> PolygonTrait for Polygon<'a, O, 2> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> PolygonTrait for &'a Polygon<'a, O, 2> {
+impl<'a, O: OffsetSizeTrait, const D: usize> PolygonTrait for &'a Polygon<'a, O, D> {
     type T = f64;
-    type ItemType<'b> = LineString<'a, O, 2> where Self: 'b;
+    type ItemType<'b> = LineString<'a, O, D> where Self: 'b;
 
     fn exterior(&self) -> Option<Self::ItemType<'_>> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
@@ -182,20 +182,20 @@ impl<'a, O: OffsetSizeTrait> PolygonTrait for &'a Polygon<'a, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<Polygon<'_, O, 2>> for geo::Polygon {
-    fn from(value: Polygon<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<Polygon<'_, O, D>> for geo::Polygon {
+    fn from(value: Polygon<'_, O, D>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait> From<&Polygon<'_, O, 2>> for geo::Polygon {
-    fn from(value: &Polygon<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<&Polygon<'_, O, D>> for geo::Polygon {
+    fn from(value: &Polygon<'_, O, D>) -> Self {
         polygon_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait> From<Polygon<'_, O, 2>> for geo::Geometry {
-    fn from(value: Polygon<'_, O, 2>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<Polygon<'_, O, D>> for geo::Geometry {
+    fn from(value: Polygon<'_, O, D>) -> Self {
         geo::Geometry::Polygon(value.into())
     }
 }
@@ -209,7 +209,9 @@ impl<O: OffsetSizeTrait> RTreeObject for Polygon<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> PartialEq<G> for Polygon<'_, O, 2> {
+impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>, const D: usize> PartialEq<G>
+    for Polygon<'_, O, D>
+{
     fn eq(&self, other: &G) -> bool {
         polygon_eq(self, other)
     }

--- a/src/test/geoarrow_data/mod.rs
+++ b/src/test/geoarrow_data/mod.rs
@@ -17,20 +17,24 @@ macro_rules! geoarrow_data_impl {
 }
 
 // Point
-geoarrow_data_impl!(example_point_interleaved, "point-interleaved", PointArray);
-geoarrow_data_impl!(example_point_separated, "point", PointArray);
+geoarrow_data_impl!(
+    example_point_interleaved,
+    "point-interleaved",
+    PointArray<2>
+);
+geoarrow_data_impl!(example_point_separated, "point", PointArray<2>);
 geoarrow_data_impl!(example_point_wkb, "point-wkb", WKBArray<i64>);
 
 // LineString
 geoarrow_data_impl!(
     example_linestring_interleaved,
     "linestring-interleaved",
-    LineStringArray<i64>
+    LineStringArray<i64, 2>
 );
 geoarrow_data_impl!(
     example_linestring_separated,
     "linestring",
-    LineStringArray<i64>
+    LineStringArray<i64, 2>
 );
 geoarrow_data_impl!(example_linestring_wkb, "linestring-wkb", WKBArray<i64>);
 
@@ -38,21 +42,21 @@ geoarrow_data_impl!(example_linestring_wkb, "linestring-wkb", WKBArray<i64>);
 geoarrow_data_impl!(
     example_polygon_interleaved,
     "polygon-interleaved",
-    PolygonArray<i64>
+    PolygonArray<i64, 2>
 );
-geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray<i64>);
+geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray<i64, 2>);
 geoarrow_data_impl!(example_polygon_wkb, "polygon-wkb", WKBArray<i64>);
 
 // MultiPoint
 geoarrow_data_impl!(
     example_multipoint_interleaved,
     "multipoint-interleaved",
-    MultiPointArray<i64>
+    MultiPointArray<i64, 2>
 );
 geoarrow_data_impl!(
     example_multipoint_separated,
     "multipoint",
-    MultiPointArray<i64>
+    MultiPointArray<i64, 2>
 );
 geoarrow_data_impl!(example_multipoint_wkb, "multipoint-wkb", WKBArray<i64>);
 
@@ -60,12 +64,12 @@ geoarrow_data_impl!(example_multipoint_wkb, "multipoint-wkb", WKBArray<i64>);
 geoarrow_data_impl!(
     example_multilinestring_interleaved,
     "multilinestring-interleaved",
-    MultiLineStringArray<i64>
+    MultiLineStringArray<i64, 2>
 );
 geoarrow_data_impl!(
     example_multilinestring_separated,
     "multilinestring",
-    MultiLineStringArray<i64>
+    MultiLineStringArray<i64, 2>
 );
 geoarrow_data_impl!(
     example_multilinestring_wkb,
@@ -77,11 +81,11 @@ geoarrow_data_impl!(
 geoarrow_data_impl!(
     example_multipolygon_interleaved,
     "multipolygon-interleaved",
-    MultiPolygonArray<i64>
+    MultiPolygonArray<i64, 2>
 );
 geoarrow_data_impl!(
     example_multipolygon_separated,
     "multipolygon",
-    MultiPolygonArray<i64>
+    MultiPolygonArray<i64, 2>
 );
 geoarrow_data_impl!(example_multipolygon_wkb, "multipolygon-wkb", WKBArray<i64>);

--- a/src/test/linestring.rs
+++ b/src/test/linestring.rs
@@ -16,10 +16,10 @@ pub(crate) fn ls1() -> LineString {
     ]
 }
 
-pub(crate) fn ls_array() -> LineStringArray<i32> {
+pub(crate) fn ls_array() -> LineStringArray<i32, 2> {
     vec![ls0(), ls1()].as_slice().into()
 }
 
-pub(crate) fn large_ls_array() -> LineStringArray<i64> {
+pub(crate) fn large_ls_array() -> LineStringArray<i64, 2> {
     vec![ls0(), ls1()].as_slice().into()
 }

--- a/src/test/multilinestring.rs
+++ b/src/test/multilinestring.rs
@@ -28,6 +28,6 @@ pub(crate) fn ml1() -> MultiLineString {
     ])
 }
 
-pub(crate) fn ml_array() -> MultiLineStringArray<i32> {
+pub(crate) fn ml_array() -> MultiLineStringArray<i32, 2> {
     vec![ml0(), ml1()].as_slice().into()
 }

--- a/src/test/multipoint.rs
+++ b/src/test/multipoint.rs
@@ -24,6 +24,6 @@ pub(crate) fn mp1() -> MultiPoint {
     ])
 }
 
-pub(crate) fn mp_array() -> MultiPointArray<i32> {
+pub(crate) fn mp_array() -> MultiPointArray<i32, 2> {
     vec![mp0(), mp1()].as_slice().into()
 }

--- a/src/test/multipolygon.rs
+++ b/src/test/multipolygon.rs
@@ -46,6 +46,6 @@ pub(crate) fn mp1() -> MultiPolygon {
     ])
 }
 
-pub(crate) fn mp_array() -> MultiPolygonArray<i32> {
+pub(crate) fn mp_array() -> MultiPolygonArray<i32, 2> {
     vec![mp0(), mp1()].as_slice().into()
 }

--- a/src/test/point.rs
+++ b/src/test/point.rs
@@ -27,7 +27,7 @@ pub(crate) fn p2() -> Point {
     )
 }
 
-pub(crate) fn point_array() -> PointArray {
+pub(crate) fn point_array() -> PointArray<2> {
     vec![p0(), p1(), p2()].as_slice().into()
 }
 

--- a/src/test/polygon.rs
+++ b/src/test/polygon.rs
@@ -29,6 +29,6 @@ pub(crate) fn p1() -> Polygon {
     )
 }
 
-pub(crate) fn p_array() -> PolygonArray<i32> {
+pub(crate) fn p_array() -> PolygonArray<i32, 2> {
     vec![p0(), p1()].as_slice().into()
 }

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -60,7 +60,7 @@ pub trait GeometryArrayTrait: std::fmt::Debug + Send + Sync {
     /// use geo::point;
     ///
     /// let point = point!(x: 1., y: 2.);
-    /// let point_array: PointArray = vec![point].as_slice().into();
+    /// let point_array: PointArray<2> = vec![point].as_slice().into();
     ///
     /// assert!(matches!(point_array.data_type(), GeoDataType::Point(_)));
     /// ```

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -231,12 +231,12 @@ pub trait GeometryArrayAccessor<'a>: GeometryArrayTrait {
 }
 
 /// Horrible name, to be changed to a better name in the future!!
-pub trait GeometryArraySelfMethods {
+pub trait GeometryArraySelfMethods<const D: usize> {
     /// Create a new array with replaced coordinates
     ///
     /// This is useful if you want to apply an operation to _every_ coordinate in unison, such as a
     /// reprojection or a scaling operation, with no regards to each individual geometry
-    fn with_coords(self, coords: CoordBuffer<2>) -> Self;
+    fn with_coords(self, coords: CoordBuffer<D>) -> Self;
 
     /// Cast the coordinate buffer of this geometry array to the given coordinate type.
     fn into_coord_type(self, coord_type: CoordType) -> Self;


### PR DESCRIPTION
This is a massive refactor for https://github.com/geoarrow/geoarrow-rs/issues/662

### Change list

- Add const generic `const D: usize` on all geometry arrays. This allows to _represent_ higher-dimension geodata in geoarrow-rs
- Essentially all algorithms are still only implemented on the 2D representation
- geo traits are still 2d only

Future work: test Arrow interop to ensure that xyz/xym/xyzm metadata is preserved. Ensure that on export we're setting the field correctly for 3d data.