### PR TITLE
Remove Cow around scalar buffers

### DIFF
--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -93,33 +99,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -142,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127ea5e585a12ec9f742232442828ebaf264dfa5eefdd71282376c599562b77"
+checksum = "05048a8932648b63f21c37d88b552ccc8a65afb6dfe9fc9f30ce79174c2e7a85"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -163,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add7f39210b7d726e2a8efc0083e7bf06e8f2d15bdb4896b564dce4410fbf5d"
+checksum = "1d8a57966e43bfe9a3277984a14c24ec617ad874e4c0e1d2a1b083a39cfbf22c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -178,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c16ec702d3898c2f5cfdc148443c6cd7dbe5bac28399859eb0a3d38f072827"
+checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -195,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae6970bab043c4fbc10aee1660ceb5b306d0c42c8cc5f6ae564efcd9759b663"
+checksum = "c975484888fc95ec4a632cdc98be39c085b1bb518531b0c80c5d462063e5daa1"
 dependencies = [
  "bytes",
  "half",
@@ -206,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7ef44f26ef4f8edc392a048324ed5d757ad09135eff6d5509e6450d39e0398"
+checksum = "da26719e76b81d8bc3faad1d4dbdc1bcc10d14704e63dc17fc9f3e7e1e567c8e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -226,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f843490bd258c5182b66e888161bb6f198f49f3792f7c7f98198b924ae0f564"
+checksum = "c13c36dc5ddf8c128df19bab27898eea64bf9da2b555ec1cd17a8ff57fba9ec2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -245,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a769666ffac256dd301006faca1ca553d0ae7cffcf4cd07095f73f95eb226514"
+checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -257,23 +263,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf9c3fb57390a1af0b7bb3b5558c1ee1f63905f3eccf49ae7676a8d1e6e5a72"
+checksum = "e786e1cdd952205d9a8afc69397b317cfbb6e0095e445c69cda7e8da5c1eeb0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
  "arrow-schema",
- "flatbuffers 24.3.25",
+ "flatbuffers",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e7f3724176b66ddfacba31af397c48e106fbe4d281c8144e7d237df5acfd7"
+checksum = "fb22284c5a2a01d73cebfd88a33511a3234ab45d66086b2ca2d1228c3498e445"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -291,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8008370e624e8e3c68174faaf793540287106cfda8ad1da862fdc53d8e096b4"
+checksum = "42745f86b1ab99ef96d1c0bcf49180848a64fe2c7a7a0d945bc64fa2b21ba9bc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -306,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5e3a6b7fda8d9fe03f3b18a2d946354ea7f3c8e4076dbdb502ad50d9d44824"
+checksum = "4cd09a518c602a55bd406bcc291a967b284cfa7a63edfbf8b897ea4748aad23c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -316,23 +322,22 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half",
- "hashbrown",
 ]
 
 [[package]]
 name = "arrow-schema"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab1c12b40e29d9f3b699e0203c2a73ba558444c05e388a4377208f8f9c97eee"
+checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80159088ffe8c48965cb9b1a7c968b2729f29f37363df7eca177fc3281fe7c3"
+checksum = "600bae05d43483d216fb3494f8c32fdbefd8aa4e1de237e790dbb3d9f44690a3"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -344,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd04a6ea7de183648edbcb7a6dd925bbd04c210895f6384c780e27a9b54afcd"
+checksum = "f0dc1985b67cb45f6606a248ac2b4a288849f196bab8c657ea5589f47cdd55e6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -393,7 +398,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -404,7 +409,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -450,7 +455,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -508,9 +513,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
 
 [[package]]
 name = "byteorder"
