### PR TITLE
Remove `validity` and `logical_nulls` trait methods

### DIFF
--- a/src/algorithm/native/binary.rs
+++ b/src/algorithm/native/binary.rs
@@ -24,7 +24,7 @@ pub trait Binary<'a, Rhs: GeometryArrayAccessor<'a> = Self>: GeometryArrayAccess
             return Ok(BooleanBuilder::new().finish());
         }
 
-        let nulls = NullBuffer::union(self.logical_nulls().as_ref(), rhs.logical_nulls().as_ref());
+        let nulls = NullBuffer::union(self.nulls(), rhs.nulls());
         let mut builder = BooleanBufferBuilder::new(self.len());
         self.iter_values()
             .zip(rhs.iter_values())
@@ -56,9 +56,7 @@ pub trait Binary<'a, Rhs: GeometryArrayAccessor<'a> = Self>: GeometryArrayAccess
             }
             Ok(BooleanArray::new(builder.finish(), None))
         } else {
-            let nulls =
-                NullBuffer::union(self.logical_nulls().as_ref(), rhs.logical_nulls().as_ref())
-                    .unwrap();
+            let nulls = NullBuffer::union(self.nulls(), rhs.nulls()).unwrap();
 
             let mut buffer = BooleanBufferBuilder::new(len);
             buffer.append_n(len, false);
@@ -100,9 +98,7 @@ pub trait Binary<'a, Rhs: GeometryArrayAccessor<'a> = Self>: GeometryArrayAccess
             }
             Ok(PrimitiveArray::new(buffer.into(), None))
         } else {
-            let nulls =
-                NullBuffer::union(self.logical_nulls().as_ref(), rhs.logical_nulls().as_ref())
-                    .unwrap();
+            let nulls = NullBuffer::union(self.nulls(), rhs.nulls()).unwrap();
 
             let mut buffer = BufferBuilder::<O::Native>::new(len);
             buffer.append_n_zeroed(len);

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -79,7 +79,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 
@@ -154,7 +154,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for WKBArray<O> {
     }
 
     /// Returns the optional validity.
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.array.nulls()
     }
 

--- a/src/array/coord/combined/array.rs
+++ b/src/array/coord/combined/array.rs
@@ -107,7 +107,7 @@ impl<const D: usize> GeometryArrayTrait for CoordBuffer<D> {
         }
     }
 
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         panic!("coordinate arrays don't have their own validity arrays")
     }
 

--- a/src/array/coord/interleaved/array.rs
+++ b/src/array/coord/interleaved/array.rs
@@ -123,7 +123,7 @@ impl<const D: usize> GeometryArrayTrait for InterleavedCoordBuffer<D> {
         self.coords.len() / D
     }
 
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         panic!("coordinate arrays don't have their own validity arrays")
     }
 

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -140,7 +140,7 @@ impl<const D: usize> GeometryArrayTrait for SeparatedCoordBuffer<D> {
         self.buffers[0].len()
     }
 
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         panic!("coordinate arrays don't have their own validity arrays")
     }
 

--- a/src/array/geometry/array.rs
+++ b/src/array/geometry/array.rs
@@ -150,7 +150,7 @@ impl<O: OffsetSizeTrait> GeometryArrayTrait for GeometryArray<O> {
     /// The validity of the [`GeometryArray`]: every array has an optional [`Bitmap`] that, when
     /// available specifies whether the geometry at a given slot is valid or not (null). When the
     /// validity is [`None`], all slots are valid.
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         match self {
             GeometryArray::Point(arr) => arr.nulls(),
             GeometryArray::LineString(arr) => arr.nulls(),

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -86,7 +86,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionArray<O, D> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 }
@@ -158,7 +158,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for GeometryCollecti
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()
     }
 

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -433,7 +433,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for GeometryCollec
         self.geom_offsets.len_proxy()
     }
 
-    fn validity(&self) -> &NullBufferBuilder {
+    fn nulls(&self) -> &NullBufferBuilder {
         &self.validity
     }
 

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -138,7 +138,7 @@ impl<O: OffsetSizeTrait, const D: usize> LineStringArray<O, D> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 }
@@ -209,7 +209,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for LineStringArray<
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()
     }
 

--- a/src/array/linestring/builder.rs
+++ b/src/array/linestring/builder.rs
@@ -321,7 +321,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for LineStringBuil
         self.geom_offsets.len_proxy()
     }
 
-    fn validity(&self) -> &NullBufferBuilder {
+    fn nulls(&self) -> &NullBufferBuilder {
         &self.validity
     }
 

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -388,7 +388,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MixedGeometryArr
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         None
     }
 

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -585,7 +585,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MixedGeometryB
         self.types.len()
     }
 
-    fn validity(&self) -> &arrow_buffer::NullBufferBuilder {
+    fn nulls(&self) -> &arrow_buffer::NullBufferBuilder {
         // Take this method off trait
         todo!()
     }

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -175,7 +175,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 }
@@ -246,7 +246,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiLineStringA
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()
     }
 

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -407,7 +407,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MultiLineStrin
         self.geom_offsets.len_proxy()
     }
 
