### PR TITLE
Remove unused error varient, clean up benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,30 @@ jobs:
           pixi install
       - name: Test
         run: cargo build ${{ matrix.args }}
+  build-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Pixi
+        run: |
+          curl -fsSL https://pixi.sh/install.sh | bash
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+          echo "GDAL_HOME=$(pwd)/build/.pixi/envs/default" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
+          echo "GEOS_LIB_DIR=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
+          # TODO: infer from toml file/lockfile
+          echo "GEOS_VERSION=3.12.1" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
+      - name: Install build requirements
+        run: |
+          cd build
+          pixi install
+      - name: Build benchmarks with no features
+        run: cargo bench --no-run
+      - name: Build benchmarks with all features
+        run: cargo bench --no-run --all-features
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ required-features = ["gdal"]
 [[bench]]
 name = "area"
 harness = false
+required-features = ["flatgeobuf"]
 
 [[bench]]
 name = "from_geo"
@@ -138,10 +139,12 @@ harness = false
 [[bench]]
 name = "geos_buffer"
 harness = false
+required-features = ["geos"]
 
 [[bench]]
 name = "nybb"
 harness = false
+required-features = ["ipc_compression"]
 
 [[bench]]
 name = "translate"
@@ -150,6 +153,8 @@ harness = false
 [[bench]]
 name = "wkb"
 harness = false
+bench = false                               # TODO fix this benchmark
+required-features = ["parquet_compression"]
 
 [package.metadata.docs.rs]
 features = [

--- a/benches/geos_buffer.rs
+++ b/benches/geos_buffer.rs
@@ -18,5 +18,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/benches/translate.rs
+++ b/benches/translate.rs
@@ -25,7 +25,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("translate PolygonArray", |b| {
         b.iter(|| {
-            let _ = data.translate(10.0.into(), 20.0.into());
+            let _ = data.translate(&10.0.into(), &20.0.into());
         })
     });
 }

--- a/benches/wkb.rs
+++ b/benches/wkb.rs
@@ -6,7 +6,7 @@ use geoarrow::trait_::GeometryArrayAccessor;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 fn load_parquet() -> WKBArray<i32> {
-    let file = File::open("fixtures/geoparquet/nz-building-outlines-geometry.parquet").unwrap();
+    let file = File::open("fixtures/geoparquet/nz-building-outlines-geometry.parquet").expect("You need to download nz-building-outlines-geometry.parquet before running this benchmark, see fixtures/README.md for more info");
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
     let reader = builder.build().unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,10 +19,6 @@ pub enum GeoArrowError {
     #[error("General error: {0}")]
     General(String),
 
-    /// Wrapper for an error triggered by a dependency
-    #[error(transparent)]
-    External(#[from] anyhow::Error),
-
     /// Whenever pushing to a container fails because it does not support more entries.
     /// The solution is usually to use a higher-capacity container-backing type.
     #[error("Overflow")]


### PR DESCRIPTION
Includes:

- Removing `GeoArrowError::External`, which appears to be unused
- Fixing up the benchmarks so that they all compile
- Tweaking the benchmark config so that they correctly declare their required features
- Tweaking the `geos_buffer` benchmark to run fewer iterations (the default config required 120 seconds to run and **criterion** was printing a warning)
- Disabling the `wkb` benchmark b/c it's currently broken (this assertion fails: https://github.com/geoarrow/geoarrow-rs/blob/bea907646232d62db7856bc87542614c27dda14d/benches/wkb.rs#L17)
- Adding CI check for the benchmarks (just to build them, not to run them)