### PR TITLE
3d builders

### DIFF
--- a/src/algorithm/native/cast.rs
+++ b/src/algorithm/native/cast.rs
@@ -68,7 +68,7 @@ impl Cast for PointArray<2> {
         use GeoDataType::*;
         match to_type {
             Point(ct, Dimension::XY) => {
-                let mut builder = PointBuilder::with_capacity_and_options(
+                let mut builder = PointBuilder::<2>::with_capacity_and_options(
                     self.buffer_lengths(),
                     *ct,
                     self.metadata(),
@@ -410,7 +410,7 @@ impl<O: OffsetSizeTrait> Cast for MultiPointArray<O, 2> {
                 }
 
                 let mut builder =
-                    PointBuilder::with_capacity_and_options(self.len(), *ct, self.metadata());
+                    PointBuilder::<2>::with_capacity_and_options(self.len(), *ct, self.metadata());
                 self.iter()
                     .for_each(|x| builder.push_point(x.map(|mp| mp.point(0).unwrap()).as_ref()));
                 Ok(Arc::new(builder.finish()))
@@ -746,7 +746,7 @@ impl<O: OffsetSizeTrait> Cast for MixedGeometryArray<O, 2> {
                 }
 
                 let mut builder =
-                    PointBuilder::with_capacity_and_options(self.len(), *ct, self.metadata());
+                    PointBuilder::<2>::with_capacity_and_options(self.len(), *ct, self.metadata());
                 self.iter()
                     .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
                 Ok(Arc::new(builder.finish()))

--- a/src/array/coord/combined/builder.rs
+++ b/src/array/coord/combined/builder.rs
@@ -1,3 +1,5 @@
+use core::f64;
+
 use crate::array::{
     CoordBuffer, CoordType, InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder,
 };
@@ -83,6 +85,21 @@ impl<const D: usize> CoordBufferBuilder<D> {
             CoordBufferBuilder::Separated(_) => CoordType::Separated,
         }
     }
+
+    // TODO: how should this handle coords that don't have the same dimension D?
+    pub fn push_point(&mut self, point: &impl PointTrait<T = f64>) {
+        match self {
+            CoordBufferBuilder::Interleaved(cb) => cb.push_point(point),
+            CoordBufferBuilder::Separated(cb) => cb.push_point(point),
+        }
+    }
+
+    pub fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) {
+        match self {
+            CoordBufferBuilder::Interleaved(cb) => cb.push_coord(coord),
+            CoordBufferBuilder::Separated(cb) => cb.push_coord(coord),
+        }
+    }
 }
 
 impl CoordBufferBuilder<2> {
@@ -90,17 +107,6 @@ impl CoordBufferBuilder<2> {
         match self {
             CoordBufferBuilder::Interleaved(cb) => cb.set_coord(i, coord),
             CoordBufferBuilder::Separated(cb) => cb.set_coord(i, coord),
-        }
-    }
-
-    pub fn push_point(&mut self, coord: &impl PointTrait<T = f64>) {
-        self.push_xy(coord.x(), coord.y())
-    }
-
-    pub fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) {
-        match self {
-            CoordBufferBuilder::Interleaved(cb) => cb.push_coord(coord),
-            CoordBufferBuilder::Separated(cb) => cb.push_coord(coord),
         }
     }
 

--- a/src/array/coord/separated/builder.rs
+++ b/src/array/coord/separated/builder.rs
@@ -1,5 +1,7 @@
+use core::f64;
+
 use crate::array::SeparatedCoordBuffer;
-use crate::geo_traits::CoordTrait;
+use crate::geo_traits::{CoordTrait, PointTrait};
 
 /// The GeoArrow equivalent to `Vec<Coord>`: a mutable collection of coordinates.
 ///
@@ -81,17 +83,24 @@ impl<const D: usize> SeparatedCoordBufferBuilder<D> {
             self.buffers[i].push(*value);
         }
     }
+
+    pub fn push_point(&mut self, point: &impl PointTrait<T = f64>) {
+        for (i, buffer) in self.buffers.iter_mut().enumerate() {
+            buffer.push(point.nth(i).unwrap_or(f64::NAN))
+        }
+    }
+
+    pub fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) {
+        for (i, buffer) in self.buffers.iter_mut().enumerate() {
+            buffer.push(coord.nth(i).unwrap_or(f64::NAN))
+        }
+    }
 }
 
 impl SeparatedCoordBufferBuilder<2> {
     pub fn set_coord(&mut self, i: usize, coord: geo::Coord) {
         self.buffers[0][i] = coord.x;
         self.buffers[1][i] = coord.y;
-    }
-
-    pub fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) {
-        self.buffers[0].push(coord.x());
-        self.buffers[1].push(coord.y());
     }
 
     pub fn set_xy(&mut self, i: usize, x: f64, y: f64) {
@@ -122,7 +131,7 @@ impl<const D: usize> From<SeparatedCoordBufferBuilder<D>> for SeparatedCoordBuff
     }
 }
 
