### PR TITLE
Use geo-traits for parsing WKT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "wkt 0.11.0",
 ]
 
 [[package]]
@@ -1308,7 +1309,7 @@ dependencies = [
  "geos-sys",
  "libc",
  "num",
- "wkt",
+ "wkt 0.10.3",
 ]
 
 [[package]]
@@ -1335,7 +1336,7 @@ dependencies = [
  "scroll",
  "serde_json",
  "thiserror",
- "wkt",
+ "wkt 0.10.3",
 ]
 
 [[package]]
@@ -4138,6 +4139,18 @@ name = "wkt"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c2252781f8927974e8ba6a67c965a759a2b88ea2b1825f6862426bbb1c8f41"
+dependencies = [
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "wkt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296937617013271141d1145d9c05861f5ed3b1bc4297e81c692aa3cff9270a9c"
 dependencies = [
  "geo-types",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ sqlx = { version = "0.7", optional = true, default-features = false, features = 
 ] }
 thiserror = "1"
 tokio = { version = "1", default-features = false, optional = true }
+wkt = "0.11"
 
 
 [dev-dependencies]

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1054,6 +1054,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "wkt 0.11.0",
 ]
 
 [[package]]
@@ -1153,7 +1154,7 @@ dependencies = [
  "scroll",
  "serde_json",
  "thiserror",
- "wkt",
+ "wkt 0.10.3",
 ]
 
 [[package]]
