### PR TITLE
Support z values in GEOS round trip

### DIFF
--- a/src/algorithm/native/eq.rs
+++ b/src/algorithm/native/eq.rs
@@ -11,14 +11,41 @@ pub fn coord_eq_allow_nan<T: CoordFloat>(
     left: &impl CoordTrait<T = T>,
     right: &impl CoordTrait<T = T>,
 ) -> bool {
+    let left_dim = left.dim();
+    if left_dim != right.dim() {
+        return false;
+    }
+
     // Specifically check for NaN because two points defined to be
     // TODO: in the future add an `is_empty` to the PointTrait and then you shouldn't check for
     // NaN manually
-    if left.x().is_nan() && right.x().is_nan() && left.y().is_nan() && right.y().is_nan() {
-        return true;
+    match left_dim {
+        2 => {
+            if left.x().is_nan() && right.x().is_nan() && left.y().is_nan() && right.y().is_nan() {
+                return true;
+            }
+        }
+        3 => {
+            if left.x().is_nan()
+                && right.x().is_nan()
+                && left.y().is_nan()
+                && right.y().is_nan()
+                && left.nth_unchecked(2).is_nan()
+                && right.nth_unchecked(2).is_nan()
+            {
+                return true;
+            }
+        }
+        _ => panic!(),
     }
 
-    left.x_y() == right.x_y()
+    for i in 0..left_dim {
+        if left.nth_unchecked(i) != right.nth_unchecked(i) {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[inline]
@@ -26,6 +53,10 @@ pub fn coord_eq<T: CoordFloat>(
     left: &impl CoordTrait<T = T>,
     right: &impl CoordTrait<T = T>,
 ) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     left.x_y() == right.x_y()
 }
 
@@ -35,16 +66,47 @@ pub fn point_eq<T: CoordFloat>(
     right: &impl PointTrait<T = T>,
     allow_nan_equal: bool,
 ) -> bool {
+    let left_dim = left.dim();
+    if left_dim != right.dim() {
+        return false;
+    }
+
     if allow_nan_equal {
         // Specifically check for NaN because two points defined to be
         // TODO: in the future add an `is_empty` to the PointTrait and then you shouldn't check for
         // NaN manually
-        if left.x().is_nan() && right.x().is_nan() && left.y().is_nan() && right.y().is_nan() {
-            return true;
+        match left_dim {
+            2 => {
+                if left.x().is_nan()
+                    && right.x().is_nan()
+                    && left.y().is_nan()
+                    && right.y().is_nan()
+                {
+                    return true;
+                }
+            }
+            3 => {
+                if left.x().is_nan()
+                    && right.x().is_nan()
+                    && left.y().is_nan()
+                    && right.y().is_nan()
+                    && left.nth_unchecked(2).is_nan()
+                    && right.nth_unchecked(2).is_nan()
+                {
+                    return true;
+                }
+            }
+            _ => panic!(),
         }
     }
 
-    left.x_y() == right.x_y()
+    for i in 0..left_dim {
+        if left.nth_unchecked(i) != right.nth_unchecked(i) {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[inline]
@@ -52,6 +114,10 @@ pub fn line_string_eq<T: CoordFloat>(
     left: &impl LineStringTrait<T = T>,
     right: &impl LineStringTrait<T = T>,
 ) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     if left.num_coords() != right.num_coords() {
         return false;
     }
@@ -70,6 +136,10 @@ pub fn polygon_eq<T: CoordFloat>(
     left: &impl PolygonTrait<T = T>,
     right: &impl PolygonTrait<T = T>,
 ) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     if left.num_interiors() != right.num_interiors() {
         return false;
     }
@@ -103,6 +173,10 @@ pub fn multi_point_eq<T: CoordFloat>(
     left: &impl MultiPointTrait<T = T>,
     right: &impl MultiPointTrait<T = T>,
 ) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     if left.num_points() != right.num_points() {
         return false;
     }
@@ -121,6 +195,10 @@ pub fn multi_line_string_eq<T: CoordFloat>(
     left: &impl MultiLineStringTrait<T = T>,
     right: &impl MultiLineStringTrait<T = T>,
 ) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     if left.num_lines() != right.num_lines() {
         return false;
     }
@@ -139,6 +217,10 @@ pub fn multi_polygon_eq<T: CoordFloat>(
     left: &impl MultiPolygonTrait<T = T>,
     right: &impl MultiPolygonTrait<T = T>,
 ) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     if left.num_polygons() != right.num_polygons() {
         return false;
     }
@@ -154,6 +236,10 @@ pub fn multi_polygon_eq<T: CoordFloat>(
 
 #[inline]
 pub fn rect_eq<T: CoordFloat>(left: &impl RectTrait<T = T>, right: &impl RectTrait<T = T>) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     if !coord_eq(&left.lower(), &right.lower()) {
         return false;
     }
@@ -170,6 +256,10 @@ pub fn geometry_eq<T: CoordFloat>(
     left: &impl GeometryTrait<T = T>,
     right: &impl GeometryTrait<T = T>,
 ) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     match (left.as_type(), right.as_type()) {
         (GeometryType::Point(l), GeometryType::Point(r)) => {
             if !point_eq(l, r, false) {
@@ -224,6 +314,10 @@ pub fn geometry_collection_eq<T: CoordFloat>(
     left: &impl GeometryCollectionTrait<T = T>,
     right: &impl GeometryCollectionTrait<T = T>,
 ) -> bool {
+    if left.dim() != right.dim() {
+        return false;
+    }
+
     if left.num_geometries() != right.num_geometries() {
         return false;
     }

--- a/src/io/geo/scalar.rs
+++ b/src/io/geo/scalar.rs
@@ -6,6 +6,8 @@ use crate::geo_traits::{
 };
 
 /// Convert any coordinate to a [`geo::Coord`].
+///
+/// Only the first two dimensions will be kept.
 pub fn coord_to_geo<T: CoordNum>(coord: &impl CoordTrait<T = T>) -> geo::Coord<T> {
     geo::Coord {
         x: coord.x(),
@@ -14,11 +16,15 @@ pub fn coord_to_geo<T: CoordNum>(coord: &impl CoordTrait<T = T>) -> geo::Coord<T
 }
 
 /// Convert any Point to a [`geo::Point`].
+///
+/// Only the first two dimensions will be kept.
 pub fn point_to_geo<T: CoordNum>(point: &impl PointTrait<T = T>) -> geo::Point<T> {
     geo::Point::new(point.x(), point.y())
 }
 
 /// Convert any LineString to a [`geo::LineString`].
+///
+/// Only the first two dimensions will be kept.
 pub fn line_string_to_geo<T: CoordNum>(
     line_string: &impl LineStringTrait<T = T>,
 ) -> geo::LineString<T> {
@@ -31,6 +37,8 @@ pub fn line_string_to_geo<T: CoordNum>(
 }
 
 /// Convert any Polygon to a [`geo::Polygon`].
+///
+/// Only the first two dimensions will be kept.
 pub fn polygon_to_geo<T: CoordNum>(polygon: &impl PolygonTrait<T = T>) -> geo::Polygon<T> {
     let exterior = line_string_to_geo(&polygon.exterior().unwrap());
     let interiors = polygon
@@ -41,6 +49,8 @@ pub fn polygon_to_geo<T: CoordNum>(polygon: &impl PolygonTrait<T = T>) -> geo::P
 }
 
 /// Convert any MultiPoint to a [`geo::MultiPoint`].
+///
+/// Only the first two dimensions will be kept.
 pub fn multi_point_to_geo<T: CoordNum>(
     multi_point: &impl MultiPointTrait<T = T>,
 ) -> geo::MultiPoint<T> {
@@ -53,6 +63,8 @@ pub fn multi_point_to_geo<T: CoordNum>(
 }
 
 /// Convert any MultiLineString to a [`geo::MultiLineString`].
+///
+/// Only the first two dimensions will be kept.
 pub fn multi_line_string_to_geo<T: CoordNum>(
     multi_line_string: &impl MultiLineStringTrait<T = T>,
 ) -> geo::MultiLineString<T> {
@@ -65,6 +77,8 @@ pub fn multi_line_string_to_geo<T: CoordNum>(
 }
 
 /// Convert any MultiPolygon to a [`geo::MultiPolygon`].
+///
+/// Only the first two dimensions will be kept.
 pub fn multi_polygon_to_geo<T: CoordNum>(
     multi_polygon: &impl MultiPolygonTrait<T = T>,
 ) -> geo::MultiPolygon<T> {
@@ -77,6 +91,8 @@ pub fn multi_polygon_to_geo<T: CoordNum>(
 }
 
 /// Convert any Rect to a [`geo::Rect`].
+///
+/// Only the first two dimensions will be kept.
 pub fn rect_to_geo<T: CoordNum>(rect: &impl RectTrait<T = T>) -> geo::Rect<T> {
     let c1 = coord_to_geo(&rect.lower());
     let c2 = coord_to_geo(&rect.upper());
@@ -84,6 +100,8 @@ pub fn rect_to_geo<T: CoordNum>(rect: &impl RectTrait<T = T>) -> geo::Rect<T> {
 }
 
 /// Convert any Geometry to a [`geo::Geometry`].
+///
+/// Only the first two dimensions will be kept.
 pub fn geometry_to_geo<T: CoordNum>(geometry: &impl GeometryTrait<T = T>) -> geo::Geometry<T> {
     match geometry.as_type() {
         GeometryType::Point(geom) => geo::Geometry::Point(point_to_geo(geom)),
@@ -102,6 +120,8 @@ pub fn geometry_to_geo<T: CoordNum>(geometry: &impl GeometryTrait<T = T>) -> geo
 }
 
 /// Convert any GeometryCollection to a [`geo::GeometryCollection`].
+///
+/// Only the first two dimensions will be kept.
 pub fn geometry_collection_to_geo<T: CoordNum>(
     geometry_collection: &impl GeometryCollectionTrait<T = T>,
 ) -> geo::GeometryCollection<T> {

--- a/src/io/geos/array/binary.rs
+++ b/src/io/geos/array/binary.rs
@@ -1,0 +1,24 @@
+use arrow::array::GenericBinaryBuilder;
+use arrow_array::OffsetSizeTrait;
+use geos::Geom;
+
+use crate::array::WKBArray;
+use crate::error::GeoArrowError;
+
+impl<O: OffsetSizeTrait> TryFrom<Vec<Option<geos::Geometry>>> for WKBArray<O> {
+    type Error = GeoArrowError;
+
+    fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
+        let mut builder = GenericBinaryBuilder::new();
+        for maybe_geom in value {
+            if let Some(geom) = maybe_geom {
+                let buf = geom.to_wkb()?;
+                builder.append_value(buf);
+            } else {
+                builder.append_null();
+            }
+        }
+
+        Ok(WKBArray::new(builder.finish(), Default::default()))
+    }
+}

--- a/src/io/geos/array/geometrycollection.rs
+++ b/src/io/geos/array/geometrycollection.rs
@@ -1,0 +1,30 @@
+use arrow_array::OffsetSizeTrait;
+
+use crate::array::{GeometryCollectionArray, GeometryCollectionBuilder};
+use crate::error::GeoArrowError;
+use crate::io::geos::scalar::GEOSGeometryCollection;
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>>
+    for GeometryCollectionBuilder<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
+        let geoms: Vec<GEOSGeometryCollection> = value
+            .into_iter()
+            .map(GEOSGeometryCollection::new_unchecked)
+            .collect();
+        Self::from_geometry_collections(&geoms, Default::default(), Default::default(), false)
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>>
+    for GeometryCollectionArray<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
+        let mutable_arr: GeometryCollectionBuilder<O, D> = value.try_into()?;
+        Ok(mutable_arr.into())
+    }
+}

--- a/src/io/geos/array/mixed.rs
+++ b/src/io/geos/array/mixed.rs
@@ -1,0 +1,25 @@
+use arrow_array::OffsetSizeTrait;
+
+use crate::array::{MixedGeometryArray, MixedGeometryBuilder};
+use crate::error::GeoArrowError;
+use crate::io::geos::scalar::GEOSGeometry;
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>>
+    for MixedGeometryBuilder<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
+        let geoms: Vec<GEOSGeometry> = value.into_iter().map(GEOSGeometry::new).collect();
+        Self::from_geometries(&geoms, Default::default(), Default::default(), false)
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>> for MixedGeometryArray<O, D> {
+    type Error = GeoArrowError;
+
+    fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
+        let mutable_arr: MixedGeometryBuilder<O, D> = value.try_into()?;
+        Ok(mutable_arr.into())
+    }
+}

--- a/src/io/geos/array/mod.rs
+++ b/src/io/geos/array/mod.rs
@@ -1,4 +1,7 @@
+mod binary;
+mod geometrycollection;
 mod linestring;
+mod mixed;
 mod multilinestring;
 mod multipoint;
 mod multipolygon;

--- a/src/io/geos/scalar/binary.rs
+++ b/src/io/geos/scalar/binary.rs
@@ -1,14 +1,6 @@
 use crate::scalar::WKB;
 use arrow_array::OffsetSizeTrait;
 
-impl<O: OffsetSizeTrait> TryFrom<WKB<'_, O>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(value: WKB<'_, O>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
-
 impl<'a, O: OffsetSizeTrait> TryFrom<&'a WKB<'_, O>> for geos::Geometry {
     type Error = geos::Error;
 

--- a/src/io/geos/scalar/coord/interleaved.rs
+++ b/src/io/geos/scalar/coord/interleaved.rs
@@ -6,6 +6,10 @@ impl<const D: usize> TryFrom<InterleavedCoordBuffer<D>> for CoordSeq {
     type Error = geos::Error;
 
     fn try_from(value: InterleavedCoordBuffer<D>) -> std::result::Result<Self, geos::Error> {
-        CoordSeq::new_from_buffer(&value.coords, value.len(), false, false)
+        match D {
+            2 => CoordSeq::new_from_buffer(&value.coords, value.len(), false, false),
+            3 => CoordSeq::new_from_buffer(&value.coords, value.len(), true, false),
+            _ => panic!(),
+        }
     }
 }

--- a/src/io/geos/scalar/coord/separated.rs
+++ b/src/io/geos/scalar/coord/separated.rs
@@ -5,6 +5,15 @@ impl<const D: usize> TryFrom<SeparatedCoordBuffer<D>> for CoordSeq {
     type Error = geos::Error;
 
     fn try_from(value: SeparatedCoordBuffer<D>) -> std::result::Result<Self, geos::Error> {
-        CoordSeq::new_from_arrays(&value.buffers[0], &value.buffers[1], None, None)
+        match D {
+            2 => CoordSeq::new_from_arrays(&value.buffers[0], &value.buffers[1], None, None),
+            3 => CoordSeq::new_from_arrays(
+                &value.buffers[0],
+                &value.buffers[1],
+                Some(&value.buffers[2]),
+                None,
+            ),
+            _ => panic!(),
+        }
     }
 }

--- a/src/io/geos/scalar/geometry.rs
+++ b/src/io/geos/scalar/geometry.rs
@@ -1,13 +1,15 @@
+use crate::geo_traits::{
+    CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait,
+    MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait,
+};
+use crate::io::geos::scalar::coord::GEOSConstCoord;
+use crate::io::geos::scalar::{
+    GEOSGeometryCollection, GEOSLineString, GEOSMultiLineString, GEOSMultiPoint, GEOSMultiPolygon,
+    GEOSPoint, GEOSPolygon,
+};
 use crate::scalar::Geometry;
 use arrow_array::OffsetSizeTrait;
-
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Geometry<'_, O, D>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(value: Geometry<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
+use geos::Geom;
 
 impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a Geometry<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
@@ -22,6 +24,110 @@ impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a Geometry<'_, O, D>> for
             Geometry::MultiPolygon(g) => g.try_into(),
             Geometry::GeometryCollection(g) => g.try_into(),
             Geometry::Rect(_g) => todo!(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum GEOSGeometry {
+    Point(GEOSPoint),
+    LineString(GEOSLineString),
+    Polygon(GEOSPolygon),
+    MultiPoint(GEOSMultiPoint),
+    MultiLineString(GEOSMultiLineString),
+    MultiPolygon(GEOSMultiPolygon),
+    GeometryCollection(GEOSGeometryCollection),
+}
+
+impl GEOSGeometry {
+    pub fn new(geom: geos::Geometry) -> Self {
+        match geom.geometry_type() {
+            geos::GeometryTypes::Point => Self::Point(GEOSPoint::new_unchecked(geom)),
+            geos::GeometryTypes::LineString => {
+                Self::LineString(GEOSLineString::new_unchecked(geom))
+            }
+            geos::GeometryTypes::Polygon => Self::Polygon(GEOSPolygon::new_unchecked(geom)),
+            geos::GeometryTypes::MultiPoint => {
+                Self::MultiPoint(GEOSMultiPoint::new_unchecked(geom))
+            }
+            geos::GeometryTypes::MultiLineString => {
+                Self::MultiLineString(GEOSMultiLineString::new_unchecked(geom))
+            }
+            geos::GeometryTypes::MultiPolygon => {
+                Self::MultiPolygon(GEOSMultiPolygon::new_unchecked(geom))
+            }
+            geos::GeometryTypes::GeometryCollection => {
+                Self::GeometryCollection(GEOSGeometryCollection::new_unchecked(geom))
+            }
+            geos::GeometryTypes::LinearRing => panic!("GEOS Linear ring not supported"),
+            geos::GeometryTypes::__Unknown(x) => panic!("Unknown geometry type {x}"),
+        }
+    }
+}
+
+pub struct GEOSRect {}
+
+impl RectTrait for GEOSRect {
+    type T = f64;
+    type ItemType<'a> = GEOSConstCoord;
+
+    fn dim(&self) -> usize {
+        todo!()
+    }
+
+    fn lower(&self) -> Self::ItemType<'_> {
+        todo!()
+    }
+
+    fn upper(&self) -> Self::ItemType<'_> {
+        todo!()
+    }
+}
+
+impl GeometryTrait for GEOSGeometry {
+    type T = f64;
+    type Point<'a> = GEOSPoint;
+    type LineString<'a> = GEOSLineString;
+    type Polygon<'a> = GEOSPolygon;
+    type MultiPoint<'a> = GEOSMultiPoint;
+    type MultiLineString<'a> = GEOSMultiLineString;
+    type MultiPolygon<'a> = GEOSMultiPolygon;
+    type GeometryCollection<'a> = GEOSGeometryCollection;
+    type Rect<'a> = GEOSRect;
+
+    fn dim(&self) -> usize {
+        match self {
+            Self::Point(g) => g.dim(),
+            Self::LineString(g) => g.dim(),
+            Self::Polygon(g) => g.dim(),
+            Self::MultiPoint(g) => g.dim(),
+            Self::MultiLineString(g) => g.dim(),
+            Self::MultiPolygon(g) => g.dim(),
+            Self::GeometryCollection(g) => g.dim(),
+        }
+    }
+
+    fn as_type(
+        &self,
+    ) -> crate::geo_traits::GeometryType<
+        '_,
+        GEOSPoint,
+        GEOSLineString,
+        GEOSPolygon,
+        GEOSMultiPoint,
+        GEOSMultiLineString,
+        GEOSMultiPolygon,
+        GEOSGeometryCollection,
+        Self::Rect<'_>,
+    > {
+        match self {
+            Self::Point(g) => crate::geo_traits::GeometryType::Point(g),
+            Self::LineString(g) => crate::geo_traits::GeometryType::LineString(g),
+            Self::Polygon(g) => crate::geo_traits::GeometryType::Polygon(g),
+            Self::MultiPoint(g) => crate::geo_traits::GeometryType::MultiPoint(g),
+            Self::MultiLineString(g) => crate::geo_traits::GeometryType::MultiLineString(g),
+            Self::MultiPolygon(g) => crate::geo_traits::GeometryType::MultiPolygon(g),
+            Self::GeometryCollection(g) => crate::geo_traits::GeometryType::GeometryCollection(g),
         }
     }
 }

--- a/src/io/geos/scalar/geometrycollection.rs
+++ b/src/io/geos/scalar/geometrycollection.rs
@@ -1,16 +1,8 @@
 use crate::geo_traits::GeometryCollectionTrait;
+use crate::io::geos::scalar::GEOSGeometry;
 use crate::scalar::GeometryCollection;
 use arrow_array::OffsetSizeTrait;
-
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollection<'_, O, D>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(
-        value: GeometryCollection<'_, O, D>,
-    ) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
+use geos::Geom;
 
 impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a GeometryCollection<'_, O, D>>
     for geos::Geometry
@@ -23,8 +15,39 @@ impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a GeometryCollection<'_, 
         geos::Geometry::create_geometry_collection(
             value
                 .geometries()
-                .map(|geometry| geometry.try_into())
+                .map(|geometry| (&geometry).try_into())
                 .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
         )
+    }
+}
+
+#[derive(Clone)]
+pub struct GEOSGeometryCollection(geos::Geometry);
+
+impl GEOSGeometryCollection {
+    pub fn new_unchecked(geom: geos::Geometry) -> Self {
+        Self(geom)
+    }
+}
+
+impl GeometryCollectionTrait for GEOSGeometryCollection {
+    type T = f64;
+    type ItemType<'a> = GEOSGeometry;
+
+    fn dim(&self) -> usize {
+        match self.0.get_coordinate_dimension().unwrap() {
+            geos::Dimensions::TwoD => 2,
+            geos::Dimensions::ThreeD => 3,
+            geos::Dimensions::Other(other) => panic!("Other dimensions not supported {other}"),
+        }
+    }
+
+    fn num_geometries(&self) -> usize {
+        self.0.get_num_geometries().unwrap()
+    }
+
+    unsafe fn geometry_unchecked(&self, _i: usize) -> Self::ItemType<'_> {
+        // self.0.get_geometry_n(n)
+        todo!()
     }
 }

--- a/src/io/geos/scalar/linestring.rs
+++ b/src/io/geos/scalar/linestring.rs
@@ -7,15 +7,6 @@ use crate::trait_::GeometryArraySelfMethods;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<LineString<'_, O, D>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(value: LineString<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
-
-// TODO: maybe this should use traits instead of a manual approach via coordbuffer?
 impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a LineString<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 

--- a/src/io/geos/scalar/mod.rs
+++ b/src/io/geos/scalar/mod.rs
@@ -10,6 +10,8 @@ mod multipolygon;
 mod point;
 mod polygon;
 
+pub use geometry::GEOSGeometry;
+pub use geometrycollection::GEOSGeometryCollection;
 pub use linearring::GEOSConstLinearRing;
 pub use linestring::{GEOSConstLineString, GEOSLineString};
 pub use multilinestring::GEOSMultiLineString;

--- a/src/io/geos/scalar/multilinestring.rs
+++ b/src/io/geos/scalar/multilinestring.rs
@@ -5,16 +5,6 @@ use crate::scalar::MultiLineString;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<MultiLineString<'_, O, D>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(
-        value: MultiLineString<'_, O, D>,
-    ) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiLineString<'_, O, D>>
     for geos::Geometry
 {
@@ -26,7 +16,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiLineString<'_, O, 
         geos::Geometry::create_multiline_string(
             value
                 .lines()
-                .map(|line| line.try_into())
+                .map(|line| (&line).try_into())
                 .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
         )
     }

--- a/src/io/geos/scalar/multipoint.rs
+++ b/src/io/geos/scalar/multipoint.rs
@@ -5,14 +5,6 @@ use crate::scalar::MultiPoint;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<MultiPoint<'_, O, D>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(value: MultiPoint<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiPoint<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 
@@ -22,7 +14,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiPoint<'_, O, D>> f
         geos::Geometry::create_multipoint(
             value
                 .points()
-                .map(|points| points.try_into())
+                .map(|point| (&point).try_into())
                 .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
         )
     }
@@ -95,43 +87,3 @@ impl MultiPointTrait for &GEOSMultiPoint {
         GEOSConstPoint::new_unchecked(point)
     }
 }
-
-// NOTE: the MultiPoint traits aren't implemented because get_geometry_n returns a ConstGeometry,
-// which then has _two_ lifetime parameters, and it looks like a total black hole to get that
-// working with these traits.
-
-// impl<'a> MultiPointTrait for GEOSMultiPoint<'a> {
-//     type T = f64;
-//     type ItemType = GEOSConstPoint<'a, 'a>;
-
-//     fn num_points(&self) -> usize {
-//         self.0.get_num_geometries().unwrap()
-//     }
-
-//     fn point(&self, i: usize) -> Option<Self::ItemType> {
-//         if i > (self.num_points()) {
-//             return None;
-//         }
-
-//         let point = self.0.get_geometry_n(i).unwrap();
-//         Some(GEOSConstPoint::new_unchecked(&point))
-//     }
-// }
-
-// impl<'a> MultiPointTrait for &GEOSMultiPoint<'a> {
-//     type T = f64;
-//     type ItemType = GEOSConstPoint<'a, 'a>;
-
-//     fn num_points(&self) -> usize {
-//         self.0.get_num_geometries().unwrap()
-//     }
-
-//     fn point(&self, i: usize) -> Option<Self::ItemType> {
-//         if i > (self.num_points()) {
-//             return None;
-//         }
-
-//         let point = self.0.get_geometry_n(i).unwrap();
-//         Some(GEOSConstPoint::new_unchecked(&point))
-//     }
-// }

--- a/src/io/geos/scalar/multipolygon.rs
+++ b/src/io/geos/scalar/multipolygon.rs
@@ -5,14 +5,6 @@ use crate::scalar::MultiPolygon;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<MultiPolygon<'_, O, D>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(value: MultiPolygon<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiPolygon<'_, O, D>>
     for geos::Geometry
 {
@@ -24,7 +16,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiPolygon<'_, O, D>>
         geos::Geometry::create_multipolygon(
             value
                 .polygons()
-                .map(|polygons| polygons.try_into())
+                .map(|polygon| (&polygon).try_into())
                 .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
         )
     }

--- a/src/io/geos/scalar/point.rs
+++ b/src/io/geos/scalar/point.rs
@@ -1,25 +1,32 @@
 use crate::error::{GeoArrowError, Result};
-use crate::geo_traits::{CoordTrait, PointTrait};
+use crate::geo_traits::PointTrait;
 use crate::scalar::Point;
 use geos::{CoordDimensions, CoordSeq, Geom, GeometryTypes};
-
-impl<const D: usize> TryFrom<Point<'_, D>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(value: Point<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
 
 impl<'a, const D: usize> TryFrom<&'a Point<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Point<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        let mut coord_seq = CoordSeq::new(1, CoordDimensions::TwoD)?;
-        coord_seq.set_x(0, PointTrait::x(&value))?;
-        coord_seq.set_y(0, PointTrait::y(&value))?;
+    fn try_from(point: &'a Point<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+        match point.dim() {
+            2 => {
+                let mut coord_seq = CoordSeq::new(1, CoordDimensions::TwoD)?;
+                coord_seq.set_x(0, point.x())?;
+                coord_seq.set_y(0, point.y())?;
 
-        geos::Geometry::create_point(coord_seq)
+                Ok(geos::Geometry::create_point(coord_seq)?)
+            }
+            3 => {
+                let mut coord_seq = CoordSeq::new(1, CoordDimensions::ThreeD)?;
+                coord_seq.set_x(0, point.x())?;
+                coord_seq.set_y(0, point.y())?;
+                coord_seq.set_z(0, point.nth(2).unwrap())?;
+
+                Ok(geos::Geometry::create_point(coord_seq)?)
+            }
+            _ => Err(geos::Error::GenericError(
+                "Unexpected dimension".to_string(),
+            )),
+        }
     }
 }
 
@@ -100,7 +107,7 @@ impl PointTrait for &GEOSPoint {
     }
 }
 
-impl CoordTrait for GEOSPoint {
+impl crate::geo_traits::CoordTrait for GEOSPoint {
     type T = f64;
 
     fn dim(&self) -> usize {
@@ -129,7 +136,7 @@ impl CoordTrait for GEOSPoint {
     }
 }
 
-impl CoordTrait for &GEOSPoint {
+impl crate::geo_traits::CoordTrait for &GEOSPoint {
     type T = f64;
 
     fn dim(&self) -> usize {
@@ -234,7 +241,7 @@ impl<'a> PointTrait for &GEOSConstPoint<'a> {
     }
 }
 
-impl<'a> CoordTrait for GEOSConstPoint<'a> {
+impl<'a> crate::geo_traits::CoordTrait for GEOSConstPoint<'a> {
     type T = f64;
 
     fn dim(&self) -> usize {
@@ -263,7 +270,7 @@ impl<'a> CoordTrait for GEOSConstPoint<'a> {
     }
 }
 
-impl<'a> CoordTrait for &GEOSConstPoint<'a> {
+impl<'a> crate::geo_traits::CoordTrait for &GEOSConstPoint<'a> {
     type T = f64;
 
     fn dim(&self) -> usize {
@@ -295,5 +302,31 @@ impl<'a> CoordTrait for &GEOSConstPoint<'a> {
 impl Clone for GEOSConstPoint<'_> {
     fn clone(&self) -> Self {
         todo!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::algorithm::native::eq::point_eq;
+    use crate::test::point;
+    use crate::trait_::GeometryArrayAccessor;
+
+    #[test]
+    fn round_trip_point() {
+        let arr = point::point_array();
+        let scalar = arr.value(0);
+        let geom = geos::Geometry::try_from(&scalar).unwrap();
+        let geos_pt = GEOSPoint::new_unchecked(geom);
+        assert!(point_eq(&scalar, &geos_pt, false))
+    }
+
+    #[test]
+    fn round_trip_point_z() {
+        let arr = point::point_z_array();
+        let scalar = arr.value(0);
+        let geom = geos::Geometry::try_from(&scalar).unwrap();
+        let geos_pt = GEOSPoint::new_unchecked(geom);
+        assert!(point_eq(&scalar, &geos_pt, false))
     }
 }

--- a/src/io/geos/scalar/polygon.rs
+++ b/src/io/geos/scalar/polygon.rs
@@ -5,14 +5,6 @@ use crate::scalar::Polygon;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Polygon<'_, O, D>> for geos::Geometry {
-    type Error = geos::Error;
-
-    fn try_from(value: Polygon<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::try_from(&value)
-    }
-}
-
 impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a Polygon<'_, O, D>> for geos::Geometry {
     type Error = geos::Error;
 


### PR DESCRIPTION
- Support 3d coordinates in geometry equality
- Support converting GEOS geometries to WKBArray, MixedGeometryArray, and ~~GeometryCollectionArray~~
- Support 3d coordinates in converting GeoArrow data to GEOS
- New GEOSGeometry and GEOSGeometryCollection structs, which can have GeometryTrait and GeometryCollectionTrait implemented on them.

Future work: 

- The geos `get_geometry_n` function returns a `ConstGeometry`, so we'd need a second set of structs to implement GeometryCollectionTrait on that

For https://github.com/geoarrow/geoarrow-rs/issues/662