### PR TITLE
Fix union array interop

### DIFF
--- a/src/algorithm/native/downcast.rs
+++ b/src/algorithm/native/downcast.rs
@@ -275,84 +275,64 @@ impl<O: OffsetSizeTrait> Downcast for MixedGeometryArray<O, 2> {
     fn downcasted_data_type(&self, small_offsets: bool) -> GeoDataType {
         let coord_type = self.coord_type();
 
-        if self.points.is_some()
-            && self.line_strings.is_none()
-            && self.polygons.is_none()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_none()
+        if self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
             return GeoDataType::Point(coord_type, Dimension::XY);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_some()
-            && self.polygons.is_none()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_none()
+        if !self.has_points()
+            && self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return self
-                .line_strings
-                .as_ref()
-                .unwrap()
-                .downcasted_data_type(small_offsets);
+            return self.line_strings.downcasted_data_type(small_offsets);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_none()
-            && self.polygons.is_some()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_none()
+        if !self.has_points()
+            && !self.has_line_strings()
+            && self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return self
-                .polygons
-                .as_ref()
-                .unwrap()
-                .downcasted_data_type(small_offsets);
+            return self.polygons.downcasted_data_type(small_offsets);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_none()
-            && self.polygons.is_none()
-            && self.multi_points.is_some()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_none()
+        if !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return self
-                .multi_points
-                .as_ref()
-                .unwrap()
-                .downcasted_data_type(small_offsets);
+            return self.multi_points.downcasted_data_type(small_offsets);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_none()
-            && self.polygons.is_none()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_some()
-            && self.multi_polygons.is_none()
+        if !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return self
-                .multi_line_strings
-                .as_ref()
-                .unwrap()
-                .downcasted_data_type(small_offsets);
+            return self.multi_line_strings.downcasted_data_type(small_offsets);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_none()
-            && self.polygons.is_none()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_some()
+        if !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && self.has_multi_polygons()
         {
-            return self
-                .multi_polygons
-                .as_ref()
-                .unwrap()
-                .downcasted_data_type(small_offsets);
+            return self.multi_polygons.downcasted_data_type(small_offsets);
         }
 
         self.data_type()
@@ -360,72 +340,64 @@ impl<O: OffsetSizeTrait> Downcast for MixedGeometryArray<O, 2> {
 
     fn downcast(&self, small_offsets: bool) -> Self::Output {
         // TODO: do I need to handle the slice offset?
-        if self.points.is_some()
-            && self.line_strings.is_none()
-            && self.polygons.is_none()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_none()
+        if self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return Arc::new(self.points.as_ref().unwrap().clone());
+            return Arc::new(self.points.clone());
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_some()
-            && self.polygons.is_none()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_none()
+        if !self.has_points()
+            && self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return self.line_strings.as_ref().unwrap().downcast(small_offsets);
+            return self.line_strings.downcast(small_offsets);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_none()
-            && self.polygons.is_some()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_none()
+        if !self.has_points()
+            && !self.has_line_strings()
+            && self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return self.polygons.as_ref().unwrap().downcast(small_offsets);
+            return self.polygons.downcast(small_offsets);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_none()
-            && self.polygons.is_none()
-            && self.multi_points.is_some()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_none()
+        if !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return self.multi_points.as_ref().unwrap().downcast(small_offsets);
+            return self.multi_points.downcast(small_offsets);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_none()
-            && self.polygons.is_none()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_some()
-            && self.multi_polygons.is_none()
+        if !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && self.has_multi_line_strings()
+            && !self.has_multi_polygons()
         {
-            return self
-                .multi_line_strings
-                .as_ref()
-                .unwrap()
-                .downcast(small_offsets);
+            return self.multi_line_strings.downcast(small_offsets);
         }
 
-        if self.points.is_none()
-            && self.line_strings.is_none()
-            && self.polygons.is_none()
-            && self.multi_points.is_none()
-            && self.multi_line_strings.is_none()
-            && self.multi_polygons.is_some()
+        if !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && self.has_multi_polygons()
         {
-            return self
-                .multi_polygons
-                .as_ref()
-                .unwrap()
-                .downcast(small_offsets);
+            return self.multi_polygons.downcast(small_offsets);
         }
 
         Arc::new(self.clone())

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use arrow_array::{Array, OffsetSizeTrait, UnionArray};
 use arrow_buffer::{NullBuffer, ScalarBuffer};
-use arrow_schema::{DataType, Field, UnionFields, UnionMode};
+use arrow_schema::{DataType, Field, UnionMode};
 
 use crate::array::metadata::ArrayMetadata;
 use crate::array::mixed::builder::MixedGeometryBuilder;
@@ -66,12 +66,12 @@ pub struct MixedGeometryArray<O: OffsetSizeTrait, const D: usize> {
     pub(crate) offsets: ScalarBuffer<i32>,
 
     /// Invariant: Any of these arrays that are `Some()` must have length >0
-    pub(crate) points: Option<PointArray<D>>,
-    pub(crate) line_strings: Option<LineStringArray<O, D>>,
-    pub(crate) polygons: Option<PolygonArray<O, D>>,
-    pub(crate) multi_points: Option<MultiPointArray<O, D>>,
-    pub(crate) multi_line_strings: Option<MultiLineStringArray<O, D>>,
-    pub(crate) multi_polygons: Option<MultiPolygonArray<O, D>>,
+    pub(crate) points: PointArray<D>,
+    pub(crate) line_strings: LineStringArray<O, D>,
+    pub(crate) polygons: PolygonArray<O, D>,
+    pub(crate) multi_points: MultiPointArray<O, D>,
+    pub(crate) multi_line_strings: MultiLineStringArray<O, D>,
+    pub(crate) multi_polygons: MultiPolygonArray<O, D>,
 
     /// An offset used for slicing into this array. The offset will be 0 if the array has not been
     /// sliced.
@@ -148,34 +148,23 @@ impl<O: OffsetSizeTrait, const D: usize> MixedGeometryArray<O, D> {
     pub fn new(
         type_ids: ScalarBuffer<i8>,
         offsets: ScalarBuffer<i32>,
-        points: Option<PointArray<D>>,
-        line_strings: Option<LineStringArray<O, D>>,
-        polygons: Option<PolygonArray<O, D>>,
-        multi_points: Option<MultiPointArray<O, D>>,
-        multi_line_strings: Option<MultiLineStringArray<O, D>>,
-        multi_polygons: Option<MultiPolygonArray<O, D>>,
+        points: PointArray<D>,
+        line_strings: LineStringArray<O, D>,
+        polygons: PolygonArray<O, D>,
+        multi_points: MultiPointArray<O, D>,
+        multi_line_strings: MultiLineStringArray<O, D>,
+        multi_polygons: MultiPolygonArray<O, D>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut coord_types = HashSet::new();
-        if let Some(ref points) = points {
-            coord_types.insert(points.coord_type());
-        }
-        if let Some(ref line_strings) = line_strings {
-            coord_types.insert(line_strings.coord_type());
-        }
-        if let Some(ref polygons) = polygons {
-            coord_types.insert(polygons.coord_type());
-        }
-        if let Some(ref multi_points) = multi_points {
-            coord_types.insert(multi_points.coord_type());
-        }
-        if let Some(ref multi_line_strings) = multi_line_strings {
-            coord_types.insert(multi_line_strings.coord_type());
-        }
-        if let Some(ref multi_polygons) = multi_polygons {
-            coord_types.insert(multi_polygons.coord_type());
-        }
+        coord_types.insert(points.coord_type());
+        coord_types.insert(line_strings.coord_type());
+        coord_types.insert(polygons.coord_type());
+        coord_types.insert(multi_points.coord_type());
+        coord_types.insert(multi_line_strings.coord_type());
+        coord_types.insert(multi_polygons.coord_type());
         assert_eq!(coord_types.len(), 1);
+
         let coord_type = coord_types.into_iter().next().unwrap();
         let data_type = match O::IS_LARGE {
             true => GeoDataType::LargeMixed(coord_type, D.try_into().unwrap()),
@@ -200,55 +189,37 @@ impl<O: OffsetSizeTrait, const D: usize> MixedGeometryArray<O, D> {
     /// The lengths of each buffer contained in this array.
     pub fn buffer_lengths(&self) -> MixedCapacity {
         MixedCapacity::new(
-            self.points
-                .as_ref()
-                .map(|arr| arr.buffer_lengths())
-                .unwrap_or_default(),
-            self.line_strings
-                .as_ref()
-                .map(|arr| arr.buffer_lengths())
-                .unwrap_or_default(),
-            self.polygons
-                .as_ref()
-                .map(|arr| arr.buffer_lengths())
-                .unwrap_or_default(),
-            self.multi_points
-                .as_ref()
-                .map(|arr| arr.buffer_lengths())
-                .unwrap_or_default(),
-            self.multi_line_strings
-                .as_ref()
-                .map(|arr| arr.buffer_lengths())
-                .unwrap_or_default(),
-            self.multi_polygons
-                .as_ref()
-                .map(|arr| arr.buffer_lengths())
-                .unwrap_or_default(),
+            self.points.buffer_lengths(),
+            self.line_strings.buffer_lengths(),
+            self.polygons.buffer_lengths(),
+            self.multi_points.buffer_lengths(),
+            self.multi_line_strings.buffer_lengths(),
+            self.multi_polygons.buffer_lengths(),
         )
     }
 
     pub fn has_points(&self) -> bool {
-        self.points.is_some()
+        !self.points.is_empty()
     }
 
-    pub fn has_line_string_2ds(&self) -> bool {
-        self.line_strings.is_some()
+    pub fn has_line_strings(&self) -> bool {
+        !self.line_strings.is_empty()
     }
 
-    pub fn has_polygon_2ds(&self) -> bool {
-        self.polygons.is_some()
+    pub fn has_polygons(&self) -> bool {
+        !self.polygons.is_empty()
     }
 
-    pub fn has_multi_point_2ds(&self) -> bool {
-        self.multi_points.is_some()
+    pub fn has_multi_points(&self) -> bool {
+        !self.multi_points.is_empty()
     }
 
-    pub fn has_multi_line_string_2ds(&self) -> bool {
-        self.multi_line_strings.is_some()
+    pub fn has_multi_line_strings(&self) -> bool {
+        !self.multi_line_strings.is_empty()
     }
 
-    pub fn has_multi_polygon_2ds(&self) -> bool {
-        self.multi_polygons.is_some()
+    pub fn has_multi_polygons(&self) -> bool {
+        !self.multi_polygons.is_empty()
     }
 
     /// The number of bytes occupied by this array.
@@ -267,36 +238,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MixedGeometryArr
     }
 
     fn storage_type(&self) -> DataType {
-        let mut fields: Vec<Arc<Field>> = vec![];
-        let mut type_ids = vec![];
-
-        if let Some(ref points) = self.points {
-            fields.push(points.extension_field());
-            type_ids.push(1);
-        }
-        if let Some(ref line_strings) = self.line_strings {
-            fields.push(line_strings.extension_field());
-            type_ids.push(2);
-        }
-        if let Some(ref polygons) = self.polygons {
-            fields.push(polygons.extension_field());
-            type_ids.push(3);
-        }
-        if let Some(ref multi_points) = self.multi_points {
-            fields.push(multi_points.extension_field());
-            type_ids.push(4);
-        }
-        if let Some(ref multi_line_strings) = self.multi_line_strings {
-            fields.push(multi_line_strings.extension_field());
-            type_ids.push(5);
-        }
-        if let Some(ref multi_polygons) = self.multi_polygons {
-            fields.push(multi_polygons.extension_field());
-            type_ids.push(6);
-        }
-
-        let union_fields = UnionFields::new(type_ids, fields);
-        DataType::Union(union_fields, UnionMode::Dense)
+        self.data_type.to_data_type()
     }
 
     fn extension_field(&self) -> Arc<Field> {
@@ -304,18 +246,6 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MixedGeometryArr
             self.data_type
                 .to_field_with_metadata("geometry", true, &self.metadata),
         )
-        // let mut metadata = HashMap::with_capacity(2);
-        // metadata.insert(
-        //     "ARROW:extension:name".to_string(),
-        //     self.extension_name().to_string(),
-        // );
-        // if self.metadata.should_serialize() {
-        //     metadata.insert(
-        //         "ARROW:extension:metadata".to_string(),
-        //         serde_json::to_string(self.metadata.as_ref()).unwrap(),
-        //     );
-        // }
-        // Arc::new(Field::new("geometry", self.storage_type(), true).with_metadata(metadata))
     }
 
     fn extension_name(&self) -> &str {
@@ -421,23 +351,21 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a>
         let offset = self.offsets[index] as usize;
 
         match type_id {
-            1 => Geometry::Point(self.points.as_ref().unwrap().value(offset)),
-            2 => Geometry::LineString(self.line_strings.as_ref().unwrap().value(offset)),
-            3 => Geometry::Polygon(self.polygons.as_ref().unwrap().value(offset)),
-            4 => Geometry::MultiPoint(self.multi_points.as_ref().unwrap().value(offset)),
-            5 => Geometry::MultiLineString(self.multi_line_strings.as_ref().unwrap().value(offset)),
-            6 => Geometry::MultiPolygon(self.multi_polygons.as_ref().unwrap().value(offset)),
+            1 => Geometry::Point(self.points.value(offset)),
+            2 => Geometry::LineString(self.line_strings.value(offset)),
+            3 => Geometry::Polygon(self.polygons.value(offset)),
+            4 => Geometry::MultiPoint(self.multi_points.value(offset)),
+            5 => Geometry::MultiLineString(self.multi_line_strings.value(offset)),
+            6 => Geometry::MultiPolygon(self.multi_polygons.value(offset)),
             7 => {
                 panic!("nested geometry collections not supported")
             }
-            11 => Geometry::Point(self.points.as_ref().unwrap().value(offset)),
-            12 => Geometry::LineString(self.line_strings.as_ref().unwrap().value(offset)),
-            13 => Geometry::Polygon(self.polygons.as_ref().unwrap().value(offset)),
-            14 => Geometry::MultiPoint(self.multi_points.as_ref().unwrap().value(offset)),
-            15 => {
-                Geometry::MultiLineString(self.multi_line_strings.as_ref().unwrap().value(offset))
-            }
-            16 => Geometry::MultiPolygon(self.multi_polygons.as_ref().unwrap().value(offset)),
+            11 => Geometry::Point(self.points.value(offset)),
+            12 => Geometry::LineString(self.line_strings.value(offset)),
+            13 => Geometry::Polygon(self.polygons.value(offset)),
+            14 => Geometry::MultiPoint(self.multi_points.value(offset)),
+            15 => Geometry::MultiLineString(self.multi_line_strings.value(offset)),
+            16 => Geometry::MultiPolygon(self.multi_polygons.value(offset)),
             17 => {
                 panic!("nested geometry collections not supported")
             }
@@ -456,12 +384,12 @@ impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MixedGeometryArray<O, D> 
         };
 
         let child_arrays = vec![
-            self.points.unwrap_or_default().into_array_ref(),
-            self.line_strings.unwrap_or_default().into_array_ref(),
-            self.polygons.unwrap_or_default().into_array_ref(),
-            self.multi_points.unwrap_or_default().into_array_ref(),
-            self.multi_line_strings.unwrap_or_default().into_array_ref(),
-            self.multi_polygons.unwrap_or_default().into_array_ref(),
+            self.points.into_array_ref(),
+            self.line_strings.into_array_ref(),
+            self.polygons.into_array_ref(),
+            self.multi_points.into_array_ref(),
+            self.multi_line_strings.into_array_ref(),
+            self.multi_polygons.into_array_ref(),
         ];
 
         UnionArray::try_new(
@@ -571,12 +499,12 @@ impl<const D: usize> TryFrom<&UnionArray> for MixedGeometryArray<i32, D> {
         Ok(Self::new(
             type_ids,
             offsets,
-            points,
-            line_strings,
-            polygons,
-            multi_points,
-            multi_line_strings,
-            multi_polygons,
+            points.unwrap_or_default(),
+            line_strings.unwrap_or_default(),
+            polygons.unwrap_or_default(),
+            multi_points.unwrap_or_default(),
+            multi_line_strings.unwrap_or_default(),
+            multi_polygons.unwrap_or_default(),
             Default::default(),
         ))
     }
@@ -678,12 +606,12 @@ impl<const D: usize> TryFrom<&UnionArray> for MixedGeometryArray<i64, D> {
         Ok(Self::new(
             type_ids,
             offsets,
-            points,
-            line_strings,
-            polygons,
-            multi_points,
-            multi_line_strings,
-            multi_polygons,
+            points.unwrap_or_default(),
+            line_strings.unwrap_or_default(),
+            polygons.unwrap_or_default(),
+            multi_points.unwrap_or_default(),
+            multi_line_strings.unwrap_or_default(),
+            multi_polygons.unwrap_or_default(),
             Default::default(),
         ))
     }
@@ -778,11 +706,11 @@ impl<const D: usize> From<MixedGeometryArray<i32, D>> for MixedGeometryArray<i64
             value.type_ids,
             value.offsets,
             value.points,
-            value.line_strings.map(|arr| arr.into()),
-            value.polygons.map(|arr| arr.into()),
-            value.multi_points.map(|arr| arr.into()),
-            value.multi_line_strings.map(|arr| arr.into()),
-            value.multi_polygons.map(|arr| arr.into()),
+            value.line_strings.into(),
+            value.polygons.into(),
+            value.multi_points.into(),
+            value.multi_line_strings.into(),
+            value.multi_polygons.into(),
             value.metadata,
         )
     }
@@ -796,14 +724,11 @@ impl<const D: usize> TryFrom<MixedGeometryArray<i64, D>> for MixedGeometryArray<
             value.type_ids,
             value.offsets,
             value.points,
-            value.line_strings.map(|arr| arr.try_into()).transpose()?,
-            value.polygons.map(|arr| arr.try_into()).transpose()?,
-            value.multi_points.map(|arr| arr.try_into()).transpose()?,
-            value
-                .multi_line_strings
-                .map(|arr| arr.try_into())
-                .transpose()?,
-            value.multi_polygons.map(|arr| arr.try_into()).transpose()?,
+            value.line_strings.try_into()?,
+            value.polygons.try_into()?,
+            value.multi_points.try_into()?,
+            value.multi_line_strings.try_into()?,
+            value.multi_polygons.try_into()?,
             value.metadata,
         ))
     }

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use arrow_array::{Array, OffsetSizeTrait, UnionArray};
@@ -23,6 +23,35 @@ use crate::GeometryArrayTrait;
 ///
 /// - All arrays must have the same dimension
 /// - All arrays must have the same coordinate layout (interleaved or separated)
+///
+/// - 1: Point
+/// - 2: LineString
+/// - 3: Polygon
+/// - 4: MultiPoint
+/// - 5: MultiLineString
+/// - 6: MultiPolygon
+/// - 7: GeometryCollection
+/// - 11: Point Z
+/// - 12: LineString Z
+/// - 13: Polygon Z
+/// - 14: MultiPoint Z
+/// - 15: MultiLineString Z
+/// - 16: MultiPolygon Z
+/// - 17: GeometryCollection Z
+/// - 21: Point M
+/// - 22: LineString M
+/// - 23: Polygon M
+/// - 24: MultiPoint M
+/// - 25: MultiLineString M
+/// - 26: MultiPolygon M
+/// - 27: GeometryCollection M
+/// - 31: Point ZM
+/// - 32: LineString ZM
+/// - 33: Polygon ZM
+/// - 34: MultiPoint ZM
+/// - 35: MultiLineString ZM
+/// - 36: MultiPolygon ZM
+/// - 37: GeometryCollection ZM
 #[derive(Debug, Clone, PartialEq)]
 pub struct MixedGeometryArray<O: OffsetSizeTrait, const D: usize> {
     /// Always GeoDataType::Mixed or GeoDataType::LargeMixed
@@ -35,36 +64,6 @@ pub struct MixedGeometryArray<O: OffsetSizeTrait, const D: usize> {
 
     /// Invariant: `offsets.len() == type_ids.len()`
     pub(crate) offsets: ScalarBuffer<i32>,
-
-    /// A lookup table for which child array is used
-    ///
-    /// To read a value:
-    /// ``rs
-    /// let child_index = self.type_ids[i];
-    /// let offset = self.offsets[i] as usize;
-    /// let geometry_type = self.map[child_index as usize];
-    /// ``
-    /// then match on the geometry_type to access the underlying array.
-    ///
-    /// Note that we include an ordering so that exporting this array to Arrow is O(1). If we used
-    /// another ordering like always Point, LineString, etc. then we'd either have to always export
-    /// all arrays (including some zero-length arrays) or have to reorder the `type_ids` buffer when
-    /// exporting.
-    ///
-    /// The default ordering is the following, chosen to match the GeoPackage spec:
-    ///
-    /// - 1: PointArray
-    /// - 2: LineStringArray
-    /// - 3: PolygonArray
-    /// - 4: MultiPointArray
-    /// - 5: MultiLineStringArray
-    /// - 6: MultiPolygonArray
-    /// - 7: GeometryCollectionArray (todo)
-    ///
-    /// But the ordering can be different if coming from an external source.
-    // TODO: change this to a wrapper type that contains this array of 6?
-    // Then that wrapper type can also take a default ordering.
-    pub(crate) map: [Option<GeometryType>; 7],
 
     /// Invariant: Any of these arrays that are `Some()` must have length >0
     pub(crate) points: Option<PointArray<D>>,
@@ -95,7 +94,7 @@ pub struct MixedGeometryArray<O: OffsetSizeTrait, const D: usize> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum GeometryType {
+pub(crate) enum GeometryType {
     Point = 1,
     LineString = 2,
     Polygon = 3,
@@ -157,16 +156,6 @@ impl<O: OffsetSizeTrait, const D: usize> MixedGeometryArray<O, D> {
         multi_polygons: Option<MultiPolygonArray<O, D>>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
-        let default_ordering = [
-            None,
-            Some(GeometryType::Point),
-            Some(GeometryType::LineString),
-            Some(GeometryType::Polygon),
-            Some(GeometryType::MultiPoint),
-            Some(GeometryType::MultiLineString),
-            Some(GeometryType::MultiPolygon),
-        ];
-
         let mut coord_types = HashSet::new();
         if let Some(ref points) = points {
             coord_types.insert(points.coord_type());
@@ -197,7 +186,6 @@ impl<O: OffsetSizeTrait, const D: usize> MixedGeometryArray<O, D> {
             data_type,
             type_ids,
             offsets,
-            map: default_ordering,
             points,
             line_strings,
             polygons,
@@ -312,18 +300,22 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MixedGeometryArr
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        let mut metadata = HashMap::with_capacity(2);
-        metadata.insert(
-            "ARROW:extension:name".to_string(),
-            self.extension_name().to_string(),
-        );
-        if self.metadata.should_serialize() {
-            metadata.insert(
-                "ARROW:extension:metadata".to_string(),
-                serde_json::to_string(self.metadata.as_ref()).unwrap(),
-            );
-        }
-        Arc::new(Field::new("geometry", self.storage_type(), true).with_metadata(metadata))
+        Arc::new(
+            self.data_type
+                .to_field_with_metadata("geometry", true, &self.metadata),
+        )
+        // let mut metadata = HashMap::with_capacity(2);
+        // metadata.insert(
+        //     "ARROW:extension:name".to_string(),
+        //     self.extension_name().to_string(),
+        // );
+        // if self.metadata.should_serialize() {
+        //     metadata.insert(
+        //         "ARROW:extension:metadata".to_string(),
+        //         serde_json::to_string(self.metadata.as_ref()).unwrap(),
+        //     );
+        // }
+        // Arc::new(Field::new("geometry", self.storage_type(), true).with_metadata(metadata))
     }
 
     fn extension_name(&self) -> &str {
@@ -339,30 +331,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MixedGeometryArr
     }
 
     fn coord_type(&self) -> crate::array::CoordType {
-        let mut coord_types = HashSet::new();
-
-        if let Some(ref points) = self.points {
-            coord_types.insert(points.coord_type());
-        }
-        if let Some(ref line_strings) = self.line_strings {
-            coord_types.insert(line_strings.coord_type());
-        }
-        if let Some(ref polygons) = self.polygons {
-            coord_types.insert(polygons.coord_type());
-        }
-        if let Some(ref multi_points) = self.multi_points {
-            coord_types.insert(multi_points.coord_type());
-        }
-        if let Some(ref multi_line_strings) = self.multi_line_strings {
-            coord_types.insert(multi_line_strings.coord_type());
-        }
-        if let Some(ref multi_polygons) = self.multi_polygons {
-            coord_types.insert(multi_polygons.coord_type());
-        }
-
-        assert_eq!(coord_types.len(), 1);
-        let coord_type = coord_types.drain().next().unwrap();
-        coord_type
+        self.data_type.coord_type().unwrap()
     }
 
     fn to_coord_type(&self, coord_type: CoordType) -> Arc<dyn GeometryArrayTrait> {
@@ -425,7 +394,6 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D> for MixedGe
             data_type: self.data_type,
             type_ids: self.type_ids.slice(offset, length),
             offsets: self.offsets.slice(offset, length),
-            map: self.map,
             points: self.points.clone(),
             line_strings: self.line_strings.clone(),
             polygons: self.polygons.clone(),
@@ -449,32 +417,31 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a>
     type ItemGeo = geo::Geometry;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        let child_index = self.type_ids[index];
+        let type_id = self.type_ids[index];
         let offset = self.offsets[index] as usize;
-        let geometry_type = self.map[child_index as usize].unwrap();
 
-        match geometry_type {
-            GeometryType::Point => Geometry::Point(self.points.as_ref().unwrap().value(offset)),
-            GeometryType::LineString => {
-                Geometry::LineString(self.line_strings.as_ref().unwrap().value(offset))
+        match type_id {
+            1 => Geometry::Point(self.points.as_ref().unwrap().value(offset)),
+            2 => Geometry::LineString(self.line_strings.as_ref().unwrap().value(offset)),
+            3 => Geometry::Polygon(self.polygons.as_ref().unwrap().value(offset)),
+            4 => Geometry::MultiPoint(self.multi_points.as_ref().unwrap().value(offset)),
+            5 => Geometry::MultiLineString(self.multi_line_strings.as_ref().unwrap().value(offset)),
+            6 => Geometry::MultiPolygon(self.multi_polygons.as_ref().unwrap().value(offset)),
+            7 => {
+                panic!("nested geometry collections not supported")
             }
-            GeometryType::Polygon => {
-                Geometry::Polygon(self.polygons.as_ref().unwrap().value(offset))
-            }
-            GeometryType::MultiPoint => {
-                Geometry::MultiPoint(self.multi_points.as_ref().unwrap().value(offset))
-            }
-            GeometryType::MultiLineString => {
+            11 => Geometry::Point(self.points.as_ref().unwrap().value(offset)),
+            12 => Geometry::LineString(self.line_strings.as_ref().unwrap().value(offset)),
+            13 => Geometry::Polygon(self.polygons.as_ref().unwrap().value(offset)),
+            14 => Geometry::MultiPoint(self.multi_points.as_ref().unwrap().value(offset)),
+            15 => {
                 Geometry::MultiLineString(self.multi_line_strings.as_ref().unwrap().value(offset))
             }
-            GeometryType::MultiPolygon => {
-                Geometry::MultiPolygon(self.multi_polygons.as_ref().unwrap().value(offset))
+            16 => Geometry::MultiPolygon(self.multi_polygons.as_ref().unwrap().value(offset)),
+            17 => {
+                panic!("nested geometry collections not supported")
             }
-            GeometryType::GeometryCollection => {
-                // We don't yet support nested geometry collections
-                todo!()
-                // Geometry::GeometryCollection(todo!())
-            }
+            _ => panic!("unknown type_id {}", type_id),
         }
     }
 }
@@ -483,43 +450,22 @@ impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MixedGeometryArray<O, D> 
     type ArrowArray = UnionArray;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let mut field_type_ids = vec![];
-        let mut fields = vec![];
-        let mut child_arrays = vec![];
+        let union_fields = match self.data_type.to_data_type() {
+            DataType::Union(union_fields, _) => union_fields,
+            _ => unreachable!(),
+        };
 
-        if let Some(ref points) = self.points {
-            field_type_ids.push(1);
-            fields.push(points.extension_field().as_ref().clone());
-            child_arrays.push(points.clone().into_array_ref());
-        }
-        if let Some(ref line_strings) = self.line_strings {
-            field_type_ids.push(2);
-            fields.push(line_strings.extension_field().as_ref().clone());
-            child_arrays.push(line_strings.clone().into_array_ref());
-        }
-        if let Some(ref polygons) = self.polygons {
-            field_type_ids.push(3);
-            fields.push(polygons.extension_field().as_ref().clone());
-            child_arrays.push(polygons.clone().into_array_ref());
-        }
-        if let Some(ref multi_points) = self.multi_points {
-            field_type_ids.push(4);
-            fields.push(multi_points.extension_field().as_ref().clone());
-            child_arrays.push(multi_points.clone().into_array_ref());
-        }
-        if let Some(ref multi_line_strings) = self.multi_line_strings {
-            field_type_ids.push(5);
-            fields.push(multi_line_strings.extension_field().as_ref().clone());
-            child_arrays.push(multi_line_strings.clone().into_array_ref());
-        }
-        if let Some(ref multi_polygons) = self.multi_polygons {
-            field_type_ids.push(6);
-            fields.push(multi_polygons.extension_field().as_ref().clone());
-            child_arrays.push(multi_polygons.clone().into_array_ref());
-        }
+        let child_arrays = vec![
+            self.points.unwrap_or_default().into_array_ref(),
+            self.line_strings.unwrap_or_default().into_array_ref(),
+            self.polygons.unwrap_or_default().into_array_ref(),
+            self.multi_points.unwrap_or_default().into_array_ref(),
+            self.multi_line_strings.unwrap_or_default().into_array_ref(),
+            self.multi_polygons.unwrap_or_default().into_array_ref(),
+        ];
 
         UnionArray::try_new(
-            UnionFields::new(field_type_ids, fields),
+            union_fields,
             self.type_ids,
             Some(self.offsets),
             child_arrays,
@@ -544,39 +490,75 @@ impl<const D: usize> TryFrom<&UnionArray> for MixedGeometryArray<i32, D> {
                     return Err(GeoArrowError::General("Expected dense union".to_string()));
                 }
 
-                for (type_id, field) in fields.iter() {
-                    if let Some(extension_name) = field.metadata().get("ARROW:extension:name") {
-                        match extension_name.as_str() {
-                            "geoarrow.point" => {
+                for (type_id, _field) in fields.iter() {
+                    match D {
+                        2 => match type_id {
+                            1 => {
                                 points = Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.linestring" => {
+                            2 => {
                                 line_strings =
                                     Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.polygon" => {
+                            3 => {
                                 polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.multipoint" => {
+                            4 => {
                                 multi_points =
                                     Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.multilinestring" => {
+                            5 => {
                                 multi_line_strings =
                                     Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.multipolygon" => {
+                            6 => {
                                 multi_polygons =
                                     Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             _ => {
                                 return Err(GeoArrowError::General(format!(
-                                    "Unexpected geoarrow type {}",
-                                    extension_name
+                                    "Unexpected type_id {} for dimension {}",
+                                    type_id, D
                                 )))
                             }
+                        },
+                        3 => match type_id {
+                            11 => {
+                                points = Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            12 => {
+                                line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            13 => {
+                                polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            14 => {
+                                multi_points =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            15 => {
+                                multi_line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            16 => {
+                                multi_polygons =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            _ => {
+                                return Err(GeoArrowError::General(format!(
+                                    "Unexpected type_id {} for dimension {}",
+                                    type_id, D
+                                )))
+                            }
+                        },
+                        _ => {
+                            return Err(GeoArrowError::General(format!(
+                                "Unexpected type_id {} for dimension {}",
+                                type_id, D
+                            )))
                         }
-                    };
+                    }
                 }
             }
             _ => panic!("expected union type"),
@@ -615,40 +597,75 @@ impl<const D: usize> TryFrom<&UnionArray> for MixedGeometryArray<i64, D> {
                 if !matches!(mode, UnionMode::Dense) {
                     return Err(GeoArrowError::General("Expected dense union".to_string()));
                 }
-
-                for (type_id, field) in fields.iter() {
-                    if let Some(extension_name) = field.metadata().get("ARROW:extension:name") {
-                        match extension_name.as_str() {
-                            "geoarrow.point" => {
+                for (type_id, _field) in fields.iter() {
+                    match D {
+                        2 => match type_id {
+                            1 => {
                                 points = Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.linestring" => {
+                            2 => {
                                 line_strings =
                                     Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.polygon" => {
+                            3 => {
                                 polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.multipoint" => {
+                            4 => {
                                 multi_points =
                                     Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.multilinestring" => {
+                            5 => {
                                 multi_line_strings =
                                     Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            "geoarrow.multipolygon" => {
+                            6 => {
                                 multi_polygons =
                                     Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             _ => {
                                 return Err(GeoArrowError::General(format!(
-                                    "Unexpected geoarrow type {}",
-                                    extension_name
+                                    "Unexpected type_id {} for dimension {}",
+                                    type_id, D
                                 )))
                             }
+                        },
+                        3 => match type_id {
+                            11 => {
+                                points = Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            12 => {
+                                line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            13 => {
+                                polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            14 => {
+                                multi_points =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            15 => {
+                                multi_line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            16 => {
+                                multi_polygons =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
+                            }
+                            _ => {
+                                return Err(GeoArrowError::General(format!(
+                                    "Unexpected type_id {} for dimension {}",
+                                    type_id, D
+                                )))
+                            }
+                        },
+                        _ => {
+                            return Err(GeoArrowError::General(format!(
+                                "Unexpected type_id {} for dimension {}",
+                                type_id, D
+                            )))
                         }
-                    };
+                    }
                 }
             }
             _ => panic!("expected union type"),

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -511,36 +511,12 @@ impl<O: OffsetSizeTrait, const D: usize> From<MixedGeometryBuilder<O, D>>
         Self::new(
             other.types.into(),
             other.offsets.into(),
-            if other.points.len() > 0 {
-                Some(other.points.into())
-            } else {
-                None
-            },
-            if other.line_strings.len() > 0 {
-                Some(other.line_strings.into())
-            } else {
-                None
-            },
-            if other.polygons.len() > 0 {
-                Some(other.polygons.into())
-            } else {
-                None
-            },
-            if other.multi_points.len() > 0 {
-                Some(other.multi_points.into())
-            } else {
-                None
-            },
-            if other.multi_line_strings.len() > 0 {
-                Some(other.multi_line_strings.into())
-            } else {
-                None
-            },
-            if other.multi_polygons.len() > 0 {
-                Some(other.multi_polygons.into())
-            } else {
-                None
-            },
+            other.points.into(),
+            other.line_strings.into(),
+            other.polygons.into(),
+            other.multi_points.into(),
+            other.multi_line_strings.into(),
+            other.multi_polygons.into(),
             other.metadata,
         )
     }

--- a/src/io/parquet/test.rs
+++ b/src/io/parquet/test.rs
@@ -1,10 +1,15 @@
 use std::fs::File;
 use std::io::Cursor;
+use std::sync::Arc;
 
+use arrow_array::{BooleanArray, RecordBatch};
+use arrow_schema::{Field, Schema};
 use bytes::Bytes;
 
+use crate::array::MixedGeometryBuilder;
 use crate::error::Result;
 use crate::io::parquet::{write_geoparquet, GeoParquetRecordBatchReaderBuilder};
+use crate::table::Table;
 
 #[ignore = "fails!"]
 #[test]
@@ -30,4 +35,34 @@ fn round_trip_nybb() -> Result<()> {
     assert_eq!(&schema, again.schema());
     Ok(())
     // assert_eq!(table.geometry().unwrap().ch, again.geometry().unwrap());
+}
+
+// Test from https://github.com/geoarrow/geoarrow-rs/pull/717
+#[test]
+fn mixed_geometry_roundtrip() {
+    let mut builder = MixedGeometryBuilder::<i32, 2>::new();
+    builder.push_point(Some(&geo::point!(x: -105., y: 40.)));
+    let geometry = crate::chunked_array::from_geoarrow_chunks(&[&builder.finish()]).unwrap();
+    let array = BooleanArray::from(vec![true]);
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "visible",
+        arrow_schema::DataType::Boolean,
+        false,
+    )]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+    let table = Table::from_arrow_and_geometry(vec![batch], schema, geometry).unwrap();
+    let mut cursor = Cursor::new(Vec::new());
+    write_geoparquet(
+        table.into_record_batch_reader(),
+        &mut cursor,
+        &Default::default(),
+    )
+    .unwrap();
+    let bytes = Bytes::from(cursor.into_inner());
+    GeoParquetRecordBatchReaderBuilder::try_new(bytes)
+        .unwrap()
+        .build()
+        .unwrap()
+        .read_table()
+        .unwrap();
 }


### PR DESCRIPTION
### Change list

- Fix DataType creation to match the spec, with hard-coded type ids.
- Don't include geoarrow metadata on underlying arrays when exporting to arrow-rs. Only include geoarrow metadata on top-level `geoarrow.geometry` array
- We no longer need a `map` attribute in the struct because the ordering of the fields is guaranteed by the spec now.
- Don't store underlying arrays under an `Option`

Closes https://github.com/geoarrow/geoarrow-rs/pull/717, closes https://github.com/geoarrow/geoarrow-rs/pull/714

Unblocks https://github.com/geoarrow/geoarrow-rs/pull/646

Progress towards https://github.com/geoarrow/geoarrow-rs/issues/679