@@ -3990,6 +3991,18 @@ name = "wkt"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c2252781f8927974e8ba6a67c965a759a2b88ea2b1825f6862426bbb1c8f41"
+dependencies = [
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "wkt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296937617013271141d1145d9c05861f5ed3b1bc4297e81c692aa3cff9270a9c"
 dependencies = [
  "geo-types",
  "log",

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -27,5 +27,6 @@ pub mod parquet;
 pub mod postgis;
 mod stream;
 pub mod wkb;
+pub mod wkt;
 
 pub use stream::RecordBatchReader;

--- a/src/io/wkt/mod.rs
+++ b/src/io/wkt/mod.rs
@@ -1,0 +1,1 @@
+pub mod reader;

--- a/src/io/wkt/reader/mod.rs
+++ b/src/io/wkt/reader/mod.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
-use arrow_array::{Array, ArrayRef, GenericStringArray, OffsetSizeTrait};
+use arrow_array::{Array, GenericStringArray, OffsetSizeTrait};
 
 use crate::array::metadata::ArrayMetadata;
 use crate::array::{CoordType, MixedGeometryBuilder};
@@ -9,6 +9,7 @@ use crate::NativeArray;
 
 mod wkt_trait;
 
+// TODO: refactor this trait implementation once a WKTArray exists
 pub trait ParseWKT {
     type Output;
 

--- a/src/io/wkt/reader/mod.rs
+++ b/src/io/wkt/reader/mod.rs
@@ -1,0 +1,33 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use arrow_array::{Array, ArrayRef, GenericStringArray, OffsetSizeTrait};
+
+use crate::array::metadata::ArrayMetadata;
+use crate::array::{CoordType, MixedGeometryBuilder};
+use crate::NativeArray;
+
+mod wkt_trait;
+
+pub trait ParseWKT {
+    type Output;
+
+    fn parse_wkt(&self, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self::Output;
+}
+
+impl<O: OffsetSizeTrait> ParseWKT for GenericStringArray<O> {
+    type Output = Arc<dyn NativeArray>;
+
+    fn parse_wkt(&self, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self::Output {
+        let mut builder = MixedGeometryBuilder::<O, 2>::new_with_options(coord_type, metadata);
+        for i in 0..self.len() {
+            if self.is_valid(i) {
+                let w = wkt::Wkt::<f64>::from_str(self.value(i)).unwrap();
+                builder.push_geometry(Some(&w)).unwrap();
+            } else {
+                builder.push_null();
+            }
+        }
+        Arc::new(builder.finish())
+    }
+}

--- a/src/io/wkt/reader/wkt_trait.rs
+++ b/src/io/wkt/reader/wkt_trait.rs
@@ -1,0 +1,449 @@
+use std::marker::PhantomData;
+
+use wkt::WktNum;
+
+use crate::geo_traits::{
+    CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait,
+    MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait, RectTrait,
+};
+
+impl<T: WktNum> CoordTrait for wkt::types::Coord<T> {
+    type T = T;
+
+    fn dim(&self) -> usize {
+        let mut dim = 2;
+        if self.z.is_some() {
+            dim += 1;
+        }
+        if self.m.is_some() {
+            dim += 1;
+        }
+        dim
+    }
+
+    fn x(&self) -> Self::T {
+        self.x
+    }
+
+    fn y(&self) -> Self::T {
+        self.y
+    }
+
+    fn nth_unchecked(&self, n: usize) -> Self::T {
+        let has_z = self.z.is_some();
+        let has_m = self.m.is_some();
+        match n {
+            0 => self.x,
+            1 => self.y,
+            2 => {
+                if has_z {
+                    self.z.unwrap()
+                } else if has_m {
+                    self.m.unwrap()
+                } else {
+                    panic!("n out of range")
+                }
+            }
+            3 => {
+                if has_z && has_m {
+                    self.m.unwrap()
+                } else {
+                    panic!("n out of range")
+                }
+            }
+            _ => panic!("n out of range"),
+        }
+    }
+}
+
+impl<'a, T: WktNum> CoordTrait for &'a wkt::types::Coord<T> {
+    type T = T;
+
+    fn dim(&self) -> usize {
+        let mut dim = 2;
+        if self.z.is_some() {
+            dim += 1;
+        }
+        if self.m.is_some() {
+            dim += 1;
+        }
+        dim
+    }
+
+    fn x(&self) -> Self::T {
+        self.x
+    }
+
+    fn y(&self) -> Self::T {
+        self.y
+    }
+
+    fn nth_unchecked(&self, n: usize) -> Self::T {
+        let has_z = self.z.is_some();
+        let has_m = self.m.is_some();
+        match n {
+            0 => self.x,
+            1 => self.y,
+            2 => {
+                if has_z {
+                    self.z.unwrap()
+                } else if has_m {
+                    self.m.unwrap()
+                } else {
+                    panic!("n out of range")
+                }
+            }
+            3 => {
+                if has_z && has_m {
+                    self.m.unwrap()
+                } else {
+                    panic!("n out of range")
+                }
+            }
+            _ => panic!("n out of range"),
+        }
+    }
+}
+
+impl<T: WktNum> PointTrait for wkt::types::Point<T> {
+    type T = T;
+
+    fn dim(&self) -> usize {
+        self.0.as_ref().unwrap().dim()
+    }
+
+    fn x(&self) -> Self::T {
+        self.0.as_ref().unwrap().x()
+    }
+
+    fn y(&self) -> Self::T {
+        self.0.as_ref().unwrap().y()
+    }
+
+    fn nth_unchecked(&self, n: usize) -> Self::T {
+        self.0.as_ref().unwrap().nth_unchecked(n)
+    }
+}
+
+impl<'a, T: WktNum> PointTrait for &'a wkt::types::Point<T> {
+    type T = T;
+
+    fn dim(&self) -> usize {
+        self.0.as_ref().unwrap().dim()
+    }
+
+    fn x(&self) -> Self::T {
+        self.0.as_ref().unwrap().x()
+    }
+
+    fn y(&self) -> Self::T {
+        self.0.as_ref().unwrap().y()
+    }
+
+    fn nth_unchecked(&self, n: usize) -> Self::T {
+        self.0.as_ref().unwrap().nth_unchecked(n)
+    }
+}
+
+impl<T: WktNum> LineStringTrait for wkt::types::LineString<T> {
+    type T = T;
+    type ItemType<'a> = &'a wkt::types::Coord<T> where Self: 'a;
+
+    fn dim(&self) -> usize {
+        if self.0.is_empty() {
+            2
+        } else {
+            self.0[0].dim()
+        }
+    }
+
+    fn num_coords(&self) -> usize {
+        self.0.len()
+    }
+
+    unsafe fn coord_unchecked(&self, i: usize) -> Self::ItemType<'_> {
+        &self.0[i]
+    }
+}
+
+impl<'a, T: WktNum> LineStringTrait for &'a wkt::types::LineString<T> {
+    type T = T;
+    type ItemType<'b> = &'b wkt::types::Coord<T> where Self: 'b;
+
+    fn dim(&self) -> usize {
+        if self.0.is_empty() {
+            2
+        } else {
+            self.0[0].dim()
+        }
+    }
+
+    fn num_coords(&self) -> usize {
+        self.0.len()
+    }
+
+    unsafe fn coord_unchecked(&self, i: usize) -> Self::ItemType<'_> {
+        &self.0[i]
+    }
+}
+
+impl<T: WktNum> PolygonTrait for wkt::types::Polygon<T> {
+    type T = T;
+    type ItemType<'a> = &'a wkt::types::LineString<T> where Self: 'a;
+
+    fn dim(&self) -> usize {
+        if self.0.is_empty() {
+            2
+        } else {
+            self.0[0].dim()
+        }
+    }
+
+    fn exterior(&self) -> Option<Self::ItemType<'_>> {
+        self.0.first()
+    }
+
+    fn num_interiors(&self) -> usize {
+        self.0.len().saturating_sub(1)
+    }
+
+    unsafe fn interior_unchecked(&self, i: usize) -> Self::ItemType<'_> {
+        &self.0[i + 1]
+    }
+}
+
+impl<'a, T: WktNum> PolygonTrait for &'a wkt::types::Polygon<T> {
+    type T = T;
+    type ItemType<'b> = &'b wkt::types::LineString<T> where Self: 'b;
+
+    fn dim(&self) -> usize {
+        if self.0.is_empty() {
+            2
+        } else {
+            self.0[0].dim()
+        }
+    }
+
+    fn exterior(&self) -> Option<Self::ItemType<'_>> {
+        self.0.first()
+    }
+
+    fn num_interiors(&self) -> usize {
+        self.0.len().saturating_sub(1)
+    }
+
+    unsafe fn interior_unchecked(&self, i: usize) -> Self::ItemType<'_> {
+        &self.0[i + 1]
+    }
+}
+
+impl<T: WktNum> MultiPointTrait for wkt::types::MultiPoint<T> {
+    type T = T;
+    type ItemType<'a> = &'a wkt::types::Point<T> where Self: 'a;
+
+    fn dim(&self) -> usize {
+        if self.0.is_empty() {
+            2
+        } else {
+            self.0[0].dim()
+        }
+    }
+
+    fn num_points(&self) -> usize {
+        self.0.len()
+    }
+
+    unsafe fn point_unchecked(&self, i: usize) -> Self::ItemType<'_> {
+        &self.0[i]
+    }
+}
+
+impl<T: WktNum> MultiLineStringTrait for wkt::types::MultiLineString<T> {
+    type T = T;
+    type ItemType<'a> = &'a wkt::types::LineString<T> where Self: 'a;
+
+    fn dim(&self) -> usize {
+        if self.0.is_empty() {
+            2
+        } else {
+            self.0[0].dim()
+        }
+    }
+
+    fn num_lines(&self) -> usize {
+        self.0.len()
+    }
+
+    unsafe fn line_unchecked(&self, i: usize) -> Self::ItemType<'_> {
+        &self.0[i]
+    }
+}
+
+impl<T: WktNum> MultiPolygonTrait for wkt::types::MultiPolygon<T> {
+    type T = T;
+    type ItemType<'a> = &'a wkt::types::Polygon<T> where Self: 'a;
+
+    fn dim(&self) -> usize {
+        if self.0.is_empty() {
+            2
+        } else {
+            self.0[0].dim()
+        }
+    }
+
+    fn num_polygons(&self) -> usize {
+        self.0.len()
+    }
+
+    unsafe fn polygon_unchecked(&self, i: usize) -> Self::ItemType<'_> {
+        &self.0[i]
+    }
+}
+
+impl<T: WktNum> GeometryTrait for wkt::Wkt<T> {
+    type T = T;
+    type Point<'b> =  wkt::types::Point<T> where Self: 'b;
+    type LineString<'b> =  wkt::types::LineString<T> where Self: 'b;
+    type Polygon<'b> =  wkt::types::Polygon<T> where Self: 'b;
+    type MultiPoint<'b> =  wkt::types::MultiPoint<T> where Self: 'b;
+    type MultiLineString<'b> =  wkt::types::MultiLineString<T> where Self: 'b;
+    type MultiPolygon<'b> =  wkt::types::MultiPolygon<T> where Self: 'b;
+    type GeometryCollection<'b> =  wkt::types::GeometryCollection<T> where Self: 'b;
+    type Rect<'b> = FakeRect<T> where Self: 'b;
+
+    fn dim(&self) -> usize {
+        use wkt::Wkt::*;
+        match self {
+            Point(geom) => geom.dim(),
+            LineString(geom) => geom.dim(),
+            Polygon(geom) => geom.dim(),
+            MultiPoint(geom) => geom.dim(),
+            MultiLineString(geom) => geom.dim(),
+            MultiPolygon(geom) => geom.dim(),
+            GeometryCollection(geom) => geom.dim(),
+        }
+    }
+
+    fn as_type(
+        &self,
+    ) -> crate::geo_traits::GeometryType<
+        '_,
+        wkt::types::Point<T>,
+        wkt::types::LineString<T>,
+        wkt::types::Polygon<T>,
+        wkt::types::MultiPoint<T>,
+        wkt::types::MultiLineString<T>,
+        wkt::types::MultiPolygon<T>,
+        wkt::types::GeometryCollection<T>,
+        Self::Rect<'_>,
+    > {
+        match self {
+            wkt::Wkt::Point(geom) => crate::geo_traits::GeometryType::Point(geom),
+            wkt::Wkt::LineString(geom) => crate::geo_traits::GeometryType::LineString(geom),
+            wkt::Wkt::Polygon(geom) => crate::geo_traits::GeometryType::Polygon(geom),
+            wkt::Wkt::MultiPoint(geom) => crate::geo_traits::GeometryType::MultiPoint(geom),
+            wkt::Wkt::MultiLineString(geom) => {
+                crate::geo_traits::GeometryType::MultiLineString(geom)
+            }
+            wkt::Wkt::MultiPolygon(geom) => crate::geo_traits::GeometryType::MultiPolygon(geom),
+            wkt::Wkt::GeometryCollection(geom) => {
+                crate::geo_traits::GeometryType::GeometryCollection(geom)
+            }
+        }
+    }
+}
+
+impl<'a, T: WktNum> GeometryTrait for &'a wkt::Wkt<T> {
+    type T = T;
+    type Point<'b> =  wkt::types::Point<T> where Self: 'b;
+    type LineString<'b> =  wkt::types::LineString<T> where Self: 'b;
+    type Polygon<'b> =  wkt::types::Polygon<T> where Self: 'b;
+    type MultiPoint<'b> =  wkt::types::MultiPoint<T> where Self: 'b;
+    type MultiLineString<'b> =  wkt::types::MultiLineString<T> where Self: 'b;
+    type MultiPolygon<'b> =  wkt::types::MultiPolygon<T> where Self: 'b;
+    type GeometryCollection<'b> =  wkt::types::GeometryCollection<T> where Self: 'b;
+    type Rect<'b> = FakeRect<T> where Self: 'b;
+
+    fn dim(&self) -> usize {
+        use wkt::Wkt::*;
+        match self {
+            Point(geom) => geom.dim(),
+            LineString(geom) => geom.dim(),
+            Polygon(geom) => geom.dim(),
+            MultiPoint(geom) => geom.dim(),
+            MultiLineString(geom) => geom.dim(),
+            MultiPolygon(geom) => geom.dim(),
+            GeometryCollection(geom) => geom.dim(),
+        }
+    }
+
+    fn as_type(
+        &self,
+    ) -> crate::geo_traits::GeometryType<
+        '_,
+        wkt::types::Point<T>,
+        wkt::types::LineString<T>,
+        wkt::types::Polygon<T>,
+        wkt::types::MultiPoint<T>,
+        wkt::types::MultiLineString<T>,
+        wkt::types::MultiPolygon<T>,
+        wkt::types::GeometryCollection<T>,
+        Self::Rect<'_>,
+    > {
+        match self {
+            wkt::Wkt::Point(geom) => crate::geo_traits::GeometryType::Point(geom),
+            wkt::Wkt::LineString(geom) => crate::geo_traits::GeometryType::LineString(geom),
+            wkt::Wkt::Polygon(geom) => crate::geo_traits::GeometryType::Polygon(geom),
+            wkt::Wkt::MultiPoint(geom) => crate::geo_traits::GeometryType::MultiPoint(geom),
+            wkt::Wkt::MultiLineString(geom) => {
+                crate::geo_traits::GeometryType::MultiLineString(geom)
+            }
+            wkt::Wkt::MultiPolygon(geom) => crate::geo_traits::GeometryType::MultiPolygon(geom),
+            wkt::Wkt::GeometryCollection(geom) => {
+                crate::geo_traits::GeometryType::GeometryCollection(geom)
+            }
+        }
+    }
+}
+
+impl<T: WktNum> GeometryCollectionTrait for wkt::types::GeometryCollection<T> {
+    type T = T;
+    type ItemType<'a> = &'a wkt::Wkt<T> where Self: 'a;
+
+    fn dim(&self) -> usize {
+        if self.0.is_empty() {
+            2
+        } else {
+            self.0[0].dim()
+        }
+    }
+
+    fn num_geometries(&self) -> usize {
+        self.0.len()
+    }
+
+    unsafe fn geometry_unchecked(&self, i: usize) -> Self::ItemType<'_> {
+        &self.0[i]
+    }
+}
+
+pub struct FakeRect<T: WktNum> {
+    unused: PhantomData<T>,
+}
+
+impl<T: WktNum> RectTrait for FakeRect<T> {
+    type T = T;
+    type ItemType<'a> = wkt::types::Coord<T> where Self: 'a;
+
+    fn dim(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn lower(&self) -> Self::ItemType<'_> {
+        unimplemented!()
+    }
+
+    fn upper(&self) -> Self::ItemType<'_> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
### Change list

- Depend on `wkt` directly (note that this means we now have two copies of `wkt` in our dependency tree, since `geos` apparently depends on `wkt 0.10.3`.
- Implement `geo-traits` traits on `wkt` types objects.
- Initial start of new `ParseWKT` trait that parses a WKT string array without using our streaming builder. I think it'll be better in the long run to minimize the use of the streaming builder.

Testing from Python, it looks like this may be minimally faster than the previous streaming implementation:

```py
import pyarrow as pa
import geopandas as gpd
import shapely
from geoarrow.rust.core import from_wkt

path = "/Users/kyle/Downloads/nz-building-outlines.parquet"
gdf = gpd.read_parquet(path)
wkt_arr = shapely.to_wkt(gdf.geometry.array)
pa_wkt_arr = pa.array(wkt_arr[:100_000])
%timeit _ = from_wkt(pa_wkt_arr)
```

Main branch:

```
242 ms ± 1.07 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

This branch:


```
234 ms ± 4.68 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Even if it's not particularly faster, it's preferable because it reuses the geo-traits conversion mechanism, which is how most data conversion is/should be handled to geoarrow arrays.

For reference, Shapely/GEOS is still 18% faster here:

```py
%timeit shapely.from_wkt(pa_wkt_arr)
```

```
192 ms ± 9.45 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

The overhead of the `wkt` crate is probably in parsing to an intermediate representation?