-    fn validity(&self) -> &NullBufferBuilder {
+    fn nulls(&self) -> &NullBufferBuilder {
         &self.validity
     }
 

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -138,7 +138,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointArray<O, D> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 }
@@ -209,7 +209,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiPointArray<
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()
     }
 

--- a/src/array/multipoint/builder.rs
+++ b/src/array/multipoint/builder.rs
@@ -354,7 +354,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MultiPointBuil
         self.coords.len()
     }
 
-    fn validity(&self) -> &NullBufferBuilder {
+    fn nulls(&self) -> &NullBufferBuilder {
         &self.validity
     }
 

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -212,7 +212,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 }
@@ -283,7 +283,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiPolygonArra
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()
     }
 

--- a/src/array/multipolygon/builder.rs
+++ b/src/array/multipolygon/builder.rs
@@ -478,7 +478,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MultiPolygonBu
         self.geom_offsets.len_proxy()
     }
 
-    fn validity(&self) -> &NullBufferBuilder {
+    fn nulls(&self) -> &NullBufferBuilder {
         &self.validity
     }
 

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -100,7 +100,7 @@ impl<const D: usize> PointArray<D> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths() * D * 8
     }
 }
@@ -171,7 +171,7 @@ impl<const D: usize> GeometryArrayTrait for PointArray<D> {
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()
     }
 

--- a/src/array/point/builder.rs
+++ b/src/array/point/builder.rs
@@ -246,7 +246,7 @@ impl<const D: usize> GeometryArrayBuilder for PointBuilder<D> {
         self.coords.len()
     }
 
-    fn validity(&self) -> &NullBufferBuilder {
+    fn nulls(&self) -> &NullBufferBuilder {
         &self.validity
     }
 

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -176,7 +176,7 @@ impl<O: OffsetSizeTrait, const D: usize> PolygonArray<O, D> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.validity().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 }
@@ -247,7 +247,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for PolygonArray<O, 
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()
     }
 

--- a/src/array/polygon/builder.rs
+++ b/src/array/polygon/builder.rs
@@ -424,7 +424,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for PolygonBuilder
         self.geom_offsets.len_proxy()
     }
 
-    fn validity(&self) -> &NullBufferBuilder {
+    fn nulls(&self) -> &NullBufferBuilder {
         &self.validity
     }
 

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -157,7 +157,7 @@ impl<const D: usize> GeometryArrayTrait for RectArray<D> {
 
     /// Returns the optional validity.
     #[inline]
-    fn validity(&self) -> Option<&NullBuffer> {
+    fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()
     }
 

--- a/src/indexed/array.rs
+++ b/src/indexed/array.rs
@@ -102,10 +102,7 @@ impl<'a, G: GeometryArrayTrait + GeometryArrayAccessor<'a>> IndexedGeometryArray
             return Ok(BooleanBuilder::new().finish());
         }
 
-        let nulls = NullBuffer::union(
-            self.array.logical_nulls().as_ref(),
-            other.array.logical_nulls().as_ref(),
-        );
+        let nulls = NullBuffer::union(self.array.nulls(), other.array.nulls());
         let mut builder_buffer = BooleanBufferBuilder::new(self.len());
         builder_buffer.append_n(self.len(), false);
 

--- a/src/io/geozero/array/mixed.rs
+++ b/src/io/geozero/array/mixed.rs
@@ -270,7 +270,7 @@ impl<O: OffsetSizeTrait> GeometryArrayBuilder for MixedGeometryStreamBuilder<O> 
         self.builder.len()
     }
 
-    fn validity(&self) -> &arrow_buffer::NullBufferBuilder {
+    fn nulls(&self) -> &arrow_buffer::NullBufferBuilder {
         // Take this method off trait
         todo!()
     }

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -101,18 +101,22 @@ pub trait GeometryArrayTrait: std::fmt::Debug + Send + Sync {
         self.len() == 0
     }
 
-    /// Access the array's validity. Every array has an optional [`NullBuffer`] that, when available
-    /// specifies whether the array slot is valid or not (null). When the validity is [`None`], all
-    /// slots are valid.
-    fn validity(&self) -> Option<&NullBuffer>;
-
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity()
-    }
-
-    fn logical_nulls(&self) -> Option<NullBuffer> {
-        self.nulls().cloned()
-    }
+    /// Returns an optional reference to the array's nulls buffer.
+    ///
+    /// Every array has an optional [`NullBuffer`] that, when available
+    /// specifies whether the array slot is valid or not (null). When the
+    /// validity is [`None`], all slots are valid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geoarrow::{GeometryArrayTrait, array::PointArray};
+    ///
+    /// let point = geo::point!(x: 1., y: 2.);
+    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// assert!(array.nulls().is_none());
+    /// ```
+    fn nulls(&self) -> Option<&NullBuffer>;
 
     fn metadata(&self) -> Arc<ArrayMetadata>;
 
@@ -294,7 +298,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     }
 
     /// The optional validity of the array.
-    fn validity(&self) -> &NullBufferBuilder;
+    fn nulls(&self) -> &NullBufferBuilder;
 
     fn new() -> Self;
 


### PR DESCRIPTION
These were a duplicate of `nulls` (in the case of `validity`) or just a simple `cloned` call that wasn't actually used anywhere in the library. By removing these methods, we simplify the API of this crate.