@@ -520,18 +525,19 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -578,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -588,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9b20c0dd58e4c2e991c8d203bbeb76c11304d1011659686b5b644bc29aa478"
+checksum = "63d19864d6b68464c59f7162c9914a0b569ddc2926b4a2d71afe62a9738eff53"
 dependencies = [
  "clap",
  "log",
@@ -598,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -610,27 +616,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -674,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -802,19 +808,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
-
-[[package]]
-name = "flatbuffers"
-version = "23.5.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
-dependencies = [
- "bitflags 1.3.2",
- "rustc_version",
-]
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "flatbuffers"
@@ -828,23 +824,23 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
 name = "flatgeobuf"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9fd319b3db16586172a3aceaa21b328999887f8b4535d4f06296138f92880"
+checksum = "83c07a71b9a55179feef8a6cf75e8f8021b1f5611ee4d8092fabc5fd52c2a9ce"
 dependencies = [
  "byteorder",
  "fallible-streaming-iterator",
- "flatbuffers 23.5.26",
+ "flatbuffers",
  "geozero",
  "log",
  "tempfile",
@@ -948,7 +944,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1074,7 +1070,7 @@ dependencies = [
  "object_store",
  "parquet",
  "range-reader",
- "reqwest 0.12.5",
+ "reqwest 0.12.7",
  "serde",
  "serde-wasm-bindgen",
  "thiserror",
@@ -1183,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1257,6 +1253,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "http"
@@ -1365,7 +1367,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -1411,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1464,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1486,20 +1488,20 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1527,18 +1529,18 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1615,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
@@ -1679,6 +1681,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicov"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71e683cd655513b99affab7d317deb690528255a0d5f717f1024093c12b169"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,14 +1700,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1791,30 +1813,30 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -1894,7 +1916,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1949,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f22ba0d95db56dde8685e3fadcb915cdaadda31ab8abbe3ff7f0ad1ef333267"
+checksum = "e977b9066b4d3b03555c22bdc442f3fadebd96a39111249113087d0edb2691cd"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2044,7 +2066,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2073,7 +2095,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2114,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2156,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -2167,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2220,7 +2242,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -2229,21 +2251,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -2264,7 +2286,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -2272,7 +2294,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2337,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.11"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2350,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -2360,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -2454,9 +2476,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -2474,22 +2496,23 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2505,6 +2528,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
@@ -2567,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.9.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4ec45f91925e2c9ab3b6a857ee9ed36916990df76a1c475d783a328e247cc8"
+checksum = "9bd14cf9e23b5241e1b1289ed3b9afc7746c95ead8df52d9254f5ed2d40c561b"
 dependencies = [
  "hashbrown",
  "num-traits",
@@ -2620,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2640,6 +2669,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "system-configuration"
@@ -2649,7 +2681,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -2663,15 +2706,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.10.1"
+name = "system-configuration-sys"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2700,7 +2754,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2740,9 +2794,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2751,18 +2805,18 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2801,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
@@ -2833,15 +2887,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2862,7 +2916,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2952,9 +3006,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2983,11 +3037,12 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -2995,24 +3050,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3022,9 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3032,31 +3087,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
+checksum = "68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
+ "minicov",
  "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3065,13 +3121,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
+checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3089,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3115,11 +3171,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3138,6 +3194,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,6 +3237,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3296,16 +3391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wkt"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,7 +3419,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]

--- a/js/src/scalar/linestring.rs
+++ b/js/src/scalar/linestring.rs
@@ -4,9 +4,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct LineString(pub(crate) OwnedLineString<i32, 2>);
 
-impl<'a> From<LineString> for geoarrow::scalar::LineString<'a, i32, 2> {
-    fn from(value: LineString) -> Self {
-        value.0.into()
+impl<'a> From<&'a LineString> for geoarrow::scalar::LineString<'a, i32, 2> {
+    fn from(value: &'a LineString) -> Self {
+        (&value.0).into()
     }
 }
 

--- a/js/src/scalar/multilinestring.rs
+++ b/js/src/scalar/multilinestring.rs
@@ -4,9 +4,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct MultiLineString(pub(crate) OwnedMultiLineString<i32, 2>);
 
-impl<'a> From<MultiLineString> for geoarrow::scalar::MultiLineString<'a, i32, 2> {
-    fn from(value: MultiLineString) -> Self {
-        value.0.into()
+impl<'a> From<&'a MultiLineString> for geoarrow::scalar::MultiLineString<'a, i32, 2> {
+    fn from(value: &'a MultiLineString) -> Self {
+        (&value.0).into()
     }
 }
 

--- a/js/src/scalar/multipoint.rs
+++ b/js/src/scalar/multipoint.rs
@@ -4,9 +4,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct MultiPoint(pub(crate) OwnedMultiPoint<i32, 2>);
 
-impl<'a> From<MultiPoint> for geoarrow::scalar::MultiPoint<'a, i32, 2> {
-    fn from(value: MultiPoint) -> Self {
-        value.0.into()
+impl<'a> From<&'a MultiPoint> for geoarrow::scalar::MultiPoint<'a, i32, 2> {
+    fn from(value: &'a MultiPoint) -> Self {
+        (&value.0).into()
     }
 }
 

--- a/js/src/scalar/multipolygon.rs
+++ b/js/src/scalar/multipolygon.rs
@@ -4,9 +4,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct MultiPolygon(pub(crate) OwnedMultiPolygon<i32, 2>);
 
-impl<'a> From<MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, i32, 2> {
-    fn from(value: MultiPolygon) -> Self {
-        value.0.into()
+impl<'a> From<&'a MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, i32, 2> {
+    fn from(value: &'a MultiPolygon) -> Self {
+        (&value.0).into()
     }
 }
 

--- a/js/src/scalar/point.rs
+++ b/js/src/scalar/point.rs
@@ -4,9 +4,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct Point(pub(crate) OwnedPoint<2>);
 
-impl<'a> From<Point> for geoarrow::scalar::Point<'a, 2> {
-    fn from(value: Point) -> Self {
-        value.0.into()
+impl<'a> From<&'a Point> for geoarrow::scalar::Point<'a, 2> {
+    fn from(value: &'a Point) -> Self {
+        (&value.0).into()
     }
 }
 

--- a/js/src/scalar/polygon.rs
+++ b/js/src/scalar/polygon.rs
@@ -4,9 +4,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct Polygon(pub(crate) OwnedPolygon<i32, 2>);
 
-impl<'a> From<Polygon> for geoarrow::scalar::Polygon<'a, i32, 2> {
-    fn from(value: Polygon) -> Self {
-        value.0.into()
+impl<'a> From<&'a Polygon> for geoarrow::scalar::Polygon<'a, i32, 2> {
+    fn from(value: &'a Polygon) -> Self {
+        (&value.0).into()
     }
 }
 

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -205,7 +205,7 @@ impl<'a, O: OffsetSizeTrait> GeometryArrayAccessor<'a> for WKBArray<O> {
     type ItemGeo = geo::Geometry;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        WKB::new_borrowed(&self.array, index)
+        WKB::new(&self.array, index)
     }
 }
 

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -120,6 +120,10 @@ impl<O: OffsetSizeTrait, const D: usize> LineStringArray<O, D> {
         &self.coords
     }
 
+    pub fn into_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, Option<NullBuffer>) {
+        (self.coords, self.geom_offsets, self.validity)
+    }
+
     pub fn geom_offsets(&self) -> &OffsetBuffer<O> {
         &self.geom_offsets
     }
@@ -288,7 +292,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a> for LineS
     type ItemGeo = geo::LineString;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        LineString::new_borrowed(&self.coords, &self.geom_offsets, index)
+        LineString::new(&self.coords, &self.geom_offsets, index)
     }
 }
 

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -329,7 +329,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a>
     type ItemGeo = geo::MultiLineString;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        MultiLineString::new_borrowed(&self.coords, &self.geom_offsets, &self.ring_offsets, index)
+        MultiLineString::new(&self.coords, &self.geom_offsets, &self.ring_offsets, index)
     }
 }
 

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -119,6 +119,10 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointArray<O, D> {
         &self.coords
     }
 
+    pub fn into_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, Option<NullBuffer>) {
+        (self.coords, self.geom_offsets, self.validity)
+    }
+
     pub fn geom_offsets(&self) -> &OffsetBuffer<O> {
         &self.geom_offsets
     }
@@ -278,7 +282,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a> for Multi
     type ItemGeo = geo::MultiPoint;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        MultiPoint::new_borrowed(&self.coords, &self.geom_offsets, index)
+        MultiPoint::new(&self.coords, &self.geom_offsets, index)
     }
 }
 

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -180,6 +180,22 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
         &self.coords
     }
 
