### PR TITLE
Simplify some CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,16 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Install Pixi
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          activate-environment: true
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          manifest-path: build/pixi.toml
+      - name: Tweak environment to find GDAL
         run: |
-          curl -fsSL https://pixi.sh/install.sh | bash
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-          echo "GDAL_HOME=$(pwd)/build/.pixi/envs/default" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-          echo "GEOS_LIB_DIR=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-          # TODO: infer from toml file/lockfile
-          echo "GEOS_VERSION=3.12.1" >> "$GITHUB_ENV"
           echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
-      - name: Install build requirements
-        run: |
-          cd build
-          pixi install
+          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
       - name: Fmt
         run: cargo fmt -- --check
       - name: Clippy
@@ -88,20 +84,16 @@ jobs:
           submodules: "recursive"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install Pixi
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          activate-environment: true
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          manifest-path: build/pixi.toml
+      - name: Tweak environment to find GDAL
         run: |
-          curl -fsSL https://pixi.sh/install.sh | bash
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-          echo "GDAL_HOME=$(pwd)/build/.pixi/envs/default" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-          echo "GEOS_LIB_DIR=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-          # TODO: infer from toml file/lockfile
-          echo "GEOS_VERSION=3.12.1" >> "$GITHUB_ENV"
           echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
-      - name: Install build requirements
-        run: |
-          cd build
-          pixi install
+          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
       - name: Test
         run: cargo check ${{ matrix.args }}
 
@@ -113,20 +105,16 @@ jobs:
           submodules: "recursive"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install Pixi
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          activate-environment: true
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          manifest-path: build/pixi.toml
+      - name: Tweak environment to find GDAL
         run: |
-          curl -fsSL https://pixi.sh/install.sh | bash
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-          echo "GDAL_HOME=$(pwd)/build/.pixi/envs/default" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-          echo "GEOS_LIB_DIR=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-          # TODO: infer from toml file/lockfile
-          echo "GEOS_VERSION=3.12.1" >> "$GITHUB_ENV"
           echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
-      - name: Install build requirements
-        run: |
-          cd build
-          pixi install
+          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
       - name: Build benchmarks with no features
         run: cargo bench --no-run
       - name: Build benchmarks with all features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-test:
+  lint-test-all-features:
     name: Lint and Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
       - uses: Swatinem/rust-cache@v2
-
       - name: Install Pixi
         run: |
           curl -fsSL https://pixi.sh/install.sh | bash
@@ -36,28 +33,20 @@ jobs:
           # TODO: infer from toml file/lockfile
           echo "GEOS_VERSION=3.12.1" >> "$GITHUB_ENV"
           echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
-
       - name: Install build requirements
         run: |
           cd build
           pixi install
+      - name: Fmt
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy --all-features --tests -- -D warnings
+      - name: Check
+        run: cargo check --all-features --features gdal/bindgen
+      - name: Test
+        run: cargo test --all-features
 
-      - name: Cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: "clippy --all"
-        run: cargo clippy --all --all-features --tests -- -D warnings
-
-      - name: "cargo check"
-        # No idea why the gdal/bindgen feature declared in dev dependencies
-        # isn't getting picked up.
-        run: cargo check --all --all-features --features gdal/bindgen
-
-      - name: "cargo test"
-        run: |
-          cargo test --all
-          cargo test --all --all-features
-  build:
+  check-features:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -83,7 +72,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Test
         run: cargo check ${{ matrix.args }}
-  build-with-external-dependencies:
+
+  check-features-with-external-dependencies:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -113,7 +103,8 @@ jobs:
           cd build
           pixi install
       - name: Test
-        run: cargo build ${{ matrix.args }}
+        run: cargo check ${{ matrix.args }}
+
   build-benchmarks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,16 +26,6 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Install Pixi
-        run: |
-          curl -fsSL https://pixi.sh/install.sh | bash
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-          echo "GDAL_HOME=$(pwd)/build/.pixi/envs/default" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-          echo "GEOS_LIB_DIR=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-          # TODO: infer from toml file/lockfile
-          echo "GEOS_VERSION=3.12.1" >> "$GITHUB_ENV"
-          echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
       - name: Fmt
         run: cargo fmt -- --check
       - name: Clippy

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,37 +17,33 @@ jobs:
     defaults:
       run:
         working-directory: python/core
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
       - uses: Swatinem/rust-cache@v2
-
-      - name: Cargo fmt
-        run: cargo fmt --all -- --check
-
-      # # Note not sure why this is needed
-      # - name: Install protobuf
-      #   run: |
-      #     sudo apt-get install libprotobuf-dev protobuf-compiler
-
-      # Don't use --all-features as we don't have GDAL 3.6 available in CI
-      - name: "clippy --all"
-        run: cargo clippy --all --tests -- -D warnings
-
-      - name: "cargo check"
-        run: cargo check --all
-
-      - name: "cargo test"
+      - name: Install Pixi
         run: |
-          cargo test --all
+          curl -fsSL https://pixi.sh/install.sh | bash
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+          echo "GDAL_HOME=$(pwd)/build/.pixi/envs/default" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
+          echo "GEOS_LIB_DIR=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
+          # TODO: infer from toml file/lockfile
+          echo "GEOS_VERSION=3.12.1" >> "$GITHUB_ENV"
+          echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
+      - name: Fmt
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy --tests -- -D warnings
+      - name: Check
+        run: cargo check
+      - name: Test
+        run: cargo test
 
   # lint-python:
   #   name: Lint Python code
@@ -75,23 +71,18 @@ jobs:
     defaults:
       run:
         working-directory: python/core
-
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
       - uses: Swatinem/rust-cache@v2
-
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:
@@ -99,25 +90,20 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-
       - name: Check Poetry lockfile up to date
         run: |
           poetry check --lock
-
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4
         with:
           path: python/core/.venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
-
       - name: Install root project
         run: poetry install --no-interaction
-
       - name: Run python tests
         run: |
           poetry run maturin develop

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -17,32 +17,21 @@ jobs:
     defaults:
       run:
         working-directory: js
-
     steps:
       - uses: actions/checkout@v4
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
       - uses: Swatinem/rust-cache@v2
-
-      - name: Cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: "clippy --all"
-        run: cargo clippy --all --all-features --tests -- -D warnings
-
-      - name: "cargo check"
-        run: |
-          cargo check --all
-          cargo check --all --all-features
-
-      - name: "cargo test"
-        run: |
-          cargo test --all
-          cargo test --all --all-features
+      - name: Fmt
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy --all-features --tests -- -D warnings
+      - name: Check
+        run: cargo check --all-features
+      - name: Test
+        run: cargo test --all-features
 
   node-test:
     name: Node Tests
@@ -50,29 +39,21 @@ jobs:
     defaults:
       run:
         working-directory: js
-
     steps:
       - uses: actions/checkout@v4
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
       - uses: Swatinem/rust-cache@v2
-
       - uses: actions/setup-node@v2
         with:
           node-version: "20"
-
       - name: Build bundle
         run: yarn build:test
-
       - name: Install dev dependencies
         run: yarn install
-
       - name: Run Node tests
         run: yarn test


### PR DESCRIPTION
- Closes #697 

I ended up touching the wasm and python workflows as well, mostly to make whitespace consistent and to remove the `--all` flags from the `cargo` commands (only used for workspaces, and its deprecated).