### PR TITLE
Cleaner casting

### DIFF
--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow"
-version = "0.3.0-beta.2"
+version = "0.3.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/js/src/algorithm/geoarrow/coord_format.rs
+++ b/js/src/algorithm/geoarrow/coord_format.rs
@@ -1,5 +1,4 @@
 use crate::data::*;
-use geoarrow::trait_::GeometryArraySelfMethods;
 use geoarrow::GeometryArrayTrait;
 use wasm_bindgen::prelude::*;
 

--- a/src/algorithm/native/downcast.rs
+++ b/src/algorithm/native/downcast.rs
@@ -83,7 +83,7 @@ fn downcast_offsets<O: OffsetSizeTrait>(buffer: &OffsetBuffer<O>) -> OffsetBuffe
 /// Note that we can't just check the value of the last offset, because there could be a null
 /// element with length 0 and then a multi point of length 2. We need to check that every offset is
 /// <= 1.
-fn can_downcast_multi<O: OffsetSizeTrait>(buffer: &OffsetBuffer<O>) -> bool {
+pub(crate) fn can_downcast_multi<O: OffsetSizeTrait>(buffer: &OffsetBuffer<O>) -> bool {
     buffer
         .windows(2)
         .all(|slice| *slice.get(1).unwrap() - *slice.first().unwrap() <= O::one())

--- a/src/algorithm/native/mod.rs
+++ b/src/algorithm/native/mod.rs
@@ -7,7 +7,7 @@ mod binary;
 pub mod bounding_rect;
 mod cast;
 mod concatenate;
-mod downcast;
+pub(crate) mod downcast;
 pub(crate) mod eq;
 mod explode;
 mod map_chunks;

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -246,15 +246,6 @@ impl<const D: usize> TryFrom<&StructArray> for SeparatedCoordBuffer<D> {
         let buffers =
             core::array::from_fn(|i| arrays[i].as_primitive::<Float64Type>().values().clone());
         Ok(Self::new(buffers))
-        // let buffers = [ScalarBuffer::<f64>::from(vec![]); D];
-
-        // let x_array_values = arrays[0].as_any().downcast_ref::<Float64Array>().unwrap();
-        // let y_array_values = arrays[1].as_any().downcast_ref::<Float64Array>().unwrap();
-
-        // Ok(SeparatedCoordBuffer::new(
-        //     x_array_values.values().clone(),
-        //     y_array_values.values().clone(),
-        // ))
     }
 }
 

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -8,7 +8,10 @@ use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::geometrycollection::{GeometryCollectionBuilder, GeometryCollectionCapacity};
 use crate::array::metadata::ArrayMetadata;
 use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
-use crate::array::{CoordBuffer, CoordType, MixedGeometryArray, WKBArray};
+use crate::array::{
+    CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, MultiLineStringArray,
+    MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray,
+};
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::GeometryCollectionTrait;
@@ -408,5 +411,59 @@ impl<O: OffsetSizeTrait, const D: usize> PartialEq for GeometryCollectionArray<O
         }
 
         true
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<PointArray<D>> for GeometryCollectionArray<O, D> {
+    fn from(value: PointArray<D>) -> Self {
+        MixedGeometryArray::<O, D>::from(value).into()
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<LineStringArray<O, D>>
+    for GeometryCollectionArray<O, D>
+{
+    fn from(value: LineStringArray<O, D>) -> Self {
+        MixedGeometryArray::<O, D>::from(value).into()
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<PolygonArray<O, D>>
+    for GeometryCollectionArray<O, D>
+{
+    fn from(value: PolygonArray<O, D>) -> Self {
+        MixedGeometryArray::<O, D>::from(value).into()
+    }
+}
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPointArray<O, D>>
+    for GeometryCollectionArray<O, D>
+{
+    fn from(value: MultiPointArray<O, D>) -> Self {
+        MixedGeometryArray::<O, D>::from(value).into()
+    }
+}
+impl<O: OffsetSizeTrait, const D: usize> From<MultiLineStringArray<O, D>>
+    for GeometryCollectionArray<O, D>
+{
+    fn from(value: MultiLineStringArray<O, D>) -> Self {
+        MixedGeometryArray::<O, D>::from(value).into()
+    }
+}
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygonArray<O, D>>
+    for GeometryCollectionArray<O, D>
+{
+    fn from(value: MultiPolygonArray<O, D>) -> Self {
+        MixedGeometryArray::<O, D>::from(value).into()
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<MixedGeometryArray<O, D>>
+    for GeometryCollectionArray<O, D>
+{
+    // TODO: We should construct the correct validity buffer from the union's underlying arrays.
+    fn from(value: MixedGeometryArray<O, D>) -> Self {
+        let metadata = value.metadata.clone();
+        let geom_offsets = OffsetBuffer::from_lengths(vec![1; value.len()]);
+        GeometryCollectionArray::new(value, geom_offsets, None, metadata)
     }
 }

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -7,7 +7,10 @@ use arrow_schema::{DataType, Field};
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::geometrycollection::{GeometryCollectionBuilder, GeometryCollectionCapacity};
 use crate::array::metadata::ArrayMetadata;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
+use crate::array::util::{
+    offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32,
+    offsets_buffer_to_i64,
+};
 use crate::array::{
     CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, MultiLineStringArray,
     MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray,
@@ -128,6 +131,37 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionArray<O, D> {
 
     pub fn owned_slice(&self, _offset: usize, _length: usize) -> Self {
         todo!()
+    }
+
+    pub fn to_coord_type(&self, coord_type: CoordType) -> Self {
+        self.clone().into_coord_type(coord_type)
+    }
+
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        Self::new(
+            self.array.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.validity,
+            self.metadata,
+        )
+    }
+
+    pub fn to_small_offsets(&self) -> Result<GeometryCollectionArray<i32, D>> {
+        Ok(GeometryCollectionArray::new(
+            self.array.to_small_offsets()?,
+            offsets_buffer_to_i32(&self.geom_offsets)?,
+            self.validity.clone(),
+            self.metadata.clone(),
+        ))
+    }
+
+    pub fn to_large_offsets(&self) -> GeometryCollectionArray<i64, D> {
+        GeometryCollectionArray::new(
+            self.array.to_large_offsets(),
+            offsets_buffer_to_i64(&self.geom_offsets),
+            self.validity.clone(),
+            self.metadata.clone(),
+        )
     }
 }
 

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -10,7 +10,8 @@ use crate::array::util::{
     offsets_buffer_to_i64, OffsetBufferUtils,
 };
 use crate::array::{
-    CoordBuffer, CoordType, MixedGeometryArray, MultiLineStringArray, MultiPointArray, WKBArray,
+    CoordBuffer, CoordType, GeometryCollectionArray, MixedGeometryArray, MultiLineStringArray,
+    MultiPointArray, WKBArray,
 };
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
@@ -577,6 +578,16 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
             .iter()
             .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>>
+    for LineStringArray<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self> {
+        MixedGeometryArray::try_from(value)?.try_into()
     }
 }
 

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -222,6 +222,60 @@ impl<O: OffsetSizeTrait, const D: usize> MixedGeometryArray<O, D> {
         !self.multi_polygons.is_empty()
     }
 
+    pub fn has_only_points(&self) -> bool {
+        self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
+    }
+
+    pub fn has_only_line_strings(&self) -> bool {
+        !self.has_points()
+            && self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
+    }
+
+    pub fn has_only_polygons(&self) -> bool {
+        !self.has_points()
+            && !self.has_line_strings()
+            && self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
+    }
+
+    pub fn has_only_multi_points(&self) -> bool {
+        !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
+    }
+
+    pub fn has_only_multi_line_strings(&self) -> bool {
+        !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && self.has_multi_line_strings()
+            && !self.has_multi_polygons()
+    }
+
+    pub fn has_only_multi_polygons(&self) -> bool {
+        !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && self.has_multi_polygons()
+    }
+
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
         self.buffer_lengths().num_bytes::<O>()
@@ -259,6 +313,52 @@ impl<O: OffsetSizeTrait, const D: usize> MixedGeometryArray<O, D> {
 
     pub fn owned_slice(&self, _offset: usize, _length: usize) -> Self {
         todo!()
+    }
+
+    pub fn to_coord_type(&self, coord_type: CoordType) -> Self {
+        self.clone().into_coord_type(coord_type)
+    }
+
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        Self::new(
+            self.type_ids,
+            self.offsets,
+            self.points.into_coord_type(coord_type),
+            self.line_strings.into_coord_type(coord_type),
+            self.polygons.into_coord_type(coord_type),
+            self.multi_points.into_coord_type(coord_type),
+            self.multi_line_strings.into_coord_type(coord_type),
+            self.multi_polygons.into_coord_type(coord_type),
+            self.metadata,
+        )
+    }
+
+    pub fn to_small_offsets(&self) -> Result<MixedGeometryArray<i32, D>> {
+        Ok(MixedGeometryArray::<i32, D>::new(
+            self.type_ids.clone(),
+            self.offsets.clone(),
+            self.points.clone(),
+            self.line_strings.to_small_offsets()?,
+            self.polygons.to_small_offsets()?,
+            self.multi_points.to_small_offsets()?,
+            self.multi_line_strings.to_small_offsets()?,
+            self.multi_polygons.to_small_offsets()?,
+            self.metadata.clone(),
+        ))
+    }
+
+    pub fn to_large_offsets(&self) -> MixedGeometryArray<i64, D> {
+        MixedGeometryArray::<i64, D>::new(
+            self.type_ids.clone(),
+            self.offsets.clone(),
+            self.points.clone(),
+            self.line_strings.to_large_offsets(),
+            self.polygons.to_large_offsets(),
+            self.multi_points.to_large_offsets(),
+            self.multi_line_strings.to_large_offsets(),
+            self.multi_polygons.to_large_offsets(),
+            self.metadata.clone(),
+        )
     }
 }
 
@@ -741,6 +841,142 @@ impl<const D: usize> TryFrom<MixedGeometryArray<i64, D>> for MixedGeometryArray<
             value.multi_polygons.try_into()?,
             value.metadata,
         ))
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<PointArray<D>> for MixedGeometryArray<O, D> {
+    fn from(value: PointArray<D>) -> Self {
+        let type_ids = match D {
+            2 => vec![1; value.len()],
+            3 => vec![11; value.len()],
+            _ => panic!(),
+        };
+        let metadata = value.metadata.clone();
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            value,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            metadata,
+        )
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<LineStringArray<O, D>> for MixedGeometryArray<O, D> {
+    fn from(value: LineStringArray<O, D>) -> Self {
+        let type_ids = match D {
+            2 => vec![2; value.len()],
+            3 => vec![12; value.len()],
+            _ => panic!(),
+        };
+        let metadata = value.metadata.clone();
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            value,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            metadata,
+        )
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<PolygonArray<O, D>> for MixedGeometryArray<O, D> {
+    fn from(value: PolygonArray<O, D>) -> Self {
+        let type_ids = match D {
+            2 => vec![3; value.len()],
+            3 => vec![13; value.len()],
+            _ => panic!(),
+        };
+        let metadata = value.metadata.clone();
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            Default::default(),
+            value,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            metadata,
+        )
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPointArray<O, D>> for MixedGeometryArray<O, D> {
+    fn from(value: MultiPointArray<O, D>) -> Self {
+        let type_ids = match D {
+            2 => vec![4; value.len()],
+            3 => vec![14; value.len()],
+            _ => panic!(),
+        };
+        let metadata = value.metadata.clone();
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            value,
+            Default::default(),
+            Default::default(),
+            metadata,
+        )
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<MultiLineStringArray<O, D>>
+    for MixedGeometryArray<O, D>
+{
+    fn from(value: MultiLineStringArray<O, D>) -> Self {
+        let type_ids = match D {
+            2 => vec![5; value.len()],
+            3 => vec![15; value.len()],
+            _ => panic!(),
+        };
+        let metadata = value.metadata.clone();
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            value,
+            Default::default(),
+            metadata,
+        )
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygonArray<O, D>>
+    for MixedGeometryArray<O, D>
+{
+    fn from(value: MultiPolygonArray<O, D>) -> Self {
+        let type_ids = match D {
+            2 => vec![6; value.len()],
+            3 => vec![16; value.len()],
+            _ => panic!(),
+        };
+        let metadata = value.metadata.clone();
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            value,
+            metadata,
+        )
     }
 }
 

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -8,7 +8,8 @@ use crate::array::util::{
     offsets_buffer_to_i64, OffsetBufferUtils,
 };
 use crate::array::{
-    CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, PolygonArray, WKBArray,
+    CoordBuffer, CoordType, GeometryCollectionArray, LineStringArray, MixedGeometryArray,
+    PolygonArray, WKBArray,
 };
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
@@ -630,6 +631,16 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
             .iter()
             .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>>
+    for MultiLineStringArray<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self> {
+        MixedGeometryArray::try_from(value)?.try_into()
     }
 }
 

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -9,7 +9,8 @@ use crate::array::util::{
     offsets_buffer_to_i64, OffsetBufferUtils,
 };
 use crate::array::{
-    CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, PointArray, WKBArray,
+    CoordBuffer, CoordType, GeometryCollectionArray, LineStringArray, MixedGeometryArray,
+    PointArray, WKBArray,
 };
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
@@ -555,6 +556,16 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
             .iter()
             .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>>
+    for MultiPointArray<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self> {
+        MixedGeometryArray::try_from(value)?.try_into()
     }
 }
 

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -4,9 +4,13 @@ use super::MultiPointBuilder;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::multipoint::MultiPointCapacity;
-use crate::array::offset_builder::OffsetsBuilder;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, OffsetBufferUtils};
-use crate::array::{CoordBuffer, CoordType, LineStringArray, PointArray, WKBArray};
+use crate::array::util::{
+    offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32,
+    offsets_buffer_to_i64, OffsetBufferUtils,
+};
+use crate::array::{
+    CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, PointArray, WKBArray,
+};
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiPointTrait;
@@ -191,6 +195,37 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointArray<O, D> {
         let validity = owned_slice_validity(self.nulls(), offset, length);
 
         Self::new(coords, geom_offsets, validity, self.metadata())
+    }
+
+    pub fn to_coord_type(&self, coord_type: CoordType) -> Self {
+        self.clone().into_coord_type(coord_type)
+    }
+
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        Self::new(
+            self.coords.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.validity,
+            self.metadata,
+        )
+    }
+
+    pub fn to_small_offsets(&self) -> Result<MultiPointArray<i32, D>> {
+        Ok(MultiPointArray::new(
+            self.coords.clone(),
+            offsets_buffer_to_i32(&self.geom_offsets)?,
+            self.validity.clone(),
+            self.metadata.clone(),
+        ))
+    }
+
+    pub fn to_large_offsets(&self) -> MultiPointArray<i64, D> {
+        MultiPointArray::new(
+            self.coords.clone(),
+            offsets_buffer_to_i64(&self.geom_offsets),
+            self.validity.clone(),
+            self.metadata.clone(),
+        )
     }
 }
 
@@ -426,27 +461,12 @@ impl<O: OffsetSizeTrait, const D: usize> From<MultiPointArray<O, D>> for LineStr
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<PointArray<D>> for MultiPointArray<O, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: PointArray<D>) -> Result<Self> {
-        let geom_length = value.len();
-
+impl<O: OffsetSizeTrait, const D: usize> From<PointArray<D>> for MultiPointArray<O, D> {
+    fn from(value: PointArray<D>) -> Self {
         let coords = value.coords;
+        let geom_offsets = OffsetBuffer::from_lengths(vec![1; coords.len()]);
         let validity = value.validity;
-
-        // Create offsets that are all of length 1
-        let mut geom_offsets = OffsetsBuilder::with_capacity(geom_length);
-        for _ in 0..coords.len() {
-            geom_offsets.try_push_usize(1)?;
-        }
-
-        Ok(Self::new(
-            coords,
-            geom_offsets.into(),
-            validity,
-            value.metadata,
-        ))
+        Self::new(coords, geom_offsets, validity, value.metadata)
     }
 }
 
@@ -496,6 +516,45 @@ impl<O: OffsetSizeTrait, const D: usize> PartialEq for MultiPointArray<O, D> {
         }
 
         true
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
+    for MultiPointArray<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: MixedGeometryArray<O, D>) -> Result<Self> {
+        if value.has_line_strings()
+            || value.has_polygons()
+            || value.has_multi_line_strings()
+            || value.has_multi_polygons()
+        {
+            return Err(GeoArrowError::General("Unable to cast".to_string()));
+        }
+
+        if value.has_only_points() {
+            return Ok(value.points.into());
+        }
+
+        if value.has_only_multi_points() {
+            return Ok(value.multi_points);
+        }
+
+        let mut capacity = value.multi_points.buffer_lengths();
+        // Hack: move to newtype
+        capacity.coord_capacity += value.points.buffer_lengths();
+        capacity.geom_capacity += value.points.buffer_lengths();
+
+        let mut builder = MultiPointBuilder::<O, D>::with_capacity_and_options(
+            capacity,
+            value.coord_type(),
+            value.metadata(),
+        );
+        value
+            .iter()
+            .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
+        Ok(builder.finish())
     }
 }
 

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -7,7 +7,9 @@ use crate::array::util::{
     offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32,
     offsets_buffer_to_i64, OffsetBufferUtils,
 };