+    pub fn into_inner(
+        self,
+    ) -> (
+        CoordBuffer<D>,
+        OffsetBuffer<O>,
+        OffsetBuffer<O>,
+        OffsetBuffer<O>,
+    ) {
+        (
+            self.coords,
+            self.geom_offsets,
+            self.polygon_offsets,
+            self.ring_offsets,
+        )
+    }
+
     pub fn geom_offsets(&self) -> &OffsetBuffer<O> {
         &self.geom_offsets
     }
@@ -375,7 +391,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a> for Multi
     type ItemGeo = geo::MultiPolygon;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        MultiPolygon::new_borrowed(
+        MultiPolygon::new(
             &self.coords,
             &self.geom_offsets,
             &self.polygon_offsets,

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -222,7 +222,7 @@ impl<'a, const D: usize> GeometryArrayAccessor<'a> for PointArray<D> {
     type ItemGeo = geo::Point;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        Point::new_borrowed(&self.coords, index)
+        Point::new(&self.coords, index)
     }
 }
 

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -326,7 +326,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryArrayAccessor<'a> for Polyg
     type ItemGeo = geo::Polygon;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        Polygon::new_borrowed(&self.coords, &self.geom_offsets, &self.ring_offsets, index)
+        Polygon::new(&self.coords, &self.geom_offsets, &self.ring_offsets, index)
     }
 }
 

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -173,7 +173,7 @@ impl<'a, const D: usize> GeometryArrayAccessor<'a> for RectArray<D> {
     type ItemGeo = geo::Rect;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        Rect::new_borrowed(&self.lower, &self.upper, index)
+        Rect::new(&self.lower, &self.upper, index)
     }
 }
 

--- a/src/io/geos/scalar/linestring.rs
+++ b/src/io/geos/scalar/linestring.rs
@@ -24,7 +24,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a LineString<'_, O, D>> f
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = value.geom_offsets.start_end(value.geom_index);
 
-        let sliced_coords = value.coords.clone().to_mut().slice(start, end - start);
+        let sliced_coords = value.coords.clone().slice(start, end - start);
 
         geos::Geometry::create_line_string(sliced_coords.try_into()?)
     }
@@ -34,7 +34,7 @@ impl<O: OffsetSizeTrait, const D: usize> LineString<'_, O, D> {
     pub fn to_geos_linear_ring(&self) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
 
-        let sliced_coords = self.coords.clone().to_mut().slice(start, end - start);
+        let sliced_coords = self.coords.clone().slice(start, end - start);
 
         geos::Geometry::create_linear_ring(sliced_coords.try_into()?)
     }

--- a/src/scalar/binary/owned.rs
+++ b/src/scalar/binary/owned.rs
@@ -14,15 +14,9 @@ impl<O: OffsetSizeTrait> OwnedWKB<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<OwnedWKB<O>> for WKB<'a, O> {
-    fn from(value: OwnedWKB<O>) -> Self {
-        Self::new_owned(value.arr, value.geom_index)
-    }
-}
-
 impl<'a, O: OffsetSizeTrait> From<&'a OwnedWKB<O>> for WKB<'a, O> {
     fn from(value: &'a OwnedWKB<O>) -> Self {
-        Self::new_borrowed(&value.arr, value.geom_index)
+        Self::new(&value.arr, value.geom_index)
     }
 }
 

