### PR TITLE
wip: union array overhaul

### DIFF
--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -22,13 +22,13 @@ use crate::GeometryArrayTrait;
 /// This is semantically equivalent to `Vec<Option<GeometryCollection>>` due to the internal
 /// validity bitmap.
 #[derive(Debug, Clone)]
-pub struct GeometryCollectionArray<O: OffsetSizeTrait, const D: usize> {
+pub struct GeometryCollectionArray<O: OffsetSizeTrait> {
     // Always GeoDataType::GeometryCollection or GeoDataType::LargeGeometryCollection
     data_type: GeoDataType,
 
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) array: MixedGeometryArray<O, D>,
+    pub(crate) array: MixedGeometryArray<O>,
 
     /// Offsets into the mixed geometry array where each geometry starts
     pub(crate) geom_offsets: OffsetBuffer<O>,
@@ -37,22 +37,22 @@ pub struct GeometryCollectionArray<O: OffsetSizeTrait, const D: usize> {
     pub(crate) validity: Option<NullBuffer>,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionArray<O, D> {
+impl<O: OffsetSizeTrait> GeometryCollectionArray<O> {
     /// Create a new GeometryCollectionArray from parts
     ///
     /// # Implementation
     ///
     /// This function is `O(1)`.
     pub fn new(
-        array: MixedGeometryArray<O, D>,
+        array: MixedGeometryArray<O>,
         geom_offsets: OffsetBuffer<O>,
         validity: Option<NullBuffer>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let coord_type = array.coord_type();
         let data_type = match O::IS_LARGE {
-            true => GeoDataType::LargeGeometryCollection(coord_type, D.try_into().unwrap()),
-            false => GeoDataType::GeometryCollection(coord_type, D.try_into().unwrap()),
+            true => GeoDataType::LargeGeometryCollection(coord_type),
+            false => GeoDataType::GeometryCollection(coord_type),
         };
 
         Self {
@@ -91,7 +91,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionArray<O, D> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for GeometryCollectionArray<O, D> {
+impl<O: OffsetSizeTrait> GeometryArrayTrait for GeometryCollectionArray<O> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -168,7 +168,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for GeometryCollecti
 }
 
 impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D>
-    for GeometryCollectionArray<O, D>
+    for GeometryCollectionArray<O>
 {
     fn with_coords(self, _coords: CoordBuffer<D>) -> Self {
         todo!()
@@ -217,9 +217,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D>
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a>
-    for GeometryCollectionArray<O, D>
-{
+impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for GeometryCollectionArray<O> {
     type Item = GeometryCollection<'a, O, D>;
     type ItemGeo = geo::GeometryCollection;
 
@@ -228,7 +226,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> IntoArrow for GeometryCollectionArray<O, D> {
+impl<O: OffsetSizeTrait> IntoArrow for GeometryCollectionArray<O> {
     type ArrowArray = GenericListArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -389,13 +387,13 @@ impl<const D: usize> TryFrom<GeometryCollectionArray<i64, D>> for GeometryCollec
 }
 
 /// Default to an empty array
-impl<O: OffsetSizeTrait, const D: usize> Default for GeometryCollectionArray<O, D> {
+impl<O: OffsetSizeTrait> Default for GeometryCollectionArray<O> {
     fn default() -> Self {
         GeometryCollectionBuilder::default().into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> PartialEq for GeometryCollectionArray<O, D> {
+impl<O: OffsetSizeTrait> PartialEq for GeometryCollectionArray<O> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -128,22 +128,22 @@ pub enum GeoDataType {
     /// Represents a [MixedGeometryArray][crate::array::MixedGeometryArray] or
     /// [ChunkedMixedGeometryArray][crate::chunked_array::ChunkedMixedGeometryArray] with `i32`
     /// offsets.
-    Mixed(CoordType, Dimension),
+    Mixed(CoordType),
 
     /// Represents a [MixedGeometryArray][crate::array::MixedGeometryArray] or
     /// [ChunkedMixedGeometryArray][crate::chunked_array::ChunkedMixedGeometryArray] with `i64`
     /// offsets.
-    LargeMixed(CoordType, Dimension),
+    LargeMixed(CoordType),
 
     /// Represents a [GeometryCollectionArray][crate::array::GeometryCollectionArray] or
     /// [ChunkedGeometryCollectionArray][crate::chunked_array::ChunkedGeometryCollectionArray] with
     /// `i32` offsets.
-    GeometryCollection(CoordType, Dimension),
+    GeometryCollection(CoordType),
 
     /// Represents a [GeometryCollectionArray][crate::array::GeometryCollectionArray] or
     /// [ChunkedGeometryCollectionArray][crate::chunked_array::ChunkedGeometryCollectionArray] with
     /// `i64` offsets.
-    LargeGeometryCollection(CoordType, Dimension),
+    LargeGeometryCollection(CoordType),
 
     /// Represents a [WKBArray][crate::array::WKBArray] or
     /// [ChunkedWKBArray][crate::chunked_array::ChunkedWKBArray] with `i32` offsets.
@@ -255,7 +255,7 @@ fn multi_polygon_data_type<O: OffsetSizeTrait>(coord_type: CoordType, dim: Dimen
     }
 }
 
-fn mixed_data_type<O: OffsetSizeTrait>(coord_type: CoordType, dim: Dimension) -> DataType {
+fn mixed_data_type<O: OffsetSizeTrait>(coord_type: CoordType) -> DataType {
     let mut fields: Vec<Arc<Field>> = vec![];
     let mut type_ids = vec![];
 
@@ -312,8 +312,7 @@ fn geometry_collection_data_type<O: OffsetSizeTrait>(
     coord_type: CoordType,
     dim: Dimension,
 ) -> DataType {
-    let geometries_field =
-        Field::new("geometries", mixed_data_type::<O>(coord_type, dim), false).into();
+    let geometries_field = Field::new("geometries", mixed_data_type::<O>(coord_type), false).into();
     match O::IS_LARGE {
         true => DataType::LargeList(geometries_field),
         false => DataType::List(geometries_field),
@@ -384,8 +383,8 @@ impl GeoDataType {
             }
             MultiPolygon(coord_type, dim) => multi_polygon_data_type::<i32>(*coord_type, *dim),
             LargeMultiPolygon(coord_type, dim) => multi_polygon_data_type::<i64>(*coord_type, *dim),
-            Mixed(coord_type, dim) => mixed_data_type::<i32>(*coord_type, *dim),
-            LargeMixed(coord_type, dim) => mixed_data_type::<i64>(*coord_type, *dim),
+            Mixed(coord_type) => mixed_data_type::<i32>(*coord_type),
+            LargeMixed(coord_type) => mixed_data_type::<i64>(*coord_type),
             GeometryCollection(coord_type, dim) => {
                 geometry_collection_data_type::<i32>(*coord_type, *dim)
             }

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -17,7 +17,7 @@ pub enum Geometry<'a, O: OffsetSizeTrait, const D: usize> {
     MultiPoint(crate::scalar::MultiPoint<'a, O, D>),
     MultiLineString(crate::scalar::MultiLineString<'a, O, D>),
     MultiPolygon(crate::scalar::MultiPolygon<'a, O, D>),
-    GeometryCollection(crate::scalar::GeometryCollection<'a, O, D>),
+    GeometryCollection(crate::scalar::GeometryCollection<'a, O>),
     Rect(crate::scalar::Rect<'a, D>),
 }
 
@@ -55,7 +55,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for Geometry<'a, O, D
     type MultiPoint<'b> = MultiPoint<'b, O, D> where Self: 'b;
     type MultiLineString<'b> = MultiLineString<'b, O, D> where Self: 'b;
     type MultiPolygon<'b> = MultiPolygon<'b, O, D> where Self: 'b;
-    type GeometryCollection<'b> = GeometryCollection<'b, O, D> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<'b, O> where Self: 'b;
     type Rect<'b> = Rect<'b, D> where Self: 'b;
 
     fn dim(&self) -> usize {
@@ -72,7 +72,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for Geometry<'a, O, D
         MultiPoint<'_, O, D>,
         MultiLineString<'_, O, D>,
         MultiPolygon<'_, O, D>,
-        GeometryCollection<'_, O, D>,
+        GeometryCollection<'_, O>,
         Rect<'_, D>,
     > {
         match self {
@@ -96,7 +96,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for &'a Geometry<'a, 
     type MultiPoint<'b> = MultiPoint<'a, O, D> where Self: 'b;
     type MultiLineString<'b> = MultiLineString<'a, O, D> where Self: 'b;
     type MultiPolygon<'b> = MultiPolygon<'a, O, D> where Self: 'b;
-    type GeometryCollection<'b> = GeometryCollection<'a, O, D> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<'a, O> where Self: 'b;
     type Rect<'b> = Rect<'a, D> where Self: 'b;
 
     fn dim(&self) -> usize {
@@ -113,7 +113,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for &'a Geometry<'a, 
         MultiPoint<'a, O, D>,
         MultiLineString<'a, O, D>,
         MultiPolygon<'a, O, D>,
-        GeometryCollection<'a, O, D>,
+        GeometryCollection<'a, O>,
         Rect<'a, D>,
     > {
         match self {

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -12,8 +12,8 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a GeometryCollection
 #[derive(Debug, Clone)]
-pub struct GeometryCollection<'a, O: OffsetSizeTrait, const D: usize> {
-    pub(crate) array: &'a MixedGeometryArray<O, D>,
+pub struct GeometryCollection<'a, O: OffsetSizeTrait> {
+    pub(crate) array: &'a MixedGeometryArray<O>,
 
     /// Offsets into the geometry array where each geometry starts
     pub(crate) geom_offsets: &'a OffsetBuffer<O>,
@@ -23,9 +23,9 @@ pub struct GeometryCollection<'a, O: OffsetSizeTrait, const D: usize> {
     start_offset: usize,
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollection<'a, O, D> {
+impl<'a, O: OffsetSizeTrait> GeometryCollection<'a, O> {
     pub fn new(
-        array: &'a MixedGeometryArray<O, D>,
+        array: &'a MixedGeometryArray<O>,
         geom_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
@@ -38,12 +38,12 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollection<'a, O, D> {
         }
     }
 
-    pub fn into_inner(&self) -> (&MixedGeometryArray<O, D>, &OffsetBuffer<O>, usize) {
+    pub fn into_inner(&self) -> (&MixedGeometryArray<O>, &OffsetBuffer<O>, usize) {
         (self.array, self.geom_offsets, self.geom_index)
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for GeometryCollection<'a, O, D> {
+impl<'a, O: OffsetSizeTrait> GeometryScalarTrait for GeometryCollection<'a, O> {
     type ScalarGeo = geo::GeometryCollection;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -60,9 +60,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryScalarTrait for GeometryCol
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
-    for GeometryCollection<'a, O, D>
-{
+impl<'a, O: OffsetSizeTrait> GeometryCollectionTrait for GeometryCollection<'a, O> {
     type T = f64;
     type ItemType<'b> = Geometry<'a, O, D> where Self: 'b;
 
@@ -80,9 +78,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
-    for &'a GeometryCollection<'a, O, D>
-{
+impl<'a, O: OffsetSizeTrait> GeometryCollectionTrait for &'a GeometryCollection<'a, O> {
     type T = f64;
     type ItemType<'b> = Geometry<'a, O, D> where Self: 'b;
 
@@ -106,15 +102,13 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
 //     }
 // }
 
-impl<O: OffsetSizeTrait, const D: usize> From<&GeometryCollection<'_, O, D>>
-    for geo::GeometryCollection
-{
+impl<O: OffsetSizeTrait> From<&GeometryCollection<'_, O, D>> for geo::GeometryCollection {
     fn from(value: &GeometryCollection<'_, O, D>) -> Self {
         geometry_collection_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<GeometryCollection<'_, O, D>> for geo::Geometry {
+impl<O: OffsetSizeTrait> From<GeometryCollection<'_, O, D>> for geo::Geometry {
     fn from(value: GeometryCollection<'_, O, D>) -> Self {
         geo::Geometry::GeometryCollection(value.into())
     }
@@ -130,7 +124,7 @@ impl<O: OffsetSizeTrait> RTreeObject for GeometryCollection<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
+impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
     for GeometryCollection<'_, O, D>
 {
     fn eq(&self, other: &G) -> bool {


### PR DESCRIPTION
### todo:

- [ ] Union arrays should not have a dimension parameter. Instead, the union will include all geometry types and all dimensions. See https://github.com/geoarrow/geoarrow/pull/43/files#diff-6a6ea8d80b9c2fea0c9877dc99e6670c16a787efdf4729056cb0bc5f3ad4e48fR144-R171.
- [ ] I suppose that means GeometryCollection arrays _can't_ have a dimension parameter either.
- [ ] `GeoDataType::Mixed` (and large mixed and geometry collection) should not have a `Dimension` field
- [ ] Update GeoParquet writer [here](https://github.com/geoarrow/geoarrow-rs/pull/713) to ensure we're writing all the correct geometry types.
- [ ] Ensure that union arrays are always exported with the known type id numbers. E.g. point should always be field 1 in the union.

For #646 , https://github.com/geoarrow/geoarrow-rs/issues/679 ,