-use crate::array::{CoordBuffer, CoordType, MixedGeometryArray, PolygonArray, WKBArray};
+use crate::array::{
+    CoordBuffer, CoordType, GeometryCollectionArray, MixedGeometryArray, PolygonArray, WKBArray,
+};
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiPolygonTrait;
@@ -712,6 +714,16 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
             .iter()
             .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>>
+    for MultiPolygonArray<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self> {
+        MixedGeometryArray::try_from(value)?.try_into()
     }
 }
 

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -3,9 +3,11 @@ use std::sync::Arc;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::multipolygon::MultiPolygonCapacity;
-use crate::array::offset_builder::OffsetsBuilder;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, OffsetBufferUtils};
-use crate::array::{CoordBuffer, CoordType, PolygonArray, WKBArray};
+use crate::array::util::{
+    offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32,
+    offsets_buffer_to_i64, OffsetBufferUtils,
+};
+use crate::array::{CoordBuffer, CoordType, MixedGeometryArray, PolygonArray, WKBArray};
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiPolygonTrait;
@@ -292,6 +294,43 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
             self.metadata(),
         )
     }
+
+    pub fn to_coord_type(&self, coord_type: CoordType) -> Self {
+        self.clone().into_coord_type(coord_type)
+    }
+
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        Self::new(
+            self.coords.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.polygon_offsets,
+            self.ring_offsets,
+            self.validity,
+            self.metadata,
+        )
+    }
+
+    pub fn to_small_offsets(&self) -> Result<MultiPolygonArray<i32, D>> {
+        Ok(MultiPolygonArray::new(
+            self.coords.clone(),
+            offsets_buffer_to_i32(&self.geom_offsets)?,
+            offsets_buffer_to_i32(&self.polygon_offsets)?,
+            offsets_buffer_to_i32(&self.ring_offsets)?,
+            self.validity.clone(),
+            self.metadata.clone(),
+        ))
+    }
+
+    pub fn to_large_offsets(&self) -> MultiPolygonArray<i64, D> {
+        MultiPolygonArray::new(
+            self.coords.clone(),
+            offsets_buffer_to_i64(&self.geom_offsets),
+            offsets_buffer_to_i64(&self.polygon_offsets),
+            offsets_buffer_to_i64(&self.ring_offsets),
+            self.validity.clone(),
+            self.metadata.clone(),
+        )
+    }
 }
 
 impl<O: OffsetSizeTrait, const D: usize> GeometryArrayTrait for MultiPolygonArray<O, D> {
@@ -560,31 +599,21 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPolygonAr
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<PolygonArray<O, D>> for MultiPolygonArray<O, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: PolygonArray<O, D>) -> Result<Self> {
-        let geom_length = value.len();
-
+impl<O: OffsetSizeTrait, const D: usize> From<PolygonArray<O, D>> for MultiPolygonArray<O, D> {
+    fn from(value: PolygonArray<O, D>) -> Self {
         let coords = value.coords;
+        let geom_offsets = OffsetBuffer::from_lengths(vec![1; coords.len()]);
         let ring_offsets = value.ring_offsets;
         let polygon_offsets = value.geom_offsets;
         let validity = value.validity;
-
-        // Create offsets that are all of length 1
-        let mut geom_offsets = OffsetsBuilder::with_capacity(geom_length);
-        for _ in 0..coords.len() {
-            geom_offsets.try_push_usize(1)?;
-        }
-
-        Ok(Self::new(
+        Self::new(
             coords,
-            geom_offsets.into(),
+            geom_offsets,
             polygon_offsets,
             ring_offsets,
             validity,
             value.metadata,
-        ))
+        )
     }
 }
 
@@ -646,6 +675,43 @@ impl<O: OffsetSizeTrait, const D: usize> PartialEq for MultiPolygonArray<O, D> {
         }
 
         true
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
+    for MultiPolygonArray<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: MixedGeometryArray<O, D>) -> Result<Self> {
+        if value.has_points()
+            || value.has_line_strings()
+            || value.has_multi_points()
+            || value.has_multi_line_strings()
+        {
+            return Err(GeoArrowError::General("Unable to cast".to_string()));
+        }
+
+        if value.has_only_polygons() {
+            return Ok(value.polygons.into());
+        }
+
+        if value.has_only_multi_polygons() {
+            return Ok(value.multi_polygons);
+        }
+
+        let mut capacity = value.multi_polygons.buffer_lengths();
+        capacity += value.polygons.buffer_lengths();
+
+        let mut builder = MultiPolygonBuilder::<O, D>::with_capacity_and_options(
+            capacity,
+            value.coord_type(),
+            value.metadata(),
+        );
+        value
+            .iter()
+            .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
+        Ok(builder.finish())
     }
 }
 

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -4,8 +4,8 @@ use crate::algorithm::native::downcast::can_downcast_multi;
 use crate::algorithm::native::eq::coord_eq_allow_nan;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::{
-    CoordBuffer, CoordType, InterleavedCoordBuffer, MixedGeometryArray, MultiPointArray,
-    PointBuilder, SeparatedCoordBuffer, WKBArray,
+    CoordBuffer, CoordType, GeometryCollectionArray, InterleavedCoordBuffer, MixedGeometryArray,
+    MultiPointArray, PointBuilder, SeparatedCoordBuffer, WKBArray,
 };
 use crate::datatypes::GeoDataType;
 use crate::error::GeoArrowError;