--- a/src/scalar/binary/scalar.rs
+++ b/src/scalar/binary/scalar.rs
@@ -3,38 +3,23 @@ use crate::trait_::GeometryScalarTrait;
 use arrow_array::{GenericBinaryArray, OffsetSizeTrait};
 use geo::BoundingRect;
 use rstar::{RTreeObject, AABB};
-use std::borrow::Cow;
 
 /// An Arrow equivalent of a Point
 #[derive(Debug, Clone)]
 pub struct WKB<'a, O: OffsetSizeTrait> {
-    pub(crate) arr: Cow<'a, GenericBinaryArray<O>>,
+    pub(crate) arr: &'a GenericBinaryArray<O>,
     pub(crate) geom_index: usize,
 }
 
 impl<'a, O: OffsetSizeTrait> WKB<'a, O> {
-    pub fn new(arr: Cow<'a, GenericBinaryArray<O>>, geom_index: usize) -> Self {
+    pub fn new(arr: &'a GenericBinaryArray<O>, geom_index: usize) -> Self {
         Self { arr, geom_index }
-    }
-
-    pub fn new_borrowed(arr: &'a GenericBinaryArray<O>, geom_index: usize) -> Self {
-        Self {
-            arr: Cow::Borrowed(arr),
-            geom_index,
-        }
-    }
-
-    pub fn new_owned(arr: GenericBinaryArray<O>, geom_index: usize) -> Self {
-        Self {
-            arr: Cow::Owned(arr),
-            geom_index,
-        }
     }
 
     pub fn into_owned_inner(self) -> (GenericBinaryArray<O>, usize) {
         // TODO: hard slice?
         // let owned = self.into_owned();
-        (self.arr.into_owned(), self.geom_index)
+        (self.arr.clone(), self.geom_index)
     }
 }
 

--- a/src/scalar/linestring/owned.rs
+++ b/src/scalar/linestring/owned.rs
@@ -25,23 +25,17 @@ impl<O: OffsetSizeTrait, const D: usize> OwnedLineString<O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedLineString<O, D>> for LineString<'a, O, D> {
-    fn from(value: OwnedLineString<O, D>) -> Self {
-        Self::new_owned(value.coords, value.geom_offsets, value.geom_index)
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedLineString<O, D>>
     for LineString<'a, O, D>
 {
     fn from(value: &'a OwnedLineString<O, D>) -> Self {
-        Self::new_borrowed(&value.coords, &value.geom_offsets, value.geom_index)
+        Self::new(&value.coords, &value.geom_offsets, value.geom_index)
     }
 }
 
 impl<O: OffsetSizeTrait> From<OwnedLineString<O, 2>> for geo::LineString {
     fn from(value: OwnedLineString<O, 2>) -> Self {
-        let geom = LineString::from(value);
+        let geom = LineString::from(&value);
         geom.into()
     }
 }

--- a/src/scalar/linestring/scalar.rs
+++ b/src/scalar/linestring/scalar.rs
@@ -9,15 +9,14 @@ use crate::trait_::{GeometryArraySelfMethods, GeometryScalarTrait};
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
-use std::borrow::Cow;
 
 /// An Arrow equivalent of a LineString
 #[derive(Debug, Clone)]
 pub struct LineString<'a, O: OffsetSizeTrait, const D: usize> {
-    pub(crate) coords: Cow<'a, CoordBuffer<D>>,
+    pub(crate) coords: &'a CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
-    pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
+    pub(crate) geom_offsets: &'a OffsetBuffer<O>,
 
     pub(crate) geom_index: usize,
 
@@ -26,8 +25,8 @@ pub struct LineString<'a, O: OffsetSizeTrait, const D: usize> {
 
 impl<'a, O: OffsetSizeTrait, const D: usize> LineString<'a, O, D> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer<D>>,
-        geom_offsets: Cow<'a, OffsetBuffer<O>>,
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
@@ -39,47 +38,16 @@ impl<'a, O: OffsetSizeTrait, const D: usize> LineString<'a, O, D> {
         }
     }
 
-    pub fn new_borrowed(
-        coords: &'a CoordBuffer<D>,
-        geom_offsets: &'a OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self::new(
-            Cow::Borrowed(coords),
-            Cow::Borrowed(geom_offsets),
-            geom_index,
-        )
-    }
-
-    pub fn new_owned(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self::new(Cow::Owned(coords), Cow::Owned(geom_offsets), geom_index)
-    }
-
-    /// Extracts the owned data.
-    ///
-    /// Clones the data if it is not already owned.
-    pub fn into_owned(self) -> Self {
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, usize) {
         let arr = LineStringArray::new(
-            self.coords.into_owned(),
-            self.geom_offsets.into_owned(),
+            self.coords.clone(),
+            self.geom_offsets.clone(),
             None,
             Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
-        Self::new_owned(sliced_arr.coords, sliced_arr.geom_offsets, 0)
-    }
-
-    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, usize) {
-        let owned = self.into_owned();
-        (
-            owned.coords.into_owned(),
-            owned.geom_offsets.into_owned(),
-            owned.geom_index,
-        )
+        let (coords, geom_offsets, _validity) = sliced_arr.into_inner();
+        (coords, geom_offsets, 0)
     }
 }
 
