### PR TITLE
Deny unused crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,58 +83,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "anstream"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anyhow"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "approx"
@@ -664,17 +616,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap-verbosity-flag"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9b20c0dd58e4c2e991c8d203bbeb76c11304d1011659686b5b644bc29aa478"
-dependencies = [
- "clap",
- "log",
 ]
 
 [[package]]
@@ -683,22 +624,8 @@ version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.58",
 ]
 
 [[package]]
@@ -715,12 +642,6 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-oid"
@@ -928,27 +849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,29 +886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
 ]
 
 [[package]]
@@ -1120,12 +997,6 @@ dependencies = [
  "reqwest 0.11.27",
  "tempfile",
 ]
-
-[[package]]
-name = "float_eq"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
 
 [[package]]
 name = "float_next_after"
@@ -1358,7 +1229,6 @@ dependencies = [
 name = "geoarrow"
 version = "0.3.0-alpha.1"
 dependencies = [
- "anyhow",
  "approx",
  "arrow",
  "arrow-array",
@@ -1366,11 +1236,9 @@ dependencies = [
  "arrow-cast",
  "arrow-data",
  "arrow-ipc",
- "arrow-json",
  "arrow-schema",
  "async-stream",
  "async-trait",
- "bumpalo",
  "byteorder",
  "bytes",
  "chrono",
@@ -1380,14 +1248,11 @@ dependencies = [
  "gdal",
  "geo",
  "geo-index",
- "geodesy",
- "geojson",
  "geos",
  "geozero",
  "half",
  "http-range-client",
  "indexmap",
- "itertools 0.13.0",
  "lexical-core",
  "num_enum",
  "object_store",
@@ -1402,25 +1267,6 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
- "url",
-]
-
-[[package]]
-name = "geodesy"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fe16d603414f308e67e919e27eabb75b1e37fa5a6b0d975a2aae186f19b7e6"
-dependencies = [
- "anyhow",
- "clap",
- "clap-verbosity-flag",
- "dirs",
- "env_logger",
- "float_eq",
- "log",
- "thiserror",
- "uuid",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1603,12 +1449,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1926,15 +1766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,16 +1889,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.5.0",
- "libc",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2405,12 +2226,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -2858,17 +2673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -3354,7 +3158,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3501,7 +3305,7 @@ checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3647,12 +3451,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -4031,21 +3829,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "uuid"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,14 @@ flatgeobuf_async = [
 ]
 gdal = ["dep:gdal"]
 geos = ["dep:geos"]
-geozero = ["dep:geozero"]
+geozero = [
+  "dep:arrow-cast",
+  "dep:chrono",
+  "dep:geozero",
+  "dep:half",
+  "dep:indexmap",
+  "dep:lexical-core",
+]
 ipc_compression = ["arrow-ipc/lz4", "arrow-ipc/zstd"]
 parquet = ["dep:parquet"]
 parquet_async = [
@@ -30,7 +37,6 @@ parquet_async = [
   "dep:async-stream",
   "dep:futures",
   "dep:tokio",
-  "dep:object_store",
 ]
 parquet_compression = [
   "parquet/snap",
@@ -40,39 +46,36 @@ parquet_compression = [
   "parquet/zstd",
 ]
 polylabel = ["dep:polylabel"]
-postgis = ["dep:async-stream", "dep:futures", "dep:sqlx", "geozero"]
+postgis = ["dep:chrono", "dep:futures", "dep:sqlx", "geozero"]
 proj = ["dep:proj"]
 rayon = ["dep:rayon"]
 
 
 [dependencies]
-anyhow = "1"
 arrow = { version = "52", features = ["ffi"] }
 arrow-array = { version = "52", features = ["chrono-tz"] }
 arrow-buffer = "52"
-arrow-cast = "52"
+arrow-cast = { version = "52", optional = true }
 arrow-data = "52"
 arrow-ipc = "52"
-arrow-json = "52"
 arrow-schema = "52"
 async-stream = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
-bumpalo = { version = "3", features = ["collections"] }
 byteorder = "1"
 bytes = { version = "1.5.0", optional = true }
-chrono = "0.4"
+chrono = { version = "0.4", optional = true }
 # Set default-features = false because async not working in wasm right now
 flatgeobuf = { version = "4.2.0", optional = true, default-features = false }
 futures = { version = "0.3", optional = true }
 gdal = { version = "0.16", optional = true }
 geo = "0.28"
 geo-index = "0.1.1"
-geodesy = { version = "0.13", optional = true }
 geos = { version = "9.0", features = ["v3_11_0", "geo"], optional = true }
 geozero = { version = "0.13", features = ["with-wkb"], optional = true }
+half = { version = "2.4.1", optional = true }
 http-range-client = { version = "0.7.2", optional = true }
-indexmap = "2"
-itertools = "0.13"
+indexmap = { version = "2", optional = true }
+lexical-core = { version = "0.8.5", optional = true }
 num_enum = "0.7"
 object_store = { version = "0.10.0", optional = true }
 parquet = { version = "52", optional = true, default-features = false, features = [
@@ -98,11 +101,6 @@ sqlx = { version = "0.7", optional = true, default-features = false, features = 
 thiserror = "1"
 tokio = { version = "1", default-features = false, optional = true }
 
-# Temporary until https://github.com/georust/geozero/pull/208 is merged and released.
-geojson = { version = "0.24.1", default-features = false }
-half = "2.4.1"
-lexical-core = "0.8.5"
-
 
 [dev-dependencies]
 approx = "0.5.1"
@@ -112,7 +110,6 @@ gdal = { version = "0.16", features = ["bindgen"] }
 geozero = { version = "0.13", features = ["with-wkb"] }
 sqlx = { version = "0.7", default-features = false, features = ["postgres"] }
 tokio = { version = "1.9", features = ["macros", "fs", "rt-multi-thread"] }
-url = "2.5.0"
 object_store = { version = "0.10.0", features = ["http", "aws"] }
 parquet = { version = "52", default-features = false, features = [
   "arrow",

--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -720,16 +720,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -741,18 +732,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -787,16 +766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,19 +776,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
 ]
 
 [[package]]
@@ -1071,32 +1027,25 @@ dependencies = [
 name = "geoarrow"
 version = "0.3.0-alpha.1"
 dependencies = [
- "anyhow",
  "arrow",
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
  "arrow-ipc",
- "arrow-json",
  "arrow-schema",
  "async-stream",
- "bumpalo",
  "byteorder",
  "chrono",
  "flatgeobuf",
  "futures",
  "geo",
  "geo-index",
- "geodesy 0.13.0",
- "geojson",
  "geozero",
  "half",
  "indexmap",
- "itertools 0.13.0",
  "lexical-core",
  "num_enum",
- "object_store",
  "parquet",
  "phf",
  "rstar",
@@ -1120,7 +1069,7 @@ dependencies = [
  "futures",
  "geo",
  "geoarrow",
- "geodesy 0.12.0",
+ "geodesy",
  "object-store-wasm",
  "object_store",
  "parquet",
@@ -1149,26 +1098,8 @@ dependencies = [
  "anyhow",
  "clap",
  "clap-verbosity-flag",
- "dirs 4.0.0",
- "env_logger 0.10.2",
- "float_eq",
- "log",
- "thiserror",
- "uuid",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "geodesy"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fe16d603414f308e67e919e27eabb75b1e37fa5a6b0d975a2aae186f19b7e6"
-dependencies = [
- "anyhow",
- "clap",
- "clap-verbosity-flag",
- "dirs 5.0.1",
- "env_logger 0.11.3",
+ "dirs",
+ "env_logger",
  "float_eq",
  "log",
  "thiserror",
@@ -1983,12 +1914,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -24,7 +24,7 @@ algorithm = []
 # Include Data classes for contiguous GeoArrow memory (PointData, etc)
 data = []
 
-geodesy = ["dep:geodesy", "geoarrow/geodesy"]
+geodesy = ["dep:geodesy"]
 debug = ["console_error_panic_hook"]
 io_flatgeobuf = ["geoarrow/flatgeobuf", "table"]
 io_geojson = ["geoarrow/geozero", "table"]

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -3,8 +3,6 @@
 pub mod broadcasting;
 pub mod geo;
 pub mod geo_index;
-#[cfg(feature = "geodesy")]
-pub mod geodesy;
 #[cfg(feature = "geos")]
 pub mod geos;
 pub mod native;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //! plus algorithms implemented on and returning these GeoArrow arrays.
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(test), deny(unused_crate_dependencies))]
 
 pub use trait_::GeometryArrayTrait;
 


### PR DESCRIPTION
This adds `#![deny(unused_crate_dependencies)]` to `lib.rs` and then does the cleanups required. Lets us drop a couple of dependencies altogether, and move a couple others to optional.