### PR TITLE
Return the GeoDataType, not a ref

### DIFF
--- a/src/algorithm/native/downcast.rs
+++ b/src/algorithm/native/downcast.rs
@@ -42,7 +42,7 @@ impl Downcast for PointArray<2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
-        *self.data_type()
+        self.data_type()
     }
 
     fn downcast(&self, small_offsets: bool) -> Self::Output {
@@ -94,12 +94,12 @@ impl<O: OffsetSizeTrait> Downcast for LineStringArray<O, 2> {
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
         match self.data_type() {
-            GeoDataType::LineString(ct, dim) => GeoDataType::LineString(*ct, *dim),
+            GeoDataType::LineString(ct, dim) => GeoDataType::LineString(ct, dim),
             GeoDataType::LargeLineString(ct, dim) => {
                 if small_offsets && can_downcast_offsets_i32(&self.geom_offsets) {
-                    GeoDataType::LineString(*ct, *dim)
+                    GeoDataType::LineString(ct, dim)
                 } else {
-                    GeoDataType::LargeLineString(*ct, *dim)
+                    GeoDataType::LargeLineString(ct, dim)
                 }
             }
             _ => unreachable!(),
@@ -107,7 +107,7 @@ impl<O: OffsetSizeTrait> Downcast for LineStringArray<O, 2> {
     }
 
     fn downcast(&self, small_offsets: bool) -> Self::Output {
-        match (*self.data_type(), self.downcasted_data_type(small_offsets)) {
+        match (self.data_type(), self.downcasted_data_type(small_offsets)) {
             (
                 GeoDataType::LineString(_, Dimension::XY),
                 GeoDataType::LineString(_, Dimension::XY),
@@ -130,12 +130,12 @@ impl<O: OffsetSizeTrait> Downcast for PolygonArray<O, 2> {
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
         match self.data_type() {
-            GeoDataType::Polygon(ct, dim) => GeoDataType::Polygon(*ct, *dim),
+            GeoDataType::Polygon(ct, dim) => GeoDataType::Polygon(ct, dim),
             GeoDataType::LargePolygon(ct, dim) => {
                 if small_offsets && can_downcast_offsets_i32(&self.ring_offsets) {
-                    GeoDataType::Polygon(*ct, *dim)
+                    GeoDataType::Polygon(ct, dim)
                 } else {
-                    GeoDataType::LargePolygon(*ct, *dim)
+                    GeoDataType::LargePolygon(ct, dim)
                 }
             }
             _ => unreachable!(),
@@ -154,9 +154,9 @@ impl<O: OffsetSizeTrait> Downcast for MultiPointArray<O, 2> {
         match self.data_type() {
             GeoDataType::MultiPoint(ct, dim) => {
                 if can_downcast_multi(&self.geom_offsets) {
-                    GeoDataType::Point(*ct, *dim)
+                    GeoDataType::Point(ct, dim)
                 } else {
-                    GeoDataType::MultiPoint(*ct, *dim)
+                    GeoDataType::MultiPoint(ct, dim)
                 }
             }
             GeoDataType::LargeMultiPoint(ct, dim) => {
@@ -164,9 +164,9 @@ impl<O: OffsetSizeTrait> Downcast for MultiPointArray<O, 2> {
                     can_downcast_multi(&self.geom_offsets),
                     small_offsets && can_downcast_offsets_i32(&self.geom_offsets),
                 ) {
-                    (true, _) => GeoDataType::Point(*ct, *dim),
-                    (false, true) => GeoDataType::MultiPoint(*ct, *dim),
-                    (false, false) => GeoDataType::LargeMultiPoint(*ct, *dim),
+                    (true, _) => GeoDataType::Point(ct, dim),
+                    (false, true) => GeoDataType::MultiPoint(ct, dim),
+                    (false, false) => GeoDataType::LargeMultiPoint(ct, dim),
                 }
             }
             _ => unreachable!(),
@@ -193,9 +193,9 @@ impl<O: OffsetSizeTrait> Downcast for MultiLineStringArray<O, 2> {
         match self.data_type() {
             GeoDataType::MultiLineString(ct, dim) => {
                 if can_downcast_multi(&self.geom_offsets) {
-                    GeoDataType::LineString(*ct, *dim)
+                    GeoDataType::LineString(ct, dim)
                 } else {
-                    GeoDataType::MultiLineString(*ct, *dim)
+                    GeoDataType::MultiLineString(ct, dim)
                 }
             }
             GeoDataType::LargeMultiLineString(ct, dim) => {
@@ -203,10 +203,10 @@ impl<O: OffsetSizeTrait> Downcast for MultiLineStringArray<O, 2> {
                     can_downcast_multi(&self.geom_offsets),
                     small_offsets && can_downcast_offsets_i32(&self.ring_offsets),
                 ) {
-                    (true, true) => GeoDataType::LineString(*ct, *dim),
-                    (true, false) => GeoDataType::LargeLineString(*ct, *dim),
-                    (false, true) => GeoDataType::MultiLineString(*ct, *dim),
-                    (false, false) => GeoDataType::LargeMultiLineString(*ct, *dim),
+                    (true, true) => GeoDataType::LineString(ct, dim),
+                    (true, false) => GeoDataType::LargeLineString(ct, dim),
+                    (false, true) => GeoDataType::MultiLineString(ct, dim),
+                    (false, false) => GeoDataType::LargeMultiLineString(ct, dim),
                 }
             }
             _ => unreachable!(),
@@ -234,9 +234,9 @@ impl<O: OffsetSizeTrait> Downcast for MultiPolygonArray<O, 2> {
         match self.data_type() {
             GeoDataType::MultiPolygon(ct, dim) => {
                 if can_downcast_multi(&self.geom_offsets) {
-                    GeoDataType::Polygon(*ct, *dim)
+                    GeoDataType::Polygon(ct, dim)
                 } else {
-                    GeoDataType::MultiPolygon(*ct, *dim)
+                    GeoDataType::MultiPolygon(ct, dim)
                 }
             }
             GeoDataType::LargeMultiPolygon(ct, dim) => {
@@ -244,10 +244,10 @@ impl<O: OffsetSizeTrait> Downcast for MultiPolygonArray<O, 2> {
                     can_downcast_multi(&self.geom_offsets),
                     small_offsets && can_downcast_offsets_i32(&self.ring_offsets),
                 ) {
-                    (true, true) => GeoDataType::Polygon(*ct, *dim),
-                    (true, false) => GeoDataType::LargePolygon(*ct, *dim),
-                    (false, true) => GeoDataType::MultiPolygon(*ct, *dim),
-                    (false, false) => GeoDataType::LargeMultiPolygon(*ct, *dim),
+                    (true, true) => GeoDataType::Polygon(ct, dim),
+                    (true, false) => GeoDataType::LargePolygon(ct, dim),
+                    (false, true) => GeoDataType::MultiPolygon(ct, dim),
+                    (false, false) => GeoDataType::LargeMultiPolygon(ct, dim),
                 }
             }
             _ => unreachable!(),
@@ -355,7 +355,7 @@ impl<O: OffsetSizeTrait> Downcast for MixedGeometryArray<O, 2> {
                 .downcasted_data_type(small_offsets);
         }
 
-        *self.data_type()
+        self.data_type()
     }
 
     fn downcast(&self, small_offsets: bool) -> Self::Output {
@@ -453,7 +453,7 @@ impl Downcast for RectArray<2> {
     type Output = Arc<dyn GeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
-        *self.data_type()
+        self.data_type()
     }
     fn downcast(&self, small_offsets: bool) -> Self::Output {
         Arc::new(self.clone())
@@ -514,8 +514,8 @@ impl Downcast for &dyn GeometryArrayTrait {
                 self.as_rect_2d().downcasted_data_type(small_offsets)
             }
             // TODO: downcast largewkb to wkb
-            GeoDataType::WKB => *self.data_type(),
-            GeoDataType::LargeWKB => *self.data_type(),
+            GeoDataType::WKB => self.data_type(),
+            GeoDataType::LargeWKB => self.data_type(),
             _ => todo!("3d support"),
         }
     }
@@ -607,7 +607,7 @@ impl Downcast for ChunkedPointArray<2> {
     type Output = Arc<dyn ChunkedGeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
-        *self.data_type()
+        self.data_type()
     }
     fn downcast(&self, small_offsets: bool) -> Self::Output {
         Arc::new(self.clone())
@@ -629,7 +629,7 @@ macro_rules! impl_chunked_downcast {
             fn downcast(&self, small_offsets: bool) -> Self::Output {
                 let to_data_type = self.downcasted_data_type(small_offsets);
 
-                if to_data_type == *self.data_type() {
+                if to_data_type == self.data_type() {
                     return Arc::new(self.clone());
                 }
 
@@ -651,7 +651,7 @@ impl Downcast for ChunkedRectArray<2> {
     type Output = Arc<dyn ChunkedGeometryArrayTrait>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
-        *self.data_type()
+        self.data_type()
     }
     fn downcast(&self, small_offsets: bool) -> Self::Output {
         Arc::new(self.clone())

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -93,8 +93,8 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for WKBArray<O> {
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/coord/combined/array.rs
+++ b/src/array/coord/combined/array.rs
@@ -51,7 +51,7 @@ impl<const D: usize> GeometryArrayTrait for CoordBuffer<D> {
         self
     }
 
-    fn data_type(&self) -> &crate::datatypes::GeoDataType {
+    fn data_type(&self) -> crate::datatypes::GeoDataType {
         panic!("Coordinate arrays do not have a GeoDataType.")
     }
 

--- a/src/array/coord/interleaved/array.rs
+++ b/src/array/coord/interleaved/array.rs
@@ -76,7 +76,7 @@ impl<const D: usize> GeometryArrayTrait for InterleavedCoordBuffer<D> {
         self
     }
 
-    fn data_type(&self) -> &crate::datatypes::GeoDataType {
+    fn data_type(&self) -> crate::datatypes::GeoDataType {
         panic!("Coordinate arrays do not have a GeoDataType.")
     }
 

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -93,7 +93,7 @@ impl<const D: usize> GeometryArrayTrait for SeparatedCoordBuffer<D> {
         self
     }
 
-    fn data_type(&self) -> &crate::datatypes::GeoDataType {
+    fn data_type(&self) -> crate::datatypes::GeoDataType {
         panic!("Coordinate arrays do not have a GeoDataType.")
     }
 

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -96,8 +96,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for GeometryCollecti
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -148,8 +148,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for LineStringArray<
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -274,8 +274,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MixedGeometryArr
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -185,8 +185,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiLineStringA
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -148,8 +148,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiPointArray<
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -222,8 +222,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiPolygonArra
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -110,8 +110,8 @@ impl<const D: usize> GeometryArrayTrait for PointArray<D> {
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -186,8 +186,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for PolygonArray<O, 
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -96,8 +96,8 @@ impl<const D: usize> GeometryArrayTrait for RectArray<D> {
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
-        &self.data_type
+    fn data_type(&self) -> GeoDataType {
+        self.data_type
     }
 
     fn storage_type(&self) -> DataType {

--- a/src/chunked_array/chunked_array.rs
+++ b/src/chunked_array/chunked_array.rs
@@ -157,7 +157,7 @@ impl<G: GeometryArrayTrait> ChunkedGeometryArray<G> {
         self.chunks.as_slice()
     }
 
-    pub fn data_type(&self) -> &GeoDataType {
+    pub fn data_type(&self) -> GeoDataType {
         self.chunks.first().unwrap().data_type()
     }
 
@@ -276,7 +276,7 @@ pub trait ChunkedGeometryArrayTrait: std::fmt::Debug + Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
     /// Returns a reference to the [`GeoDataType`] of this array.
-    fn data_type(&self) -> &GeoDataType;
+    fn data_type(&self) -> GeoDataType;
 
     /// Returns an Arrow [`Field`] describing this chunked array. This field will always have the
     /// `ARROW:extension:name` key of the field metadata set, signifying that it describes a
@@ -299,7 +299,7 @@ impl<const D: usize> ChunkedGeometryArrayTrait for ChunkedPointArray<D> {
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
+    fn data_type(&self) -> GeoDataType {
         self.chunks.first().unwrap().data_type()
     }
 
@@ -334,7 +334,7 @@ impl<O: OffsetSizeTrait> ChunkedGeometryArrayTrait for ChunkedWKBArray<O> {
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
+    fn data_type(&self) -> GeoDataType {
         self.chunks.first().unwrap().data_type()
     }
 
@@ -371,7 +371,7 @@ macro_rules! impl_trait {
                 self
             }
 
-            fn data_type(&self) -> &GeoDataType {
+            fn data_type(&self) -> GeoDataType {
                 self.chunks.first().unwrap().data_type()
             }
 
@@ -416,7 +416,7 @@ impl<const D: usize> ChunkedGeometryArrayTrait for ChunkedRectArray<D> {
         self
     }
 
-    fn data_type(&self) -> &GeoDataType {
+    fn data_type(&self) -> GeoDataType {
         self.chunks.first().unwrap().data_type()
     }
 
@@ -542,7 +542,7 @@ pub fn from_geoarrow_chunks(
         }
 
         use GeoDataType::*;
-        let result: Arc<dyn ChunkedGeometryArrayTrait> = match *data_types.drain().next().unwrap() {
+        let result: Arc<dyn ChunkedGeometryArrayTrait> = match data_types.drain().next().unwrap() {
             Point(_, Dimension::XY) => impl_downcast!(as_point_2d),
             LineString(_, Dimension::XY) => impl_downcast!(as_line_string_2d),
             LargeLineString(_, Dimension::XY) => impl_downcast!(as_large_line_string_2d),

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -852,12 +852,12 @@ mod test {
         let point_array = crate::test::point::point_array();
         let field = point_array.extension_field();
         let data_type: GeoDataType = field.as_ref().try_into().unwrap();
-        assert_eq!(point_array.data_type(), &data_type);
+        assert_eq!(point_array.data_type(), data_type);
 
         let ml_array = crate::test::multilinestring::ml_array();
         let field = ml_array.extension_field();
         let data_type: GeoDataType = field.as_ref().try_into().unwrap();
-        assert_eq!(ml_array.data_type(), &data_type);
+        assert_eq!(ml_array.data_type(), data_type);
 
         let mut builder = MixedGeometryBuilder::<i32, 2>::new();
         builder.push_point(Some(&crate::test::point::p0()));
@@ -872,6 +872,6 @@ mod test {
         let mixed_array = builder.finish();
         let field = mixed_array.extension_field();
         let data_type: GeoDataType = field.as_ref().try_into().unwrap();
-        assert_eq!(mixed_array.data_type(), &data_type);
+        assert_eq!(mixed_array.data_type(), data_type);
     }
 }

--- a/src/indexed/array.rs
+++ b/src/indexed/array.rs
@@ -29,7 +29,7 @@ impl<G: GeometryArrayTrait> IndexedGeometryArray<G> {
         Self { array, index }
     }
 
-    pub fn data_type(&self) -> &GeoDataType {
+    pub fn data_type(&self) -> GeoDataType {
         self.array.data_type()
     }
 

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -49,7 +49,7 @@ pub trait GeometryArrayTrait: std::fmt::Debug + Send + Sync {
     /// ```
     fn as_any(&self) -> &dyn Any;
 
-    /// Returns a reference to the [`GeoDataType`] of this array.
+    /// Returns a the [`GeoDataType`] of this array.
     ///
     /// # Example:
     ///
@@ -64,7 +64,7 @@ pub trait GeometryArrayTrait: std::fmt::Debug + Send + Sync {
     ///
     /// assert!(matches!(point_array.data_type(), GeoDataType::Point(_, _)));
     /// ```
-    fn data_type(&self) -> &GeoDataType;
+    fn data_type(&self) -> GeoDataType;
 
     /// Get the logical DataType of this array.
     fn storage_type(&self) -> DataType;


### PR DESCRIPTION
`GeoDataType` is `Copy`, so it's cheap to return as-is. This also aligns it to be a similar return to `GeometryArrayTrait::storage_type`.

This was prompted by seeing the following method in `Downcast`:

```rust
fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
    *self.data_type()
}
```

This felt a little funny from an interface perspective — to me, it feels more natural to always return a `GeoDataType` instead of a `&`-ref in some places but not others.

If there's ever a future case where `GeoDataType` _won't_ be `Copy`, then this PR is a bad idea and should be rejected 🙇🏼.