@@ -114,7 +82,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> LineStringTrait for LineString<'a, 
     }
 
     unsafe fn coord_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        Point::new(self.coords.clone(), self.start_offset + i)
+        Point::new(self.coords, self.start_offset + i)
     }
 }
 
@@ -132,7 +100,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> LineStringTrait for &'a LineString<
     }
 
     unsafe fn coord_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        Point::new(self.coords.clone(), self.start_offset + i)
+        Point::new(self.coords, self.start_offset + i)
     }
 }
 

--- a/src/scalar/multilinestring/owned.rs
+++ b/src/scalar/multilinestring/owned.rs
@@ -33,24 +33,11 @@ impl<O: OffsetSizeTrait, const D: usize> OwnedMultiLineString<O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedMultiLineString<O, D>>
-    for MultiLineString<'a, O, D>
-{
-    fn from(value: OwnedMultiLineString<O, D>) -> Self {
-        Self::new_owned(
-            value.coords,
-            value.geom_offsets,
-            value.ring_offsets,
-            value.geom_index,
-        )
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiLineString<O, D>>
     for MultiLineString<'a, O, D>
 {
     fn from(value: &'a OwnedMultiLineString<O, D>) -> Self {
-        Self::new_borrowed(
+        Self::new(
             &value.coords,
             &value.geom_offsets,
             &value.ring_offsets,
@@ -61,7 +48,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiLineString<O, D>
 
 impl<O: OffsetSizeTrait> From<OwnedMultiLineString<O, 2>> for geo::MultiLineString {
     fn from(value: OwnedMultiLineString<O, 2>) -> Self {
-        let geom = MultiLineString::from(value);
+        let geom = MultiLineString::from(&value);
         geom.into()
     }
 }

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -10,18 +10,17 @@ use crate::trait_::GeometryScalarTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
-use std::borrow::Cow;
 
 /// An Arrow equivalent of a MultiLineString
 #[derive(Debug, Clone)]
 pub struct MultiLineString<'a, O: OffsetSizeTrait, const D: usize> {
-    pub(crate) coords: Cow<'a, CoordBuffer<D>>,
+    pub(crate) coords: &'a CoordBuffer<D>,
 
     /// Offsets into the ring array where each geometry starts
-    pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
+    pub(crate) geom_offsets: &'a OffsetBuffer<O>,
 
     /// Offsets into the coordinate array where each ring starts
-    pub(crate) ring_offsets: Cow<'a, OffsetBuffer<O>>,
+    pub(crate) ring_offsets: &'a OffsetBuffer<O>,
 
     pub(crate) geom_index: usize,
 
@@ -30,9 +29,9 @@ pub struct MultiLineString<'a, O: OffsetSizeTrait, const D: usize> {
 
 impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineString<'a, O, D> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer<D>>,
-        geom_offsets: Cow<'a, OffsetBuffer<O>>,
-        ring_offsets: Cow<'a, OffsetBuffer<O>>,
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<O>,
+        ring_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
@@ -45,61 +44,20 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineString<'a, O, D> {
         }
     }
 
-    pub fn new_borrowed(
-        coords: &'a CoordBuffer<D>,
-        geom_offsets: &'a OffsetBuffer<O>,
-        ring_offsets: &'a OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self::new(
-            Cow::Borrowed(coords),
-            Cow::Borrowed(geom_offsets),
-            Cow::Borrowed(ring_offsets),
-            geom_index,
-        )
-    }
-
-    pub fn new_owned(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self::new(
-            Cow::Owned(coords),
-            Cow::Owned(geom_offsets),
-            Cow::Owned(ring_offsets),
-            geom_index,
-        )
-    }
-
-    /// Extracts the owned data.
-    ///
-    /// Clones the data if it is not already owned.
-    pub fn into_owned(self) -> Self {
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
         let arr = MultiLineStringArray::new(
-            self.coords.into_owned(),
-            self.geom_offsets.into_owned(),
-            self.ring_offsets.into_owned(),
+            self.coords.clone(),
+            self.geom_offsets.clone(),
+            self.ring_offsets.clone(),
             None,
             Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
-        Self::new_owned(
+        (
             sliced_arr.coords,
             sliced_arr.geom_offsets,
             sliced_arr.ring_offsets,
             0,
-        )
-    }
-
-    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
-        let owned = self.into_owned();
-        (
-            owned.coords.into_owned(),
-            owned.geom_offsets.into_owned(),
-            owned.ring_offsets.into_owned(),
-            owned.geom_index,
         )
     }
 }
@@ -135,11 +93,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineStringTrait for MultiLineS
     }
 
     unsafe fn line_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        LineString::new(
-            self.coords.clone(),
-            self.ring_offsets.clone(),
-            self.start_offset + i,
-        )
+        LineString::new(self.coords, self.ring_offsets, self.start_offset + i)
     }
 }
 
@@ -159,11 +113,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineStringTrait
     }
 
     unsafe fn line_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        LineString::new(
-            self.coords.clone(),
-            self.ring_offsets.clone(),
-            self.start_offset + i,
-        )
+        LineString::new(self.coords, self.ring_offsets, self.start_offset + i)
     }
 }
 