@@ -427,6 +427,14 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>> for P
             .iter()
             .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>> for PointArray<D> {
+    type Error = GeoArrowError;
+
+    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self, Self::Error> {
+        MixedGeometryArray::try_from(value)?.try_into()
     }
 }
 

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -1,10 +1,17 @@
 use std::sync::Arc;
 
+use crate::algorithm::native::downcast::can_downcast_multi;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::polygon::PolygonCapacity;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, OffsetBufferUtils};
-use crate::array::{CoordBuffer, CoordType, MultiLineStringArray, RectArray, WKBArray};
+use crate::array::util::{
+    offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32,
+    offsets_buffer_to_i64, OffsetBufferUtils,
+};
+use crate::array::{
+    CoordBuffer, CoordType, MixedGeometryArray, MultiLineStringArray, MultiPolygonArray, RectArray,
+    WKBArray,
+};
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::PolygonTrait;
@@ -226,6 +233,40 @@ impl<O: OffsetSizeTrait, const D: usize> PolygonArray<O, D> {
             geom_offsets,
             ring_offsets,
             validity,
+            self.metadata.clone(),
+        )
+    }
+
+    pub fn to_coord_type(&self, coord_type: CoordType) -> Self {
+        self.clone().into_coord_type(coord_type)
+    }
+
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        Self::new(
+            self.coords.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.ring_offsets,
+            self.validity,
+            self.metadata,
+        )
+    }
+
+    pub fn to_small_offsets(&self) -> Result<PolygonArray<i32, D>> {
+        Ok(PolygonArray::new(
+            self.coords.clone(),
+            offsets_buffer_to_i32(&self.geom_offsets)?,
+            offsets_buffer_to_i32(&self.ring_offsets)?,
+            self.validity.clone(),
+            self.metadata.clone(),
+        ))
+    }
+
+    pub fn to_large_offsets(&self) -> PolygonArray<i64, D> {
+        PolygonArray::new(
+            self.coords.clone(),
+            offsets_buffer_to_i64(&self.geom_offsets),
+            offsets_buffer_to_i64(&self.ring_offsets),
+            self.validity.clone(),
             self.metadata.clone(),
         )
     }
