### PR TITLE
Make `WKBType` public

### DIFF
--- a/src/io/wkb/mod.rs
+++ b/src/io/wkb/mod.rs
@@ -1,8 +1,9 @@
 //! An optimized implementation of reading and writing ISO-flavored WKB-encoded geometries.
 
 mod api;
-pub(crate) mod common;
+mod common;
 pub(crate) mod reader;
 pub(crate) mod writer;
 
 pub use api::{from_wkb, to_wkb, FromWKB, ToWKB};
+pub use common::WKBType;


### PR DESCRIPTION
This makes `get_wkb_geometry_type` usable.