-impl<G: CoordTrait<T = f64>> From<&[G]> for SeparatedCoordBufferBuilder<2> {
+impl<G: CoordTrait<T = f64>, const D: usize> From<&[G]> for SeparatedCoordBufferBuilder<D> {
     fn from(value: &[G]) -> Self {
         let mut buffer = SeparatedCoordBufferBuilder::with_capacity(value.len());
         for coord in value {

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -31,7 +31,7 @@ pub struct GeometryCollectionBuilder<O: OffsetSizeTrait, const D: usize> {
     pub(crate) validity: NullBufferBuilder,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionBuilder<O, D> {
+impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionBuilder<O, D> {
     /// Creates a new empty [`GeometryCollectionBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -104,9 +104,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionBuilder<O, D> {
     pub fn finish(self) -> GeometryCollectionArray<O, D> {
         self.into()
     }
-}
 
-impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O, 2> {
     pub fn with_capacity_from_iter(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
     ) -> Result<Self> {
@@ -150,7 +148,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O, 2> {
         prefer_multi: bool,
     ) -> Result<()> {
         if prefer_multi {
-            self.geoms.push_point_as_multi_point_2d(value)?;
+            self.geoms.push_point_as_multi_point(value)?;
         } else {
             self.geoms.push_point(value);
         }
@@ -167,7 +165,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O, 2> {
         prefer_multi: bool,
     ) -> Result<()> {
         if prefer_multi {
-            self.geoms.push_line_string_as_multi_line_string_2d(value)?;
+            self.geoms.push_line_string_as_multi_line_string(value)?;
         } else {
             self.geoms.push_line_string(value)?;
         }
@@ -184,7 +182,7 @@ impl<'a, O: OffsetSizeTrait> GeometryCollectionBuilder<O, 2> {
         prefer_multi: bool,
     ) -> Result<()> {
         if prefer_multi {
-            self.geoms.push_polygon_as_multi_polygon_2d(value)?;
+            self.geoms.push_polygon_as_multi_polygon(value)?;
         } else {
             self.geoms.push_polygon(value)?;
         }

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -44,7 +44,7 @@ pub struct MixedGeometryBuilder<O: OffsetSizeTrait, const D: usize> {
     offsets: Vec<i32>,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> MixedGeometryBuilder<O, D> {
+impl<'a, O: OffsetSizeTrait, const D: usize> MixedGeometryBuilder<O, D> {
     /// Creates a new empty [`MixedGeometryBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -159,9 +159,7 @@ impl<O: OffsetSizeTrait, const D: usize> MixedGeometryBuilder<O, D> {
     pub fn finish(self) -> MixedGeometryArray<O, D> {
         self.into()
     }
-}
 
-impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O, 2> {
     pub fn with_capacity_from_iter(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
     ) -> Result<Self> {
@@ -213,7 +211,7 @@ impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O, 2> {
     /// Add a new Point to the end of this array, storing it in the MultiPointBuilder child
     /// array.
     #[inline]
-    pub fn push_point_as_multi_point_2d(
+    pub fn push_point_as_multi_point(
         &mut self,
         value: Option<&impl PointTrait<T = f64>>,
     ) -> Result<()> {
@@ -250,7 +248,7 @@ impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O, 2> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_line_string_as_multi_line_string_2d(
+    pub fn push_line_string_as_multi_line_string(
         &mut self,
         value: Option<&impl LineStringTrait<T = f64>>,
     ) -> Result<()> {
@@ -283,7 +281,7 @@ impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O, 2> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_polygon_as_multi_polygon_2d(
+    pub fn push_polygon_as_multi_polygon(
         &mut self,
         value: Option<&impl PolygonTrait<T = f64>>,
     ) -> Result<()> {
@@ -379,21 +377,21 @@ impl<'a, O: OffsetSizeTrait> MixedGeometryBuilder<O, 2> {
             match geom.as_type() {
                 crate::geo_traits::GeometryType::Point(g) => {
                     if prefer_multi {
-                        self.push_point_as_multi_point_2d(Some(g))?;
+                        self.push_point_as_multi_point(Some(g))?;
                     } else {
                         self.push_point(Some(g));
                     }
                 }
                 crate::geo_traits::GeometryType::LineString(g) => {
                     if prefer_multi {
-                        self.push_line_string_as_multi_line_string_2d(Some(g))?;
+                        self.push_line_string_as_multi_line_string(Some(g))?;
                     } else {
                         self.push_line_string(Some(g))?;
                     }
                 }
                 crate::geo_traits::GeometryType::Polygon(g) => {
                     if prefer_multi {
-                        self.push_polygon_as_multi_polygon_2d(Some(g))?;
+                        self.push_polygon_as_multi_polygon(Some(g))?;
                     } else {
                         self.push_polygon(Some(g))?;
                     }

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -9,7 +9,9 @@ use crate::array::{
     PolygonBuilder, SeparatedCoordBufferBuilder, WKBArray,
 };
 use crate::error::{GeoArrowError, Result};
-use crate::geo_traits::{GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
+use crate::geo_traits::{
+    CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait,
+};
 use crate::io::wkb::reader::WKBMaybeMultiLineString;
 use crate::scalar::WKB;
 use crate::trait_::{GeometryArrayAccessor, GeometryArrayBuilder, IntoArrow};
@@ -185,9 +187,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringBuilder<O, D> {
     pub fn finish(self) -> MultiLineStringArray<O, D> {
         self.into()
     }
-}
 
-impl<O: OffsetSizeTrait> MultiLineStringBuilder<O, 2> {
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
     ) -> Self {
@@ -323,8 +323,8 @@ impl<O: OffsetSizeTrait> MultiLineStringBuilder<O, 2> {
     /// This is marked as unsafe because care must be taken to ensure that pushing raw coordinates
     /// to the array upholds the necessary invariants of the array.
     #[inline]
-    pub unsafe fn push_xy(&mut self, x: f64, y: f64) -> Result<()> {
-        self.coords.push_xy(x, y);
+    pub unsafe fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) -> Result<()> {
+        self.coords.push_coord(coord);
         Ok(())
     }
 

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -462,16 +462,16 @@ impl<O: OffsetSizeTrait, const D: usize> From<MultiLineStringBuilder<O, D>>
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<&[G]>
-    for MultiLineStringBuilder<O, 2>
+impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>, const D: usize> From<&[G]>
+    for MultiLineStringBuilder<O, D>
 {
     fn from(geoms: &[G]) -> Self {
         Self::from_multi_line_strings(geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> From<Vec<Option<G>>>
-    for MultiLineStringBuilder<O, 2>
+impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>, const D: usize> From<Vec<Option<G>>>
+    for MultiLineStringBuilder<O, D>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_multi_line_strings(&geoms, Default::default(), Default::default())

--- a/src/array/multipolygon/builder.rs
+++ b/src/array/multipolygon/builder.rs
@@ -10,7 +10,7 @@ use crate::array::{
 };
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{
-    GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait,
+    CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait,
 };
 use crate::io::wkb::reader::WKBMaybeMultiPolygon;
 use crate::scalar::WKB;
@@ -175,9 +175,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonBuilder<O, D> {
     pub fn finish(self) -> MultiPolygonArray<O, D> {
         self.into()
     }
-}
 
-impl<O: OffsetSizeTrait> MultiPolygonBuilder<O, 2> {
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
     ) -> Self {
@@ -376,8 +374,8 @@ impl<O: OffsetSizeTrait> MultiPolygonBuilder<O, 2> {
     /// This is marked as unsafe because care must be taken to ensure that pushing raw coordinates
     /// to the array upholds the necessary invariants of the array.
     #[inline]
-    pub unsafe fn push_xy(&mut self, x: f64, y: f64) -> Result<()> {
-        self.coords.push_xy(x, y);
+    pub unsafe fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) -> Result<()> {
+        self.coords.push_coord(coord);
         Ok(())
     }
 
@@ -529,14 +527,16 @@ impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygonBuilder<O, D>>
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<&[G]> for MultiPolygonBuilder<O, 2> {
+impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>, const D: usize> From<&[G]>
+    for MultiPolygonBuilder<O, D>
+{
     fn from(geoms: &[G]) -> Self {
         Self::from_multi_polygons(geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> From<Vec<Option<G>>>
-    for MultiPolygonBuilder<O, 2>
+impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>, const D: usize> From<Vec<Option<G>>>
+    for MultiPolygonBuilder<O, D>
 {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_multi_polygons(&geoms, Default::default(), Default::default())

--- a/src/array/rect/builder.rs
+++ b/src/array/rect/builder.rs
@@ -119,9 +119,7 @@ impl<const D: usize> RectBuilder<D> {
     pub fn finish(self) -> RectArray<D> {
         self.into()
     }
-}
 
-impl RectBuilder<2> {
     /// Add a new Rect to the end of this builder.
     #[inline]
     pub fn push_rect(&mut self, value: Option<&impl RectTrait<T = f64>>) {
@@ -134,8 +132,8 @@ impl RectBuilder<2> {
             self.validity.append_non_null()
         } else {
             // Since it's a struct, we still need to push coords when null
-            self.lower.push_xy(0., 0.);
-            self.upper.push_xy(0., 0.);
+            self.lower.push(core::array::from_fn(|_| 0.));
+            self.upper.push(core::array::from_fn(|_| 0.));
             self.validity.append_null();
         }
     }
@@ -143,7 +141,7 @@ impl RectBuilder<2> {
     /// Add a new null value to the end of this builder.
     #[inline]
     pub fn push_null(&mut self) {
-        self.push_rect(None::<&Rect<2>>);
+        self.push_rect(None::<&Rect<D>>);
     }
 
     /// Create this builder from a iterator of Rects.
@@ -197,13 +195,13 @@ impl<const D: usize> From<RectBuilder<D>> for RectArray<D> {
     }
 }
 
-impl<G: RectTrait<T = f64>> From<&[G]> for RectBuilder<2> {
+impl<G: RectTrait<T = f64>, const D: usize> From<&[G]> for RectBuilder<D> {
     fn from(geoms: &[G]) -> Self {
         RectBuilder::from_rects(geoms.iter(), Default::default())
     }
 }
 
-impl<G: RectTrait<T = f64>> From<Vec<Option<G>>> for RectBuilder<2> {
+impl<G: RectTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for RectBuilder<D> {
     fn from(geoms: Vec<Option<G>>) -> Self {
         RectBuilder::from_nullable_rects(geoms.iter().map(|x| x.as_ref()), Default::default())
     }

--- a/src/io/geos/array/linestring.rs
+++ b/src/io/geos/array/linestring.rs
@@ -4,7 +4,9 @@ use crate::array::{LineStringArray, LineStringBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSLineString;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringBuilder<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for LineStringBuilder<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -17,11 +19,13 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringBuil
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for LineStringArray<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for LineStringArray<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: LineStringBuilder<O, 2> = value.try_into()?;
+        let mutable_arr: LineStringBuilder<O, D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }
@@ -33,17 +37,14 @@ mod test {
     use crate::test::linestring::ls_array;
     use crate::trait_::{GeometryArrayAccessor, GeometryScalarTrait};
 
-    #[ignore = "geos lifetime error"]
     #[test]
     fn geos_round_trip() {
         let arr = ls_array();
-        let _scalars = arr.iter().collect::<Vec<_>>();
-        todo!()
-        // let geos_geoms = scalars
-        //     .iter()
-        //     .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-        //     .collect::<Vec<_>>();
-        // let round_trip: LineStringArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
+        let round_trip: LineStringArray<i32, 2> = geos_geoms.try_into().unwrap();
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/multilinestring.rs
+++ b/src/io/geos/array/multilinestring.rs
@@ -4,7 +4,9 @@ use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSMultiLineString;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringBuilder<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiLineStringBuilder<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -17,11 +19,13 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStrin
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringArray<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiLineStringArray<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: MultiLineStringBuilder<O, 2> = value.try_into()?;
+        let mutable_arr: MultiLineStringBuilder<O, D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }
@@ -33,17 +37,14 @@ mod test {
     use crate::test::multilinestring::ml_array;
     use crate::trait_::{GeometryArrayAccessor, GeometryScalarTrait};
 
-    #[ignore = "geos lifetime error"]
     #[test]
     fn geos_round_trip() {
-        let _arr = ml_array();
-        todo!()
-
-        // let geos_geoms: Vec<Option<geos::Geometry>> = arr
-        //     .iter()
-        //     .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-        //     .collect();
-        // let round_trip: MultiLineStringArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        let arr = ml_array();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
+        let round_trip: MultiLineStringArray<i32, 2> = geos_geoms.try_into().unwrap();
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/multipoint.rs
+++ b/src/io/geos/array/multipoint.rs
@@ -4,7 +4,9 @@ use crate::array::{MultiPointArray, MultiPointBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSMultiPoint;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointBuilder<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiPointBuilder<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
@@ -17,11 +19,13 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointBuil
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointArray<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiPointArray<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: MultiPointBuilder<O, 2> = value.try_into()?;
+        let mutable_arr: MultiPointBuilder<O, D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }
@@ -33,18 +37,14 @@ mod test {
     use crate::test::multipoint::mp_array;
     use crate::trait_::{GeometryArrayAccessor, GeometryScalarTrait};
 
-    #[ignore = "geos lifetime error"]
     #[test]
     fn geos_round_trip() {
-        let _arr = mp_array();
-
-        todo!()
-
-        // let geos_geoms: Vec<Option<geos::Geometry>> = arr
-        //     .iter()
-        //     .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-        //     .collect();
-        // let round_trip: MultiPointArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        let arr = mp_array();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
+        let round_trip: MultiPointArray<i32, 2> = geos_geoms.try_into().unwrap();
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/multipolygon.rs
+++ b/src/io/geos/array/multipolygon.rs
@@ -4,7 +4,9 @@ use crate::array::{MultiPolygonArray, MultiPolygonBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSMultiPolygon;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonBuilder<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiPolygonBuilder<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -17,11 +19,13 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonBu
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonArray<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiPolygonArray<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: MultiPolygonBuilder<O, 2> = value.try_into()?;
+        let mutable_arr: MultiPolygonBuilder<O, D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }
@@ -33,17 +37,14 @@ mod test {
     use crate::test::multipolygon::mp_array;
     use crate::trait_::{GeometryArrayAccessor, GeometryScalarTrait};
 
-    #[ignore = "geos lifetime error"]
     #[test]
     fn geos_round_trip() {
-        let _arr = mp_array();
-        todo!()
-
-        // let geos_geoms: Vec<Option<geos::Geometry>> = arr
-        //     .iter()
-        //     .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-        //     .collect();
-        // let round_trip: MultiPolygonArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        let arr = mp_array();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
+        let round_trip: MultiPolygonArray<i32, 2> = geos_geoms.try_into().unwrap();
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/point.rs
+++ b/src/io/geos/array/point.rs
@@ -2,7 +2,7 @@ use crate::array::{PointArray, PointBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSPoint;
 
-impl TryFrom<Vec<Option<geos::Geometry>>> for PointBuilder<2> {
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for PointBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
@@ -15,11 +15,11 @@ impl TryFrom<Vec<Option<geos::Geometry>>> for PointBuilder<2> {
     }
 }
 
-impl TryFrom<Vec<Option<geos::Geometry>>> for PointArray<2> {
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for PointArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: PointBuilder<2> = value.try_into()?;
+        let mutable_arr: PointBuilder<D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/polygon.rs
+++ b/src/io/geos/array/polygon.rs
@@ -4,7 +4,9 @@ use crate::array::{PolygonArray, PolygonBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSPolygon;
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for PolygonBuilder<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for PolygonBuilder<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -18,11 +20,13 @@ impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for PolygonBuilder
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for PolygonArray<O, 2> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for PolygonArray<O, D>
+{
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: PolygonBuilder<O, 2> = value.try_into()?;
+        let mutable_arr: PolygonBuilder<O, D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }
@@ -34,17 +38,14 @@ mod test {
     use crate::test::polygon::p_array;
     use crate::trait_::{GeometryArrayAccessor, GeometryScalarTrait};
 
-    #[ignore = "geos lifetime error"]
     #[test]
     fn geos_round_trip() {
-        let _arr = p_array();
-        todo!()
-
-        // let geos_geoms: Vec<Option<geos::Geometry>> = arr
-        //     .iter()
-        //     .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-        //     .collect();
-        // let round_trip: PolygonArray<i32> = geos_geoms.try_into().unwrap();
-        // assert_eq!(arr, round_trip);
+        let arr = p_array();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
+        let round_trip: PolygonArray<i32, 2> = geos_geoms.try_into().unwrap();
+        assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/scalar/coord/mod.rs
+++ b/src/io/geos/scalar/coord/mod.rs
@@ -8,13 +8,14 @@ mod separated;
 pub struct GEOSConstCoord {
     pub(crate) coords: geos::CoordSeq,
     pub(crate) geom_index: usize,
+    pub(crate) dim: usize,
 }
 
 impl CoordTrait for GEOSConstCoord {
     type T = f64;
 
     fn dim(&self) -> usize {
-        todo!()
+        self.dim
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {

--- a/src/io/geos/scalar/linearring.rs
+++ b/src/io/geos/scalar/linearring.rs
@@ -27,7 +27,11 @@ impl<'a> LineStringTrait for GEOSConstLinearRing<'a> {
     type ItemType<'c> = GEOSConstCoord where Self: 'c;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn num_coords(&self) -> usize {
@@ -39,6 +43,7 @@ impl<'a> LineStringTrait for GEOSConstLinearRing<'a> {
         GEOSConstCoord {
             coords: seq,
             geom_index: i,
+            dim: self.dim(),
         }
     }
 }

--- a/src/io/geos/scalar/linestring.rs
+++ b/src/io/geos/scalar/linestring.rs
@@ -63,7 +63,11 @@ impl LineStringTrait for GEOSLineString {
     type ItemType<'b> = GEOSPoint where Self: 'b;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn num_coords(&self) -> usize {
@@ -81,7 +85,11 @@ impl LineStringTrait for &GEOSLineString {
     type ItemType<'b> = GEOSPoint where Self: 'b;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn num_coords(&self) -> usize {
@@ -118,7 +126,11 @@ impl<'a> LineStringTrait for GEOSConstLineString<'a> {
     type ItemType<'c> = GEOSPoint where Self: 'c;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn num_coords(&self) -> usize {
@@ -136,7 +148,11 @@ impl<'a> LineStringTrait for &'a GEOSConstLineString<'a> {
     type ItemType<'c> = GEOSPoint where Self: 'c;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn num_coords(&self) -> usize {

--- a/src/io/geos/scalar/multilinestring.rs
+++ b/src/io/geos/scalar/multilinestring.rs
@@ -72,7 +72,11 @@ impl MultiLineStringTrait for GEOSMultiLineString {
     type ItemType<'a> = GEOSConstLineString<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn num_lines(&self) -> usize {

--- a/src/io/geos/scalar/multipoint.rs
+++ b/src/io/geos/scalar/multipoint.rs
@@ -57,12 +57,11 @@ impl MultiPointTrait for GEOSMultiPoint {
     type ItemType<'a> = GEOSConstPoint<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-                match self.0.get_coordinate_dimension().unwrap() {
+        match self.0.get_coordinate_dimension().unwrap() {
             geos::Dimensions::TwoD => 2,
             geos::Dimensions::ThreeD => 3,
             geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
         }
-
     }
 
     fn num_points(&self) -> usize {
@@ -80,12 +79,11 @@ impl MultiPointTrait for &GEOSMultiPoint {
     type ItemType<'a> = GEOSConstPoint<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-                match self.0.get_coordinate_dimension().unwrap() {
+        match self.0.get_coordinate_dimension().unwrap() {
             geos::Dimensions::TwoD => 2,
             geos::Dimensions::ThreeD => 3,
             geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
         }
-
     }
 
     fn num_points(&self) -> usize {

--- a/src/io/geos/scalar/multipoint.rs
+++ b/src/io/geos/scalar/multipoint.rs
@@ -57,7 +57,12 @@ impl MultiPointTrait for GEOSMultiPoint {
     type ItemType<'a> = GEOSConstPoint<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+                match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
+
     }
 
     fn num_points(&self) -> usize {
@@ -75,7 +80,12 @@ impl MultiPointTrait for &GEOSMultiPoint {
     type ItemType<'a> = GEOSConstPoint<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+                match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
+
     }
 
     fn num_points(&self) -> usize {

--- a/src/io/geos/scalar/multipolygon.rs
+++ b/src/io/geos/scalar/multipolygon.rs
@@ -55,7 +55,12 @@ impl MultiPolygonTrait for GEOSMultiPolygon {
     type ItemType<'a> = GEOSConstPolygon<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+                match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
+
     }
 
     fn num_polygons(&self) -> usize {

--- a/src/io/geos/scalar/multipolygon.rs
+++ b/src/io/geos/scalar/multipolygon.rs
@@ -55,12 +55,11 @@ impl MultiPolygonTrait for GEOSMultiPolygon {
     type ItemType<'a> = GEOSConstPolygon<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-                match self.0.get_coordinate_dimension().unwrap() {
+        match self.0.get_coordinate_dimension().unwrap() {
             geos::Dimensions::TwoD => 2,
             geos::Dimensions::ThreeD => 3,
             geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
         }
-
     }
 
     fn num_polygons(&self) -> usize {

--- a/src/io/geos/scalar/point.rs
+++ b/src/io/geos/scalar/point.rs
@@ -46,7 +46,11 @@ impl PointTrait for GEOSPoint {
     type T = f64;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -71,7 +75,11 @@ impl PointTrait for &GEOSPoint {
     type T = f64;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -96,7 +104,11 @@ impl CoordTrait for GEOSPoint {
     type T = f64;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -121,7 +133,11 @@ impl CoordTrait for &GEOSPoint {
     type T = f64;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -164,7 +180,11 @@ impl<'a> PointTrait for GEOSConstPoint<'a> {
     type T = f64;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -189,7 +209,11 @@ impl<'a> PointTrait for &GEOSConstPoint<'a> {
     type T = f64;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -214,7 +238,11 @@ impl<'a> CoordTrait for GEOSConstPoint<'a> {
     type T = f64;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -239,7 +267,11 @@ impl<'a> CoordTrait for &GEOSConstPoint<'a> {
     type T = f64;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
     }
 
     fn nth_unchecked(&self, n: usize) -> Self::T {

--- a/src/io/geos/scalar/polygon.rs
+++ b/src/io/geos/scalar/polygon.rs
@@ -83,7 +83,12 @@ impl PolygonTrait for GEOSPolygon {
     type ItemType<'a> = GEOSConstLinearRing<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+                match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
+
     }
 
     fn num_interiors(&self) -> usize {
@@ -131,7 +136,12 @@ impl<'a> PolygonTrait for GEOSConstPolygon<'a> {
     type ItemType<'c> = GEOSConstLinearRing< 'c> where Self: 'c;
 
     fn dim(&self) -> usize {
-        self.0.get_num_dimensions().unwrap()
+                match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
+
     }
 
     fn num_interiors(&self) -> usize {

--- a/src/io/geos/scalar/polygon.rs
+++ b/src/io/geos/scalar/polygon.rs
@@ -83,12 +83,11 @@ impl PolygonTrait for GEOSPolygon {
     type ItemType<'a> = GEOSConstLinearRing<'a> where Self: 'a;
 
     fn dim(&self) -> usize {
-                match self.0.get_coordinate_dimension().unwrap() {
+        match self.0.get_coordinate_dimension().unwrap() {
             geos::Dimensions::TwoD => 2,
             geos::Dimensions::ThreeD => 3,
             geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
         }
-
     }
 
     fn num_interiors(&self) -> usize {
@@ -136,12 +135,11 @@ impl<'a> PolygonTrait for GEOSConstPolygon<'a> {
     type ItemType<'c> = GEOSConstLinearRing< 'c> where Self: 'c;
 
     fn dim(&self) -> usize {
-                match self.0.get_coordinate_dimension().unwrap() {
+        match self.0.get_coordinate_dimension().unwrap() {
             geos::Dimensions::TwoD => 2,
             geos::Dimensions::ThreeD => 3,
             geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
         }
-
     }
 
     fn num_interiors(&self) -> usize {

--- a/src/io/geozero/array/linestring.rs
+++ b/src/io/geozero/array/linestring.rs
@@ -62,7 +62,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for LineStringBuilder<O, 2> {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_xy(x, y) }
+        unsafe { self.push_coord(&geo::Coord { x, y }) }
         Ok(())
     }
 

--- a/src/io/geozero/array/multilinestring.rs
+++ b/src/io/geozero/array/multilinestring.rs
@@ -63,7 +63,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for MultiLineStringBuilder<O, 2> {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_xy(x, y).unwrap() }
+        unsafe { self.push_coord(&geo::Coord { x, y }).unwrap() }
         Ok(())
     }
 

--- a/src/io/geozero/array/multipoint.rs
+++ b/src/io/geozero/array/multipoint.rs
@@ -56,7 +56,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for MultiPointBuilder<O, 2> {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_xy(x, y).unwrap() }
+        unsafe { self.push_coord(&geo::Coord { x, y }).unwrap() }
         Ok(())
     }
 

--- a/src/io/geozero/array/multipolygon.rs
+++ b/src/io/geozero/array/multipolygon.rs
@@ -63,7 +63,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for MultiPolygonBuilder<O, 2> {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_xy(x, y).unwrap() }
+        unsafe { self.push_coord(&geo::Coord { x, y }).unwrap() }
         Ok(())
     }
 

--- a/src/io/geozero/array/polygon.rs
+++ b/src/io/geozero/array/polygon.rs
@@ -62,7 +62,7 @@ impl<O: OffsetSizeTrait> GeomProcessor for PolygonBuilder<O, 2> {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_xy(x, y).unwrap() }
+        unsafe { self.push_coord(&geo::Coord { x, y }).unwrap() }
         Ok(())
     }
 

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -149,7 +149,8 @@ pub fn from_wkb<O: OffsetSizeTrait>(
     let wkb_objects: Vec<Option<crate::scalar::WKB<'_, O>>> = arr.iter().collect();
     match target_geo_data_type {
         Point(coord_type, Dimension::XY) => {
-            let builder = PointBuilder::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder =
+                PointBuilder::<2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         LineString(coord_type, Dimension::XY) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //! ```
 //! use geoarrow::array::PointBuilder;
-//! let mut builder = PointBuilder::new();
+//! let mut builder = PointBuilder::<2>::new();
 //! builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
 //! let array = builder.finish();
 //! ```

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -677,7 +677,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
     ///
-    /// let mut builder = PointBuilder::new();
+    /// let mut builder = PointBuilder::<2>::new();
     /// assert_eq!(builder.len(), 0);
     /// builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
     /// assert_eq!(builder.len(), 1);
@@ -691,7 +691,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
     ///
-    /// let mut builder = PointBuilder::new();
+    /// let mut builder = PointBuilder::<2>::new();
     /// assert!(builder.is_empty());
     /// builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
     /// assert!(!builder.is_empty());
@@ -791,7 +791,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::{GeometryArrayBuilder, GeometryArrayTrait}};
     ///
-    /// let mut builder = PointBuilder::new();
+    /// let mut builder = PointBuilder::<2>::new();
     /// builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
     /// let array = builder.finish();
     /// assert_eq!(array.len(), 1);


### PR DESCRIPTION
This extends builders to support 3d coordinates. 

Note that users still have to know in advance which dimensionality of array they want to create. So it isn't ideal for unknown-dimension input, but still an improvement.

This also fixes GEOS interop (I was previously using the incorrect GEOS function to see the number of dimensions)