@@ -564,6 +605,62 @@ impl<O: OffsetSizeTrait, const D: usize> PartialEq for PolygonArray<O, D> {
         }
 
         true
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<MultiPolygonArray<O, D>> for PolygonArray<O, D> {
+    type Error = GeoArrowError;
+
+    fn try_from(value: MultiPolygonArray<O, D>) -> Result<Self> {
+        if !can_downcast_multi(&value.geom_offsets) {
+            return Err(GeoArrowError::General("Unable to cast".to_string()));
+        }
+
+        Ok(PolygonArray::new(
+            value.coords,
+            value.polygon_offsets,
+            value.ring_offsets,
+            value.validity,
+            value.metadata,
+        ))
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>> for PolygonArray<O, D> {
+    type Error = GeoArrowError;
+
+    fn try_from(value: MixedGeometryArray<O, D>) -> Result<Self> {
+        if value.has_points()
+            || value.has_line_strings()
+            || value.has_multi_points()
+            || value.has_multi_line_strings()
+        {
+            return Err(GeoArrowError::General("Unable to cast".to_string()));
+        }
+
+        if value.has_only_polygons() {
+            return Ok(value.polygons);
+        }
+
+        if value.has_only_multi_polygons() {
+            return value.multi_polygons.try_into();
+        }
+
+        let mut capacity = value.polygons.buffer_lengths();
+        let buffer_lengths = value.multi_polygons.buffer_lengths();
+        capacity.coord_capacity += buffer_lengths.coord_capacity;
+        capacity.ring_capacity += buffer_lengths.ring_capacity;
+        capacity.geom_capacity += buffer_lengths.polygon_capacity;
+
+        let mut builder = PolygonBuilder::<O, D>::with_capacity_and_options(
+            capacity,
+            value.coord_type(),
+            value.metadata(),
+        );
+        value
+            .iter()
+            .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
+        Ok(builder.finish())
     }
 }
 

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -9,8 +9,8 @@ use crate::array::util::{
     offsets_buffer_to_i64, OffsetBufferUtils,
 };
 use crate::array::{
-    CoordBuffer, CoordType, MixedGeometryArray, MultiLineStringArray, MultiPolygonArray, RectArray,
-    WKBArray,
+    CoordBuffer, CoordType, GeometryCollectionArray, MixedGeometryArray, MultiLineStringArray,
+    MultiPolygonArray, RectArray, WKBArray,
 };
 use crate::datatypes::GeoDataType;
 use crate::error::{GeoArrowError, Result};
@@ -661,6 +661,16 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>> for P
             .iter()
             .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
+    }
+}
+
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>>
+    for PolygonArray<O, D>
+{
+    type Error = GeoArrowError;
+
+    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self> {
+        MixedGeometryArray::try_from(value)?.try_into()
     }
 }
 