--- a/src/scalar/multipoint/owned.rs
+++ b/src/scalar/multipoint/owned.rs
@@ -25,23 +25,17 @@ impl<O: OffsetSizeTrait, const D: usize> OwnedMultiPoint<O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedMultiPoint<O, D>> for MultiPoint<'a, O, D> {
-    fn from(value: OwnedMultiPoint<O, D>) -> Self {
-        Self::new_owned(value.coords, value.geom_offsets, value.geom_index)
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiPoint<O, D>>
     for MultiPoint<'a, O, D>
 {
     fn from(value: &'a OwnedMultiPoint<O, D>) -> Self {
-        Self::new_borrowed(&value.coords, &value.geom_offsets, value.geom_index)
+        Self::new(&value.coords, &value.geom_offsets, value.geom_index)
     }
 }
 
 impl<O: OffsetSizeTrait> From<OwnedMultiPoint<O, 2>> for geo::MultiPoint {
     fn from(value: OwnedMultiPoint<O, 2>) -> Self {
-        let geom = MultiPoint::from(value);
+        let geom = MultiPoint::from(&value);
         geom.into()
     }
 }

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -10,16 +10,15 @@ use crate::trait_::GeometryScalarTrait;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
-use std::borrow::Cow;
 
 /// An Arrow equivalent of a MultiPoint
 #[derive(Debug, Clone)]
 pub struct MultiPoint<'a, O: OffsetSizeTrait, const D: usize> {
     /// Buffer of coordinates
-    pub(crate) coords: Cow<'a, CoordBuffer<D>>,
+    pub(crate) coords: &'a CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
-    pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
+    pub(crate) geom_offsets: &'a OffsetBuffer<O>,
 
     pub(crate) geom_index: usize,
 
@@ -28,8 +27,8 @@ pub struct MultiPoint<'a, O: OffsetSizeTrait, const D: usize> {
 
 impl<'a, O: OffsetSizeTrait, const D: usize> MultiPoint<'a, O, D> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer<D>>,
-        geom_offsets: Cow<'a, OffsetBuffer<O>>,
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
@@ -41,47 +40,16 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPoint<'a, O, D> {
         }
     }
 
-    pub fn new_borrowed(
-        coords: &'a CoordBuffer<D>,
-        geom_offsets: &'a OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self::new(
-            Cow::Borrowed(coords),
-            Cow::Borrowed(geom_offsets),
-            geom_index,
-        )
-    }
-
-    pub fn new_owned(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self::new(Cow::Owned(coords), Cow::Owned(geom_offsets), geom_index)
-    }
-
-    /// Extracts the owned data.
-    ///
-    /// Clones the data if it is not already owned.
-    pub fn into_owned(self) -> Self {
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, usize) {
         let arr = MultiPointArray::new(
-            self.coords.into_owned(),
-            self.geom_offsets.into_owned(),
+            self.coords.clone(),
+            self.geom_offsets.clone(),
             None,
             Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
-        Self::new_owned(sliced_arr.coords, sliced_arr.geom_offsets, 0)
-    }
-
-    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, usize) {
-        let owned = self.into_owned();
-        (
-            owned.coords.into_owned(),
-            owned.geom_offsets.into_owned(),
-            owned.geom_index,
-        )
+        let (coords, geom_offsets, _validity) = sliced_arr.into_inner();
+        (coords, geom_offsets, 0)
     }
 }
 
@@ -116,7 +84,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPointTrait for MultiPoint<'a, 
     }
 
     unsafe fn point_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        Point::new(self.coords.clone(), self.start_offset + i)
+        Point::new(self.coords, self.start_offset + i)
     }
 }
 
@@ -134,7 +102,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPointTrait for &'a MultiPoint<
     }
 
     unsafe fn point_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        Point::new(self.coords.clone(), self.start_offset + i)
+        Point::new(self.coords, self.start_offset + i)
     }
 }
 

