### PR TITLE
Relax geos to v3.10.0, bump geoarrow to v0.3.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **This is the changelog for the core Rust library**. There's a [separate changelog](./python/core/CHANGELOG.md) for the Python bindings, and there will be another for the JS bindings.
 
-## [0.3.0-beta.1] - 2024-08-23
+## [0.3.0-beta.2] - 2024-08-23
 
 ### Added
 
@@ -55,6 +55,6 @@
 
 - Initial public release.
 
-[0.3.0-beta.1]: https://github.com/geoarrow/geoarrow-rs/compare/rust-v0.2.0...rust-v0.3.0-beta.1
+[0.3.0-beta.2]: https://github.com/geoarrow/geoarrow-rs/compare/rust-v0.2.0...rust-v0.3.0-beta.2
 [0.2.0]: https://github.com/geoarrow/geoarrow-rs/compare/rust-v0.1.0...rust-v0.2.0
 [0.1.0]: https://github.com/geoarrow/geoarrow-rs/releases/tag/rust-v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 dependencies = [
  "approx",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geoarrow"
-version = "0.3.0-beta.1"
+version = "0.3.0-beta.2"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -70,7 +70,7 @@ futures = { version = "0.3", optional = true }
 gdal = { version = "0.17", optional = true }
 geo = "0.28"
 geo-index = "0.1.1"
-geos = { version = "9.0", features = ["v3_11_0", "geo"], optional = true }
+geos = { version = "9.0", features = ["v3_10_0", "geo"], optional = true }
 geozero = { version = "0.13", features = ["with-wkb"], optional = true }
 half = { version = "2.4.1", optional = true }
 http-range-client = { version = "0.8", optional = true }


### PR DESCRIPTION
Hoping to fix docs.rs builds.

- Closes #706 