--- a/src/array/util.rs
+++ b/src/array/util.rs
@@ -19,6 +19,30 @@ pub(crate) fn offsets_buffer_i64_to_i32(offsets: &OffsetBuffer<i64>) -> Result<O
     Ok(unsafe { OffsetBuffer::new_unchecked(i32_offsets.into()) })
 }
 
+pub(crate) fn offsets_buffer_to_i64<O: OffsetSizeTrait>(
+    offsets: &OffsetBuffer<O>,
+) -> OffsetBuffer<i64> {
+    let i64_offsets = offsets
+        .iter()
+        .map(|x| x.to_i64().unwrap())
+        .collect::<Vec<_>>();
+    unsafe { OffsetBuffer::new_unchecked(i64_offsets.into()) }
+}
+
+pub(crate) fn offsets_buffer_to_i32<O: OffsetSizeTrait>(
+    offsets: &OffsetBuffer<O>,
+) -> Result<OffsetBuffer<i32>> {
+    // TODO: raise nicer error. Ref:
+    // https://github.com/jorgecarleitao/arrow2/blob/6a4b53169a48cbd234cecde6ab6a98f84146fca2/src/offset.rs#L492
+    i32::try_from(offsets.last().as_usize()).unwrap();
+
+    let i32_offsets = offsets
+        .iter()
+        .map(|x| x.to_usize().unwrap() as i32)
+        .collect::<Vec<_>>();
+    Ok(unsafe { OffsetBuffer::new_unchecked(i32_offsets.into()) })
+}
+
 /// Returns an iterator with the lengths of the offsets
 #[inline]
 pub(crate) fn offset_lengths<O: OffsetSizeTrait>(


### PR DESCRIPTION
### Change list 

- Don't use builders for simple casts (this should be faster)
- Direct `From` and `TryFrom` implementations