--- a/src/scalar/multipolygon/owned.rs
+++ b/src/scalar/multipolygon/owned.rs
@@ -37,25 +37,11 @@ impl<O: OffsetSizeTrait, const D: usize> OwnedMultiPolygon<O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedMultiPolygon<O, D>>
-    for MultiPolygon<'a, O, D>
-{
-    fn from(value: OwnedMultiPolygon<O, D>) -> Self {
-        Self::new_owned(
-            value.coords,
-            value.geom_offsets,
-            value.polygon_offsets,
-            value.ring_offsets,
-            value.geom_index,
-        )
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiPolygon<O, D>>
     for MultiPolygon<'a, O, D>
 {
     fn from(value: &'a OwnedMultiPolygon<O, D>) -> Self {
-        Self::new_borrowed(
+        Self::new(
             &value.coords,
             &value.geom_offsets,
             &value.polygon_offsets,
@@ -67,7 +53,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiPolygon<O, D>>
 
 impl<O: OffsetSizeTrait> From<OwnedMultiPolygon<O, 2>> for geo::MultiPolygon {
     fn from(value: OwnedMultiPolygon<O, 2>) -> Self {
-        let geom = MultiPolygon::from(value);
+        let geom = MultiPolygon::from(&value);
         geom.into()
     }
 }

--- a/src/scalar/point/owned.rs
+++ b/src/scalar/point/owned.rs
@@ -21,15 +21,9 @@ impl<const D: usize> OwnedPoint<D> {
     }
 }
 
-impl<'a, const D: usize> From<OwnedPoint<D>> for Point<'a, D> {
-    fn from(value: OwnedPoint<D>) -> Self {
-        Self::new_owned(value.coords, value.geom_index)
-    }
-}
-
 impl<'a, const D: usize> From<&'a OwnedPoint<D>> for Point<'a, D> {
     fn from(value: &'a OwnedPoint<D>) -> Self {
-        Self::new_borrowed(&value.coords, value.geom_index)
+        Self::new(&value.coords, value.geom_index)
     }
 }
 

--- a/src/scalar/polygon/owned.rs
+++ b/src/scalar/polygon/owned.rs
@@ -33,20 +33,9 @@ impl<O: OffsetSizeTrait, const D: usize> OwnedPolygon<O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<OwnedPolygon<O, D>> for Polygon<'a, O, D> {
-    fn from(value: OwnedPolygon<O, D>) -> Self {
-        Self::new_owned(
-            value.coords,
-            value.geom_offsets,
-            value.ring_offsets,
-            value.geom_index,
-        )
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedPolygon<O, D>> for Polygon<'a, O, D> {
     fn from(value: &'a OwnedPolygon<O, D>) -> Self {
-        Self::new_borrowed(
+        Self::new(
             &value.coords,
             &value.geom_offsets,
             &value.ring_offsets,
@@ -57,7 +46,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedPolygon<O, D>> for Po
 
 impl<O: OffsetSizeTrait> From<OwnedPolygon<O, 2>> for geo::Polygon {
     fn from(value: OwnedPolygon<O, 2>) -> Self {
-        let geom = Polygon::from(value);
+        let geom = Polygon::from(&value);
         geom.into()
     }
 }

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -9,18 +9,17 @@ use crate::trait_::{GeometryArraySelfMethods, GeometryScalarTrait};
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
-use std::borrow::Cow;
 
 /// An Arrow equivalent of a Polygon
 #[derive(Debug, Clone)]
 pub struct Polygon<'a, O: OffsetSizeTrait, const D: usize> {
-    pub(crate) coords: Cow<'a, CoordBuffer<D>>,
+    pub(crate) coords: &'a CoordBuffer<D>,
 
     /// Offsets into the ring array where each geometry starts
-    pub(crate) geom_offsets: Cow<'a, OffsetBuffer<O>>,
+    pub(crate) geom_offsets: &'a OffsetBuffer<O>,
 
     /// Offsets into the coordinate array where each ring starts
-    pub(crate) ring_offsets: Cow<'a, OffsetBuffer<O>>,
+    pub(crate) ring_offsets: &'a OffsetBuffer<O>,
 
     pub(crate) geom_index: usize,
 
@@ -29,9 +28,9 @@ pub struct Polygon<'a, O: OffsetSizeTrait, const D: usize> {
 
 impl<'a, O: OffsetSizeTrait, const D: usize> Polygon<'a, O, D> {
     pub fn new(
-        coords: Cow<'a, CoordBuffer<D>>,
-        geom_offsets: Cow<'a, OffsetBuffer<O>>,
-        ring_offsets: Cow<'a, OffsetBuffer<O>>,
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<O>,
+        ring_offsets: &'a OffsetBuffer<O>,
         geom_index: usize,
     ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
@@ -44,61 +43,21 @@ impl<'a, O: OffsetSizeTrait, const D: usize> Polygon<'a, O, D> {
         }
     }
 
-    pub fn new_borrowed(
-        coords: &'a CoordBuffer<D>,
-        geom_offsets: &'a OffsetBuffer<O>,
-        ring_offsets: &'a OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self::new(
-            Cow::Borrowed(coords),
-            Cow::Borrowed(geom_offsets),
-            Cow::Borrowed(ring_offsets),
-            geom_index,
-        )
-    }
-
-    pub fn new_owned(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self::new(
-            Cow::Owned(coords),
-            Cow::Owned(geom_offsets),
-            Cow::Owned(ring_offsets),
-            geom_index,
-        )
-    }
-
-    /// Extracts the owned data.
-    ///
-    /// Clones the data if it is not already owned.
-    pub fn into_owned(self) -> Self {
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
         let arr = PolygonArray::new(
-            self.coords.into_owned(),
-            self.geom_offsets.into_owned(),
-            self.ring_offsets.into_owned(),
+            self.coords.clone(),
+            self.geom_offsets.clone(),
+            self.ring_offsets.clone(),
             None,
             Default::default(),
         );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
-        Self::new_owned(
+
+        (
             sliced_arr.coords,
             sliced_arr.geom_offsets,
             sliced_arr.ring_offsets,
             0,
-        )
-    }
-
-    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
-        let owned = self.into_owned();
-        (
-            owned.coords.into_owned(),
-            owned.geom_offsets.into_owned(),
-            owned.ring_offsets.into_owned(),
-            owned.geom_index,
         )
     }
 }
@@ -133,11 +92,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> PolygonTrait for Polygon<'a, O, D> 
         if start == end {
             None
         } else {
-            Some(LineString::new(
-                self.coords.clone(),
-                self.ring_offsets.clone(),
-                start,
-            ))
+            Some(LineString::new(self.coords, self.ring_offsets, start))
         }
     }
 
@@ -147,11 +102,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> PolygonTrait for Polygon<'a, O, D> 
     }
 
     unsafe fn interior_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        LineString::new(
-            self.coords.clone(),
-            self.ring_offsets.clone(),
-            self.start_offset + 1 + i,
-        )
+        LineString::new(self.coords, self.ring_offsets, self.start_offset + 1 + i)
     }
 }
 
@@ -168,11 +119,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> PolygonTrait for &'a Polygon<'a, O,
         if start == end {
             None
         } else {
-            Some(LineString::new(
-                self.coords.clone(),
-                self.ring_offsets.clone(),
-                start,
-            ))
+            Some(LineString::new(self.coords, self.ring_offsets, start))
         }
     }
 
@@ -182,11 +129,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> PolygonTrait for &'a Polygon<'a, O,
     }
 
     unsafe fn interior_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        LineString::new(
-            self.coords.clone(),
-            self.ring_offsets.clone(),
-            self.start_offset + 1 + i,
-        )
+        LineString::new(self.coords, self.ring_offsets, self.start_offset + 1 + i)
     }
 }
 

