### PR TITLE
Bump msrv to 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/geoarrow/geoarrow-rs"
 description = "Rust implementation of GeoArrow"
 categories = ["science::geo"]
-rust-version = "1.75"
+rust-version = "1.80"
 
 [features]
 csv = ["dep:geozero", "geozero/with-csv"]

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["webassembly", "arrow", "geospatial"]
 categories = ["wasm", "science::geo"]
-rust-version = "1.62"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/python/core/Cargo.toml
+++ b/python/core/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "arrow", "geospatial"]
 categories = ["wasm", "science::geo"]
-rust-version = "1.75"
+rust-version = "1.80"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
I'm not sure what recent rust feature I'm using, but @bonkles was unable to compile the JS bindings on rust 1.77