--- a/src/scalar/rect/owned.rs
+++ b/src/scalar/rect/owned.rs
@@ -24,15 +24,9 @@ impl<const D: usize> OwnedRect<D> {
     }
 }
 
-impl<'a, const D: usize> From<OwnedRect<D>> for Rect<'a, D> {
-    fn from(value: OwnedRect<D>) -> Self {
-        Self::new_owned(value.lower, value.upper, value.geom_index)
-    }
-}
-
 impl<'a, const D: usize> From<&'a OwnedRect<D>> for Rect<'a, D> {
     fn from(value: &'a OwnedRect<D>) -> Self {
-        Self::new_borrowed(&value.lower, &value.upper, value.geom_index)
+        Self::new(&value.lower, &value.upper, value.geom_index)
     }
 }
 

--- a/src/scalar/rect/scalar.rs
+++ b/src/scalar/rect/scalar.rs
@@ -1,5 +1,4 @@
 use rstar::{RTreeObject, AABB};
-use std::borrow::Cow;
 
 use crate::algorithm::native::eq::rect_eq;
 use crate::array::SeparatedCoordBuffer;
@@ -9,15 +8,15 @@ use crate::trait_::GeometryScalarTrait;
 
 #[derive(Debug, Clone)]
 pub struct Rect<'a, const D: usize> {
-    lower: Cow<'a, SeparatedCoordBuffer<D>>,
-    upper: Cow<'a, SeparatedCoordBuffer<D>>,
+    lower: &'a SeparatedCoordBuffer<D>,
+    upper: &'a SeparatedCoordBuffer<D>,
     pub(crate) geom_index: usize,
 }
 
 impl<'a, const D: usize> Rect<'a, D> {
     pub fn new(
-        lower: Cow<'a, SeparatedCoordBuffer<D>>,
-        upper: Cow<'a, SeparatedCoordBuffer<D>>,
+        lower: &'a SeparatedCoordBuffer<D>,
+        upper: &'a SeparatedCoordBuffer<D>,
         geom_index: usize,
     ) -> Self {
         Self {
@@ -26,38 +25,9 @@ impl<'a, const D: usize> Rect<'a, D> {
             geom_index,
         }
     }
-
-    pub fn new_borrowed(
-        lower: &'a SeparatedCoordBuffer<D>,
-        upper: &'a SeparatedCoordBuffer<D>,
-        geom_index: usize,
-    ) -> Self {
-        Self {
-            lower: Cow::Borrowed(lower),
-            upper: Cow::Borrowed(upper),
-            geom_index,
-        }
-    }
-
-    pub fn new_owned(
-        lower: SeparatedCoordBuffer<D>,
-        upper: SeparatedCoordBuffer<D>,
-        geom_index: usize,
-    ) -> Self {
-        Self {
-            lower: Cow::Owned(lower),
-            upper: Cow::Owned(upper),
-            geom_index,
-        }
-    }
-
     pub fn into_owned_inner(self) -> (SeparatedCoordBuffer<D>, SeparatedCoordBuffer<D>, usize) {
         // TODO: make hard slice?
-        (
-            self.lower.into_owned(),
-            self.upper.into_owned(),
-            self.geom_index,
-        )
+        (self.lower.clone(), self.upper.clone(), self.geom_index)
     }
 }
 


### PR DESCRIPTION
Originally scalars were always references onto external buffers. Then in https://github.com/geoarrow/geoarrow-rs/pull/119 that was changed to try to better support bindings that can't have lifetime references. (E.g. neither python nor JS allow exports with lifetime references, because they can't verify when data will still be valid in those environments).

But over time it turned out that we really needed fully separate structs for these (e.g. `OwnedPoint`) that don't have their own lifetime parameters. This means that we never actually needed to make `Point` _itself_ owned. We need to have separate structs anyways for the bindings. 

Having Cow on the scalars only serves to make coordinate access slower, because there's an indirection on access to the coordinate buffer.

### Change list

- Remove `Cow` wrappers on the internal buffers on scalars.

Closes https://github.com/geoarrow/geoarrow-rs/pull/472

Closes https://github.com/geoarrow/geoarrow-rs/issues/449