### PR TITLE
Remove "large" arrays and scalars with `i64` offsets

### DIFF
--- a/benches/area.rs
+++ b/benches/area.rs
@@ -4,18 +4,10 @@ use geoarrow::array::{AsChunkedNativeArray, MultiPolygonArray};
 use geoarrow::io::flatgeobuf::read_flatgeobuf;
 use std::fs::File;
 
-fn load_file() -> MultiPolygonArray<i32, 2> {
+fn load_file() -> MultiPolygonArray<2> {
     let mut file = File::open("fixtures/flatgeobuf/countries.fgb").unwrap();
     let table = read_flatgeobuf(&mut file, Default::default()).unwrap();
-    table
-        .geometry_column(None)
-        .unwrap()
-        .as_ref()
-        .as_multi_polygon::<2>()
-        .chunks()
-        .first()
-        .unwrap()
-        .clone()
+    table.geometry_column(None).unwrap().as_ref().as_multi_polygon::<2>().chunks().first().unwrap().clone()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/benches/area.rs
+++ b/benches/area.rs
@@ -7,7 +7,15 @@ use std::fs::File;
 fn load_file() -> MultiPolygonArray<2> {
     let mut file = File::open("fixtures/flatgeobuf/countries.fgb").unwrap();
     let table = read_flatgeobuf(&mut file, Default::default()).unwrap();
-    table.geometry_column(None).unwrap().as_ref().as_multi_polygon::<2>().chunks().first().unwrap().clone()
+    table
+        .geometry_column(None)
+        .unwrap()
+        .as_ref()
+        .as_multi_polygon::<2>()
+        .chunks()
+        .first()
+        .unwrap()
+        .clone()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/benches/from_geo.rs
+++ b/benches/from_geo.rs
@@ -24,7 +24,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("convert Vec<geo::Polygon> to PolygonArray", |b| {
         b.iter(|| {
-            let mut_arr = PolygonBuilder::<2>::from_polygons(&data, Default::default(), Default::default());
+            let mut_arr =
+                PolygonBuilder::<2>::from_polygons(&data, Default::default(), Default::default());
             let _arr: PolygonArray<2> = mut_arr.into();
         })
     });

--- a/benches/from_geo.rs
+++ b/benches/from_geo.rs
@@ -24,12 +24,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("convert Vec<geo::Polygon> to PolygonArray", |b| {
         b.iter(|| {
-            let mut_arr = PolygonBuilder::<i32, 2>::from_polygons(
-                &data,
-                Default::default(),
-                Default::default(),
-            );
-            let _arr: PolygonArray<i32, 2> = mut_arr.into();
+            let mut_arr = PolygonBuilder::<2>::from_polygons(&data, Default::default(), Default::default());
+            let _arr: PolygonArray<2> = mut_arr.into();
         })
     });
 }

--- a/benches/geos_buffer.rs
+++ b/benches/geos_buffer.rs
@@ -13,7 +13,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("buffer", |b| {
         b.iter(|| {
-            let _buffered: PolygonArray<i32, 2> = point_array.buffer(1.0, 8).unwrap();
+            let _buffered: PolygonArray<2> = point_array.buffer(1.0, 8).unwrap();
         })
     });
 }

--- a/benches/nybb.rs
+++ b/benches/nybb.rs
@@ -6,21 +6,16 @@ use geoarrow::algorithm::geo::EuclideanDistance;
 use geoarrow::array::{MultiPolygonArray, PointArray};
 use geoarrow::trait_::ArrayAccessor;
 
-fn load_nybb() -> MultiPolygonArray<i32, 2> {
+fn load_nybb() -> MultiPolygonArray<2> {
     let file = File::open("fixtures/nybb.arrow").unwrap();
     let reader = FileReader::try_new(file, None).unwrap();
 
     let mut arrays = vec![];
     for maybe_record_batch in reader {
         let record_batch = maybe_record_batch.unwrap();
-        let geom_idx = record_batch
-            .schema()
-            .fields()
-            .iter()
-            .position(|field| field.name() == "geometry")
-            .unwrap();
+        let geom_idx = record_batch.schema().fields().iter().position(|field| field.name() == "geometry").unwrap();
         let arr = record_batch.column(geom_idx);
-        let multi_poly_arr: MultiPolygonArray<i32, 2> = arr.as_ref().try_into().unwrap();
+        let multi_poly_arr: MultiPolygonArray<2> = arr.as_ref().try_into().unwrap();
         arrays.push(multi_poly_arr);
     }
 

--- a/benches/nybb.rs
+++ b/benches/nybb.rs
@@ -13,7 +13,12 @@ fn load_nybb() -> MultiPolygonArray<2> {
     let mut arrays = vec![];
     for maybe_record_batch in reader {
         let record_batch = maybe_record_batch.unwrap();
-        let geom_idx = record_batch.schema().fields().iter().position(|field| field.name() == "geometry").unwrap();
+        let geom_idx = record_batch
+            .schema()
+            .fields()
+            .iter()
+            .position(|field| field.name() == "geometry")
+            .unwrap();
         let arr = record_batch.column(geom_idx);
         let multi_poly_arr: MultiPolygonArray<2> = arr.as_ref().try_into().unwrap();
         arrays.push(multi_poly_arr);

--- a/benches/translate.rs
+++ b/benches/translate.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use geoarrow::algorithm::geo::Translate;
 use geoarrow::array::PolygonArray;
 
-fn create_data() -> PolygonArray<i32, 2> {
+fn create_data() -> PolygonArray<2> {
     // An L shape
     // https://github.com/georust/geo/blob/7cb7d0ffa6bf1544c5ca9922bd06100c36f815d7/README.md?plain=1#L40
     let poly = polygon![

--- a/benches/wkb.rs
+++ b/benches/wkb.rs
@@ -12,11 +12,7 @@ fn load_parquet() -> WKBArray<i32> {
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
     let parquet_schema = builder.parquet_schema();
-    let geometry_column_index = parquet_schema
-        .columns()
-        .iter()
-        .position(|column| column.name() == "geometry")
-        .unwrap();
+    let geometry_column_index = parquet_schema.columns().iter().position(|column| column.name() == "geometry").unwrap();
     let projection = ProjectionMask::roots(parquet_schema, vec![geometry_column_index]);
     let reader = builder.with_projection(projection).build().unwrap();
 
@@ -37,21 +33,15 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("parse WKBArray to geoarrow MultiPolygonArray", |b| {
         b.iter(|| {
-            let _values: MultiPolygonArray<i32, 2> = array.clone().try_into().unwrap();
+            let _values: MultiPolygonArray<2> = array.clone().try_into().unwrap();
         })
     });
-    c.bench_function(
-        "parse WKBArray to geoarrow MultiPolygonArray then to Vec<geo::Geometry>",
-        |b| {
-            b.iter(|| {
-                let array: MultiPolygonArray<i32, 2> = array.clone().try_into().unwrap();
-                let _out: Vec<geo::Geometry> = array
-                    .iter_geo_values()
-                    .map(geo::Geometry::MultiPolygon)
-                    .collect();
-            })
-        },
-    );
+    c.bench_function("parse WKBArray to geoarrow MultiPolygonArray then to Vec<geo::Geometry>", |b| {
+        b.iter(|| {
+            let array: MultiPolygonArray<2> = array.clone().try_into().unwrap();
+            let _out: Vec<geo::Geometry> = array.iter_geo_values().map(geo::Geometry::MultiPolygon).collect();
+        })
+    });
     c.bench_function("parse WKBArray to Vec<geo::Geometry>", |b| {
         b.iter(|| {
             // Note: As of Sept 2023, `to_geo` uses geozero. This could change in the future, in

--- a/benches/wkb.rs
+++ b/benches/wkb.rs
@@ -12,7 +12,11 @@ fn load_parquet() -> WKBArray<i32> {
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
     let parquet_schema = builder.parquet_schema();
-    let geometry_column_index = parquet_schema.columns().iter().position(|column| column.name() == "geometry").unwrap();
+    let geometry_column_index = parquet_schema
+        .columns()
+        .iter()
+        .position(|column| column.name() == "geometry")
+        .unwrap();
     let projection = ProjectionMask::roots(parquet_schema, vec![geometry_column_index]);
     let reader = builder.with_projection(projection).build().unwrap();
 
@@ -36,12 +40,18 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let _values: MultiPolygonArray<2> = array.clone().try_into().unwrap();
         })
     });
-    c.bench_function("parse WKBArray to geoarrow MultiPolygonArray then to Vec<geo::Geometry>", |b| {
-        b.iter(|| {
-            let array: MultiPolygonArray<2> = array.clone().try_into().unwrap();
-            let _out: Vec<geo::Geometry> = array.iter_geo_values().map(geo::Geometry::MultiPolygon).collect();
-        })
-    });
+    c.bench_function(
+        "parse WKBArray to geoarrow MultiPolygonArray then to Vec<geo::Geometry>",
+        |b| {
+            b.iter(|| {
+                let array: MultiPolygonArray<2> = array.clone().try_into().unwrap();
+                let _out: Vec<geo::Geometry> = array
+                    .iter_geo_values()
+                    .map(geo::Geometry::MultiPolygon)
+                    .collect();
+            })
+        },
+    );
     c.bench_function("parse WKBArray to Vec<geo::Geometry>", |b| {
         b.iter(|| {
             // Note: As of Sept 2023, `to_geo` uses geozero. This could change in the future, in

--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -715,6 +715,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbase"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847c0b5d4f3a3d80f9c64db3cb60eb00304b3ea1262c7299dd6274a83e714d24"
+dependencies = [
+ "byteorder",
+ "time",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "flatgeobuf"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c07a71b9a55179feef8a6cf75e8f8021b1f5611ee4d8092fabc5fd52c2a9ce"
+checksum = "36ae7433806df7b5066c8ca3d17eb29f795f70bdc7326ce9faf714991fdb558f"
 dependencies = [
  "byteorder",
  "fallible-streaming-iterator",
@@ -1041,8 +1060,10 @@ dependencies = [
  "rstar",
  "serde",
  "serde_json",
+ "shapefile",
  "thiserror",
  "tokio",
+ "wkt",
 ]
 
 [[package]]
@@ -1120,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "geozero"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd8fb67347739a057fd607b6d8b43ba4ed93619ed84b8f429fa3296f8ae504c"
+checksum = "e5f28f34864745eb2f123c990c6ffd92c1584bd39439b3f27ff2a0f4ea5b309b"
 dependencies = [
  "geo-types",
  "geojson",
@@ -1756,6 +1777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2127,12 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro-crate"
@@ -2515,6 +2548,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shapefile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d5472e932503059d02779ad2c1b96258980940c6923e49f427fbe80eb3053c"
+dependencies = [
+ "byteorder",
+ "dbase",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,6 +2795,25 @@ dependencies = [
  "integer-encoding",
  "ordered-float",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tiny-keccak"
@@ -3377,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "wkt"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c2252781f8927974e8ba6a67c965a759a2b88ea2b1825f6862426bbb1c8f41"
+checksum = "296937617013271141d1145d9c05861f5ed3b1bc4297e81c692aa3cff9270a9c"
 dependencies = [
  "geo-types",
  "log",

--- a/js/src/broadcasting/linestring.rs
+++ b/js/src/broadcasting/linestring.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 enum _BroadcastableLineString {
     Scalar(geoarrow::scalar::OwnedLineString<i32>),
-    Array(geoarrow::array::LineStringArray<i32, 2>),
+    Array(geoarrow::array::LineStringArray<2>),
 }
 
 #[wasm_bindgen]

--- a/js/src/broadcasting/multilinestring.rs
+++ b/js/src/broadcasting/multilinestring.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 
 enum _BroadcastableMultiLineString {
     Scalar(geoarrow::scalar::OwnedMultiLineString<i32>),
-    Array(geoarrow::array::MultiLineStringArray<i32, 2>),
+    Array(geoarrow::array::MultiLineStringArray<2>),
 }
 
 #[wasm_bindgen]

--- a/js/src/data/mod.rs
+++ b/js/src/data/mod.rs
@@ -49,37 +49,37 @@ impl_data! {
 impl_data! {
     /// An immutable array of LineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct LineStringData(pub(crate) geoarrow::array::LineStringArray<i32, 2>);
+    pub struct LineStringData(pub(crate) geoarrow::array::LineStringArray<2>);
 }
 impl_data! {
     /// An immutable array of Polygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct PolygonData(pub(crate) geoarrow::array::PolygonArray<i32, 2>);
+    pub struct PolygonData(pub(crate) geoarrow::array::PolygonArray<2>);
 }
 impl_data! {
     /// An immutable array of MultiPoint geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPointData(pub(crate) geoarrow::array::MultiPointArray<i32, 2>);
+    pub struct MultiPointData(pub(crate) geoarrow::array::MultiPointArray<2>);
 }
 impl_data! {
     /// An immutable array of MultiLineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiLineStringData(pub(crate) geoarrow::array::MultiLineStringArray<i32, 2>);
+    pub struct MultiLineStringData(pub(crate) geoarrow::array::MultiLineStringArray<2>);
 }
 impl_data! {
     /// An immutable array of MultiPolygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPolygonData(pub(crate) geoarrow::array::MultiPolygonArray<i32, 2>);
+    pub struct MultiPolygonData(pub(crate) geoarrow::array::MultiPolygonArray<2>);
 }
 impl_data! {
     /// An immutable array of Geometry geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MixedGeometryData(pub(crate) geoarrow::array::MixedGeometryArray<i32, 2>);
+    pub struct MixedGeometryData(pub(crate) geoarrow::array::MixedGeometryArray<2>);
 }
 impl_data! {
     /// An immutable array of GeometryCollection geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct GeometryCollectionData(pub(crate) geoarrow::array::GeometryCollectionArray<i32, 2>);
+    pub struct GeometryCollectionData(pub(crate) geoarrow::array::GeometryCollectionArray<2>);
 }
 impl_data! {
     /// An immutable array of WKB-encoded geometries in WebAssembly memory using GeoArrow's
@@ -215,7 +215,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoLineStringArray)]
     pub fn into_line_string_array(self) -> WasmResult<LineStringData> {
-        let arr: geoarrow::array::LineStringArray<i32, 2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::LineStringArray<2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -227,7 +227,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoPolygonArray)]
     pub fn into_polygon_array(self) -> WasmResult<PolygonData> {
-        let arr: geoarrow::array::PolygonArray<i32, 2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::PolygonArray<2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -239,7 +239,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiPointArray)]
     pub fn into_multi_point_array(self) -> WasmResult<MultiPointData> {
-        let arr: geoarrow::array::MultiPointArray<i32, 2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiPointArray<2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -251,7 +251,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiLineStringArray)]
     pub fn into_multi_line_string_array(self) -> WasmResult<MultiLineStringData> {
-        let arr: geoarrow::array::MultiLineStringArray<i32, 2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiLineStringArray<2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -263,7 +263,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiPolygonArray)]
     pub fn into_multi_polygon_array(self) -> WasmResult<MultiPolygonData> {
-        let arr: geoarrow::array::MultiPolygonArray<i32, 2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiPolygonArray<2> = self.0.try_into().unwrap();
         Ok(arr.into())
     }
 }

--- a/js/src/scalar/linestring.rs
+++ b/js/src/scalar/linestring.rs
@@ -2,7 +2,7 @@ use geoarrow::scalar::OwnedLineString;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct LineString(pub(crate) OwnedLineString<i32, 2>);
+pub struct LineString(pub(crate) OwnedLineString<2>);
 
 impl<'a> From<&'a LineString> for geoarrow::scalar::LineString<'a, i32, 2> {
     fn from(value: &'a LineString) -> Self {
@@ -10,7 +10,7 @@ impl<'a> From<&'a LineString> for geoarrow::scalar::LineString<'a, i32, 2> {
     }
 }
 
-impl From<LineString> for geoarrow::scalar::OwnedLineString<i32, 2> {
+impl From<LineString> for geoarrow::scalar::OwnedLineString<2> {
     fn from(value: LineString) -> Self {
         value.0
     }

--- a/js/src/scalar/linestring.rs
+++ b/js/src/scalar/linestring.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct LineString(pub(crate) OwnedLineString<2>);
 
-impl<'a> From<&'a LineString> for geoarrow::scalar::LineString<'a, i32, 2> {
+impl<'a> From<&'a LineString> for geoarrow::scalar::LineString<'a, 2> {
     fn from(value: &'a LineString) -> Self {
         (&value.0).into()
     }
@@ -16,8 +16,8 @@ impl From<LineString> for geoarrow::scalar::OwnedLineString<2> {
     }
 }
 
-impl<'a> From<geoarrow::scalar::LineString<'a, i32, 2>> for LineString {
-    fn from(value: geoarrow::scalar::LineString<'a, i32, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::LineString<'a, 2>> for LineString {
+    fn from(value: geoarrow::scalar::LineString<'a, 2>) -> Self {
         LineString(value.into())
     }
 }

--- a/js/src/scalar/multilinestring.rs
+++ b/js/src/scalar/multilinestring.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct MultiLineString(pub(crate) OwnedMultiLineString<2>);
 
-impl<'a> From<&'a MultiLineString> for geoarrow::scalar::MultiLineString<'a, i32, 2> {
+impl<'a> From<&'a MultiLineString> for geoarrow::scalar::MultiLineString<'a, 2> {
     fn from(value: &'a MultiLineString) -> Self {
         (&value.0).into()
     }
@@ -16,8 +16,8 @@ impl From<MultiLineString> for geoarrow::scalar::OwnedMultiLineString<2> {
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiLineString<'a, i32, 2>> for MultiLineString {
-    fn from(value: geoarrow::scalar::MultiLineString<'a, i32, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiLineString<'a, 2>> for MultiLineString {
+    fn from(value: geoarrow::scalar::MultiLineString<'a, 2>) -> Self {
         MultiLineString(value.into())
     }
 }

--- a/js/src/scalar/multilinestring.rs
+++ b/js/src/scalar/multilinestring.rs
@@ -2,7 +2,7 @@ use geoarrow::scalar::OwnedMultiLineString;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiLineString(pub(crate) OwnedMultiLineString<i32, 2>);
+pub struct MultiLineString(pub(crate) OwnedMultiLineString<2>);
 
 impl<'a> From<&'a MultiLineString> for geoarrow::scalar::MultiLineString<'a, i32, 2> {
     fn from(value: &'a MultiLineString) -> Self {
@@ -10,7 +10,7 @@ impl<'a> From<&'a MultiLineString> for geoarrow::scalar::MultiLineString<'a, i32
     }
 }
 
-impl From<MultiLineString> for geoarrow::scalar::OwnedMultiLineString<i32, 2> {
+impl From<MultiLineString> for geoarrow::scalar::OwnedMultiLineString<2> {
     fn from(value: MultiLineString) -> Self {
         value.0
     }

--- a/js/src/scalar/multipoint.rs
+++ b/js/src/scalar/multipoint.rs
@@ -2,7 +2,7 @@ use geoarrow::scalar::OwnedMultiPoint;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiPoint(pub(crate) OwnedMultiPoint<i32, 2>);
+pub struct MultiPoint(pub(crate) OwnedMultiPoint<2>);
 
 impl<'a> From<&'a MultiPoint> for geoarrow::scalar::MultiPoint<'a, i32, 2> {
     fn from(value: &'a MultiPoint) -> Self {
@@ -10,7 +10,7 @@ impl<'a> From<&'a MultiPoint> for geoarrow::scalar::MultiPoint<'a, i32, 2> {
     }
 }
 
-impl From<MultiPoint> for geoarrow::scalar::OwnedMultiPoint<i32, 2> {
+impl From<MultiPoint> for geoarrow::scalar::OwnedMultiPoint<2> {
     fn from(value: MultiPoint) -> Self {
         value.0
     }

--- a/js/src/scalar/multipoint.rs
+++ b/js/src/scalar/multipoint.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct MultiPoint(pub(crate) OwnedMultiPoint<2>);
 
-impl<'a> From<&'a MultiPoint> for geoarrow::scalar::MultiPoint<'a, i32, 2> {
+impl<'a> From<&'a MultiPoint> for geoarrow::scalar::MultiPoint<'a, 2> {
     fn from(value: &'a MultiPoint) -> Self {
         (&value.0).into()
     }
@@ -16,8 +16,8 @@ impl From<MultiPoint> for geoarrow::scalar::OwnedMultiPoint<2> {
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiPoint<'a, i32, 2>> for MultiPoint {
-    fn from(value: geoarrow::scalar::MultiPoint<'a, i32, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiPoint<'a, 2>> for MultiPoint {
+    fn from(value: geoarrow::scalar::MultiPoint<'a, 2>) -> Self {
         MultiPoint(value.into())
     }
 }

--- a/js/src/scalar/multipolygon.rs
+++ b/js/src/scalar/multipolygon.rs
@@ -2,7 +2,7 @@ use geoarrow::scalar::OwnedMultiPolygon;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiPolygon(pub(crate) OwnedMultiPolygon<i32, 2>);
+pub struct MultiPolygon(pub(crate) OwnedMultiPolygon<2>);
 
 impl<'a> From<&'a MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, i32, 2> {
     fn from(value: &'a MultiPolygon) -> Self {
@@ -10,7 +10,7 @@ impl<'a> From<&'a MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, i32, 2> {
     }
 }
 
-impl From<MultiPolygon> for geoarrow::scalar::OwnedMultiPolygon<i32, 2> {
+impl From<MultiPolygon> for geoarrow::scalar::OwnedMultiPolygon<2> {
     fn from(value: MultiPolygon) -> Self {
         value.0
     }

--- a/js/src/scalar/multipolygon.rs
+++ b/js/src/scalar/multipolygon.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct MultiPolygon(pub(crate) OwnedMultiPolygon<2>);
 
-impl<'a> From<&'a MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, i32, 2> {
+impl<'a> From<&'a MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, 2> {
     fn from(value: &'a MultiPolygon) -> Self {
         (&value.0).into()
     }
@@ -16,8 +16,8 @@ impl From<MultiPolygon> for geoarrow::scalar::OwnedMultiPolygon<2> {
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiPolygon<'a, i32, 2>> for MultiPolygon {
-    fn from(value: geoarrow::scalar::MultiPolygon<'a, i32, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiPolygon<'a, 2>> for MultiPolygon {
+    fn from(value: geoarrow::scalar::MultiPolygon<'a, 2>) -> Self {
         MultiPolygon(value.into())
     }
 }

--- a/js/src/scalar/polygon.rs
+++ b/js/src/scalar/polygon.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct Polygon(pub(crate) OwnedPolygon<2>);
 
-impl<'a> From<&'a Polygon> for geoarrow::scalar::Polygon<'a, i32, 2> {
+impl<'a> From<&'a Polygon> for geoarrow::scalar::Polygon<'a, 2> {
     fn from(value: &'a Polygon) -> Self {
         (&value.0).into()
     }
@@ -16,8 +16,8 @@ impl From<Polygon> for geoarrow::scalar::OwnedPolygon<2> {
     }
 }
 
-impl<'a> From<geoarrow::scalar::Polygon<'a, i32, 2>> for Polygon {
-    fn from(value: geoarrow::scalar::Polygon<'a, i32, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::Polygon<'a, 2>> for Polygon {
+    fn from(value: geoarrow::scalar::Polygon<'a, 2>) -> Self {
         Polygon(value.into())
     }
 }

--- a/js/src/scalar/polygon.rs
+++ b/js/src/scalar/polygon.rs
@@ -2,7 +2,7 @@ use geoarrow::scalar::OwnedPolygon;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct Polygon(pub(crate) OwnedPolygon<i32, 2>);
+pub struct Polygon(pub(crate) OwnedPolygon<2>);
 
 impl<'a> From<&'a Polygon> for geoarrow::scalar::Polygon<'a, i32, 2> {
     fn from(value: &'a Polygon) -> Self {
@@ -10,7 +10,7 @@ impl<'a> From<&'a Polygon> for geoarrow::scalar::Polygon<'a, i32, 2> {
     }
 }
 
-impl From<Polygon> for geoarrow::scalar::OwnedPolygon<i32, 2> {
+impl From<Polygon> for geoarrow::scalar::OwnedPolygon<2> {
     fn from(value: Polygon) -> Self {
         value.0
     }

--- a/js/src/vector/mod.rs
+++ b/js/src/vector/mod.rs
@@ -31,37 +31,37 @@ impl_vector! {
 impl_vector! {
     /// An immutable chunked array of LineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct LineStringVector(pub(crate) geoarrow::chunked_array::ChunkedLineStringArray<i32, 2>);
+    pub struct LineStringVector(pub(crate) geoarrow::chunked_array::ChunkedLineStringArray<2>);
 }
 impl_vector! {
     /// An immutable chunked array of Polygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct PolygonVector(pub(crate) geoarrow::chunked_array::ChunkedPolygonArray<i32, 2>);
+    pub struct PolygonVector(pub(crate) geoarrow::chunked_array::ChunkedPolygonArray<2>);
 }
 impl_vector! {
     /// An immutable chunked array of MultiPoint geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPointVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPointArray<i32, 2>);
+    pub struct MultiPointVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPointArray<2>);
 }
 impl_vector! {
     /// An immutable chunked array of MultiLineString geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MultiLineStringVector(pub(crate) geoarrow::chunked_array::ChunkedMultiLineStringArray<i32, 2>);
+    pub struct MultiLineStringVector(pub(crate) geoarrow::chunked_array::ChunkedMultiLineStringArray<2>);
 }
 impl_vector! {
     /// An immutable chunked array of MultiPolygon geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MultiPolygonVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPolygonArray<i32, 2>);
+    pub struct MultiPolygonVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPolygonArray<2>);
 }
 impl_vector! {
     /// An immutable chunked array of Geometry geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MixedGeometryVector(pub(crate) geoarrow::chunked_array::ChunkedMixedGeometryArray<i32, 2>);
+    pub struct MixedGeometryVector(pub(crate) geoarrow::chunked_array::ChunkedMixedGeometryArray<2>);
 }
 impl_vector! {
     /// An immutable chunked array of GeometryCollection geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct GeometryCollectionVector(pub(crate) geoarrow::chunked_array::ChunkedGeometryCollectionArray<i32, 2>);
+    pub struct GeometryCollectionVector(pub(crate) geoarrow::chunked_array::ChunkedGeometryCollectionArray<2>);
 }
 impl_vector! {
     /// An immutable chunked array of WKB-encoded geometries in WebAssembly memory using GeoArrow's

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -330,18 +330,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -361,9 +361,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -469,9 +469,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "jobserver",
  "libc",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -945,7 +945,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1420,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1433,7 +1433,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -1616,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libm"
@@ -1891,7 +1890,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1952,9 +1951,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl"
@@ -1979,7 +1981,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2148,7 +2150,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2158,26 +2160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -2215,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polylabel"
@@ -2232,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -2369,7 +2351,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2382,7 +2364,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2397,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
@@ -2529,18 +2511,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2550,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2561,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -2780,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -2866,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2903,7 +2885,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3321,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3368,9 +3350,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3381,22 +3363,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3477,7 +3459,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3533,35 +3515,14 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3589,7 +3550,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3756,7 +3717,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -3790,7 +3751,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3803,9 +3764,9 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4038,9 +3999,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -4075,7 +4036,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/python/geoarrow-compute/src/algorithm/geo/convex_hull.rs
+++ b/python/geoarrow-compute/src/algorithm/geo/convex_hull.rs
@@ -12,11 +12,11 @@ use pyo3_geoarrow::PyGeoArrowResult;
 pub fn convex_hull(py: Python, input: AnyNativeInput) -> PyGeoArrowResult<PyObject> {
     match input {
         AnyNativeInput::Array(arr) => {
-            let out: PolygonArray<i32, 2> = arr.as_ref().convex_hull()?;
+            let out: PolygonArray<2> = arr.as_ref().convex_hull()?;
             return_geometry_array(py, Arc::new(out))
         }
         AnyNativeInput::Chunked(arr) => {
-            let out: ChunkedGeometryArray<PolygonArray<i32, 2>> = arr.as_ref().convex_hull()?;
+            let out: ChunkedGeometryArray<PolygonArray<2>> = arr.as_ref().convex_hull()?;
             return_chunked_geometry_array(py, Arc::new(out))
         }
     }

--- a/python/geoarrow-core/src/interop/shapely/from_shapely.rs
+++ b/python/geoarrow-core/src/interop/shapely/from_shapely.rs
@@ -202,7 +202,7 @@ fn make_linestring_arr(
         }
         Dimension::XYZ => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(geoarrow::array::LineStringArray::<i32, 3>::new(
+            Ok(Arc::new(geoarrow::array::LineStringArray::<3>::new(
                 cb.into(),
                 geom_offsets,
                 None,
@@ -237,7 +237,7 @@ fn make_polygon_arr(
         }
         Dimension::XYZ => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(geoarrow::array::PolygonArray::<i32, 3>::new(
+            Ok(Arc::new(geoarrow::array::PolygonArray::<3>::new(
                 cb.into(),
                 geom_offsets,
                 ring_offsets,
@@ -270,7 +270,7 @@ fn make_multipoint_arr(
         }
         Dimension::XYZ => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(geoarrow::array::MultiPointArray::<i32, 3>::new(
+            Ok(Arc::new(geoarrow::array::MultiPointArray::<3>::new(
                 cb.into(),
                 geom_offsets,
                 None,
@@ -305,15 +305,13 @@ fn make_multilinestring_arr(
         }
         Dimension::XYZ => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(
-                geoarrow::array::MultiLineStringArray::<i32, 3>::new(
-                    cb.into(),
-                    geom_offsets,
-                    ring_offsets,
-                    None,
-                    metadata,
-                ),
-            ))
+            Ok(Arc::new(geoarrow::array::MultiLineStringArray::<3>::new(
+                cb.into(),
+                geom_offsets,
+                ring_offsets,
+                None,
+                metadata,
+            )))
         }
     }
 }
@@ -348,7 +346,7 @@ fn make_multipolygon_arr(
         }
         Dimension::XYZ => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(geoarrow::array::MultiPolygonArray::<i32, 3>::new(
+            Ok(Arc::new(geoarrow::array::MultiPolygonArray::<3>::new(
                 cb.into(),
                 geom_offsets,
                 polygon_offsets,

--- a/python/geoarrow-core/src/interop/shapely/from_shapely.rs
+++ b/python/geoarrow-core/src/interop/shapely/from_shapely.rs
@@ -193,7 +193,7 @@ fn make_linestring_arr(
     match dim {
         Dimension::XY => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(geoarrow::array::LineStringArray::<i32, 2>::new(
+            Ok(Arc::new(geoarrow::array::LineStringArray::<2>::new(
                 cb.into(),
                 geom_offsets,
                 None,
@@ -227,7 +227,7 @@ fn make_polygon_arr(
     match dim {
         Dimension::XY => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(geoarrow::array::PolygonArray::<i32, 2>::new(
+            Ok(Arc::new(geoarrow::array::PolygonArray::<2>::new(
                 cb.into(),
                 geom_offsets,
                 ring_offsets,
@@ -261,7 +261,7 @@ fn make_multipoint_arr(
     match dim {
         Dimension::XY => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(geoarrow::array::MultiPointArray::<i32, 2>::new(
+            Ok(Arc::new(geoarrow::array::MultiPointArray::<2>::new(
                 cb.into(),
                 geom_offsets,
                 None,
@@ -295,15 +295,13 @@ fn make_multilinestring_arr(
     match dim {
         Dimension::XY => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(
-                geoarrow::array::MultiLineStringArray::<i32, 2>::new(
-                    cb.into(),
-                    geom_offsets,
-                    ring_offsets,
-                    None,
-                    metadata,
-                ),
-            ))
+            Ok(Arc::new(geoarrow::array::MultiLineStringArray::<2>::new(
+                cb.into(),
+                geom_offsets,
+                ring_offsets,
+                None,
+                metadata,
+            )))
         }
         Dimension::XYZ => {
             let cb = coords_to_buffer(coords)?;
@@ -339,7 +337,7 @@ fn make_multipolygon_arr(
     match dim {
         Dimension::XY => {
             let cb = coords_to_buffer(coords)?;
-            Ok(Arc::new(geoarrow::array::MultiPolygonArray::<i32, 2>::new(
+            Ok(Arc::new(geoarrow::array::MultiPolygonArray::<2>::new(
                 cb.into(),
                 geom_offsets,
                 polygon_offsets,

--- a/python/geoarrow-core/src/interop/shapely/to_shapely.rs
+++ b/python/geoarrow-core/src/interop/shapely/to_shapely.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use crate::interop::numpy::to_numpy::wkb_array_to_numpy;
 use crate::interop::shapely::utils::import_shapely;
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBuffer;
 use geoarrow::array::{
     AsNativeArray, AsSerializedArray, CoordBuffer, NativeArrayDyn, SerializedArrayDyn,
@@ -153,7 +152,7 @@ fn point_arr<const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn linestring_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
+fn linestring_arr<const D: usize>(
     py: Python,
     arr: geoarrow::array::LineStringArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -171,7 +170,7 @@ fn linestring_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn polygon_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
+fn polygon_arr<const D: usize>(
     py: Python,
     arr: geoarrow::array::PolygonArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -192,7 +191,7 @@ fn polygon_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn multipoint_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
+fn multipoint_arr<const D: usize>(
     py: Python,
     arr: geoarrow::array::MultiPointArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -210,7 +209,7 @@ fn multipoint_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn multilinestring_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
+fn multilinestring_arr<const D: usize>(
     py: Python,
     arr: geoarrow::array::MultiLineStringArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -231,7 +230,7 @@ fn multilinestring_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn multipolygon_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
+fn multipolygon_arr<const D: usize>(
     py: Python,
     arr: geoarrow::array::MultiPolygonArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {

--- a/python/geoarrow-core/src/interop/shapely/to_shapely.rs
+++ b/python/geoarrow-core/src/interop/shapely/to_shapely.rs
@@ -155,7 +155,7 @@ fn point_arr<const D: usize>(
 
 fn linestring_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     py: Python,
-    arr: geoarrow::array::LineStringArray<O, D>,
+    arr: geoarrow::array::LineStringArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
@@ -173,7 +173,7 @@ fn linestring_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
 
 fn polygon_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     py: Python,
-    arr: geoarrow::array::PolygonArray<O, D>,
+    arr: geoarrow::array::PolygonArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
@@ -194,7 +194,7 @@ fn polygon_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
 
 fn multipoint_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     py: Python,
-    arr: geoarrow::array::MultiPointArray<O, D>,
+    arr: geoarrow::array::MultiPointArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
@@ -212,7 +212,7 @@ fn multipoint_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
 
 fn multilinestring_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     py: Python,
-    arr: geoarrow::array::MultiLineStringArray<O, D>,
+    arr: geoarrow::array::MultiLineStringArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
@@ -233,7 +233,7 @@ fn multilinestring_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
 
 fn multipolygon_arr<O: OffsetSizeTrait + numpy::Element, const D: usize>(
     py: Python,
-    arr: geoarrow::array::MultiPolygonArray<O, D>,
+    arr: geoarrow::array::MultiPolygonArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;

--- a/python/geoarrow-core/src/interop/wkt.rs
+++ b/python/geoarrow-core/src/interop/wkt.rs
@@ -47,7 +47,7 @@ pub fn from_wkt(
             let chunked_arr = s.into_chunked_array()?;
             let (chunks, field) = chunked_arr.into_inner();
             let metadata = Arc::new(ArrayMetadata::try_from(field.as_ref())?);
-            let geo_array: ChunkedMixedGeometryArray<i32, 2> = match field.data_type() {
+            let geo_array: ChunkedMixedGeometryArray<2> = match field.data_type() {
                 DataType::Utf8 => {
                     let string_chunks = chunks
                         .iter()

--- a/python/pyo3-geoarrow/src/ffi/from_python/scalar.rs
+++ b/python/pyo3-geoarrow/src/ffi/from_python/scalar.rs
@@ -25,7 +25,7 @@ impl<'a> FromPyObject<'a> for PyGeometry {
             let reader = GeoJsonString(json_string);
 
             // TODO: we need a dynamic dimensionality reader
-            let arr: MixedGeometryArray<i32, 2> = reader
+            let arr: MixedGeometryArray<2> = reader
                 .to_mixed_geometry_array()
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
             Ok(Self(

--- a/src/algorithm/broadcasting/linestring.rs
+++ b/src/algorithm/broadcasting/linestring.rs
@@ -11,7 +11,7 @@ use crate::scalar::LineString;
 #[derive(Debug, Clone)]
 pub enum BroadcastableLineString<'a, O: OffsetSizeTrait> {
     Scalar(LineString<'a, O>),
-    Array(LineStringArray<O, 2>),
+    Array(LineStringArray<2>),
 }
 
 pub enum BroadcastLineStringIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/broadcasting/multilinestring.rs
+++ b/src/algorithm/broadcasting/multilinestring.rs
@@ -11,7 +11,7 @@ use crate::scalar::MultiLineString;
 #[derive(Debug, Clone)]
 pub enum BroadcastableMultiLineString<'a, O: OffsetSizeTrait> {
     Scalar(MultiLineString<'a, O>),
-    Array(MultiLineStringArray<O, 2>),
+    Array(MultiLineStringArray<2>),
 }
 
 pub enum BroadcastMultiLineStringIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/broadcasting/multipoint.rs
+++ b/src/algorithm/broadcasting/multipoint.rs
@@ -11,7 +11,7 @@ use crate::scalar::MultiPoint;
 #[derive(Debug, Clone)]
 pub enum BroadcastableMultiPoint<'a, O: OffsetSizeTrait> {
     Scalar(MultiPoint<'a, O>),
-    Array(MultiPointArray<O, 2>),
+    Array(MultiPointArray<2>),
 }
 
 pub enum BroadcastMultiPointIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/broadcasting/multipolygon.rs
+++ b/src/algorithm/broadcasting/multipolygon.rs
@@ -11,7 +11,7 @@ use crate::scalar::MultiPolygon;
 #[derive(Debug, Clone)]
 pub enum BroadcastableMultiPolygon<'a, O: OffsetSizeTrait> {
     Scalar(MultiPolygon<'a, O>),
-    Array(MultiPolygonArray<O, 2>),
+    Array(MultiPolygonArray<2>),
 }
 
 pub enum BroadcastMultiPolygonIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/broadcasting/polygon.rs
+++ b/src/algorithm/broadcasting/polygon.rs
@@ -11,7 +11,7 @@ use crate::scalar::Polygon;
 #[derive(Debug, Clone)]
 pub enum BroadcastablePolygon<'a, O: OffsetSizeTrait> {
     Scalar(Polygon<'a, O>),
-    Array(PolygonArray<O, 2>),
+    Array(PolygonArray<2>),
 }
 
 pub enum BroadcastPolygonIter<'a, O: OffsetSizeTrait> {

--- a/src/algorithm/geo/affine_ops.rs
+++ b/src/algorithm/geo/affine_ops.rs
@@ -60,7 +60,13 @@ impl AffineOps<&AffineTransform> for PointArray<2> {
     fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo().for_each(|maybe_g| output_array.push_point(maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))).as_ref()));
+        self.iter_geo().for_each(|maybe_g| {
+            output_array.push_point(
+                maybe_g
+                    .map(|geom| geom.map_coords(|coord| transform.apply(coord)))
+                    .as_ref(),
+            )
+        });
 
         output_array.finish()
     }
@@ -75,7 +81,15 @@ macro_rules! iter_geo_impl {
             fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().for_each(|maybe_g| output_array.$push_func(maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))).as_ref()).unwrap());
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array
+                        .$push_func(
+                            maybe_g
+                                .map(|geom| geom.map_coords(|coord| transform.apply(coord)))
+                                .as_ref(),
+                        )
+                        .unwrap()
+                });
 
                 output_array.finish()
             }
@@ -86,10 +100,26 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
-iter_geo_impl!(MixedGeometryArray<2>, MixedGeometryBuilder<2>, push_geometry);
-iter_geo_impl!(GeometryCollectionArray<2>, GeometryCollectionBuilder<2>, push_geometry_collection);
+iter_geo_impl!(
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
+    push_multi_line_string
+);
+iter_geo_impl!(
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
+    push_multi_polygon
+);
+iter_geo_impl!(
+    MixedGeometryArray<2>,
+    MixedGeometryBuilder<2>,
+    push_geometry
+);
+iter_geo_impl!(
+    GeometryCollectionArray<2>,
+    GeometryCollectionBuilder<2>,
+    push_geometry_collection
+);
 
 impl AffineOps<&AffineTransform> for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -123,7 +153,9 @@ impl AffineOps<&AffineTransform> for ChunkedPointArray<2> {
     type Output = Self;
 
     fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
-        self.map(|chunk| chunk.affine_transform(transform)).try_into().unwrap()
+        self.map(|chunk| chunk.affine_transform(transform))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -133,7 +165,9 @@ macro_rules! impl_chunked {
             type Output = Self;
 
             fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
-                self.map(|chunk| chunk.affine_transform(transform)).try_into().unwrap()
+                self.map(|chunk| chunk.affine_transform(transform))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -188,7 +222,15 @@ impl AffineOps<&[AffineTransform]> for PointArray<2> {
     fn affine_transform(&self, transform: &[AffineTransform]) -> Self::Output {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo().zip(transform.iter()).for_each(|(maybe_g, transform)| output_array.push_point(maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))).as_ref()));
+        self.iter_geo()
+            .zip(transform.iter())
+            .for_each(|(maybe_g, transform)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| geom.map_coords(|coord| transform.apply(coord)))
+                        .as_ref(),
+                )
+            });
 
         output_array.finish()
     }
@@ -203,7 +245,17 @@ macro_rules! iter_geo_impl2 {
             fn affine_transform(&self, transform: &[AffineTransform]) -> Self::Output {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().zip(transform.iter()).for_each(|(maybe_g, transform)| output_array.$push_func(maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))).as_ref()).unwrap());
+                self.iter_geo()
+                    .zip(transform.iter())
+                    .for_each(|(maybe_g, transform)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| geom.map_coords(|coord| transform.apply(coord)))
+                                    .as_ref(),
+                            )
+                            .unwrap()
+                    });
 
                 output_array.finish()
             }
@@ -214,10 +266,26 @@ macro_rules! iter_geo_impl2 {
 iter_geo_impl2!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl2!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl2!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl2!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
-iter_geo_impl2!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
-iter_geo_impl2!(MixedGeometryArray<2>, MixedGeometryBuilder<2>, push_geometry);
-iter_geo_impl2!(GeometryCollectionArray<2>, GeometryCollectionBuilder<2>, push_geometry_collection);
+iter_geo_impl2!(
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
+    push_multi_line_string
+);
+iter_geo_impl2!(
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
+    push_multi_polygon
+);
+iter_geo_impl2!(
+    MixedGeometryArray<2>,
+    MixedGeometryBuilder<2>,
+    push_geometry
+);
+iter_geo_impl2!(
+    GeometryCollectionArray<2>,
+    GeometryCollectionBuilder<2>,
+    push_geometry_collection
+);
 
 impl AffineOps<&[AffineTransform]> for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -231,10 +299,17 @@ impl AffineOps<&[AffineTransform]> for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().affine_transform(transform)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().affine_transform(transform)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().affine_transform(transform)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().affine_transform(transform)),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().affine_transform(transform)),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string::<2>().affine_transform(transform))
+            }
+            MultiPolygon(_, XY) => {
+                Arc::new(self.as_multi_polygon::<2>().affine_transform(transform))
+            }
             Mixed(_, XY) => Arc::new(self.as_mixed::<2>().affine_transform(transform)),
-            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection::<2>().affine_transform(transform)),
+            GeometryCollection(_, XY) => Arc::new(
+                self.as_geometry_collection::<2>()
+                    .affine_transform(transform),
+            ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/affine_ops.rs
+++ b/src/algorithm/geo/affine_ops.rs
@@ -76,7 +76,7 @@ impl AffineOps<&AffineTransform> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $builder_type:ty, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> AffineOps<&AffineTransform> for $type {
+        impl AffineOps<&AffineTransform> for $type {
             type Output = Self;
 
             fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
@@ -98,27 +98,27 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
+iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
+iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
+iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringBuilder<O, 2>,
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonBuilder<O, 2>,
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
     push_multi_polygon
 );
 iter_geo_impl!(
-    MixedGeometryArray<O, 2>,
-    MixedGeometryBuilder<O, 2>,
+    MixedGeometryArray<2>,
+    MixedGeometryBuilder<2>,
     push_geometry
 );
 iter_geo_impl!(
-    GeometryCollectionArray<O, 2>,
-    GeometryCollectionBuilder<O, 2>,
+    GeometryCollectionArray<2>,
+    GeometryCollectionBuilder<2>,
     push_geometry_collection
 );
 
@@ -137,23 +137,12 @@ impl AffineOps<&AffineTransform> for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_downcast!(as_point),
             LineString(_, XY) => impl_downcast!(as_line_string),
-            LargeLineString(_, XY) => impl_downcast!(as_large_line_string),
             Polygon(_, XY) => impl_downcast!(as_polygon),
-            LargePolygon(_, XY) => impl_downcast!(as_large_polygon),
             MultiPoint(_, XY) => impl_downcast!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_downcast!(as_large_multi_point),
             MultiLineString(_, XY) => impl_downcast!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => impl_downcast!(as_large_multi_line_string),
             MultiPolygon(_, XY) => impl_downcast!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_downcast!(as_large_multi_polygon),
             Mixed(_, XY) => impl_downcast!(as_mixed),
-            LargeMixed(_, XY) => impl_downcast!(as_large_mixed),
             GeometryCollection(_, XY) => impl_downcast!(as_geometry_collection),
-            LargeGeometryCollection(_, XY) => {
-                impl_downcast!(as_large_geometry_collection)
-            }
-            // WKB => impl_downcast!(as_wkb),
-            // LargeWKB => impl_downcast!(as_large_wkb),
             // Rect => impl_downcast!(as_rect),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -173,7 +162,7 @@ impl AffineOps<&AffineTransform> for ChunkedPointArray<2> {
 
 macro_rules! impl_chunked {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait> AffineOps<&AffineTransform> for $struct_name {
+        impl AffineOps<&AffineTransform> for $struct_name {
             type Output = Self;
 
             fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
@@ -185,13 +174,13 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<O, 2>);
-impl_chunked!(ChunkedPolygonArray<O, 2>);
-impl_chunked!(ChunkedMultiPointArray<O, 2>);
-impl_chunked!(ChunkedMultiLineStringArray<O, 2>);
-impl_chunked!(ChunkedMultiPolygonArray<O, 2>);
-impl_chunked!(ChunkedMixedGeometryArray<O, 2>);
-impl_chunked!(ChunkedGeometryCollectionArray<O, 2>);
+impl_chunked!(ChunkedLineStringArray<2>);
+impl_chunked!(ChunkedPolygonArray<2>);
+impl_chunked!(ChunkedMultiPointArray<2>);
+impl_chunked!(ChunkedMultiLineStringArray<2>);
+impl_chunked!(ChunkedMultiPolygonArray<2>);
+impl_chunked!(ChunkedMixedGeometryArray<2>);
+impl_chunked!(ChunkedGeometryCollectionArray<2>);
 
 impl AffineOps<&AffineTransform> for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -208,21 +197,12 @@ impl AffineOps<&AffineTransform> for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             Point(_, XY) => impl_downcast!(as_point),
             LineString(_, XY) => impl_downcast!(as_line_string),
-            LargeLineString(_, XY) => impl_downcast!(as_large_line_string),
             Polygon(_, XY) => impl_downcast!(as_polygon),
-            LargePolygon(_, XY) => impl_downcast!(as_large_polygon),
             MultiPoint(_, XY) => impl_downcast!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_downcast!(as_large_multi_point),
             MultiLineString(_, XY) => impl_downcast!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => impl_downcast!(as_large_multi_line_string),
             MultiPolygon(_, XY) => impl_downcast!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_downcast!(as_large_multi_polygon),
             Mixed(_, XY) => impl_downcast!(as_mixed),
-            LargeMixed(_, XY) => impl_downcast!(as_large_mixed),
             GeometryCollection(_, XY) => impl_downcast!(as_geometry_collection),
-            LargeGeometryCollection(_, XY) => {
-                impl_downcast!(as_large_geometry_collection)
-            }
             // WKB => impl_downcast!(as_wkb),
             // LargeWKB => impl_downcast!(as_large_wkb),
             // Rect => impl_downcast!(as_rect),
@@ -260,7 +240,7 @@ impl AffineOps<&[AffineTransform]> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl2 {
     ($type:ty, $builder_type:ty, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> AffineOps<&[AffineTransform]> for $type {
+        impl AffineOps<&[AffineTransform]> for $type {
             type Output = Self;
 
             fn affine_transform(&self, transform: &[AffineTransform]) -> Self::Output {
@@ -284,27 +264,27 @@ macro_rules! iter_geo_impl2 {
     };
 }
 
-iter_geo_impl2!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
-iter_geo_impl2!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
-iter_geo_impl2!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
+iter_geo_impl2!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
+iter_geo_impl2!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
+iter_geo_impl2!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
 iter_geo_impl2!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringBuilder<O, 2>,
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
     push_multi_line_string
 );
 iter_geo_impl2!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonBuilder<O, 2>,
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
     push_multi_polygon
 );
 iter_geo_impl2!(
-    MixedGeometryArray<O, 2>,
-    MixedGeometryBuilder<O, 2>,
+    MixedGeometryArray<2>,
+    MixedGeometryBuilder<2>,
     push_geometry
 );
 iter_geo_impl2!(
-    GeometryCollectionArray<O, 2>,
-    GeometryCollectionBuilder<O, 2>,
+    GeometryCollectionArray<2>,
+    GeometryCollectionBuilder<2>,
     push_geometry_collection
 );
 
@@ -318,39 +298,17 @@ impl AffineOps<&[AffineTransform]> for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().affine_transform(transform)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().affine_transform(transform)),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().affine_transform(transform))
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().affine_transform(transform)),
-            LargePolygon(_, XY) => {
-                Arc::new(self.as_large_polygon::<2>().affine_transform(transform))
-            }
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().affine_transform(transform)),
-            LargeMultiPoint(_, XY) => {
-                Arc::new(self.as_large_multi_point::<2>().affine_transform(transform))
-            }
             MultiLineString(_, XY) => {
                 Arc::new(self.as_multi_line_string::<2>().affine_transform(transform))
             }
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
-                    .affine_transform(transform),
-            ),
             MultiPolygon(_, XY) => {
                 Arc::new(self.as_multi_polygon::<2>().affine_transform(transform))
             }
-            LargeMultiPolygon(_, XY) => Arc::new(
-                self.as_large_multi_polygon::<2>()
-                    .affine_transform(transform),
-            ),
             Mixed(_, XY) => Arc::new(self.as_mixed::<2>().affine_transform(transform)),
-            LargeMixed(_, XY) => Arc::new(self.as_large_mixed::<2>().affine_transform(transform)),
             GeometryCollection(_, XY) => Arc::new(
                 self.as_geometry_collection::<2>()
-                    .affine_transform(transform),
-            ),
-            LargeGeometryCollection(_, XY) => Arc::new(
-                self.as_large_geometry_collection::<2>()
                     .affine_transform(transform),
             ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),

--- a/src/algorithm/geo/area.rs
+++ b/src/algorithm/geo/area.rs
@@ -7,7 +7,7 @@ use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;
 // use crate::array::ArrayBase;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::prelude::Area as GeoArea;
 
 /// Signed and unsigned planar area of a geometry.

--- a/src/algorithm/geo/area.rs
+++ b/src/algorithm/geo/area.rs
@@ -150,11 +150,13 @@ impl<G: NativeArray> Area for ChunkedGeometryArray<G> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn signed_area(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().signed_area())?.try_into()
+        self.try_map(|chunk| chunk.as_ref().signed_area())?
+            .try_into()
     }
 
     fn unsigned_area(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().unsigned_area())?.try_into()
+        self.try_map(|chunk| chunk.as_ref().unsigned_area())?
+            .try_into()
     }
 }
 

--- a/src/algorithm/geo/area.rs
+++ b/src/algorithm/geo/area.rs
@@ -33,8 +33,8 @@ use geo::prelude::Area as GeoArea;
 ///     line_string.0.reverse();
 /// });
 ///
-/// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
-/// let reversed_polygon_array: PolygonArray<i32, 2> = vec![reversed_polygon].as_slice().into();
+/// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
+/// let reversed_polygon_array: PolygonArray<2> = vec![reversed_polygon].as_slice().into();
 ///
 /// assert_eq!(polygon_array.signed_area().value(0), 30.);
 /// assert_eq!(polygon_array.unsigned_area().value(0), 30.);
@@ -66,7 +66,7 @@ macro_rules! zero_impl {
         }
     };
     ($type:ty, "O") => {
-        impl<O: OffsetSizeTrait> Area for $type {
+        impl Area for $type {
             type Output = Float64Array;
 
             fn signed_area(&self) -> Self::Output {
@@ -81,13 +81,13 @@ macro_rules! zero_impl {
 }
 
 zero_impl!(PointArray<2>);
-zero_impl!(LineStringArray<O, 2>, "O");
-zero_impl!(MultiPointArray<O, 2>, "O");
-zero_impl!(MultiLineStringArray<O, 2>, "O");
+zero_impl!(LineStringArray<2>, "O");
+zero_impl!(MultiPointArray<2>, "O");
+zero_impl!(MultiLineStringArray<2>, "O");
 
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Area for $type {
+        impl Area for $type {
             type Output = Float64Array;
 
             fn signed_area(&self) -> Self::Output {
@@ -101,11 +101,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>);
-iter_geo_impl!(MixedGeometryArray<O, 2>);
-iter_geo_impl!(GeometryCollectionArray<O, 2>);
-iter_geo_impl!(WKBArray<O>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
 impl Area for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -117,21 +116,12 @@ impl Area for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().signed_area(),
             LineString(_, XY) => self.as_line_string::<2>().signed_area(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().signed_area(),
             Polygon(_, XY) => self.as_polygon::<2>().signed_area(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().signed_area(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().signed_area(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().signed_area(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().signed_area(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().signed_area(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().signed_area(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().signed_area(),
             Mixed(_, XY) => self.as_mixed::<2>().signed_area(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().signed_area(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().signed_area(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().signed_area()
-            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -144,21 +134,12 @@ impl Area for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().unsigned_area(),
             LineString(_, XY) => self.as_line_string::<2>().unsigned_area(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().unsigned_area(),
             Polygon(_, XY) => self.as_polygon::<2>().unsigned_area(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().unsigned_area(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().unsigned_area(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().unsigned_area(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().unsigned_area(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().unsigned_area(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().unsigned_area(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().unsigned_area(),
             Mixed(_, XY) => self.as_mixed::<2>().unsigned_area(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().unsigned_area(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().unsigned_area(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().unsigned_area()
-            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -169,13 +150,11 @@ impl<G: NativeArray> Area for ChunkedGeometryArray<G> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn signed_area(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().signed_area())?
-            .try_into()
+        self.try_map(|chunk| chunk.as_ref().signed_area())?.try_into()
     }
 
     fn unsigned_area(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().unsigned_area())?
-            .try_into()
+        self.try_map(|chunk| chunk.as_ref().unsigned_area())?.try_into()
     }
 }
 
@@ -189,21 +168,12 @@ impl Area for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().signed_area(),
             LineString(_, XY) => self.as_line_string::<2>().signed_area(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().signed_area(),
             Polygon(_, XY) => self.as_polygon::<2>().signed_area(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().signed_area(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().signed_area(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().signed_area(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().signed_area(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().signed_area(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().signed_area(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().signed_area(),
             Mixed(_, XY) => self.as_mixed::<2>().signed_area(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().signed_area(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().signed_area(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().signed_area()
-            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -215,21 +185,12 @@ impl Area for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().unsigned_area(),
             LineString(_, XY) => self.as_line_string::<2>().unsigned_area(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().unsigned_area(),
             Polygon(_, XY) => self.as_polygon::<2>().unsigned_area(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().unsigned_area(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().unsigned_area(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().unsigned_area(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().unsigned_area(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().unsigned_area(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().unsigned_area(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().unsigned_area(),
             Mixed(_, XY) => self.as_mixed::<2>().unsigned_area(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().unsigned_area(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().unsigned_area(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().unsigned_area()
-            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/bounding_rect.rs
+++ b/src/algorithm/geo/bounding_rect.rs
@@ -52,7 +52,7 @@ impl BoundingRect for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> BoundingRect for $type {
+        impl BoundingRect for $type {
             type Output = RectArray<2>;
 
             fn bounding_rect(&self) -> Self::Output {
@@ -67,13 +67,13 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>);
-iter_geo_impl!(MixedGeometryArray<O, 2>);
-iter_geo_impl!(GeometryCollectionArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
 impl BoundingRect for &dyn NativeArray {
     type Output = Result<RectArray<2>>;
@@ -85,21 +85,12 @@ impl BoundingRect for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().bounding_rect(),
             LineString(_, XY) => self.as_line_string::<2>().bounding_rect(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().bounding_rect(),
             Polygon(_, XY) => self.as_polygon::<2>().bounding_rect(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().bounding_rect(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().bounding_rect(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().bounding_rect(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().bounding_rect(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().bounding_rect(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().bounding_rect(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().bounding_rect(),
             Mixed(_, XY) => self.as_mixed::<2>().bounding_rect(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().bounding_rect(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().bounding_rect(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().bounding_rect()
-            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -125,21 +116,12 @@ impl BoundingRect for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().bounding_rect(),
             LineString(_, XY) => self.as_line_string::<2>().bounding_rect(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().bounding_rect(),
             Polygon(_, XY) => self.as_polygon::<2>().bounding_rect(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().bounding_rect(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().bounding_rect(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().bounding_rect(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().bounding_rect(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().bounding_rect(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().bounding_rect(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().bounding_rect(),
             Mixed(_, XY) => self.as_mixed::<2>().bounding_rect(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().bounding_rect(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().bounding_rect(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().bounding_rect()
-            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/bounding_rect.rs
+++ b/src/algorithm/geo/bounding_rect.rs
@@ -39,7 +39,10 @@ impl BoundingRect for PointArray<2> {
     type Output = RectArray<2>;
 
     fn bounding_rect(&self) -> Self::Output {
-        let output_geoms: Vec<Option<Rect>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.bounding_rect())).collect();
+        let output_geoms: Vec<Option<Rect>> = self
+            .iter_geo()
+            .map(|maybe_g| maybe_g.map(|geom| geom.bounding_rect()))
+            .collect();
 
         output_geoms.into()
     }
@@ -52,7 +55,10 @@ macro_rules! iter_geo_impl {
             type Output = RectArray<2>;
 
             fn bounding_rect(&self) -> Self::Output {
-                let output_geoms: Vec<Option<Rect>> = self.iter_geo().map(|maybe_g| maybe_g.and_then(|geom| geom.bounding_rect())).collect();
+                let output_geoms: Vec<Option<Rect>> = self
+                    .iter_geo()
+                    .map(|maybe_g| maybe_g.and_then(|geom| geom.bounding_rect()))
+                    .collect();
 
                 output_geoms.into()
             }
@@ -94,7 +100,8 @@ impl<G: NativeArray> BoundingRect for ChunkedGeometryArray<G> {
     type Output = Result<ChunkedGeometryArray<RectArray<2>>>;
 
     fn bounding_rect(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().bounding_rect())?.try_into()
+        self.try_map(|chunk| chunk.as_ref().bounding_rect())?
+            .try_into()
     }
 }
 

--- a/src/algorithm/geo/bounding_rect.rs
+++ b/src/algorithm/geo/bounding_rect.rs
@@ -4,7 +4,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::algorithm::bounding_rect::BoundingRect as GeoBoundingRect;
 use geo::Rect;
 
@@ -40,10 +39,7 @@ impl BoundingRect for PointArray<2> {
     type Output = RectArray<2>;
 
     fn bounding_rect(&self) -> Self::Output {
-        let output_geoms: Vec<Option<Rect>> = self
-            .iter_geo()
-            .map(|maybe_g| maybe_g.map(|geom| geom.bounding_rect()))
-            .collect();
+        let output_geoms: Vec<Option<Rect>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.bounding_rect())).collect();
 
         output_geoms.into()
     }
@@ -56,10 +52,7 @@ macro_rules! iter_geo_impl {
             type Output = RectArray<2>;
 
             fn bounding_rect(&self) -> Self::Output {
-                let output_geoms: Vec<Option<Rect>> = self
-                    .iter_geo()
-                    .map(|maybe_g| maybe_g.and_then(|geom| geom.bounding_rect()))
-                    .collect();
+                let output_geoms: Vec<Option<Rect>> = self.iter_geo().map(|maybe_g| maybe_g.and_then(|geom| geom.bounding_rect())).collect();
 
                 output_geoms.into()
             }
@@ -101,8 +94,7 @@ impl<G: NativeArray> BoundingRect for ChunkedGeometryArray<G> {
     type Output = Result<ChunkedGeometryArray<RectArray<2>>>;
 
     fn bounding_rect(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().bounding_rect())?
-            .try_into()
+        self.try_map(|chunk| chunk.as_ref().bounding_rect())?.try_into()
     }
 }
 

--- a/src/algorithm/geo/center.rs
+++ b/src/algorithm/geo/center.rs
@@ -27,7 +27,7 @@ impl Center for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Center for $type {
+        impl Center for $type {
             type Output = PointArray<2>;
 
             fn center(&self) -> Self::Output {
@@ -45,13 +45,13 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>);
-iter_geo_impl!(MixedGeometryArray<O, 2>);
-iter_geo_impl!(GeometryCollectionArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
 impl Center for &dyn NativeArray {
     type Output = Result<PointArray<2>>;
@@ -63,19 +63,12 @@ impl Center for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().center(),
             LineString(_, XY) => self.as_line_string::<2>().center(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().center(),
             Polygon(_, XY) => self.as_polygon::<2>().center(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().center(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().center(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().center(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().center(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().center(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().center(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().center(),
             Mixed(_, XY) => self.as_mixed::<2>().center(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().center(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().center(),
-            LargeGeometryCollection(_, XY) => self.as_large_geometry_collection::<2>().center(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -100,19 +93,12 @@ impl Center for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().center(),
             LineString(_, XY) => self.as_line_string::<2>().center(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().center(),
             Polygon(_, XY) => self.as_polygon::<2>().center(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().center(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().center(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().center(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().center(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().center(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().center(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().center(),
             Mixed(_, XY) => self.as_mixed::<2>().center(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().center(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().center(),
-            LargeGeometryCollection(_, XY) => self.as_large_geometry_collection::<2>().center(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/center.rs
+++ b/src/algorithm/geo/center.rs
@@ -31,7 +31,13 @@ macro_rules! iter_geo_impl {
 
             fn center(&self) -> Self::Output {
                 let mut output_array = PointBuilder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| output_array.push_point(maybe_g.and_then(|g| g.bounding_rect().map(|rect| rect.center())).as_ref()));
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array.push_point(
+                        maybe_g
+                            .and_then(|g| g.bounding_rect().map(|rect| rect.center()))
+                            .as_ref(),
+                    )
+                });
                 output_array.into()
             }
         }

--- a/src/algorithm/geo/center.rs
+++ b/src/algorithm/geo/center.rs
@@ -4,7 +4,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::BoundingRect;
 
 /// Compute the center of geometries
@@ -32,13 +31,7 @@ macro_rules! iter_geo_impl {
 
             fn center(&self) -> Self::Output {
                 let mut output_array = PointBuilder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| {
-                    output_array.push_point(
-                        maybe_g
-                            .and_then(|g| g.bounding_rect().map(|rect| rect.center()))
-                            .as_ref(),
-                    )
-                });
+                self.iter_geo().for_each(|maybe_g| output_array.push_point(maybe_g.and_then(|g| g.bounding_rect().map(|rect| rect.center())).as_ref()));
                 output_array.into()
             }
         }

--- a/src/algorithm/geo/centroid.rs
+++ b/src/algorithm/geo/centroid.rs
@@ -80,7 +80,9 @@ macro_rules! iter_geo_impl {
 
             fn centroid(&self) -> Self::Output {
                 let mut output_array = PointBuilder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| output_array.push_point(maybe_g.and_then(|g| g.centroid()).as_ref()));
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array.push_point(maybe_g.and_then(|g| g.centroid()).as_ref())
+                });
                 output_array.into()
             }
         }

--- a/src/algorithm/geo/centroid.rs
+++ b/src/algorithm/geo/centroid.rs
@@ -4,7 +4,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::algorithm::centroid::Centroid as GeoCentroid;
 
 /// Calculation of the centroid.
@@ -81,9 +80,7 @@ macro_rules! iter_geo_impl {
 
             fn centroid(&self) -> Self::Output {
                 let mut output_array = PointBuilder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| {
-                    output_array.push_point(maybe_g.and_then(|g| g.centroid()).as_ref())
-                });
+                self.iter_geo().for_each(|maybe_g| output_array.push_point(maybe_g.and_then(|g| g.centroid()).as_ref()));
                 output_array.into()
             }
         }

--- a/src/algorithm/geo/centroid.rs
+++ b/src/algorithm/geo/centroid.rs
@@ -31,7 +31,7 @@ use geo::algorithm::centroid::Centroid as GeoCentroid;
 ///     (x: 1., y: -1.),
 ///     (x: -2., y: 1.),
 /// ];
-/// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
+/// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
 ///
 /// assert_eq!(
 ///     Some(point!(x: 1., y: 1.)),
@@ -55,7 +55,7 @@ pub trait Centroid {
     ///     (x: 40.02f64, y: 116.34),
     ///     (x: 40.02f64, y: 118.23),
     /// ];
-    /// let line_string_array: LineStringArray<i32, 2> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray<2> = vec![line_string].as_slice().into();
     ///
     /// assert_eq!(
     ///     Some(point!(x: 40.02, y: 117.285)),
@@ -76,7 +76,7 @@ impl Centroid for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Centroid for $type {
+        impl Centroid for $type {
             type Output = PointArray<2>;
 
             fn centroid(&self) -> Self::Output {
@@ -90,13 +90,13 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>);
-iter_geo_impl!(MixedGeometryArray<O, 2>);
-iter_geo_impl!(GeometryCollectionArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
 impl Centroid for &dyn NativeArray {
     type Output = Result<PointArray<2>>;
@@ -108,19 +108,12 @@ impl Centroid for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().centroid(),
             LineString(_, XY) => self.as_line_string::<2>().centroid(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().centroid(),
             Polygon(_, XY) => self.as_polygon::<2>().centroid(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().centroid(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().centroid(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().centroid(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().centroid(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().centroid(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().centroid(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().centroid(),
             Mixed(_, XY) => self.as_mixed::<2>().centroid(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().centroid(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().centroid(),
-            LargeGeometryCollection(_, XY) => self.as_large_geometry_collection::<2>().centroid(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -145,19 +138,12 @@ impl Centroid for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().centroid(),
             LineString(_, XY) => self.as_line_string::<2>().centroid(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().centroid(),
             Polygon(_, XY) => self.as_polygon::<2>().centroid(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().centroid(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().centroid(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().centroid(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().centroid(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().centroid(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().centroid(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().centroid(),
             Mixed(_, XY) => self.as_mixed::<2>().centroid(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().centroid(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().centroid(),
-            LargeGeometryCollection(_, XY) => self.as_large_geometry_collection::<2>().centroid(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/chaikin_smoothing.rs
+++ b/src/algorithm/geo/chaikin_smoothing.rs
@@ -30,7 +30,7 @@ pub trait ChaikinSmoothing {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: OffsetSizeTrait> ChaikinSmoothing for $type {
+        impl ChaikinSmoothing for $type {
             type Output = Self;
 
             fn chaikin_smoothing(&self, n_iterations: u32) -> Self::Output {
@@ -47,10 +47,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
-iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
+iter_geo_impl!(LineStringArray<2>, geo::LineString);
+iter_geo_impl!(PolygonArray<2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
 
 impl ChaikinSmoothing for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -63,29 +63,14 @@ impl ChaikinSmoothing for &dyn NativeArray {
             LineString(_, XY) => {
                 Arc::new(self.as_line_string::<2>().chaikin_smoothing(n_iterations))
             }
-            LargeLineString(_, XY) => Arc::new(
-                self.as_large_line_string::<2>()
-                    .chaikin_smoothing(n_iterations),
-            ),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().chaikin_smoothing(n_iterations)),
-            LargePolygon(_, XY) => {
-                Arc::new(self.as_large_polygon::<2>().chaikin_smoothing(n_iterations))
-            }
             MultiLineString(_, XY) => Arc::new(
                 self.as_multi_line_string::<2>()
-                    .chaikin_smoothing(n_iterations),
-            ),
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
                     .chaikin_smoothing(n_iterations),
             ),
             MultiPolygon(_, XY) => {
                 Arc::new(self.as_multi_polygon::<2>().chaikin_smoothing(n_iterations))
             }
-            LargeMultiPolygon(_, XY) => Arc::new(
-                self.as_large_multi_polygon::<2>()
-                    .chaikin_smoothing(n_iterations),
-            ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -94,7 +79,7 @@ impl ChaikinSmoothing for &dyn NativeArray {
 
 macro_rules! impl_chunked {
     ($chunked_array:ty) => {
-        impl<O: OffsetSizeTrait> ChaikinSmoothing for $chunked_array {
+        impl ChaikinSmoothing for $chunked_array {
             type Output = Self;
 
             fn chaikin_smoothing(&self, n_iterations: u32) -> Self::Output {
@@ -106,10 +91,10 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<O, 2>);
-impl_chunked!(ChunkedPolygonArray<O, 2>);
-impl_chunked!(ChunkedMultiLineStringArray<O, 2>);
-impl_chunked!(ChunkedMultiPolygonArray<O, 2>);
+impl_chunked!(ChunkedLineStringArray<2>);
+impl_chunked!(ChunkedPolygonArray<2>);
+impl_chunked!(ChunkedMultiLineStringArray<2>);
+impl_chunked!(ChunkedMultiPolygonArray<2>);
 
 impl ChaikinSmoothing for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -122,29 +107,14 @@ impl ChaikinSmoothing for &dyn ChunkedNativeArray {
             LineString(_, XY) => {
                 Arc::new(self.as_line_string::<2>().chaikin_smoothing(n_iterations))
             }
-            LargeLineString(_, XY) => Arc::new(
-                self.as_large_line_string::<2>()
-                    .chaikin_smoothing(n_iterations),
-            ),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().chaikin_smoothing(n_iterations)),
-            LargePolygon(_, XY) => {
-                Arc::new(self.as_large_polygon::<2>().chaikin_smoothing(n_iterations))
-            }
             MultiLineString(_, XY) => Arc::new(
                 self.as_multi_line_string::<2>()
-                    .chaikin_smoothing(n_iterations),
-            ),
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
                     .chaikin_smoothing(n_iterations),
             ),
             MultiPolygon(_, XY) => {
                 Arc::new(self.as_multi_polygon::<2>().chaikin_smoothing(n_iterations))
             }
-            LargeMultiPolygon(_, XY) => Arc::new(
-                self.as_large_multi_polygon::<2>()
-                    .chaikin_smoothing(n_iterations),
-            ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/chaikin_smoothing.rs
+++ b/src/algorithm/geo/chaikin_smoothing.rs
@@ -33,7 +33,12 @@ macro_rules! iter_geo_impl {
             type Output = Self;
 
             fn chaikin_smoothing(&self, n_iterations: u32) -> Self::Output {
-                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.chaikin_smoothing(n_iterations.try_into().unwrap()))).collect();
+                let output_geoms: Vec<Option<$geo_type>> = self
+                    .iter_geo()
+                    .map(|maybe_g| {
+                        maybe_g.map(|geom| geom.chaikin_smoothing(n_iterations.try_into().unwrap()))
+                    })
+                    .collect();
 
                 output_geoms.into()
             }
@@ -54,10 +59,17 @@ impl ChaikinSmoothing for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().chaikin_smoothing(n_iterations)),
+            LineString(_, XY) => {
+                Arc::new(self.as_line_string::<2>().chaikin_smoothing(n_iterations))
+            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().chaikin_smoothing(n_iterations)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().chaikin_smoothing(n_iterations)),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().chaikin_smoothing(n_iterations)),
+            MultiLineString(_, XY) => Arc::new(
+                self.as_multi_line_string::<2>()
+                    .chaikin_smoothing(n_iterations),
+            ),
+            MultiPolygon(_, XY) => {
+                Arc::new(self.as_multi_polygon::<2>().chaikin_smoothing(n_iterations))
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -70,7 +82,9 @@ macro_rules! impl_chunked {
             type Output = Self;
 
             fn chaikin_smoothing(&self, n_iterations: u32) -> Self::Output {
-                self.map(|chunk| chunk.chaikin_smoothing(n_iterations.into())).try_into().unwrap()
+                self.map(|chunk| chunk.chaikin_smoothing(n_iterations.into()))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -89,10 +103,17 @@ impl ChaikinSmoothing for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().chaikin_smoothing(n_iterations)),
+            LineString(_, XY) => {
+                Arc::new(self.as_line_string::<2>().chaikin_smoothing(n_iterations))
+            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().chaikin_smoothing(n_iterations)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().chaikin_smoothing(n_iterations)),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().chaikin_smoothing(n_iterations)),
+            MultiLineString(_, XY) => Arc::new(
+                self.as_multi_line_string::<2>()
+                    .chaikin_smoothing(n_iterations),
+            ),
+            MultiPolygon(_, XY) => {
+                Arc::new(self.as_multi_polygon::<2>().chaikin_smoothing(n_iterations))
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -6,7 +6,7 @@ use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
 use arrow_array::builder::Float64Builder;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::prelude::ChamberlainDuquetteArea as GeoChamberlainDuquetteArea;
 
 /// Calculate the signed approximate geodesic area of a `Geometry`.
@@ -107,19 +107,13 @@ macro_rules! iter_geo_impl {
 
             fn chamberlain_duquette_signed_area(&self) -> Self::Output {
                 let mut output_array = Float64Builder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| {
-                    output_array
-                        .append_option(maybe_g.map(|g| g.chamberlain_duquette_signed_area()))
-                });
+                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.chamberlain_duquette_signed_area())));
                 output_array.finish()
             }
 
             fn chamberlain_duquette_unsigned_area(&self) -> Self::Output {
                 let mut output_array = Float64Builder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| {
-                    output_array
-                        .append_option(maybe_g.map(|g| g.chamberlain_duquette_unsigned_area()))
-                });
+                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.chamberlain_duquette_unsigned_area())));
                 output_array.finish()
             }
         }
@@ -140,23 +134,13 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().chamberlain_duquette_signed_area(),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .chamberlain_duquette_signed_area(),
+            LineString(_, XY) => self.as_line_string::<2>().chamberlain_duquette_signed_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_signed_area(),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .chamberlain_duquette_signed_area(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .chamberlain_duquette_signed_area(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .chamberlain_duquette_signed_area(),
+            MultiPoint(_, XY) => self.as_multi_point::<2>().chamberlain_duquette_signed_area(),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().chamberlain_duquette_signed_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().chamberlain_duquette_signed_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_signed_area(),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .chamberlain_duquette_signed_area(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().chamberlain_duquette_signed_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -168,23 +152,13 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().chamberlain_duquette_unsigned_area(),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .chamberlain_duquette_unsigned_area(),
+            LineString(_, XY) => self.as_line_string::<2>().chamberlain_duquette_unsigned_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_unsigned_area(),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .chamberlain_duquette_unsigned_area(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .chamberlain_duquette_unsigned_area(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .chamberlain_duquette_unsigned_area(),
+            MultiPoint(_, XY) => self.as_multi_point::<2>().chamberlain_duquette_unsigned_area(),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().chamberlain_duquette_unsigned_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().chamberlain_duquette_unsigned_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_unsigned_area(),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .chamberlain_duquette_unsigned_area(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().chamberlain_duquette_unsigned_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -222,23 +196,13 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().chamberlain_duquette_signed_area(),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .chamberlain_duquette_signed_area(),
+            LineString(_, XY) => self.as_line_string::<2>().chamberlain_duquette_signed_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_signed_area(),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .chamberlain_duquette_signed_area(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .chamberlain_duquette_signed_area(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .chamberlain_duquette_signed_area(),
+            MultiPoint(_, XY) => self.as_multi_point::<2>().chamberlain_duquette_signed_area(),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().chamberlain_duquette_signed_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().chamberlain_duquette_signed_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_signed_area(),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .chamberlain_duquette_signed_area(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().chamberlain_duquette_signed_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -249,23 +213,13 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().chamberlain_duquette_unsigned_area(),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .chamberlain_duquette_unsigned_area(),
+            LineString(_, XY) => self.as_line_string::<2>().chamberlain_duquette_unsigned_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_unsigned_area(),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .chamberlain_duquette_unsigned_area(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .chamberlain_duquette_unsigned_area(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .chamberlain_duquette_unsigned_area(),
+            MultiPoint(_, XY) => self.as_multi_point::<2>().chamberlain_duquette_unsigned_area(),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().chamberlain_duquette_unsigned_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().chamberlain_duquette_unsigned_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_unsigned_area(),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .chamberlain_duquette_unsigned_area(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().chamberlain_duquette_unsigned_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -107,13 +107,19 @@ macro_rules! iter_geo_impl {
 
             fn chamberlain_duquette_signed_area(&self) -> Self::Output {
                 let mut output_array = Float64Builder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.chamberlain_duquette_signed_area())));
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array
+                        .append_option(maybe_g.map(|g| g.chamberlain_duquette_signed_area()))
+                });
                 output_array.finish()
             }
 
             fn chamberlain_duquette_unsigned_area(&self) -> Self::Output {
                 let mut output_array = Float64Builder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.chamberlain_duquette_unsigned_area())));
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array
+                        .append_option(maybe_g.map(|g| g.chamberlain_duquette_unsigned_area()))
+                });
                 output_array.finish()
             }
         }
@@ -134,13 +140,23 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().chamberlain_duquette_signed_area(),
-            LineString(_, XY) => self.as_line_string::<2>().chamberlain_duquette_signed_area(),
+            LineString(_, XY) => self
+                .as_line_string::<2>()
+                .chamberlain_duquette_signed_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_signed_area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().chamberlain_duquette_signed_area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().chamberlain_duquette_signed_area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().chamberlain_duquette_signed_area(),
+            MultiPoint(_, XY) => self
+                .as_multi_point::<2>()
+                .chamberlain_duquette_signed_area(),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .chamberlain_duquette_signed_area(),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .chamberlain_duquette_signed_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_signed_area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().chamberlain_duquette_signed_area(),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .chamberlain_duquette_signed_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -152,13 +168,23 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().chamberlain_duquette_unsigned_area(),
-            LineString(_, XY) => self.as_line_string::<2>().chamberlain_duquette_unsigned_area(),
+            LineString(_, XY) => self
+                .as_line_string::<2>()
+                .chamberlain_duquette_unsigned_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_unsigned_area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().chamberlain_duquette_unsigned_area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().chamberlain_duquette_unsigned_area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().chamberlain_duquette_unsigned_area(),
+            MultiPoint(_, XY) => self
+                .as_multi_point::<2>()
+                .chamberlain_duquette_unsigned_area(),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .chamberlain_duquette_unsigned_area(),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .chamberlain_duquette_unsigned_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_unsigned_area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().chamberlain_duquette_unsigned_area(),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .chamberlain_duquette_unsigned_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -196,13 +222,23 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().chamberlain_duquette_signed_area(),
-            LineString(_, XY) => self.as_line_string::<2>().chamberlain_duquette_signed_area(),
+            LineString(_, XY) => self
+                .as_line_string::<2>()
+                .chamberlain_duquette_signed_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_signed_area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().chamberlain_duquette_signed_area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().chamberlain_duquette_signed_area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().chamberlain_duquette_signed_area(),
+            MultiPoint(_, XY) => self
+                .as_multi_point::<2>()
+                .chamberlain_duquette_signed_area(),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .chamberlain_duquette_signed_area(),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .chamberlain_duquette_signed_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_signed_area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().chamberlain_duquette_signed_area(),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .chamberlain_duquette_signed_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -213,13 +249,23 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().chamberlain_duquette_unsigned_area(),
-            LineString(_, XY) => self.as_line_string::<2>().chamberlain_duquette_unsigned_area(),
+            LineString(_, XY) => self
+                .as_line_string::<2>()
+                .chamberlain_duquette_unsigned_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_unsigned_area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().chamberlain_duquette_unsigned_area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().chamberlain_duquette_unsigned_area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().chamberlain_duquette_unsigned_area(),
+            MultiPoint(_, XY) => self
+                .as_multi_point::<2>()
+                .chamberlain_duquette_unsigned_area(),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .chamberlain_duquette_unsigned_area(),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .chamberlain_duquette_unsigned_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_unsigned_area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().chamberlain_duquette_unsigned_area(),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .chamberlain_duquette_unsigned_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -47,8 +47,8 @@ use geo::prelude::ChamberlainDuquetteArea as GeoChamberlainDuquetteArea;
 ///     line_string.0.reverse();
 /// });
 ///
-/// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
-/// let reversed_polygon_array: PolygonArray<i32, 2> = vec![reversed_polygon].as_slice().into();
+/// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
+/// let reversed_polygon_array: PolygonArray<2> = vec![reversed_polygon].as_slice().into();
 ///
 /// // 78,478 meters²
 /// assert_eq!(78_478., polygon_array.chamberlain_duquette_unsigned_area().value(0).round());
@@ -81,7 +81,7 @@ impl ChamberlainDuquetteArea for PointArray<2> {
 /// Generate a `ChamberlainDuquetteArea` implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> ChamberlainDuquetteArea for $type {
+        impl ChamberlainDuquetteArea for $type {
             type Output = Float64Array;
 
             fn chamberlain_duquette_signed_area(&self) -> Self::Output {
@@ -95,14 +95,14 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(LineStringArray<O, 2>);
-zero_impl!(MultiPointArray<O, 2>);
-zero_impl!(MultiLineStringArray<O, 2>);
+zero_impl!(LineStringArray<2>);
+zero_impl!(MultiPointArray<2>);
+zero_impl!(MultiLineStringArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> ChamberlainDuquetteArea for $type {
+        impl ChamberlainDuquetteArea for $type {
             type Output = Float64Array;
 
             fn chamberlain_duquette_signed_area(&self) -> Self::Output {
@@ -126,10 +126,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>);
-iter_geo_impl!(MixedGeometryArray<O, 2>);
-iter_geo_impl!(GeometryCollectionArray<O, 2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
 impl ChamberlainDuquetteArea for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -143,40 +143,19 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
             LineString(_, XY) => self
                 .as_line_string::<2>()
                 .chamberlain_duquette_signed_area(),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .chamberlain_duquette_signed_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_signed_area(),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .chamberlain_duquette_signed_area(),
             MultiPoint(_, XY) => self
                 .as_multi_point::<2>()
-                .chamberlain_duquette_signed_area(),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
                 .chamberlain_duquette_signed_area(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string::<2>()
                 .chamberlain_duquette_signed_area(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .chamberlain_duquette_signed_area(),
             MultiPolygon(_, XY) => self
                 .as_multi_polygon::<2>()
                 .chamberlain_duquette_signed_area(),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .chamberlain_duquette_signed_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_signed_area(),
-            LargeMixed(_, XY) => self
-                .as_large_mixed::<2>()
-                .chamberlain_duquette_signed_area(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection::<2>()
-                .chamberlain_duquette_signed_area(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
                 .chamberlain_duquette_signed_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -192,40 +171,19 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
             LineString(_, XY) => self
                 .as_line_string::<2>()
                 .chamberlain_duquette_unsigned_area(),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .chamberlain_duquette_unsigned_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_unsigned_area(),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .chamberlain_duquette_unsigned_area(),
             MultiPoint(_, XY) => self
                 .as_multi_point::<2>()
-                .chamberlain_duquette_unsigned_area(),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
                 .chamberlain_duquette_unsigned_area(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string::<2>()
                 .chamberlain_duquette_unsigned_area(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .chamberlain_duquette_unsigned_area(),
             MultiPolygon(_, XY) => self
                 .as_multi_polygon::<2>()
                 .chamberlain_duquette_unsigned_area(),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .chamberlain_duquette_unsigned_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_unsigned_area(),
-            LargeMixed(_, XY) => self
-                .as_large_mixed::<2>()
-                .chamberlain_duquette_unsigned_area(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection::<2>()
-                .chamberlain_duquette_unsigned_area(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
                 .chamberlain_duquette_unsigned_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -267,40 +225,19 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
             LineString(_, XY) => self
                 .as_line_string::<2>()
                 .chamberlain_duquette_signed_area(),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .chamberlain_duquette_signed_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_signed_area(),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .chamberlain_duquette_signed_area(),
             MultiPoint(_, XY) => self
                 .as_multi_point::<2>()
-                .chamberlain_duquette_signed_area(),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
                 .chamberlain_duquette_signed_area(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string::<2>()
                 .chamberlain_duquette_signed_area(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .chamberlain_duquette_signed_area(),
             MultiPolygon(_, XY) => self
                 .as_multi_polygon::<2>()
                 .chamberlain_duquette_signed_area(),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .chamberlain_duquette_signed_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_signed_area(),
-            LargeMixed(_, XY) => self
-                .as_large_mixed::<2>()
-                .chamberlain_duquette_signed_area(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection::<2>()
-                .chamberlain_duquette_signed_area(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
                 .chamberlain_duquette_signed_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -315,40 +252,19 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
             LineString(_, XY) => self
                 .as_line_string::<2>()
                 .chamberlain_duquette_unsigned_area(),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .chamberlain_duquette_unsigned_area(),
             Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_unsigned_area(),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .chamberlain_duquette_unsigned_area(),
             MultiPoint(_, XY) => self
                 .as_multi_point::<2>()
-                .chamberlain_duquette_unsigned_area(),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
                 .chamberlain_duquette_unsigned_area(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string::<2>()
                 .chamberlain_duquette_unsigned_area(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .chamberlain_duquette_unsigned_area(),
             MultiPolygon(_, XY) => self
                 .as_multi_polygon::<2>()
                 .chamberlain_duquette_unsigned_area(),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .chamberlain_duquette_unsigned_area(),
             Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_unsigned_area(),
-            LargeMixed(_, XY) => self
-                .as_large_mixed::<2>()
-                .chamberlain_duquette_unsigned_area(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection::<2>()
-                .chamberlain_duquette_unsigned_area(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
                 .chamberlain_duquette_unsigned_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }

--- a/src/algorithm/geo/contains.rs
+++ b/src/algorithm/geo/contains.rs
@@ -7,7 +7,7 @@ use crate::io::geo::{geometry_collection_to_geo, geometry_to_geo, line_string_to
 use crate::trait_::{ArrayAccessor, NativeScalar};
 use crate::NativeArray;
 use arrow_array::builder::BooleanBuilder;
-use arrow_array::{BooleanArray, OffsetSizeTrait};
+use arrow_array::BooleanArray;
 use geo::Contains as _Contains;
 
 /// Checks if `rhs` is completely contained within `self`.

--- a/src/algorithm/geo/contains.rs
+++ b/src/algorithm/geo/contains.rs
@@ -2,8 +2,14 @@ use crate::algorithm::native::{Binary, Unary};
 use crate::array::*;
 use crate::datatypes::{Dimension, NativeType};
 use crate::error::GeoArrowError;
-use crate::geo_traits::{GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait};
-use crate::io::geo::{geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo, multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo};
+use crate::geo_traits::{
+    GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
+    MultiPolygonTrait, PointTrait, PolygonTrait,
+};
+use crate::io::geo::{
+    geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo,
+    multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo,
+};
 use crate::trait_::{ArrayAccessor, NativeScalar};
 use crate::NativeArray;
 use arrow_array::builder::BooleanBuilder;
@@ -55,7 +61,10 @@ pub trait Contains<Rhs = Self> {
 // Note: this implementation is outside the macro because it is not generic over O
 impl Contains for PointArray<2> {
     fn contains(&self, rhs: &Self) -> BooleanArray {
-        self.try_binary_boolean(rhs, |left, right| Ok(left.to_geo().contains(&right.to_geo()))).unwrap()
+        self.try_binary_boolean(rhs, |left, right| {
+            Ok(left.to_geo().contains(&right.to_geo()))
+        })
+        .unwrap()
     }
 }
 
@@ -64,7 +73,10 @@ macro_rules! iter_geo_impl {
     ($first:ty, $second:ty) => {
         impl<'a> Contains<$second> for $first {
             fn contains(&self, rhs: &$second) -> BooleanArray {
-                self.try_binary_boolean(rhs, |left, right| Ok(left.to_geo().contains(&right.to_geo()))).unwrap()
+                self.try_binary_boolean(rhs, |left, right| {
+                    Ok(left.to_geo().contains(&right.to_geo()))
+                })
+                .unwrap()
             }
         }
     };
@@ -128,7 +140,8 @@ pub trait ContainsPoint<Rhs> {
 impl<G: PointTrait<T = f64>> ContainsPoint<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = point_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+            .unwrap()
     }
 }
 
@@ -137,7 +150,8 @@ macro_rules! impl_contains_point {
         impl<G: PointTrait<T = f64>> ContainsPoint<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = point_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+                    .unwrap()
             }
         }
     };
@@ -161,10 +175,14 @@ impl<G: PointTrait<T = f64>> ContainsPoint<G> for &dyn NativeArray {
             LineString(_, XY) => ContainsPoint::contains(self.as_line_string::<2>(), rhs),
             Polygon(_, XY) => ContainsPoint::contains(self.as_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsPoint::contains(self.as_multi_point::<2>(), rhs),
-            MultiLineString(_, XY) => ContainsPoint::contains(self.as_multi_line_string::<2>(), rhs),
+            MultiLineString(_, XY) => {
+                ContainsPoint::contains(self.as_multi_line_string::<2>(), rhs)
+            }
             MultiPolygon(_, XY) => ContainsPoint::contains(self.as_multi_polygon::<2>(), rhs),
             Mixed(_, XY) => ContainsPoint::contains(self.as_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => ContainsPoint::contains(self.as_geometry_collection::<2>(), rhs),
+            GeometryCollection(_, XY) => {
+                ContainsPoint::contains(self.as_geometry_collection::<2>(), rhs)
+            }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -177,7 +195,8 @@ pub trait ContainsLineString<Rhs> {
 impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = line_string_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+            .unwrap()
     }
 }
 
@@ -217,10 +236,14 @@ impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for &dyn NativeArray {
             LineString(_, XY) => ContainsLineString::contains(self.as_line_string::<2>(), rhs),
             Polygon(_, XY) => ContainsLineString::contains(self.as_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsLineString::contains(self.as_multi_point::<2>(), rhs),
-            MultiLineString(_, XY) => ContainsLineString::contains(self.as_multi_line_string::<2>(), rhs),
+            MultiLineString(_, XY) => {
+                ContainsLineString::contains(self.as_multi_line_string::<2>(), rhs)
+            }
             MultiPolygon(_, XY) => ContainsLineString::contains(self.as_multi_polygon::<2>(), rhs),
             Mixed(_, XY) => ContainsLineString::contains(self.as_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => ContainsLineString::contains(self.as_geometry_collection::<2>(), rhs),
+            GeometryCollection(_, XY) => {
+                ContainsLineString::contains(self.as_geometry_collection::<2>(), rhs)
+            }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -233,7 +256,8 @@ pub trait ContainsPolygon<Rhs> {
 impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = polygon_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+            .unwrap()
     }
 }
 
@@ -242,7 +266,8 @@ macro_rules! impl_contains_polygon {
         impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = polygon_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+                    .unwrap()
             }
         }
     };
@@ -266,10 +291,14 @@ impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for &dyn NativeArray {
             LineString(_, XY) => ContainsPolygon::contains(self.as_line_string::<2>(), rhs),
             Polygon(_, XY) => ContainsPolygon::contains(self.as_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsPolygon::contains(self.as_multi_point::<2>(), rhs),
-            MultiLineString(_, XY) => ContainsPolygon::contains(self.as_multi_line_string::<2>(), rhs),
+            MultiLineString(_, XY) => {
+                ContainsPolygon::contains(self.as_multi_line_string::<2>(), rhs)
+            }
             MultiPolygon(_, XY) => ContainsPolygon::contains(self.as_multi_polygon::<2>(), rhs),
             Mixed(_, XY) => ContainsPolygon::contains(self.as_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => ContainsPolygon::contains(self.as_geometry_collection::<2>(), rhs),
+            GeometryCollection(_, XY) => {
+                ContainsPolygon::contains(self.as_geometry_collection::<2>(), rhs)
+            }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -282,7 +311,8 @@ pub trait ContainsMultiPoint<Rhs> {
 impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_point_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+            .unwrap()
     }
 }
 
@@ -291,7 +321,8 @@ macro_rules! impl_contains_multi_point {
         impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = multi_point_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+                    .unwrap()
             }
         }
     };
@@ -315,10 +346,14 @@ impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for &dyn NativeArray {
             LineString(_, XY) => ContainsMultiPoint::contains(self.as_line_string::<2>(), rhs),
             Polygon(_, XY) => ContainsMultiPoint::contains(self.as_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsMultiPoint::contains(self.as_multi_point::<2>(), rhs),
-            MultiLineString(_, XY) => ContainsMultiPoint::contains(self.as_multi_line_string::<2>(), rhs),
+            MultiLineString(_, XY) => {
+                ContainsMultiPoint::contains(self.as_multi_line_string::<2>(), rhs)
+            }
             MultiPolygon(_, XY) => ContainsMultiPoint::contains(self.as_multi_polygon::<2>(), rhs),
             Mixed(_, XY) => ContainsMultiPoint::contains(self.as_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => ContainsMultiPoint::contains(self.as_geometry_collection::<2>(), rhs),
+            GeometryCollection(_, XY) => {
+                ContainsMultiPoint::contains(self.as_geometry_collection::<2>(), rhs)
+            }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -331,7 +366,8 @@ pub trait ContainsMultiLineString<Rhs> {
 impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_line_string_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+            .unwrap()
     }
 }
 
@@ -340,7 +376,8 @@ macro_rules! impl_contains_multi_line_string {
         impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = multi_line_string_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+                    .unwrap()
             }
         }
     };
@@ -364,10 +401,16 @@ impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for &dyn Nativ
             LineString(_, XY) => ContainsMultiLineString::contains(self.as_line_string::<2>(), rhs),
             Polygon(_, XY) => ContainsMultiLineString::contains(self.as_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsMultiLineString::contains(self.as_multi_point::<2>(), rhs),
-            MultiLineString(_, XY) => ContainsMultiLineString::contains(self.as_multi_line_string::<2>(), rhs),
-            MultiPolygon(_, XY) => ContainsMultiLineString::contains(self.as_multi_polygon::<2>(), rhs),
+            MultiLineString(_, XY) => {
+                ContainsMultiLineString::contains(self.as_multi_line_string::<2>(), rhs)
+            }
+            MultiPolygon(_, XY) => {
+                ContainsMultiLineString::contains(self.as_multi_polygon::<2>(), rhs)
+            }
             Mixed(_, XY) => ContainsMultiLineString::contains(self.as_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => ContainsMultiLineString::contains(self.as_geometry_collection::<2>(), rhs),
+            GeometryCollection(_, XY) => {
+                ContainsMultiLineString::contains(self.as_geometry_collection::<2>(), rhs)
+            }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -380,7 +423,8 @@ pub trait ContainsMultiPolygon<Rhs> {
 impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_polygon_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+            .unwrap()
     }
 }
 
@@ -389,7 +433,8 @@ macro_rules! impl_contains_multi_polygon {
         impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = multi_polygon_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+                    .unwrap()
             }
         }
     };
@@ -413,10 +458,16 @@ impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for &dyn NativeArray
             LineString(_, XY) => ContainsMultiPolygon::contains(self.as_line_string::<2>(), rhs),
             Polygon(_, XY) => ContainsMultiPolygon::contains(self.as_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsMultiPolygon::contains(self.as_multi_point::<2>(), rhs),
-            MultiLineString(_, XY) => ContainsMultiPolygon::contains(self.as_multi_line_string::<2>(), rhs),
-            MultiPolygon(_, XY) => ContainsMultiPolygon::contains(self.as_multi_polygon::<2>(), rhs),
+            MultiLineString(_, XY) => {
+                ContainsMultiPolygon::contains(self.as_multi_line_string::<2>(), rhs)
+            }
+            MultiPolygon(_, XY) => {
+                ContainsMultiPolygon::contains(self.as_multi_polygon::<2>(), rhs)
+            }
             Mixed(_, XY) => ContainsMultiPolygon::contains(self.as_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => ContainsMultiPolygon::contains(self.as_geometry_collection::<2>(), rhs),
+            GeometryCollection(_, XY) => {
+                ContainsMultiPolygon::contains(self.as_geometry_collection::<2>(), rhs)
+            }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -429,7 +480,8 @@ pub trait ContainsGeometry<Rhs> {
 impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = geometry_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+            .unwrap()
     }
 }
 
@@ -438,7 +490,8 @@ macro_rules! impl_contains_geometry {
         impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = geometry_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+                    .unwrap()
             }
         }
     };
@@ -462,10 +515,14 @@ impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for &dyn NativeArray {
             LineString(_, XY) => ContainsGeometry::contains(self.as_line_string::<2>(), rhs),
             Polygon(_, XY) => ContainsGeometry::contains(self.as_polygon::<2>(), rhs),
             MultiPoint(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_point::<2>(), rhs),
-            MultiLineString(_, XY) => ContainsGeometry::contains(self.as_multi_line_string::<2>(), rhs),
+            MultiLineString(_, XY) => {
+                ContainsGeometry::contains(self.as_multi_line_string::<2>(), rhs)
+            }
             MultiPolygon(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_polygon::<2>(), rhs),
             Mixed(_, XY) => ContainsGeometry::contains(self.as_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => ContainsGeometry::contains(self.as_geometry_collection::<2>(), rhs),
+            GeometryCollection(_, XY) => {
+                ContainsGeometry::contains(self.as_geometry_collection::<2>(), rhs)
+            }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -478,7 +535,8 @@ pub trait ContainsGeometryCollection<Rhs> {
 impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = geometry_collection_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+            .unwrap()
     }
 }
 
@@ -487,7 +545,8 @@ macro_rules! impl_contains_geometry_collection {
         impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = geometry_collection_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
+                    .unwrap()
             }
         }
     };
@@ -508,13 +567,23 @@ impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for &dyn
 
         match self.data_type() {
             Point(_, XY) => ContainsGeometryCollection::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => ContainsGeometryCollection::contains(self.as_line_string::<2>(), rhs),
+            LineString(_, XY) => {
+                ContainsGeometryCollection::contains(self.as_line_string::<2>(), rhs)
+            }
             Polygon(_, XY) => ContainsGeometryCollection::contains(self.as_polygon::<2>(), rhs),
-            MultiPoint(_, XY) => ContainsGeometryCollection::contains(self.as_multi_point::<2>(), rhs),
-            MultiLineString(_, XY) => ContainsGeometryCollection::contains(self.as_multi_line_string::<2>(), rhs),
-            MultiPolygon(_, XY) => ContainsGeometryCollection::contains(self.as_multi_polygon::<2>(), rhs),
+            MultiPoint(_, XY) => {
+                ContainsGeometryCollection::contains(self.as_multi_point::<2>(), rhs)
+            }
+            MultiLineString(_, XY) => {
+                ContainsGeometryCollection::contains(self.as_multi_line_string::<2>(), rhs)
+            }
+            MultiPolygon(_, XY) => {
+                ContainsGeometryCollection::contains(self.as_multi_polygon::<2>(), rhs)
+            }
             Mixed(_, XY) => ContainsGeometryCollection::contains(self.as_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => ContainsGeometryCollection::contains(self.as_geometry_collection::<2>(), rhs),
+            GeometryCollection(_, XY) => {
+                ContainsGeometryCollection::contains(self.as_geometry_collection::<2>(), rhs)
+            }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/contains.rs
+++ b/src/algorithm/geo/contains.rs
@@ -2,14 +2,8 @@ use crate::algorithm::native::{Binary, Unary};
 use crate::array::*;
 use crate::datatypes::{Dimension, NativeType};
 use crate::error::GeoArrowError;
-use crate::geo_traits::{
-    GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
-    MultiPolygonTrait, PointTrait, PolygonTrait,
-};
-use crate::io::geo::{
-    geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo,
-    multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo,
-};
+use crate::geo_traits::{GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait};
+use crate::io::geo::{geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo, multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo};
 use crate::trait_::{ArrayAccessor, NativeScalar};
 use crate::NativeArray;
 use arrow_array::builder::BooleanBuilder;
@@ -61,73 +55,67 @@ pub trait Contains<Rhs = Self> {
 // Note: this implementation is outside the macro because it is not generic over O
 impl Contains for PointArray<2> {
     fn contains(&self, rhs: &Self) -> BooleanArray {
-        self.try_binary_boolean(rhs, |left, right| {
-            Ok(left.to_geo().contains(&right.to_geo()))
-        })
-        .unwrap()
+        self.try_binary_boolean(rhs, |left, right| Ok(left.to_geo().contains(&right.to_geo()))).unwrap()
     }
 }
 
 // Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($first:ty, $second:ty) => {
-        impl<'a, O: OffsetSizeTrait> Contains<$second> for $first {
+        impl<'a> Contains<$second> for $first {
             fn contains(&self, rhs: &$second) -> BooleanArray {
-                self.try_binary_boolean(rhs, |left, right| {
-                    Ok(left.to_geo().contains(&right.to_geo()))
-                })
-                .unwrap()
+                self.try_binary_boolean(rhs, |left, right| Ok(left.to_geo().contains(&right.to_geo()))).unwrap()
             }
         }
     };
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray<2>, LineStringArray<O, 2>);
-iter_geo_impl!(PointArray<2>, PolygonArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiPointArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(PointArray<2>, LineStringArray<2>);
+iter_geo_impl!(PointArray<2>, PolygonArray<2>);
+iter_geo_impl!(PointArray<2>, MultiPointArray<2>);
+iter_geo_impl!(PointArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(PointArray<2>, MultiPolygonArray<2>);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<O, 2>, PointArray<2>);
-iter_geo_impl!(LineStringArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>, PointArray<2>);
+iter_geo_impl!(LineStringArray<2>, LineStringArray<2>);
+iter_geo_impl!(LineStringArray<2>, PolygonArray<2>);
+iter_geo_impl!(LineStringArray<2>, MultiPointArray<2>);
+iter_geo_impl!(LineStringArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(LineStringArray<2>, MultiPolygonArray<2>);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<O, 2>, PointArray<2>);
-iter_geo_impl!(PolygonArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(PolygonArray<2>, PointArray<2>);
+iter_geo_impl!(PolygonArray<2>, LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>, PolygonArray<2>);
+iter_geo_impl!(PolygonArray<2>, MultiPointArray<2>);
+iter_geo_impl!(PolygonArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<O, 2>, PointArray<2>);
-iter_geo_impl!(MultiPointArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<2>, PointArray<2>);
+iter_geo_impl!(MultiPointArray<2>, LineStringArray<2>);
+iter_geo_impl!(MultiPointArray<2>, PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>, MultiPointArray<2>);
+iter_geo_impl!(MultiPointArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(MultiPointArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<O, 2>, PointArray<2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<2>, PointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, LineStringArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, PolygonArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<O, 2>, PointArray<2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<2>, PointArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, LineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, PolygonArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, MultiPointArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonArray<2>);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
@@ -140,30 +128,28 @@ pub trait ContainsPoint<Rhs> {
 impl<G: PointTrait<T = f64>> ContainsPoint<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = point_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-            .unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
     }
 }
 
 macro_rules! impl_contains_point {
     ($array:ty) => {
-        impl<O: OffsetSizeTrait, G: PointTrait<T = f64>> ContainsPoint<G> for $array {
+        impl<G: PointTrait<T = f64>> ContainsPoint<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = point_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-                    .unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
             }
         }
     };
 }
 
-impl_contains_point!(LineStringArray<O, 2>);
-impl_contains_point!(PolygonArray<O, 2>);
-impl_contains_point!(MultiPointArray<O, 2>);
-impl_contains_point!(MultiLineStringArray<O, 2>);
-impl_contains_point!(MultiPolygonArray<O, 2>);
-impl_contains_point!(MixedGeometryArray<O, 2>);
-impl_contains_point!(GeometryCollectionArray<O, 2>);
+impl_contains_point!(LineStringArray<2>);
+impl_contains_point!(PolygonArray<2>);
+impl_contains_point!(MultiPointArray<2>);
+impl_contains_point!(MultiLineStringArray<2>);
+impl_contains_point!(MultiPolygonArray<2>);
+impl_contains_point!(MixedGeometryArray<2>);
+impl_contains_point!(GeometryCollectionArray<2>);
 
 impl<G: PointTrait<T = f64>> ContainsPoint<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -173,33 +159,12 @@ impl<G: PointTrait<T = f64>> ContainsPoint<G> for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => ContainsPoint::contains(self.as_point::<2>(), rhs),
             LineString(_, XY) => ContainsPoint::contains(self.as_line_string::<2>(), rhs),
-            LargeLineString(_, XY) => {
-                ContainsPoint::contains(self.as_large_line_string::<2>(), rhs)
-            }
             Polygon(_, XY) => ContainsPoint::contains(self.as_polygon::<2>(), rhs),
-            LargePolygon(_, XY) => ContainsPoint::contains(self.as_large_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsPoint::contains(self.as_multi_point::<2>(), rhs),
-            LargeMultiPoint(_, XY) => {
-                ContainsPoint::contains(self.as_large_multi_point::<2>(), rhs)
-            }
-            MultiLineString(_, XY) => {
-                ContainsPoint::contains(self.as_multi_line_string::<2>(), rhs)
-            }
-            LargeMultiLineString(_, XY) => {
-                ContainsPoint::contains(self.as_large_multi_line_string::<2>(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsPoint::contains(self.as_multi_line_string::<2>(), rhs),
             MultiPolygon(_, XY) => ContainsPoint::contains(self.as_multi_polygon::<2>(), rhs),
-            LargeMultiPolygon(_, XY) => {
-                ContainsPoint::contains(self.as_large_multi_polygon::<2>(), rhs)
-            }
             Mixed(_, XY) => ContainsPoint::contains(self.as_mixed::<2>(), rhs),
-            LargeMixed(_, XY) => ContainsPoint::contains(self.as_large_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => {
-                ContainsPoint::contains(self.as_geometry_collection::<2>(), rhs)
-            }
-            LargeGeometryCollection(_, XY) => {
-                ContainsPoint::contains(self.as_large_geometry_collection::<2>(), rhs)
-            }
+            GeometryCollection(_, XY) => ContainsPoint::contains(self.as_geometry_collection::<2>(), rhs),
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -212,14 +177,13 @@ pub trait ContainsLineString<Rhs> {
 impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = line_string_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-            .unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
     }
 }
 
 macro_rules! impl_contains_line_string {
     ($array:ty) => {
-        impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> ContainsLineString<G> for $array {
+        impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let mut output_array = BooleanBuilder::with_capacity(self.len());
                 let rhs = line_string_to_geo(rhs);
@@ -235,13 +199,13 @@ macro_rules! impl_contains_line_string {
     };
 }
 
-impl_contains_line_string!(LineStringArray<O, 2>);
-impl_contains_line_string!(PolygonArray<O, 2>);
-impl_contains_line_string!(MultiPointArray<O, 2>);
-impl_contains_line_string!(MultiLineStringArray<O, 2>);
-impl_contains_line_string!(MultiPolygonArray<O, 2>);
-impl_contains_line_string!(MixedGeometryArray<O, 2>);
-impl_contains_line_string!(GeometryCollectionArray<O, 2>);
+impl_contains_line_string!(LineStringArray<2>);
+impl_contains_line_string!(PolygonArray<2>);
+impl_contains_line_string!(MultiPointArray<2>);
+impl_contains_line_string!(MultiLineStringArray<2>);
+impl_contains_line_string!(MultiPolygonArray<2>);
+impl_contains_line_string!(MixedGeometryArray<2>);
+impl_contains_line_string!(GeometryCollectionArray<2>);
 
 impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -251,33 +215,12 @@ impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => ContainsLineString::contains(self.as_point::<2>(), rhs),
             LineString(_, XY) => ContainsLineString::contains(self.as_line_string::<2>(), rhs),
-            LargeLineString(_, XY) => {
-                ContainsLineString::contains(self.as_large_line_string::<2>(), rhs)
-            }
             Polygon(_, XY) => ContainsLineString::contains(self.as_polygon::<2>(), rhs),
-            LargePolygon(_, XY) => ContainsLineString::contains(self.as_large_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsLineString::contains(self.as_multi_point::<2>(), rhs),
-            LargeMultiPoint(_, XY) => {
-                ContainsLineString::contains(self.as_large_multi_point::<2>(), rhs)
-            }
-            MultiLineString(_, XY) => {
-                ContainsLineString::contains(self.as_multi_line_string::<2>(), rhs)
-            }
-            LargeMultiLineString(_, XY) => {
-                ContainsLineString::contains(self.as_large_multi_line_string::<2>(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsLineString::contains(self.as_multi_line_string::<2>(), rhs),
             MultiPolygon(_, XY) => ContainsLineString::contains(self.as_multi_polygon::<2>(), rhs),
-            LargeMultiPolygon(_, XY) => {
-                ContainsLineString::contains(self.as_large_multi_polygon::<2>(), rhs)
-            }
             Mixed(_, XY) => ContainsLineString::contains(self.as_mixed::<2>(), rhs),
-            LargeMixed(_, XY) => ContainsLineString::contains(self.as_large_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => {
-                ContainsLineString::contains(self.as_geometry_collection::<2>(), rhs)
-            }
-            LargeGeometryCollection(_, XY) => {
-                ContainsLineString::contains(self.as_large_geometry_collection::<2>(), rhs)
-            }
+            GeometryCollection(_, XY) => ContainsLineString::contains(self.as_geometry_collection::<2>(), rhs),
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -290,30 +233,28 @@ pub trait ContainsPolygon<Rhs> {
 impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = polygon_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-            .unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
     }
 }
 
 macro_rules! impl_contains_polygon {
     ($array:ty) => {
-        impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> ContainsPolygon<G> for $array {
+        impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = polygon_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-                    .unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
             }
         }
     };
 }
 
-impl_contains_polygon!(LineStringArray<O, 2>);
-impl_contains_polygon!(PolygonArray<O, 2>);
-impl_contains_polygon!(MultiPointArray<O, 2>);
-impl_contains_polygon!(MultiLineStringArray<O, 2>);
-impl_contains_polygon!(MultiPolygonArray<O, 2>);
-impl_contains_polygon!(MixedGeometryArray<O, 2>);
-impl_contains_polygon!(GeometryCollectionArray<O, 2>);
+impl_contains_polygon!(LineStringArray<2>);
+impl_contains_polygon!(PolygonArray<2>);
+impl_contains_polygon!(MultiPointArray<2>);
+impl_contains_polygon!(MultiLineStringArray<2>);
+impl_contains_polygon!(MultiPolygonArray<2>);
+impl_contains_polygon!(MixedGeometryArray<2>);
+impl_contains_polygon!(GeometryCollectionArray<2>);
 
 impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -323,33 +264,12 @@ impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => ContainsPolygon::contains(self.as_point::<2>(), rhs),
             LineString(_, XY) => ContainsPolygon::contains(self.as_line_string::<2>(), rhs),
-            LargeLineString(_, XY) => {
-                ContainsPolygon::contains(self.as_large_line_string::<2>(), rhs)
-            }
             Polygon(_, XY) => ContainsPolygon::contains(self.as_polygon::<2>(), rhs),
-            LargePolygon(_, XY) => ContainsPolygon::contains(self.as_large_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsPolygon::contains(self.as_multi_point::<2>(), rhs),
-            LargeMultiPoint(_, XY) => {
-                ContainsPolygon::contains(self.as_large_multi_point::<2>(), rhs)
-            }
-            MultiLineString(_, XY) => {
-                ContainsPolygon::contains(self.as_multi_line_string::<2>(), rhs)
-            }
-            LargeMultiLineString(_, XY) => {
-                ContainsPolygon::contains(self.as_large_multi_line_string::<2>(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsPolygon::contains(self.as_multi_line_string::<2>(), rhs),
             MultiPolygon(_, XY) => ContainsPolygon::contains(self.as_multi_polygon::<2>(), rhs),
-            LargeMultiPolygon(_, XY) => {
-                ContainsPolygon::contains(self.as_large_multi_polygon::<2>(), rhs)
-            }
             Mixed(_, XY) => ContainsPolygon::contains(self.as_mixed::<2>(), rhs),
-            LargeMixed(_, XY) => ContainsPolygon::contains(self.as_large_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => {
-                ContainsPolygon::contains(self.as_geometry_collection::<2>(), rhs)
-            }
-            LargeGeometryCollection(_, XY) => {
-                ContainsPolygon::contains(self.as_large_geometry_collection::<2>(), rhs)
-            }
+            GeometryCollection(_, XY) => ContainsPolygon::contains(self.as_geometry_collection::<2>(), rhs),
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -362,30 +282,28 @@ pub trait ContainsMultiPoint<Rhs> {
 impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_point_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-            .unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
     }
 }
 
 macro_rules! impl_contains_multi_point {
     ($array:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for $array {
+        impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = multi_point_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-                    .unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
             }
         }
     };
 }
 
-impl_contains_multi_point!(LineStringArray<O, 2>);
-impl_contains_multi_point!(PolygonArray<O, 2>);
-impl_contains_multi_point!(MultiPointArray<O, 2>);
-impl_contains_multi_point!(MultiLineStringArray<O, 2>);
-impl_contains_multi_point!(MultiPolygonArray<O, 2>);
-impl_contains_multi_point!(MixedGeometryArray<O, 2>);
-impl_contains_multi_point!(GeometryCollectionArray<O, 2>);
+impl_contains_multi_point!(LineStringArray<2>);
+impl_contains_multi_point!(PolygonArray<2>);
+impl_contains_multi_point!(MultiPointArray<2>);
+impl_contains_multi_point!(MultiLineStringArray<2>);
+impl_contains_multi_point!(MultiPolygonArray<2>);
+impl_contains_multi_point!(MixedGeometryArray<2>);
+impl_contains_multi_point!(GeometryCollectionArray<2>);
 
 impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -395,33 +313,12 @@ impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => ContainsMultiPoint::contains(self.as_point::<2>(), rhs),
             LineString(_, XY) => ContainsMultiPoint::contains(self.as_line_string::<2>(), rhs),
-            LargeLineString(_, XY) => {
-                ContainsMultiPoint::contains(self.as_large_line_string::<2>(), rhs)
-            }
             Polygon(_, XY) => ContainsMultiPoint::contains(self.as_polygon::<2>(), rhs),
-            LargePolygon(_, XY) => ContainsMultiPoint::contains(self.as_large_polygon::<2>(), rhs),
             MultiPoint(_, XY) => ContainsMultiPoint::contains(self.as_multi_point::<2>(), rhs),
-            LargeMultiPoint(_, XY) => {
-                ContainsMultiPoint::contains(self.as_large_multi_point::<2>(), rhs)
-            }
-            MultiLineString(_, XY) => {
-                ContainsMultiPoint::contains(self.as_multi_line_string::<2>(), rhs)
-            }
-            LargeMultiLineString(_, XY) => {
-                ContainsMultiPoint::contains(self.as_large_multi_line_string::<2>(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsMultiPoint::contains(self.as_multi_line_string::<2>(), rhs),
             MultiPolygon(_, XY) => ContainsMultiPoint::contains(self.as_multi_polygon::<2>(), rhs),
-            LargeMultiPolygon(_, XY) => {
-                ContainsMultiPoint::contains(self.as_large_multi_polygon::<2>(), rhs)
-            }
             Mixed(_, XY) => ContainsMultiPoint::contains(self.as_mixed::<2>(), rhs),
-            LargeMixed(_, XY) => ContainsMultiPoint::contains(self.as_large_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => {
-                ContainsMultiPoint::contains(self.as_geometry_collection::<2>(), rhs)
-            }
-            LargeGeometryCollection(_, XY) => {
-                ContainsMultiPoint::contains(self.as_large_geometry_collection::<2>(), rhs)
-            }
+            GeometryCollection(_, XY) => ContainsMultiPoint::contains(self.as_geometry_collection::<2>(), rhs),
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -434,32 +331,28 @@ pub trait ContainsMultiLineString<Rhs> {
 impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_line_string_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-            .unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
     }
 }
 
 macro_rules! impl_contains_multi_line_string {
     ($array:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G>
-            for $array
-        {
+        impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = multi_line_string_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-                    .unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
             }
         }
     };
 }
 
-impl_contains_multi_line_string!(LineStringArray<O, 2>);
-impl_contains_multi_line_string!(PolygonArray<O, 2>);
-impl_contains_multi_line_string!(MultiPointArray<O, 2>);
-impl_contains_multi_line_string!(MultiLineStringArray<O, 2>);
-impl_contains_multi_line_string!(MultiPolygonArray<O, 2>);
-impl_contains_multi_line_string!(MixedGeometryArray<O, 2>);
-impl_contains_multi_line_string!(GeometryCollectionArray<O, 2>);
+impl_contains_multi_line_string!(LineStringArray<2>);
+impl_contains_multi_line_string!(PolygonArray<2>);
+impl_contains_multi_line_string!(MultiPointArray<2>);
+impl_contains_multi_line_string!(MultiLineStringArray<2>);
+impl_contains_multi_line_string!(MultiPolygonArray<2>);
+impl_contains_multi_line_string!(MixedGeometryArray<2>);
+impl_contains_multi_line_string!(GeometryCollectionArray<2>);
 
 impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -469,37 +362,12 @@ impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for &dyn Nativ
         match self.data_type() {
             Point(_, XY) => ContainsMultiLineString::contains(self.as_point::<2>(), rhs),
             LineString(_, XY) => ContainsMultiLineString::contains(self.as_line_string::<2>(), rhs),
-            LargeLineString(_, XY) => {
-                ContainsMultiLineString::contains(self.as_large_line_string::<2>(), rhs)
-            }
             Polygon(_, XY) => ContainsMultiLineString::contains(self.as_polygon::<2>(), rhs),
-            LargePolygon(_, XY) => {
-                ContainsMultiLineString::contains(self.as_large_polygon::<2>(), rhs)
-            }
             MultiPoint(_, XY) => ContainsMultiLineString::contains(self.as_multi_point::<2>(), rhs),
-            LargeMultiPoint(_, XY) => {
-                ContainsMultiLineString::contains(self.as_large_multi_point::<2>(), rhs)
-            }
-            MultiLineString(_, XY) => {
-                ContainsMultiLineString::contains(self.as_multi_line_string::<2>(), rhs)
-            }
-            LargeMultiLineString(_, XY) => {
-                ContainsMultiLineString::contains(self.as_large_multi_line_string::<2>(), rhs)
-            }
-            MultiPolygon(_, XY) => {
-                ContainsMultiLineString::contains(self.as_multi_polygon::<2>(), rhs)
-            }
-            LargeMultiPolygon(_, XY) => {
-                ContainsMultiLineString::contains(self.as_large_multi_polygon::<2>(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsMultiLineString::contains(self.as_multi_line_string::<2>(), rhs),
+            MultiPolygon(_, XY) => ContainsMultiLineString::contains(self.as_multi_polygon::<2>(), rhs),
             Mixed(_, XY) => ContainsMultiLineString::contains(self.as_mixed::<2>(), rhs),
-            LargeMixed(_, XY) => ContainsMultiLineString::contains(self.as_large_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => {
-                ContainsMultiLineString::contains(self.as_geometry_collection::<2>(), rhs)
-            }
-            LargeGeometryCollection(_, XY) => {
-                ContainsMultiLineString::contains(self.as_large_geometry_collection::<2>(), rhs)
-            }
+            GeometryCollection(_, XY) => ContainsMultiLineString::contains(self.as_geometry_collection::<2>(), rhs),
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -512,30 +380,28 @@ pub trait ContainsMultiPolygon<Rhs> {
 impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_polygon_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-            .unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
     }
 }
 
 macro_rules! impl_contains_multi_polygon {
     ($array:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for $array {
+        impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = multi_polygon_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-                    .unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
             }
         }
     };
 }
 
-impl_contains_multi_polygon!(LineStringArray<O, 2>);
-impl_contains_multi_polygon!(PolygonArray<O, 2>);
-impl_contains_multi_polygon!(MultiPointArray<O, 2>);
-impl_contains_multi_polygon!(MultiLineStringArray<O, 2>);
-impl_contains_multi_polygon!(MultiPolygonArray<O, 2>);
-impl_contains_multi_polygon!(MixedGeometryArray<O, 2>);
-impl_contains_multi_polygon!(GeometryCollectionArray<O, 2>);
+impl_contains_multi_polygon!(LineStringArray<2>);
+impl_contains_multi_polygon!(PolygonArray<2>);
+impl_contains_multi_polygon!(MultiPointArray<2>);
+impl_contains_multi_polygon!(MultiLineStringArray<2>);
+impl_contains_multi_polygon!(MultiPolygonArray<2>);
+impl_contains_multi_polygon!(MixedGeometryArray<2>);
+impl_contains_multi_polygon!(GeometryCollectionArray<2>);
 
 impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -545,37 +411,12 @@ impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for &dyn NativeArray
         match self.data_type() {
             Point(_, XY) => ContainsMultiPolygon::contains(self.as_point::<2>(), rhs),
             LineString(_, XY) => ContainsMultiPolygon::contains(self.as_line_string::<2>(), rhs),
-            LargeLineString(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_large_line_string::<2>(), rhs)
-            }
             Polygon(_, XY) => ContainsMultiPolygon::contains(self.as_polygon::<2>(), rhs),
-            LargePolygon(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_large_polygon::<2>(), rhs)
-            }
             MultiPoint(_, XY) => ContainsMultiPolygon::contains(self.as_multi_point::<2>(), rhs),
-            LargeMultiPoint(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_large_multi_point::<2>(), rhs)
-            }
-            MultiLineString(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_multi_line_string::<2>(), rhs)
-            }
-            LargeMultiLineString(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_large_multi_line_string::<2>(), rhs)
-            }
-            MultiPolygon(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_multi_polygon::<2>(), rhs)
-            }
-            LargeMultiPolygon(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_large_multi_polygon::<2>(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsMultiPolygon::contains(self.as_multi_line_string::<2>(), rhs),
+            MultiPolygon(_, XY) => ContainsMultiPolygon::contains(self.as_multi_polygon::<2>(), rhs),
             Mixed(_, XY) => ContainsMultiPolygon::contains(self.as_mixed::<2>(), rhs),
-            LargeMixed(_, XY) => ContainsMultiPolygon::contains(self.as_large_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_geometry_collection::<2>(), rhs)
-            }
-            LargeGeometryCollection(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_large_geometry_collection::<2>(), rhs)
-            }
+            GeometryCollection(_, XY) => ContainsMultiPolygon::contains(self.as_geometry_collection::<2>(), rhs),
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -588,30 +429,28 @@ pub trait ContainsGeometry<Rhs> {
 impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = geometry_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-            .unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
     }
 }
 
 macro_rules! impl_contains_geometry {
     ($array:ty) => {
-        impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> ContainsGeometry<G> for $array {
+        impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = geometry_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-                    .unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
             }
         }
     };
 }
 
-impl_contains_geometry!(LineStringArray<O, 2>);
-impl_contains_geometry!(PolygonArray<O, 2>);
-// impl_contains_geometry!(MultiPointArray<O, 2>); // Not implemented in geo
-impl_contains_geometry!(MultiLineStringArray<O, 2>);
-// impl_contains_geometry!(MultiPolygonArray<O, 2>); // Not implemented in geo
-impl_contains_geometry!(MixedGeometryArray<O, 2>);
-impl_contains_geometry!(GeometryCollectionArray<O, 2>);
+impl_contains_geometry!(LineStringArray<2>);
+impl_contains_geometry!(PolygonArray<2>);
+// impl_contains_geometry!(MultiPointArray<2>); // Not implemented in geo
+impl_contains_geometry!(MultiLineStringArray<2>);
+// impl_contains_geometry!(MultiPolygonArray<2>); // Not implemented in geo
+impl_contains_geometry!(MixedGeometryArray<2>);
+impl_contains_geometry!(GeometryCollectionArray<2>);
 
 impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -621,35 +460,12 @@ impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => ContainsGeometry::contains(self.as_point::<2>(), rhs),
             LineString(_, XY) => ContainsGeometry::contains(self.as_line_string::<2>(), rhs),
-            LargeLineString(_, XY) => {
-                ContainsGeometry::contains(self.as_large_line_string::<2>(), rhs)
-            }
             Polygon(_, XY) => ContainsGeometry::contains(self.as_polygon::<2>(), rhs),
-            LargePolygon(_, XY) => ContainsGeometry::contains(self.as_large_polygon::<2>(), rhs),
             MultiPoint(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_point::<2>(), rhs),
-            LargeMultiPoint(_, XY) => {
-                todo!()
-                // ContainsGeometry::contains(self.as_large_multi_point::<2>(), rhs)
-            }
-            MultiLineString(_, XY) => {
-                ContainsGeometry::contains(self.as_multi_line_string::<2>(), rhs)
-            }
-            LargeMultiLineString(_, XY) => {
-                ContainsGeometry::contains(self.as_large_multi_line_string::<2>(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsGeometry::contains(self.as_multi_line_string::<2>(), rhs),
             MultiPolygon(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_polygon::<2>(), rhs),
-            LargeMultiPolygon(_, XY) => {
-                todo!()
-                // ContainsGeometry::contains(self.as_large_multi_polygon::<2>(), rhs)
-            }
             Mixed(_, XY) => ContainsGeometry::contains(self.as_mixed::<2>(), rhs),
-            LargeMixed(_, XY) => ContainsGeometry::contains(self.as_large_mixed::<2>(), rhs),
-            GeometryCollection(_, XY) => {
-                ContainsGeometry::contains(self.as_geometry_collection::<2>(), rhs)
-            }
-            LargeGeometryCollection(_, XY) => {
-                ContainsGeometry::contains(self.as_large_geometry_collection::<2>(), rhs)
-            }
+            GeometryCollection(_, XY) => ContainsGeometry::contains(self.as_geometry_collection::<2>(), rhs),
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -662,32 +478,28 @@ pub trait ContainsGeometryCollection<Rhs> {
 impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for PointArray<2> {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = geometry_collection_to_geo(rhs);
-        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-            .unwrap()
+        self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
     }
 }
 
 macro_rules! impl_contains_geometry_collection {
     ($array:ty) => {
-        impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G>
-            for $array
-        {
+        impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for $array {
             fn contains(&self, rhs: &G) -> BooleanArray {
                 let rhs = geometry_collection_to_geo(rhs);
-                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
-                    .unwrap()
+                self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs))).unwrap()
             }
         }
     };
 }
 
-impl_contains_geometry_collection!(LineStringArray<O, 2>);
-impl_contains_geometry_collection!(PolygonArray<O, 2>);
-impl_contains_geometry_collection!(MultiPointArray<O, 2>);
-impl_contains_geometry_collection!(MultiLineStringArray<O, 2>);
-impl_contains_geometry_collection!(MultiPolygonArray<O, 2>);
-impl_contains_geometry_collection!(MixedGeometryArray<O, 2>);
-impl_contains_geometry_collection!(GeometryCollectionArray<O, 2>);
+impl_contains_geometry_collection!(LineStringArray<2>);
+impl_contains_geometry_collection!(PolygonArray<2>);
+impl_contains_geometry_collection!(MultiPointArray<2>);
+impl_contains_geometry_collection!(MultiLineStringArray<2>);
+impl_contains_geometry_collection!(MultiPolygonArray<2>);
+impl_contains_geometry_collection!(MixedGeometryArray<2>);
+impl_contains_geometry_collection!(GeometryCollectionArray<2>);
 
 impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -696,44 +508,13 @@ impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for &dyn
 
         match self.data_type() {
             Point(_, XY) => ContainsGeometryCollection::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_line_string::<2>(), rhs)
-            }
-            LargeLineString(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_large_line_string::<2>(), rhs)
-            }
+            LineString(_, XY) => ContainsGeometryCollection::contains(self.as_line_string::<2>(), rhs),
             Polygon(_, XY) => ContainsGeometryCollection::contains(self.as_polygon::<2>(), rhs),
-            LargePolygon(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_large_polygon::<2>(), rhs)
-            }
-            MultiPoint(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_multi_point::<2>(), rhs)
-            }
-            LargeMultiPoint(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_large_multi_point::<2>(), rhs)
-            }
-            MultiLineString(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_multi_line_string::<2>(), rhs)
-            }
-            LargeMultiLineString(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_large_multi_line_string::<2>(), rhs)
-            }
-            MultiPolygon(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_multi_polygon::<2>(), rhs)
-            }
-            LargeMultiPolygon(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_large_multi_polygon::<2>(), rhs)
-            }
+            MultiPoint(_, XY) => ContainsGeometryCollection::contains(self.as_multi_point::<2>(), rhs),
+            MultiLineString(_, XY) => ContainsGeometryCollection::contains(self.as_multi_line_string::<2>(), rhs),
+            MultiPolygon(_, XY) => ContainsGeometryCollection::contains(self.as_multi_polygon::<2>(), rhs),
             Mixed(_, XY) => ContainsGeometryCollection::contains(self.as_mixed::<2>(), rhs),
-            LargeMixed(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_large_mixed::<2>(), rhs)
-            }
-            GeometryCollection(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_geometry_collection::<2>(), rhs)
-            }
-            LargeGeometryCollection(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_large_geometry_collection::<2>(), rhs)
-            }
+            GeometryCollection(_, XY) => ContainsGeometryCollection::contains(self.as_geometry_collection::<2>(), rhs),
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/convex_hull.rs
+++ b/src/algorithm/geo/convex_hull.rs
@@ -53,7 +53,10 @@ impl ConvexHull for PointArray<2> {
     type Output = PolygonArray<2>;
 
     fn convex_hull(&self) -> Self::Output {
-        let output_geoms: Vec<Option<Polygon>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.convex_hull())).collect();
+        let output_geoms: Vec<Option<Polygon>> = self
+            .iter_geo()
+            .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
+            .collect();
 
         output_geoms.into()
     }
@@ -66,7 +69,10 @@ macro_rules! iter_geo_impl {
             type Output = PolygonArray<2>;
 
             fn convex_hull(&self) -> Self::Output {
-                let output_geoms: Vec<Option<Polygon>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.convex_hull())).collect();
+                let output_geoms: Vec<Option<Polygon>> = self
+                    .iter_geo()
+                    .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
+                    .collect();
 
                 output_geoms.into()
             }
@@ -108,7 +114,8 @@ impl<G: NativeArray> ConvexHull for ChunkedGeometryArray<G> {
     type Output = Result<ChunkedGeometryArray<PolygonArray<2>>>;
 
     fn convex_hull(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().convex_hull())?.try_into()
+        self.try_map(|chunk| chunk.as_ref().convex_hull())?
+            .try_into()
     }
 }
 
@@ -144,7 +151,18 @@ mod tests {
     #[test]
     fn convex_hull_for_multipoint() {
         // Values borrowed from this test in geo crate: https://docs.rs/geo/0.14.2/src/geo/algorithm/convexhull.rs.html#323
-        let input_geom: MultiPoint = vec![Point::new(0.0, 10.0), Point::new(1.0, 1.0), Point::new(10.0, 0.0), Point::new(1.0, -1.0), Point::new(0.0, -10.0), Point::new(-1.0, -1.0), Point::new(-10.0, 0.0), Point::new(-1.0, 1.0), Point::new(0.0, 10.0)].into();
+        let input_geom: MultiPoint = vec![
+            Point::new(0.0, 10.0),
+            Point::new(1.0, 1.0),
+            Point::new(10.0, 0.0),
+            Point::new(1.0, -1.0),
+            Point::new(0.0, -10.0),
+            Point::new(-1.0, -1.0),
+            Point::new(-10.0, 0.0),
+            Point::new(-1.0, 1.0),
+            Point::new(0.0, 10.0),
+        ]
+        .into();
         let input_array: MultiPointArray<2> = vec![input_geom].as_slice().into();
         let result_array: PolygonArray<2> = input_array.convex_hull();
 

--- a/src/algorithm/geo/convex_hull.rs
+++ b/src/algorithm/geo/convex_hull.rs
@@ -4,7 +4,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::algorithm::convex_hull::ConvexHull as GeoConvexHull;
 use geo::Polygon;
 

--- a/src/algorithm/geo/convex_hull.rs
+++ b/src/algorithm/geo/convex_hull.rs
@@ -44,20 +44,17 @@ use geo::Polygon;
 /// let res = poly.convex_hull();
 /// assert_eq!(res.exterior(), &correct_hull);
 /// ```
-pub trait ConvexHull<O: OffsetSizeTrait> {
+pub trait ConvexHull {
     type Output;
 
     fn convex_hull(&self) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> ConvexHull<O> for PointArray<2> {
-    type Output = PolygonArray<O, 2>;
+impl ConvexHull for PointArray<2> {
+    type Output = PolygonArray<2>;
 
     fn convex_hull(&self) -> Self::Output {
-        let output_geoms: Vec<Option<Polygon>> = self
-            .iter_geo()
-            .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
-            .collect();
+        let output_geoms: Vec<Option<Polygon>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.convex_hull())).collect();
 
         output_geoms.into()
     }
@@ -66,14 +63,11 @@ impl<O: OffsetSizeTrait> ConvexHull<O> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait, O2: OffsetSizeTrait> ConvexHull<O> for $type {
-            type Output = PolygonArray<O, 2>;
+        impl ConvexHull for $type {
+            type Output = PolygonArray<2>;
 
             fn convex_hull(&self) -> Self::Output {
-                let output_geoms: Vec<Option<Polygon>> = self
-                    .iter_geo()
-                    .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
-                    .collect();
+                let output_geoms: Vec<Option<Polygon>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.convex_hull())).collect();
 
                 output_geoms.into()
             }
@@ -81,16 +75,16 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O2, 2>);
-iter_geo_impl!(PolygonArray<O2, 2>);
-iter_geo_impl!(MultiPointArray<O2, 2>);
-iter_geo_impl!(MultiLineStringArray<O2, 2>);
-iter_geo_impl!(MultiPolygonArray<O2, 2>);
-iter_geo_impl!(MixedGeometryArray<O2, 2>);
-iter_geo_impl!(GeometryCollectionArray<O2, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
-impl<O: OffsetSizeTrait> ConvexHull<O> for &dyn NativeArray {
-    type Output = Result<PolygonArray<O, 2>>;
+impl ConvexHull for &dyn NativeArray {
+    type Output = Result<PolygonArray<2>>;
 
     fn convex_hull(&self) -> Self::Output {
         use Dimension::*;
@@ -99,38 +93,28 @@ impl<O: OffsetSizeTrait> ConvexHull<O> for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().convex_hull(),
             LineString(_, XY) => self.as_line_string::<2>().convex_hull(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().convex_hull(),
             Polygon(_, XY) => self.as_polygon::<2>().convex_hull(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().convex_hull(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().convex_hull(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().convex_hull(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().convex_hull(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().convex_hull(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().convex_hull(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().convex_hull(),
             Mixed(_, XY) => self.as_mixed::<2>().convex_hull(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().convex_hull(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().convex_hull(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().convex_hull()
-            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl<O: OffsetSizeTrait, G: NativeArray> ConvexHull<O> for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedGeometryArray<PolygonArray<O, 2>>>;
+impl<G: NativeArray> ConvexHull for ChunkedGeometryArray<G> {
+    type Output = Result<ChunkedGeometryArray<PolygonArray<2>>>;
 
     fn convex_hull(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().convex_hull())?
-            .try_into()
+        self.try_map(|chunk| chunk.as_ref().convex_hull())?.try_into()
     }
 }
 
-impl<O: OffsetSizeTrait> ConvexHull<O> for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPolygonArray<O, 2>>;
+impl ConvexHull for &dyn ChunkedNativeArray {
+    type Output = Result<ChunkedPolygonArray<2>>;
 
     fn convex_hull(&self) -> Self::Output {
         use Dimension::*;
@@ -139,21 +123,12 @@ impl<O: OffsetSizeTrait> ConvexHull<O> for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().convex_hull(),
             LineString(_, XY) => self.as_line_string::<2>().convex_hull(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().convex_hull(),
             Polygon(_, XY) => self.as_polygon::<2>().convex_hull(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().convex_hull(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().convex_hull(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().convex_hull(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().convex_hull(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().convex_hull(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().convex_hull(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().convex_hull(),
             Mixed(_, XY) => self.as_mixed::<2>().convex_hull(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().convex_hull(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().convex_hull(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().convex_hull()
-            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -170,20 +145,9 @@ mod tests {
     #[test]
     fn convex_hull_for_multipoint() {
         // Values borrowed from this test in geo crate: https://docs.rs/geo/0.14.2/src/geo/algorithm/convexhull.rs.html#323
-        let input_geom: MultiPoint = vec![
-            Point::new(0.0, 10.0),
-            Point::new(1.0, 1.0),
-            Point::new(10.0, 0.0),
-            Point::new(1.0, -1.0),
-            Point::new(0.0, -10.0),
-            Point::new(-1.0, -1.0),
-            Point::new(-10.0, 0.0),
-            Point::new(-1.0, 1.0),
-            Point::new(0.0, 10.0),
-        ]
-        .into();
-        let input_array: MultiPointArray<i64, 2> = vec![input_geom].as_slice().into();
-        let result_array: PolygonArray<i32, 2> = input_array.convex_hull();
+        let input_geom: MultiPoint = vec![Point::new(0.0, 10.0), Point::new(1.0, 1.0), Point::new(10.0, 0.0), Point::new(1.0, -1.0), Point::new(0.0, -10.0), Point::new(-1.0, -1.0), Point::new(-10.0, 0.0), Point::new(-1.0, 1.0), Point::new(0.0, 10.0)].into();
+        let input_array: MultiPointArray<2> = vec![input_geom].as_slice().into();
+        let result_array: PolygonArray<2> = input_array.convex_hull();
 
         let expected = polygon![
             (x:0.0, y: -10.0),
@@ -210,8 +174,8 @@ mod tests {
             (x: 0.0, y: 10.0),
         ];
 
-        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
-        let result_array: PolygonArray<i32, 2> = input_array.convex_hull();
+        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
+        let result_array: PolygonArray<2> = input_array.convex_hull();
 
         let expected = polygon![
             (x: 0.0, y: -10.0),

--- a/src/algorithm/geo/densify.rs
+++ b/src/algorithm/geo/densify.rs
@@ -37,7 +37,10 @@ macro_rules! iter_geo_impl {
             type Output = $type;
 
             fn densify(&self, max_distance: f64) -> Self::Output {
-                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.densify(max_distance))).collect();
+                let output_geoms: Vec<Option<$geo_type>> = self
+                    .iter_geo()
+                    .map(|maybe_g| maybe_g.map(|geom| geom.densify(max_distance)))
+                    .collect();
 
                 output_geoms.into()
             }
@@ -60,7 +63,9 @@ impl Densify for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().densify(max_distance)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().densify(max_distance)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().densify(max_distance)),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string::<2>().densify(max_distance))
+            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().densify(max_distance)),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -74,7 +79,9 @@ macro_rules! impl_chunked {
             type Output = $struct_name;
 
             fn densify(&self, max_distance: f64) -> Self::Output {
-                self.map(|chunk| chunk.densify(max_distance)).try_into().unwrap()
+                self.map(|chunk| chunk.densify(max_distance))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -95,7 +102,9 @@ impl Densify for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().densify(max_distance)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().densify(max_distance)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().densify(max_distance)),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string::<2>().densify(max_distance))
+            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().densify(max_distance)),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };

--- a/src/algorithm/geo/densify.rs
+++ b/src/algorithm/geo/densify.rs
@@ -6,7 +6,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::Densify as _Densify;
 
 /// Return a new linear geometry containing both existing and new interpolated coordinates with
@@ -38,10 +37,7 @@ macro_rules! iter_geo_impl {
             type Output = $type;
 
             fn densify(&self, max_distance: f64) -> Self::Output {
-                let output_geoms: Vec<Option<$geo_type>> = self
-                    .iter_geo()
-                    .map(|maybe_g| maybe_g.map(|geom| geom.densify(max_distance)))
-                    .collect();
+                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.densify(max_distance))).collect();
 
                 output_geoms.into()
             }
@@ -64,9 +60,7 @@ impl Densify for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().densify(max_distance)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().densify(max_distance)),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().densify(max_distance))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().densify(max_distance)),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().densify(max_distance)),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -80,9 +74,7 @@ macro_rules! impl_chunked {
             type Output = $struct_name;
 
             fn densify(&self, max_distance: f64) -> Self::Output {
-                self.map(|chunk| chunk.densify(max_distance))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| chunk.densify(max_distance)).try_into().unwrap()
             }
         }
     };
@@ -103,9 +95,7 @@ impl Densify for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().densify(max_distance)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().densify(max_distance)),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().densify(max_distance))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().densify(max_distance)),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().densify(max_distance)),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };

--- a/src/algorithm/geo/densify.rs
+++ b/src/algorithm/geo/densify.rs
@@ -34,7 +34,7 @@ pub trait Densify {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: OffsetSizeTrait> Densify for $type {
+        impl Densify for $type {
             type Output = $type;
 
             fn densify(&self, max_distance: f64) -> Self::Output {
@@ -49,10 +49,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
-iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
+iter_geo_impl!(LineStringArray<2>, geo::LineString);
+iter_geo_impl!(PolygonArray<2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
 
 impl Densify for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -63,21 +63,11 @@ impl Densify for &dyn NativeArray {
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().densify(max_distance)),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().densify(max_distance))
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().densify(max_distance)),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().densify(max_distance)),
             MultiLineString(_, XY) => {
                 Arc::new(self.as_multi_line_string::<2>().densify(max_distance))
             }
-            LargeMultiLineString(_, XY) => {
-                Arc::new(self.as_large_multi_line_string::<2>().densify(max_distance))
-            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().densify(max_distance)),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().densify(max_distance))
-            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -86,7 +76,7 @@ impl Densify for &dyn NativeArray {
 
 macro_rules! impl_chunked {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait> Densify for $struct_name {
+        impl Densify for $struct_name {
             type Output = $struct_name;
 
             fn densify(&self, max_distance: f64) -> Self::Output {
@@ -98,10 +88,10 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<O, 2>);
-impl_chunked!(ChunkedPolygonArray<O, 2>);
-impl_chunked!(ChunkedMultiLineStringArray<O, 2>);
-impl_chunked!(ChunkedMultiPolygonArray<O, 2>);
+impl_chunked!(ChunkedLineStringArray<2>);
+impl_chunked!(ChunkedPolygonArray<2>);
+impl_chunked!(ChunkedMultiLineStringArray<2>);
+impl_chunked!(ChunkedMultiPolygonArray<2>);
 
 impl Densify for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -112,21 +102,11 @@ impl Densify for &dyn ChunkedNativeArray {
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().densify(max_distance)),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().densify(max_distance))
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().densify(max_distance)),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().densify(max_distance)),
             MultiLineString(_, XY) => {
                 Arc::new(self.as_multi_line_string::<2>().densify(max_distance))
             }
-            LargeMultiLineString(_, XY) => {
-                Arc::new(self.as_large_multi_line_string::<2>().densify(max_distance))
-            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().densify(max_distance)),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().densify(max_distance))
-            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/dimensions.rs
+++ b/src/algorithm/geo/dimensions.rs
@@ -50,7 +50,7 @@ impl HasDimensions for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> HasDimensions for $type {
+        impl HasDimensions for $type {
             type Output = BooleanArray;
 
             fn is_empty(&self) -> Self::Output {
@@ -63,13 +63,13 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>);
-iter_geo_impl!(MixedGeometryArray<O, 2>);
-iter_geo_impl!(GeometryCollectionArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
 impl HasDimensions for &dyn NativeArray {
     type Output = Result<BooleanArray>;
@@ -81,24 +81,13 @@ impl HasDimensions for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => HasDimensions::is_empty(self.as_point::<2>()),
             LineString(_, XY) => HasDimensions::is_empty(self.as_line_string::<2>()),
-            LargeLineString(_, XY) => HasDimensions::is_empty(self.as_large_line_string::<2>()),
             Polygon(_, XY) => HasDimensions::is_empty(self.as_polygon::<2>()),
-            LargePolygon(_, XY) => HasDimensions::is_empty(self.as_large_polygon::<2>()),
             MultiPoint(_, XY) => HasDimensions::is_empty(self.as_multi_point::<2>()),
-            LargeMultiPoint(_, XY) => HasDimensions::is_empty(self.as_large_multi_point::<2>()),
             MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string::<2>()),
-            LargeMultiLineString(_, XY) => {
-                HasDimensions::is_empty(self.as_large_multi_line_string::<2>())
-            }
             MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon::<2>()),
-            LargeMultiPolygon(_, XY) => HasDimensions::is_empty(self.as_large_multi_polygon::<2>()),
             Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed::<2>()),
-            LargeMixed(_, XY) => HasDimensions::is_empty(self.as_large_mixed::<2>()),
             GeometryCollection(_, XY) => {
                 HasDimensions::is_empty(self.as_geometry_collection::<2>())
-            }
-            LargeGeometryCollection(_, XY) => {
-                HasDimensions::is_empty(self.as_large_geometry_collection::<2>())
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -125,24 +114,13 @@ impl HasDimensions for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => HasDimensions::is_empty(self.as_point::<2>()),
             LineString(_, XY) => HasDimensions::is_empty(self.as_line_string::<2>()),
-            LargeLineString(_, XY) => HasDimensions::is_empty(self.as_large_line_string::<2>()),
             Polygon(_, XY) => HasDimensions::is_empty(self.as_polygon::<2>()),
-            LargePolygon(_, XY) => HasDimensions::is_empty(self.as_large_polygon::<2>()),
             MultiPoint(_, XY) => HasDimensions::is_empty(self.as_multi_point::<2>()),
-            LargeMultiPoint(_, XY) => HasDimensions::is_empty(self.as_large_multi_point::<2>()),
             MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string::<2>()),
-            LargeMultiLineString(_, XY) => {
-                HasDimensions::is_empty(self.as_large_multi_line_string::<2>())
-            }
             MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon::<2>()),
-            LargeMultiPolygon(_, XY) => HasDimensions::is_empty(self.as_large_multi_polygon::<2>()),
             Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed::<2>()),
-            LargeMixed(_, XY) => HasDimensions::is_empty(self.as_large_mixed::<2>()),
             GeometryCollection(_, XY) => {
                 HasDimensions::is_empty(self.as_geometry_collection::<2>())
-            }
-            LargeGeometryCollection(_, XY) => {
-                HasDimensions::is_empty(self.as_large_geometry_collection::<2>())
             }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }

--- a/src/algorithm/geo/dimensions.rs
+++ b/src/algorithm/geo/dimensions.rs
@@ -5,7 +5,7 @@ use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
 use arrow_array::builder::BooleanBuilder;
-use arrow_array::{BooleanArray, OffsetSizeTrait};
+use arrow_array::BooleanArray;
 use geo::dimensions::HasDimensions as GeoHasDimensions;
 
 /// Operate on the dimensionality of geometries.
@@ -41,8 +41,7 @@ impl HasDimensions for PointArray<2> {
 
     fn is_empty(&self) -> Self::Output {
         let mut output_array = BooleanBuilder::with_capacity(self.len());
-        self.iter_geo()
-            .for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.is_empty())));
+        self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.is_empty())));
         output_array.finish()
     }
 }
@@ -55,8 +54,7 @@ macro_rules! iter_geo_impl {
 
             fn is_empty(&self) -> Self::Output {
                 let mut output_array = BooleanBuilder::with_capacity(self.len());
-                self.iter_geo()
-                    .for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.is_empty())));
+                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.is_empty())));
                 output_array.finish()
             }
         }
@@ -86,9 +84,7 @@ impl HasDimensions for &dyn NativeArray {
             MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string::<2>()),
             MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon::<2>()),
             Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed::<2>()),
-            GeometryCollection(_, XY) => {
-                HasDimensions::is_empty(self.as_geometry_collection::<2>())
-            }
+            GeometryCollection(_, XY) => HasDimensions::is_empty(self.as_geometry_collection::<2>()),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -99,8 +95,7 @@ impl<G: NativeArray> HasDimensions for ChunkedGeometryArray<G> {
     type Output = Result<ChunkedArray<BooleanArray>>;
 
     fn is_empty(&self) -> Self::Output {
-        self.try_map(|chunk| HasDimensions::is_empty(&chunk.as_ref()))?
-            .try_into()
+        self.try_map(|chunk| HasDimensions::is_empty(&chunk.as_ref()))?.try_into()
     }
 }
 
@@ -119,9 +114,7 @@ impl HasDimensions for &dyn ChunkedNativeArray {
             MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string::<2>()),
             MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon::<2>()),
             Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed::<2>()),
-            GeometryCollection(_, XY) => {
-                HasDimensions::is_empty(self.as_geometry_collection::<2>())
-            }
+            GeometryCollection(_, XY) => HasDimensions::is_empty(self.as_geometry_collection::<2>()),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/dimensions.rs
+++ b/src/algorithm/geo/dimensions.rs
@@ -41,7 +41,8 @@ impl HasDimensions for PointArray<2> {
 
     fn is_empty(&self) -> Self::Output {
         let mut output_array = BooleanBuilder::with_capacity(self.len());
-        self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.is_empty())));
+        self.iter_geo()
+            .for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.is_empty())));
         output_array.finish()
     }
 }
@@ -54,7 +55,8 @@ macro_rules! iter_geo_impl {
 
             fn is_empty(&self) -> Self::Output {
                 let mut output_array = BooleanBuilder::with_capacity(self.len());
-                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.is_empty())));
+                self.iter_geo()
+                    .for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.is_empty())));
                 output_array.finish()
             }
         }
@@ -84,7 +86,9 @@ impl HasDimensions for &dyn NativeArray {
             MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string::<2>()),
             MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon::<2>()),
             Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed::<2>()),
-            GeometryCollection(_, XY) => HasDimensions::is_empty(self.as_geometry_collection::<2>()),
+            GeometryCollection(_, XY) => {
+                HasDimensions::is_empty(self.as_geometry_collection::<2>())
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -95,7 +99,8 @@ impl<G: NativeArray> HasDimensions for ChunkedGeometryArray<G> {
     type Output = Result<ChunkedArray<BooleanArray>>;
 
     fn is_empty(&self) -> Self::Output {
-        self.try_map(|chunk| HasDimensions::is_empty(&chunk.as_ref()))?.try_into()
+        self.try_map(|chunk| HasDimensions::is_empty(&chunk.as_ref()))?
+            .try_into()
     }
 }
 
@@ -114,7 +119,9 @@ impl HasDimensions for &dyn ChunkedNativeArray {
             MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string::<2>()),
             MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon::<2>()),
             Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed::<2>()),
-            GeometryCollection(_, XY) => HasDimensions::is_empty(self.as_geometry_collection::<2>()),
+            GeometryCollection(_, XY) => {
+                HasDimensions::is_empty(self.as_geometry_collection::<2>())
+            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/euclidean_distance.rs
+++ b/src/algorithm/geo/euclidean_distance.rs
@@ -98,14 +98,10 @@ impl EuclideanDistance<PointArray<2>> for PointArray<2> {
         assert_eq!(self.len(), other.len());
         let mut output_array = Float64Builder::with_capacity(self.len());
 
-        self.iter_geo()
-            .zip(other.iter_geo())
-            .for_each(|(first, second)| match (first, second) {
-                (Some(first), Some(second)) => {
-                    output_array.append_value(first.euclidean_distance(&second))
-                }
-                _ => output_array.append_null(),
-            });
+        self.iter_geo().zip(other.iter_geo()).for_each(|(first, second)| match (first, second) {
+            (Some(first), Some(second)) => output_array.append_value(first.euclidean_distance(&second)),
+            _ => output_array.append_null(),
+        });
 
         output_array.finish()
     }
@@ -114,19 +110,15 @@ impl EuclideanDistance<PointArray<2>> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($first:ty, $second:ty) => {
-        impl<'a, O: OffsetSizeTrait> EuclideanDistance<$second> for $first {
+        impl<'a> EuclideanDistance<$second> for $first {
             fn euclidean_distance(&self, other: &$second) -> Float64Array {
                 assert_eq!(self.len(), other.len());
                 let mut output_array = Float64Builder::with_capacity(self.len());
 
-                self.iter_geo()
-                    .zip(other.iter_geo())
-                    .for_each(|(first, second)| match (first, second) {
-                        (Some(first), Some(second)) => {
-                            output_array.append_value(first.euclidean_distance(&second))
-                        }
-                        _ => output_array.append_null(),
-                    });
+                self.iter_geo().zip(other.iter_geo()).for_each(|(first, second)| match (first, second) {
+                    (Some(first), Some(second)) => output_array.append_value(first.euclidean_distance(&second)),
+                    _ => output_array.append_null(),
+                });
 
                 output_array.finish()
             }
@@ -135,51 +127,51 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray<2>, LineStringArray<O, 2>);
-iter_geo_impl!(PointArray<2>, PolygonArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiPointArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(PointArray<2>, LineStringArray<2>);
+iter_geo_impl!(PointArray<2>, PolygonArray<2>);
+iter_geo_impl!(PointArray<2>, MultiPointArray<2>);
+iter_geo_impl!(PointArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(PointArray<2>, MultiPolygonArray<2>);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<O, 2>, PointArray<2>);
-iter_geo_impl!(LineStringArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, PolygonArray<O, 2>);
-// iter_geo_impl!(LineStringArray<O, 2>, MultiPointArray<O, 2>);
-// iter_geo_impl!(LineStringArray<O, 2>, MultiLineStringArray<O, 2>);
-// iter_geo_impl!(LineStringArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>, PointArray<2>);
+iter_geo_impl!(LineStringArray<2>, LineStringArray<2>);
+iter_geo_impl!(LineStringArray<2>, PolygonArray<2>);
+// iter_geo_impl!(LineStringArray<2>, MultiPointArray<2>);
+// iter_geo_impl!(LineStringArray<2>, MultiLineStringArray<2>);
+// iter_geo_impl!(LineStringArray<2>, MultiPolygonArray<2>);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<O, 2>, PointArray<2>);
-iter_geo_impl!(PolygonArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonArray<O, 2>);
-// iter_geo_impl!(PolygonArray<O, 2>, MultiPointArray<O, 2>);
-// iter_geo_impl!(PolygonArray<O, 2>, MultiLineStringArray<O, 2>);
-// iter_geo_impl!(PolygonArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(PolygonArray<2>, PointArray<2>);
+iter_geo_impl!(PolygonArray<2>, LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>, PolygonArray<2>);
+// iter_geo_impl!(PolygonArray<2>, MultiPointArray<2>);
+// iter_geo_impl!(PolygonArray<2>, MultiLineStringArray<2>);
+// iter_geo_impl!(PolygonArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<O, 2>, PointArray<2>);
-// iter_geo_impl!(MultiPointArray<O, 2>, LineStringArray<O, 2>);
-// iter_geo_impl!(MultiPointArray<O, 2>, PolygonArray<O, 2>);
-// iter_geo_impl!(MultiPointArray<O, 2>, MultiPointArray<O, 2>);
-// iter_geo_impl!(MultiPointArray<O, 2>, MultiLineStringArray<O, 2>);
-// iter_geo_impl!(MultiPointArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<2>, PointArray<2>);
+// iter_geo_impl!(MultiPointArray<2>, LineStringArray<2>);
+// iter_geo_impl!(MultiPointArray<2>, PolygonArray<2>);
+// iter_geo_impl!(MultiPointArray<2>, MultiPointArray<2>);
+// iter_geo_impl!(MultiPointArray<2>, MultiLineStringArray<2>);
+// iter_geo_impl!(MultiPointArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<O, 2>, PointArray<2>);
-// iter_geo_impl!(MultiLineStringArray<O, 2>, LineStringArray<O, 2>);
-// iter_geo_impl!(MultiLineStringArray<O, 2>, PolygonArray<O, 2>);
-// iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPointArray<O, 2>);
-// iter_geo_impl!(MultiLineStringArray<O, 2>, MultiLineStringArray<O, 2>);
-// iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<2>, PointArray<2>);
+// iter_geo_impl!(MultiLineStringArray<2>, LineStringArray<2>);
+// iter_geo_impl!(MultiLineStringArray<2>, PolygonArray<2>);
+// iter_geo_impl!(MultiLineStringArray<2>, MultiPointArray<2>);
+// iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringArray<2>);
+// iter_geo_impl!(MultiLineStringArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<O, 2>, PointArray<2>);
-// iter_geo_impl!(MultiPolygonArray<O, 2>, LineStringArray<O, 2>);
-// iter_geo_impl!(MultiPolygonArray<O, 2>, PolygonArray<O, 2>);
-// iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPointArray<O, 2>);
-// iter_geo_impl!(MultiPolygonArray<O, 2>, MultiLineStringArray<O, 2>);
-// iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<2>, PointArray<2>);
+// iter_geo_impl!(MultiPolygonArray<2>, LineStringArray<2>);
+// iter_geo_impl!(MultiPolygonArray<2>, PolygonArray<2>);
+// iter_geo_impl!(MultiPolygonArray<2>, MultiPointArray<2>);
+// iter_geo_impl!(MultiPolygonArray<2>, MultiLineStringArray<2>);
+// iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonArray<2>);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
@@ -203,7 +195,7 @@ impl<'a> EuclideanDistance<Point<'a, 2>> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl_scalar {
     ($first:ty, $second:ty) => {
-        impl<'a, O: OffsetSizeTrait> EuclideanDistance<$second> for $first {
+        impl<'a> EuclideanDistance<$second> for $first {
             fn euclidean_distance(&self, other: &$second) -> Float64Array {
                 let mut output_array = Float64Builder::with_capacity(self.len());
                 let other_geo = other.to_geo();
@@ -220,48 +212,48 @@ macro_rules! iter_geo_impl_scalar {
 }
 
 // Implementations on PointArray
-iter_geo_impl_scalar!(PointArray<2>, LineString<'a, O, 2>);
-iter_geo_impl_scalar!(PointArray<2>, Polygon<'a, O, 2>);
-iter_geo_impl_scalar!(PointArray<2>, MultiPoint<'a, O, 2>);
-iter_geo_impl_scalar!(PointArray<2>, MultiLineString<'a, O, 2>);
-iter_geo_impl_scalar!(PointArray<2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_scalar!(PointArray<2>, LineString<'a, 2>);
+iter_geo_impl_scalar!(PointArray<2>, Polygon<'a, 2>);
+iter_geo_impl_scalar!(PointArray<2>, MultiPoint<'a, 2>);
+iter_geo_impl_scalar!(PointArray<2>, MultiLineString<'a, 2>);
+iter_geo_impl_scalar!(PointArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl_scalar!(LineStringArray<O, 2>, Point<'a, 2>);
-iter_geo_impl_scalar!(LineStringArray<O, 2>, LineString<'a, O, 2>);
-iter_geo_impl_scalar!(LineStringArray<O, 2>, Polygon<'a, O, 2>);
-// iter_geo_impl_scalar!(LineStringArray<O, 2>, MultiPoint<'a, O, 2>);
-// iter_geo_impl_scalar!(LineStringArray<O, 2>, MultiLineString<'a, O, 2>);
-// iter_geo_impl_scalar!(LineStringArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_scalar!(LineStringArray<2>, Point<'a, 2>);
+iter_geo_impl_scalar!(LineStringArray<2>, LineString<'a, 2>);
+iter_geo_impl_scalar!(LineStringArray<2>, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(LineStringArray<2>, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(LineStringArray<2>, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(LineStringArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl_scalar!(PolygonArray<O, 2>, Point<'a, 2>);
-iter_geo_impl_scalar!(PolygonArray<O, 2>, LineString<'a, O, 2>);
-iter_geo_impl_scalar!(PolygonArray<O, 2>, Polygon<'a, O, 2>);
-// iter_geo_impl_scalar!(PolygonArray<O, 2>, MultiPoint<'a, O, 2>);
-// iter_geo_impl_scalar!(PolygonArray<O, 2>, MultiLineString<'a, O, 2>);
-// iter_geo_impl_scalar!(PolygonArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_scalar!(PolygonArray<2>, Point<'a, 2>);
+iter_geo_impl_scalar!(PolygonArray<2>, LineString<'a, 2>);
+iter_geo_impl_scalar!(PolygonArray<2>, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(PolygonArray<2>, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(PolygonArray<2>, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(PolygonArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl_scalar!(MultiPointArray<O, 2>, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<O, 2>, LineString<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<O, 2>, Polygon<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<O, 2>, MultiPoint<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<O, 2>, MultiLineString<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_scalar!(MultiPointArray<2>, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<2>, LineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<2>, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<2>, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<2>, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, LineString<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, Polygon<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, MultiPoint<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, MultiLineString<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_scalar!(MultiLineStringArray<2>, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<2>, LineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<2>, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<2>, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<2>, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, LineString<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, Polygon<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, MultiPoint<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, MultiLineString<'a, O, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_scalar!(MultiPolygonArray<2>, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<2>, LineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<2>, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<2>, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<2>, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray<2>, MultiPolygon<'a, 2>);

--- a/src/algorithm/geo/euclidean_distance.rs
+++ b/src/algorithm/geo/euclidean_distance.rs
@@ -3,7 +3,7 @@ use crate::scalar::*;
 use crate::trait_::ArrayAccessor;
 use crate::trait_::NativeScalar;
 use arrow_array::builder::Float64Builder;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::EuclideanDistance as _EuclideanDistance;
 
 pub trait EuclideanDistance<Rhs> {

--- a/src/algorithm/geo/euclidean_distance.rs
+++ b/src/algorithm/geo/euclidean_distance.rs
@@ -98,10 +98,14 @@ impl EuclideanDistance<PointArray<2>> for PointArray<2> {
         assert_eq!(self.len(), other.len());
         let mut output_array = Float64Builder::with_capacity(self.len());
 
-        self.iter_geo().zip(other.iter_geo()).for_each(|(first, second)| match (first, second) {
-            (Some(first), Some(second)) => output_array.append_value(first.euclidean_distance(&second)),
-            _ => output_array.append_null(),
-        });
+        self.iter_geo()
+            .zip(other.iter_geo())
+            .for_each(|(first, second)| match (first, second) {
+                (Some(first), Some(second)) => {
+                    output_array.append_value(first.euclidean_distance(&second))
+                }
+                _ => output_array.append_null(),
+            });
 
         output_array.finish()
     }
@@ -115,10 +119,14 @@ macro_rules! iter_geo_impl {
                 assert_eq!(self.len(), other.len());
                 let mut output_array = Float64Builder::with_capacity(self.len());
 
-                self.iter_geo().zip(other.iter_geo()).for_each(|(first, second)| match (first, second) {
-                    (Some(first), Some(second)) => output_array.append_value(first.euclidean_distance(&second)),
-                    _ => output_array.append_null(),
-                });
+                self.iter_geo()
+                    .zip(other.iter_geo())
+                    .for_each(|(first, second)| match (first, second) {
+                        (Some(first), Some(second)) => {
+                            output_array.append_value(first.euclidean_distance(&second))
+                        }
+                        _ => output_array.append_null(),
+                    });
 
                 output_array.finish()
             }

--- a/src/algorithm/geo/euclidean_length.rs
+++ b/src/algorithm/geo/euclidean_length.rs
@@ -25,7 +25,7 @@ pub trait EuclideanLength {
     ///     (x: 40.02f64, y: 116.34),
     ///     (x: 42.02f64, y: 116.34),
     /// ];
-    /// let linestring_array: LineStringArray<i32, 2> = vec![line_string].as_slice().into();
+    /// let linestring_array: LineStringArray<2> = vec![line_string].as_slice().into();
     ///
     /// let length_array = linestring_array.euclidean_length();
     ///
@@ -49,7 +49,7 @@ impl EuclideanLength for PointArray<2> {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> EuclideanLength for $type {
+        impl EuclideanLength for $type {
             type Output = Float64Array;
 
             fn euclidean_length(&self) -> Self::Output {
@@ -59,12 +59,12 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(MultiPointArray<O, 2>);
+zero_impl!(MultiPointArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> EuclideanLength for $type {
+        impl EuclideanLength for $type {
             type Output = Float64Array;
 
             fn euclidean_length(&self) -> Self::Output {
@@ -74,8 +74,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
 
 impl EuclideanLength for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -87,15 +87,10 @@ impl EuclideanLength for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().euclidean_length(),
             LineString(_, XY) => self.as_line_string::<2>().euclidean_length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().euclidean_length(),
             // Polygon(_, XY) => self.as_polygon::<2>().euclidean_length(),
             // LargePolygon(_, XY) => self.as_large_polygon::<2>().euclidean_length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().euclidean_length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().euclidean_length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().euclidean_length(),
-            LargeMultiLineString(_, XY) => {
-                self.as_large_multi_line_string::<2>().euclidean_length()
-            }
             // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().euclidean_length(),
             // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().euclidean_length(),
             // Mixed(_, XY) => self.as_mixed::<2>().euclidean_length(),
@@ -121,7 +116,7 @@ impl EuclideanLength for ChunkedGeometryArray<PointArray<2>> {
 /// Implementation that iterates over chunks
 macro_rules! chunked_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> EuclideanLength for $type {
+        impl EuclideanLength for $type {
             type Output = Result<ChunkedArray<Float64Array>>;
 
             fn euclidean_length(&self) -> Self::Output {
@@ -131,9 +126,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
 
 impl EuclideanLength for &dyn ChunkedNativeArray {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -145,15 +140,10 @@ impl EuclideanLength for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().euclidean_length(),
             LineString(_, XY) => self.as_line_string::<2>().euclidean_length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().euclidean_length(),
             // Polygon(_, XY) => self.as_polygon::<2>().euclidean_length(),
             // LargePolygon(_, XY) => self.as_large_polygon::<2>().euclidean_length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().euclidean_length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().euclidean_length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().euclidean_length(),
-            LargeMultiLineString(_, XY) => {
-                self.as_large_multi_line_string::<2>().euclidean_length()
-            }
             // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().euclidean_length(),
             // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().euclidean_length(),
             // Mixed(_, XY) => self.as_mixed::<2>().euclidean_length(),
@@ -184,7 +174,7 @@ mod tests {
             (x: 10., y: 1.),
             (x: 11., y: 1.)
         ];
-        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
         let result_array = input_array.euclidean_length();
 
         let expected = 10.0_f64;

--- a/src/algorithm/geo/euclidean_length.rs
+++ b/src/algorithm/geo/euclidean_length.rs
@@ -6,7 +6,7 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::EuclideanLength as _EuclideanLength;
 
 pub trait EuclideanLength {

--- a/src/algorithm/geo/frechet_distance.rs
+++ b/src/algorithm/geo/frechet_distance.rs
@@ -7,7 +7,7 @@ use crate::geo_traits::LineStringTrait;
 use crate::io::geo::line_string_to_geo;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::FrechetDistance as _FrechetDistance;
 
 // ┌────────────────────────────────┐

--- a/src/algorithm/geo/frechet_distance.rs
+++ b/src/algorithm/geo/frechet_distance.rs
@@ -30,7 +30,10 @@ impl FrechetDistance<LineStringArray<2>> for LineStringArray<2> {
     type Output = Float64Array;
 
     fn frechet_distance(&self, rhs: &LineStringArray<2>) -> Self::Output {
-        self.try_binary_primitive(rhs, |left, right| Ok(left.to_geo().frechet_distance(&right.to_geo()))).unwrap()
+        self.try_binary_primitive(rhs, |left, right| {
+            Ok(left.to_geo().frechet_distance(&right.to_geo()))
+        })
+        .unwrap()
     }
 }
 
@@ -38,7 +41,9 @@ impl FrechetDistance<ChunkedLineStringArray<2>> for ChunkedLineStringArray<2> {
     type Output = ChunkedArray<Float64Array>;
 
     fn frechet_distance(&self, rhs: &ChunkedLineStringArray<2>) -> Self::Output {
-        ChunkedArray::new(self.binary_map(rhs.chunks(), |(left, right)| FrechetDistance::frechet_distance(left, right)))
+        ChunkedArray::new(self.binary_map(rhs.chunks(), |(left, right)| {
+            FrechetDistance::frechet_distance(left, right)
+        }))
     }
 }
 
@@ -50,7 +55,10 @@ impl FrechetDistance for &dyn NativeArray {
         use NativeType::*;
 
         let result = match (self.data_type(), rhs.data_type()) {
-            (LineString(_, XY), LineString(_, XY)) => FrechetDistance::frechet_distance(self.as_line_string::<2>(), rhs.as_line_string::<2>()),
+            (LineString(_, XY), LineString(_, XY)) => FrechetDistance::frechet_distance(
+                self.as_line_string::<2>(),
+                rhs.as_line_string::<2>(),
+            ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -65,7 +73,10 @@ impl FrechetDistance for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result = match (self.data_type(), rhs.data_type()) {
-            (LineString(_, XY), LineString(_, XY)) => FrechetDistance::frechet_distance(self.as_line_string::<2>(), rhs.as_line_string::<2>()),
+            (LineString(_, XY), LineString(_, XY)) => FrechetDistance::frechet_distance(
+                self.as_line_string::<2>(),
+                rhs.as_line_string::<2>(),
+            ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -87,11 +98,16 @@ impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for LineStringArr
 
     fn frechet_distance(&self, rhs: &G) -> Self::Output {
         let rhs = line_string_to_geo(rhs);
-        self.try_unary_primitive(|geom| Ok::<_, GeoArrowError>(geom.to_geo().frechet_distance(&rhs))).unwrap()
+        self.try_unary_primitive(|geom| {
+            Ok::<_, GeoArrowError>(geom.to_geo().frechet_distance(&rhs))
+        })
+        .unwrap()
     }
 }
 
-impl<G: LineStringTrait<T = f64> + Sync> FrechetDistanceLineString<G> for ChunkedLineStringArray<2> {
+impl<G: LineStringTrait<T = f64> + Sync> FrechetDistanceLineString<G>
+    for ChunkedLineStringArray<2>
+{
     type Output = ChunkedArray<Float64Array>;
 
     fn frechet_distance(&self, rhs: &G) -> Self::Output {
@@ -107,7 +123,9 @@ impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for &dyn NativeAr
         use NativeType::*;
 
         let result = match self.data_type() {
-            LineString(_, XY) => FrechetDistanceLineString::frechet_distance(self.as_line_string::<2>(), rhs),
+            LineString(_, XY) => {
+                FrechetDistanceLineString::frechet_distance(self.as_line_string::<2>(), rhs)
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -123,7 +141,9 @@ impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for &dyn ChunkedN
 
         let rhs = line_string_to_geo(rhs);
         let result = match self.data_type() {
-            LineString(_, XY) => FrechetDistanceLineString::frechet_distance(self.as_line_string::<2>(), &rhs),
+            LineString(_, XY) => {
+                FrechetDistanceLineString::frechet_distance(self.as_line_string::<2>(), &rhs)
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/geodesic_area.rs
+++ b/src/algorithm/geo/geodesic_area.rs
@@ -60,7 +60,7 @@ pub trait GeodesicArea {
     ///     (x: 0.00185608, y: 51.501770),
     ///     (x: 0.00388383, y: 51.501574),
     /// ];
-    /// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
+    /// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
     ///
     /// let area_array = polygon_array.geodesic_area_signed();
     ///
@@ -100,7 +100,7 @@ pub trait GeodesicArea {
     ///     (x: 1.0, y: 1.0),
     ///     (x: 1.0, y: 0.0),
     /// ];
-    /// let polygon_array: PolygonArray<i32, 2> = vec![polygon].as_slice().into();
+    /// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
     ///
     /// let area_array = polygon_array.geodesic_area_unsigned();
     ///
@@ -210,7 +210,7 @@ impl GeodesicArea for PointArray<2> {
 /// Generate a `GeodesicArea` implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> GeodesicArea for $type {
+        impl GeodesicArea for $type {
             type OutputSingle = Float64Array;
             type OutputDouble = (Float64Array, Float64Array);
 
@@ -243,14 +243,14 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(LineStringArray<O, 2>);
-zero_impl!(MultiPointArray<O, 2>);
-zero_impl!(MultiLineStringArray<O, 2>);
+zero_impl!(LineStringArray<2>);
+zero_impl!(MultiPointArray<2>);
+zero_impl!(MultiLineStringArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> GeodesicArea for $type {
+        impl GeodesicArea for $type {
             type OutputSingle = Float64Array;
             type OutputDouble = (Float64Array, Float64Array);
 
@@ -323,10 +323,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>);
-iter_geo_impl!(MixedGeometryArray<O, 2>);
-iter_geo_impl!(GeometryCollectionArray<O, 2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
 impl GeodesicArea for &dyn NativeArray {
     type OutputSingle = Result<Float64Array>;
@@ -339,23 +339,12 @@ impl GeodesicArea for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_area_signed(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_area_signed(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().geodesic_area_signed(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_area_signed(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().geodesic_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_area_signed(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().geodesic_area_signed(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_signed(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .geodesic_area_signed(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_signed(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().geodesic_area_signed(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_signed(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_area_signed(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_area_signed(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .geodesic_area_signed(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -368,25 +357,14 @@ impl GeodesicArea for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_area_unsigned(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_area_unsigned(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().geodesic_area_unsigned(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_area_unsigned(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().geodesic_area_unsigned(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_area_unsigned(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().geodesic_area_unsigned(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_unsigned(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .geodesic_area_unsigned(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_unsigned(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().geodesic_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_unsigned(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_area_unsigned(),
             GeometryCollection(_, XY) => {
                 self.as_geometry_collection::<2>().geodesic_area_unsigned()
             }
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .geodesic_area_unsigned(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -399,23 +377,12 @@ impl GeodesicArea for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_perimeter(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().geodesic_perimeter(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().geodesic_perimeter(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().geodesic_perimeter(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter(),
-            LargeMultiLineString(_, XY) => {
-                self.as_large_multi_line_string::<2>().geodesic_perimeter()
-            }
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().geodesic_perimeter(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_perimeter(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .geodesic_perimeter(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -428,36 +395,17 @@ impl GeodesicArea for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_signed(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_signed(),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .geodesic_perimeter_area_signed(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_signed(),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .geodesic_perimeter_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_signed(),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
-                .geodesic_perimeter_area_signed(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string::<2>()
-                .geodesic_perimeter_area_signed(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
                 .geodesic_perimeter_area_signed(),
             MultiPolygon(_, XY) => self
                 .as_multi_polygon::<2>()
                 .geodesic_perimeter_area_signed(),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .geodesic_perimeter_area_signed(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_signed(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_perimeter_area_signed(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection::<2>()
-                .geodesic_perimeter_area_signed(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
                 .geodesic_perimeter_area_signed(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -473,40 +421,19 @@ impl GeodesicArea for &dyn NativeArray {
             LineString(_, XY) => self
                 .as_line_string::<2>()
                 .geodesic_perimeter_area_unsigned(),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .geodesic_perimeter_area_unsigned(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_unsigned(),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .geodesic_perimeter_area_unsigned(),
             MultiPoint(_, XY) => self
                 .as_multi_point::<2>()
-                .geodesic_perimeter_area_unsigned(),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
                 .geodesic_perimeter_area_unsigned(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string::<2>()
                 .geodesic_perimeter_area_unsigned(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .geodesic_perimeter_area_unsigned(),
             MultiPolygon(_, XY) => self
                 .as_multi_polygon::<2>()
                 .geodesic_perimeter_area_unsigned(),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .geodesic_perimeter_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_unsigned(),
-            LargeMixed(_, XY) => self
-                .as_large_mixed::<2>()
-                .geodesic_perimeter_area_unsigned(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection::<2>()
-                .geodesic_perimeter_area_unsigned(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
                 .geodesic_perimeter_area_unsigned(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -561,23 +488,12 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_area_signed(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_area_signed(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().geodesic_area_signed(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_area_signed(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().geodesic_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_area_signed(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().geodesic_area_signed(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_signed(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .geodesic_area_signed(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_signed(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().geodesic_area_signed(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_signed(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_area_signed(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_area_signed(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .geodesic_area_signed(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -589,25 +505,14 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_area_unsigned(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_area_unsigned(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().geodesic_area_unsigned(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_area_unsigned(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().geodesic_area_unsigned(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_area_unsigned(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().geodesic_area_unsigned(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_unsigned(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .geodesic_area_unsigned(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_unsigned(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().geodesic_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_unsigned(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_area_unsigned(),
             GeometryCollection(_, XY) => {
                 self.as_geometry_collection::<2>().geodesic_area_unsigned()
             }
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .geodesic_area_unsigned(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -619,23 +524,12 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_perimeter(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().geodesic_perimeter(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().geodesic_perimeter(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().geodesic_perimeter(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter(),
-            LargeMultiLineString(_, XY) => {
-                self.as_large_multi_line_string::<2>().geodesic_perimeter()
-            }
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().geodesic_perimeter(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_perimeter(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .geodesic_perimeter(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -647,36 +541,17 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_signed(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_signed(),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .geodesic_perimeter_area_signed(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_signed(),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .geodesic_perimeter_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_signed(),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
-                .geodesic_perimeter_area_signed(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string::<2>()
-                .geodesic_perimeter_area_signed(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
                 .geodesic_perimeter_area_signed(),
             MultiPolygon(_, XY) => self
                 .as_multi_polygon::<2>()
                 .geodesic_perimeter_area_signed(),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .geodesic_perimeter_area_signed(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_signed(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_perimeter_area_signed(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection::<2>()
-                .geodesic_perimeter_area_signed(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
                 .geodesic_perimeter_area_signed(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -691,40 +566,19 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
             LineString(_, XY) => self
                 .as_line_string::<2>()
                 .geodesic_perimeter_area_unsigned(),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .geodesic_perimeter_area_unsigned(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_unsigned(),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .geodesic_perimeter_area_unsigned(),
             MultiPoint(_, XY) => self
                 .as_multi_point::<2>()
-                .geodesic_perimeter_area_unsigned(),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
                 .geodesic_perimeter_area_unsigned(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string::<2>()
                 .geodesic_perimeter_area_unsigned(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .geodesic_perimeter_area_unsigned(),
             MultiPolygon(_, XY) => self
                 .as_multi_polygon::<2>()
                 .geodesic_perimeter_area_unsigned(),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .geodesic_perimeter_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_unsigned(),
-            LargeMixed(_, XY) => self
-                .as_large_mixed::<2>()
-                .geodesic_perimeter_area_unsigned(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection::<2>()
-                .geodesic_perimeter_area_unsigned(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
                 .geodesic_perimeter_area_unsigned(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }

--- a/src/algorithm/geo/geodesic_area.rs
+++ b/src/algorithm/geo/geodesic_area.rs
@@ -6,7 +6,7 @@ use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
 use arrow_array::builder::Float64Builder;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::prelude::GeodesicArea as _GeodesicArea;
 
 /// Determine the perimeter and area of a geometry on an ellipsoidal model of the earth.
@@ -193,17 +193,11 @@ impl GeodesicArea for PointArray<2> {
     }
 
     fn geodesic_perimeter_area_signed(&self) -> Self::OutputDouble {
-        (
-            zeroes(self.len(), self.nulls()),
-            zeroes(self.len(), self.nulls()),
-        )
+        (zeroes(self.len(), self.nulls()), zeroes(self.len(), self.nulls()))
     }
 
     fn geodesic_perimeter_area_unsigned(&self) -> Self::OutputDouble {
-        (
-            zeroes(self.len(), self.nulls()),
-            zeroes(self.len(), self.nulls()),
-        )
+        (zeroes(self.len(), self.nulls()), zeroes(self.len(), self.nulls()))
     }
 }
 
@@ -227,17 +221,11 @@ macro_rules! zero_impl {
             }
 
             fn geodesic_perimeter_area_signed(&self) -> Self::OutputDouble {
-                (
-                    zeroes(self.len(), self.nulls()),
-                    zeroes(self.len(), self.nulls()),
-                )
+                (zeroes(self.len(), self.nulls()), zeroes(self.len(), self.nulls()))
             }
 
             fn geodesic_perimeter_area_unsigned(&self) -> Self::OutputDouble {
-                (
-                    zeroes(self.len(), self.nulls()),
-                    zeroes(self.len(), self.nulls()),
-                )
+                (zeroes(self.len(), self.nulls()), zeroes(self.len(), self.nulls()))
             }
         }
     };
@@ -257,9 +245,7 @@ macro_rules! iter_geo_impl {
             fn geodesic_perimeter(&self) -> Self::OutputSingle {
                 let mut output_array = Float64Builder::with_capacity(self.len());
 
-                self.iter_geo().for_each(|maybe_g| {
-                    output_array.append_option(maybe_g.map(|g| g.geodesic_perimeter()))
-                });
+                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.geodesic_perimeter())));
 
                 output_array.finish()
             }
@@ -267,9 +253,7 @@ macro_rules! iter_geo_impl {
             fn geodesic_area_signed(&self) -> Self::OutputSingle {
                 let mut output_array = Float64Builder::with_capacity(self.len());
 
-                self.iter_geo().for_each(|maybe_g| {
-                    output_array.append_option(maybe_g.map(|g| g.geodesic_area_signed()))
-                });
+                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.geodesic_area_signed())));
 
                 output_array.finish()
             }
@@ -277,9 +261,7 @@ macro_rules! iter_geo_impl {
             fn geodesic_area_unsigned(&self) -> Self::OutputSingle {
                 let mut output_array = Float64Builder::with_capacity(self.len());
 
-                self.iter_geo().for_each(|maybe_g| {
-                    output_array.append_option(maybe_g.map(|g| g.geodesic_area_unsigned()))
-                });
+                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.geodesic_area_unsigned())));
 
                 output_array.finish()
             }
@@ -362,9 +344,7 @@ impl GeodesicArea for &dyn NativeArray {
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_unsigned(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_unsigned(),
-            GeometryCollection(_, XY) => {
-                self.as_geometry_collection::<2>().geodesic_area_unsigned()
-            }
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_area_unsigned(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -397,16 +377,10 @@ impl GeodesicArea for &dyn NativeArray {
             LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_signed(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_signed(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .geodesic_perimeter_area_signed(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .geodesic_perimeter_area_signed(),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter_area_signed(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter_area_signed(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_signed(),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .geodesic_perimeter_area_signed(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter_area_signed(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -418,23 +392,13 @@ impl GeodesicArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_unsigned(),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .geodesic_perimeter_area_unsigned(),
+            LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_unsigned(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_unsigned(),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .geodesic_perimeter_area_unsigned(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .geodesic_perimeter_area_unsigned(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .geodesic_perimeter_area_unsigned(),
+            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_unsigned(),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter_area_unsigned(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_unsigned(),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .geodesic_perimeter_area_unsigned(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter_area_unsigned(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -446,33 +410,24 @@ impl<G: NativeArray> GeodesicArea for ChunkedGeometryArray<G> {
     type OutputDouble = Result<(ChunkedArray<Float64Array>, ChunkedArray<Float64Array>)>;
 
     fn geodesic_area_signed(&self) -> Self::OutputSingle {
-        self.try_map(|chunk| chunk.as_ref().geodesic_area_signed())?
-            .try_into()
+        self.try_map(|chunk| chunk.as_ref().geodesic_area_signed())?.try_into()
     }
 
     fn geodesic_area_unsigned(&self) -> Self::OutputSingle {
-        self.try_map(|chunk| chunk.as_ref().geodesic_area_unsigned())?
-            .try_into()
+        self.try_map(|chunk| chunk.as_ref().geodesic_area_unsigned())?.try_into()
     }
 
     fn geodesic_perimeter(&self) -> Self::OutputSingle {
-        self.try_map(|chunk| chunk.as_ref().geodesic_perimeter())?
-            .try_into()
+        self.try_map(|chunk| chunk.as_ref().geodesic_perimeter())?.try_into()
     }
 
     fn geodesic_perimeter_area_signed(&self) -> Self::OutputDouble {
-        let (left, right): (Vec<_>, Vec<_>) = self
-            .try_map(|chunk| chunk.as_ref().geodesic_perimeter_area_signed())?
-            .into_iter()
-            .unzip();
+        let (left, right): (Vec<_>, Vec<_>) = self.try_map(|chunk| chunk.as_ref().geodesic_perimeter_area_signed())?.into_iter().unzip();
         Ok((left.try_into().unwrap(), right.try_into().unwrap()))
     }
 
     fn geodesic_perimeter_area_unsigned(&self) -> Self::OutputDouble {
-        let (left, right): (Vec<_>, Vec<_>) = self
-            .try_map(|chunk| chunk.as_ref().geodesic_perimeter_area_unsigned())?
-            .into_iter()
-            .unzip();
+        let (left, right): (Vec<_>, Vec<_>) = self.try_map(|chunk| chunk.as_ref().geodesic_perimeter_area_unsigned())?.into_iter().unzip();
         Ok((left.try_into().unwrap(), right.try_into().unwrap()))
     }
 }
@@ -510,9 +465,7 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_unsigned(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_unsigned(),
-            GeometryCollection(_, XY) => {
-                self.as_geometry_collection::<2>().geodesic_area_unsigned()
-            }
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_area_unsigned(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -543,16 +496,10 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
             LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_signed(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_signed(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .geodesic_perimeter_area_signed(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .geodesic_perimeter_area_signed(),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter_area_signed(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter_area_signed(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_signed(),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .geodesic_perimeter_area_signed(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter_area_signed(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -563,23 +510,13 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_unsigned(),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .geodesic_perimeter_area_unsigned(),
+            LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_unsigned(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_unsigned(),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .geodesic_perimeter_area_unsigned(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .geodesic_perimeter_area_unsigned(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .geodesic_perimeter_area_unsigned(),
+            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_unsigned(),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter_area_unsigned(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_unsigned(),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .geodesic_perimeter_area_unsigned(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter_area_unsigned(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/geodesic_area.rs
+++ b/src/algorithm/geo/geodesic_area.rs
@@ -193,11 +193,17 @@ impl GeodesicArea for PointArray<2> {
     }
 
     fn geodesic_perimeter_area_signed(&self) -> Self::OutputDouble {
-        (zeroes(self.len(), self.nulls()), zeroes(self.len(), self.nulls()))
+        (
+            zeroes(self.len(), self.nulls()),
+            zeroes(self.len(), self.nulls()),
+        )
     }
 
     fn geodesic_perimeter_area_unsigned(&self) -> Self::OutputDouble {
-        (zeroes(self.len(), self.nulls()), zeroes(self.len(), self.nulls()))
+        (
+            zeroes(self.len(), self.nulls()),
+            zeroes(self.len(), self.nulls()),
+        )
     }
 }
 
@@ -221,11 +227,17 @@ macro_rules! zero_impl {
             }
 
             fn geodesic_perimeter_area_signed(&self) -> Self::OutputDouble {
-                (zeroes(self.len(), self.nulls()), zeroes(self.len(), self.nulls()))
+                (
+                    zeroes(self.len(), self.nulls()),
+                    zeroes(self.len(), self.nulls()),
+                )
             }
 
             fn geodesic_perimeter_area_unsigned(&self) -> Self::OutputDouble {
-                (zeroes(self.len(), self.nulls()), zeroes(self.len(), self.nulls()))
+                (
+                    zeroes(self.len(), self.nulls()),
+                    zeroes(self.len(), self.nulls()),
+                )
             }
         }
     };
@@ -245,7 +257,9 @@ macro_rules! iter_geo_impl {
             fn geodesic_perimeter(&self) -> Self::OutputSingle {
                 let mut output_array = Float64Builder::with_capacity(self.len());
 
-                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.geodesic_perimeter())));
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array.append_option(maybe_g.map(|g| g.geodesic_perimeter()))
+                });
 
                 output_array.finish()
             }
@@ -253,7 +267,9 @@ macro_rules! iter_geo_impl {
             fn geodesic_area_signed(&self) -> Self::OutputSingle {
                 let mut output_array = Float64Builder::with_capacity(self.len());
 
-                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.geodesic_area_signed())));
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array.append_option(maybe_g.map(|g| g.geodesic_area_signed()))
+                });
 
                 output_array.finish()
             }
@@ -261,7 +277,9 @@ macro_rules! iter_geo_impl {
             fn geodesic_area_unsigned(&self) -> Self::OutputSingle {
                 let mut output_array = Float64Builder::with_capacity(self.len());
 
-                self.iter_geo().for_each(|maybe_g| output_array.append_option(maybe_g.map(|g| g.geodesic_area_unsigned())));
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array.append_option(maybe_g.map(|g| g.geodesic_area_unsigned()))
+                });
 
                 output_array.finish()
             }
@@ -344,7 +362,9 @@ impl GeodesicArea for &dyn NativeArray {
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_unsigned(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_unsigned(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_area_unsigned(),
+            GeometryCollection(_, XY) => {
+                self.as_geometry_collection::<2>().geodesic_area_unsigned()
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -377,10 +397,16 @@ impl GeodesicArea for &dyn NativeArray {
             LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_signed(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_signed(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter_area_signed(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter_area_signed(),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .geodesic_perimeter_area_signed(),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .geodesic_perimeter_area_signed(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_signed(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter_area_signed(),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .geodesic_perimeter_area_signed(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -392,13 +418,23 @@ impl GeodesicArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_unsigned(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_unsigned(),
+            LineString(_, XY) => self
+                .as_line_string::<2>()
+                .geodesic_perimeter_area_unsigned(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_unsigned(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_unsigned(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter_area_unsigned(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter_area_unsigned(),
+            MultiPoint(_, XY) => self
+                .as_multi_point::<2>()
+                .geodesic_perimeter_area_unsigned(),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .geodesic_perimeter_area_unsigned(),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .geodesic_perimeter_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_unsigned(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter_area_unsigned(),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .geodesic_perimeter_area_unsigned(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -410,24 +446,33 @@ impl<G: NativeArray> GeodesicArea for ChunkedGeometryArray<G> {
     type OutputDouble = Result<(ChunkedArray<Float64Array>, ChunkedArray<Float64Array>)>;
 
     fn geodesic_area_signed(&self) -> Self::OutputSingle {
-        self.try_map(|chunk| chunk.as_ref().geodesic_area_signed())?.try_into()
+        self.try_map(|chunk| chunk.as_ref().geodesic_area_signed())?
+            .try_into()
     }
 
     fn geodesic_area_unsigned(&self) -> Self::OutputSingle {
-        self.try_map(|chunk| chunk.as_ref().geodesic_area_unsigned())?.try_into()
+        self.try_map(|chunk| chunk.as_ref().geodesic_area_unsigned())?
+            .try_into()
     }
 
     fn geodesic_perimeter(&self) -> Self::OutputSingle {
-        self.try_map(|chunk| chunk.as_ref().geodesic_perimeter())?.try_into()
+        self.try_map(|chunk| chunk.as_ref().geodesic_perimeter())?
+            .try_into()
     }
 
     fn geodesic_perimeter_area_signed(&self) -> Self::OutputDouble {
-        let (left, right): (Vec<_>, Vec<_>) = self.try_map(|chunk| chunk.as_ref().geodesic_perimeter_area_signed())?.into_iter().unzip();
+        let (left, right): (Vec<_>, Vec<_>) = self
+            .try_map(|chunk| chunk.as_ref().geodesic_perimeter_area_signed())?
+            .into_iter()
+            .unzip();
         Ok((left.try_into().unwrap(), right.try_into().unwrap()))
     }
 
     fn geodesic_perimeter_area_unsigned(&self) -> Self::OutputDouble {
-        let (left, right): (Vec<_>, Vec<_>) = self.try_map(|chunk| chunk.as_ref().geodesic_perimeter_area_unsigned())?.into_iter().unzip();
+        let (left, right): (Vec<_>, Vec<_>) = self
+            .try_map(|chunk| chunk.as_ref().geodesic_perimeter_area_unsigned())?
+            .into_iter()
+            .unzip();
         Ok((left.try_into().unwrap(), right.try_into().unwrap()))
     }
 }
@@ -465,7 +510,9 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_unsigned(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_unsigned(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_area_unsigned(),
+            GeometryCollection(_, XY) => {
+                self.as_geometry_collection::<2>().geodesic_area_unsigned()
+            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -496,10 +543,16 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
             LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_signed(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_signed(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter_area_signed(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter_area_signed(),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .geodesic_perimeter_area_signed(),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .geodesic_perimeter_area_signed(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_signed(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter_area_signed(),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .geodesic_perimeter_area_signed(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -510,13 +563,23 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_unsigned(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_unsigned(),
+            LineString(_, XY) => self
+                .as_line_string::<2>()
+                .geodesic_perimeter_area_unsigned(),
             Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_unsigned(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_unsigned(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter_area_unsigned(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter_area_unsigned(),
+            MultiPoint(_, XY) => self
+                .as_multi_point::<2>()
+                .geodesic_perimeter_area_unsigned(),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .geodesic_perimeter_area_unsigned(),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .geodesic_perimeter_area_unsigned(),
             Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_unsigned(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter_area_unsigned(),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .geodesic_perimeter_area_unsigned(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/geodesic_length.rs
+++ b/src/algorithm/geo/geodesic_length.rs
@@ -6,7 +6,7 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::GeodesicLength as _GeodesicLength;
 
 /// Determine the length of a geometry on an ellipsoidal model of the earth.

--- a/src/algorithm/geo/geodesic_length.rs
+++ b/src/algorithm/geo/geodesic_length.rs
@@ -43,7 +43,7 @@ pub trait GeodesicLength {
     ///     // Osaka
     ///     (135.5244559, 34.687455)
     /// ]);
-    /// let linestring_array: LineStringArray<i32, 2> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray<2> = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.geodesic_length();
     ///
@@ -69,7 +69,7 @@ impl GeodesicLength for PointArray<2> {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> GeodesicLength for $type {
+        impl GeodesicLength for $type {
             type Output = Float64Array;
 
             fn geodesic_length(&self) -> Self::Output {
@@ -79,12 +79,12 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(MultiPointArray<O, 2>);
+zero_impl!(MultiPointArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> GeodesicLength for $type {
+        impl GeodesicLength for $type {
             type Output = Float64Array;
 
             fn geodesic_length(&self) -> Self::Output {
@@ -94,8 +94,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
 
 impl GeodesicLength for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -107,21 +107,12 @@ impl GeodesicLength for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_length(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().geodesic_length(),
             // Polygon(_, XY) => self.as_polygon::<2>().geodesic_length(),
-            // LargePolygon(_, XY) => self.as_large_polygon::<2>().geodesic_length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().geodesic_length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_length(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().geodesic_length(),
             // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_length(),
-            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().geodesic_length(),
             // Mixed(_, XY) => self.as_mixed::<2>().geodesic_length(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_length(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_length(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().geodesic_length()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -139,7 +130,7 @@ impl GeodesicLength for ChunkedGeometryArray<PointArray<2>> {
 /// Implementation that iterates over chunks
 macro_rules! chunked_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> GeodesicLength for $type {
+        impl GeodesicLength for $type {
             type Output = Result<ChunkedArray<Float64Array>>;
 
             fn geodesic_length(&self) -> Self::Output {
@@ -149,9 +140,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
 
 impl GeodesicLength for &dyn ChunkedNativeArray {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -163,21 +154,12 @@ impl GeodesicLength for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().geodesic_length(),
             LineString(_, XY) => self.as_line_string::<2>().geodesic_length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().geodesic_length(),
             // Polygon(_, XY) => self.as_polygon::<2>().geodesic_length(),
-            // LargePolygon(_, XY) => self.as_large_polygon::<2>().geodesic_length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().geodesic_length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_length(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().geodesic_length(),
             // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_length(),
-            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().geodesic_length(),
             // Mixed(_, XY) => self.as_mixed::<2>().geodesic_length(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().geodesic_length(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_length(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().geodesic_length()
-            // }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -200,7 +182,7 @@ mod tests {
             // Osaka
             (x: 135.5244559, y: 34.687455),
         ];
-        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
         let result_array = input_array.geodesic_length();
 
         // Meters

--- a/src/algorithm/geo/haversine_length.rs
+++ b/src/algorithm/geo/haversine_length.rs
@@ -6,7 +6,7 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::HaversineLength as _HaversineLength;
 
 /// Determine the length of a geometry using the [haversine formula].

--- a/src/algorithm/geo/haversine_length.rs
+++ b/src/algorithm/geo/haversine_length.rs
@@ -37,7 +37,7 @@ pub trait HaversineLength {
     ///     // London
     ///     (-0.1278, 51.5074),
     /// ]);
-    /// let linestring_array: LineStringArray<i32, 2> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray<2> = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.haversine_length();
     ///
@@ -63,7 +63,7 @@ impl HaversineLength for PointArray<2> {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> HaversineLength for $type {
+        impl HaversineLength for $type {
             type Output = Float64Array;
 
             fn haversine_length(&self) -> Self::Output {
@@ -73,12 +73,12 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(MultiPointArray<O, 2>);
+zero_impl!(MultiPointArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> HaversineLength for $type {
+        impl HaversineLength for $type {
             type Output = Float64Array;
 
             fn haversine_length(&self) -> Self::Output {
@@ -88,8 +88,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
 
 impl HaversineLength for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -101,23 +101,12 @@ impl HaversineLength for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().haversine_length(),
             LineString(_, XY) => self.as_line_string::<2>().haversine_length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().haversine_length(),
             // Polygon(_, XY) => self.as_polygon::<2>().haversine_length(),
-            // LargePolygon(_, XY) => self.as_large_polygon::<2>().haversine_length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().haversine_length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().haversine_length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().haversine_length(),
-            LargeMultiLineString(_, XY) => {
-                self.as_large_multi_line_string::<2>().haversine_length()
-            }
             // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().haversine_length(),
-            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().haversine_length(),
             // Mixed(_, XY) => self.as_mixed::<2>().haversine_length(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().haversine_length(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().haversine_length(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().haversine_length()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -135,7 +124,7 @@ impl HaversineLength for ChunkedGeometryArray<PointArray<2>> {
 /// Implementation that iterates over chunks
 macro_rules! chunked_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> HaversineLength for $type {
+        impl HaversineLength for $type {
             type Output = Result<ChunkedArray<Float64Array>>;
 
             fn haversine_length(&self) -> Self::Output {
@@ -145,9 +134,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
 
 impl HaversineLength for &dyn ChunkedNativeArray {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -159,23 +148,12 @@ impl HaversineLength for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().haversine_length(),
             LineString(_, XY) => self.as_line_string::<2>().haversine_length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().haversine_length(),
             // Polygon(_, XY) => self.as_polygon::<2>().haversine_length(),
-            // LargePolygon(_, XY) => self.as_large_polygon::<2>().haversine_length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().haversine_length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().haversine_length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().haversine_length(),
-            LargeMultiLineString(_, XY) => {
-                self.as_large_multi_line_string::<2>().haversine_length()
-            }
             // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().haversine_length(),
-            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().haversine_length(),
             // Mixed(_, XY) => self.as_mixed::<2>().haversine_length(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().haversine_length(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().haversine_length(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().haversine_length()
-            // }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -196,7 +174,7 @@ mod tests {
             // London
             (x: -0.1278, y: 51.5074),
         ];
-        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
         let result_array = input_array.haversine_length();
 
         // Meters

--- a/src/algorithm/geo/intersects.rs
+++ b/src/algorithm/geo/intersects.rs
@@ -1,14 +1,8 @@
 use crate::chunked_array::ChunkedArray;
-use crate::geo_traits::{
-    GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
-    MultiPolygonTrait, PointTrait, PolygonTrait,
-};
+use crate::geo_traits::{GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait};
 use crate::indexed::array::*;
 use crate::indexed::chunked::*;
-use crate::io::geo::{
-    geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo,
-    multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo,
-};
+use crate::io::geo::{geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo, multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo};
 use crate::trait_::NativeScalar;
 use arrow_array::{BooleanArray, OffsetSizeTrait};
 use geo::{BoundingRect, Intersects as _Intersects};
@@ -59,96 +53,81 @@ impl Intersects for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &Self) -> Self::Output {
-        self.try_binary_boolean(rhs, |left, right| {
-            Ok(left.to_geo().intersects(&right.to_geo()))
-        })
-        .unwrap()
+        self.try_binary_boolean(rhs, |left, right| Ok(left.to_geo().intersects(&right.to_geo()))).unwrap()
     }
 }
 
 // Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($first:ty, $second:ty) => {
-        impl<'a, O: OffsetSizeTrait> Intersects<$second> for $first {
+        impl<'a> Intersects<$second> for $first {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &$second) -> Self::Output {
-                self.try_binary_boolean(rhs, |left, right| {
-                    Ok(left.to_geo().intersects(&right.to_geo()))
-                })
-                .unwrap()
+                self.try_binary_boolean(rhs, |left, right| Ok(left.to_geo().intersects(&right.to_geo()))).unwrap()
             }
         }
     };
 }
 
 // Implementations on PointArray
-iter_geo_impl!(IndexedPointArray<2>, IndexedLineStringArray<O, 2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedPolygonArray<O, 2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedMultiPointArray<O, 2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedMultiLineStringArray<O, 2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedMultiPolygonArray<O, 2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedMixedGeometryArray<O, 2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedGeometryCollectionArray<O, 2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedLineStringArray<2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedPolygonArray<2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedMultiPointArray<2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedMultiLineStringArray<2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedMultiPolygonArray<2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedMixedGeometryArray<2>);
+iter_geo_impl!(IndexedPointArray<2>, IndexedGeometryCollectionArray<2>);
 
 // Implementations on LineStringArray
-iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedLineStringArray<O, 2>);
-iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedPolygonArray<O, 2>);
-iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedMultiPointArray<O, 2>);
-iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedMultiLineStringArray<O, 2>);
-iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
-iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
-iter_geo_impl!(IndexedLineStringArray<O, 2>, IndexedGeometryCollectionArray<O, 2>);
+iter_geo_impl!(IndexedLineStringArray<2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedLineStringArray<2>, IndexedLineStringArray<2>);
+iter_geo_impl!(IndexedLineStringArray<2>, IndexedPolygonArray<2>);
+iter_geo_impl!(IndexedLineStringArray<2>, IndexedMultiPointArray<2>);
+iter_geo_impl!(IndexedLineStringArray<2>, IndexedMultiLineStringArray<2>);
+iter_geo_impl!(IndexedLineStringArray<2>, IndexedMultiPolygonArray<2>);
+iter_geo_impl!(IndexedLineStringArray<2>, IndexedMixedGeometryArray<2>);
+iter_geo_impl!(IndexedLineStringArray<2>, IndexedGeometryCollectionArray<2>);
 
 // Implementations on PolygonArray
-iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedLineStringArray<O, 2>);
-iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedPolygonArray<O, 2>);
-iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedMultiPointArray<O, 2>);
-iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedMultiLineStringArray<O, 2>);
-iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
-iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
-iter_geo_impl!(IndexedPolygonArray<O, 2>, IndexedGeometryCollectionArray<O, 2>);
+iter_geo_impl!(IndexedPolygonArray<2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedPolygonArray<2>, IndexedLineStringArray<2>);
+iter_geo_impl!(IndexedPolygonArray<2>, IndexedPolygonArray<2>);
+iter_geo_impl!(IndexedPolygonArray<2>, IndexedMultiPointArray<2>);
+iter_geo_impl!(IndexedPolygonArray<2>, IndexedMultiLineStringArray<2>);
+iter_geo_impl!(IndexedPolygonArray<2>, IndexedMultiPolygonArray<2>);
+iter_geo_impl!(IndexedPolygonArray<2>, IndexedMixedGeometryArray<2>);
+iter_geo_impl!(IndexedPolygonArray<2>, IndexedGeometryCollectionArray<2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedLineStringArray<O, 2>);
-iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedPolygonArray<O, 2>);
-iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedMultiPointArray<O, 2>);
-iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedMultiLineStringArray<O, 2>);
-iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
-iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
-iter_geo_impl!(IndexedMultiPointArray<O, 2>, IndexedGeometryCollectionArray<O, 2>);
+iter_geo_impl!(IndexedMultiPointArray<2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedMultiPointArray<2>, IndexedLineStringArray<2>);
+iter_geo_impl!(IndexedMultiPointArray<2>, IndexedPolygonArray<2>);
+iter_geo_impl!(IndexedMultiPointArray<2>, IndexedMultiPointArray<2>);
+iter_geo_impl!(IndexedMultiPointArray<2>, IndexedMultiLineStringArray<2>);
+iter_geo_impl!(IndexedMultiPointArray<2>, IndexedMultiPolygonArray<2>);
+iter_geo_impl!(IndexedMultiPointArray<2>, IndexedMixedGeometryArray<2>);
+iter_geo_impl!(IndexedMultiPointArray<2>, IndexedGeometryCollectionArray<2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedLineStringArray<O, 2>);
-iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedPolygonArray<O, 2>);
-iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedMultiPointArray<O, 2>);
-iter_geo_impl!(
-    IndexedMultiLineStringArray<O, 2>,
-    IndexedMultiLineStringArray<O, 2>
-);
-iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
-iter_geo_impl!(IndexedMultiLineStringArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
-iter_geo_impl!(
-    IndexedMultiLineStringArray<O, 2>,
-    IndexedGeometryCollectionArray<O, 2>
-);
+iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedLineStringArray<2>);
+iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedPolygonArray<2>);
+iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMultiPointArray<2>);
+iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMultiLineStringArray<2>);
+iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMultiPolygonArray<2>);
+iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMixedGeometryArray<2>);
+iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedGeometryCollectionArray<2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedLineStringArray<O, 2>);
-iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedPolygonArray<O, 2>);
-iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedMultiPointArray<O, 2>);
-iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedMultiLineStringArray<O, 2>);
-iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedMultiPolygonArray<O, 2>);
-iter_geo_impl!(IndexedMultiPolygonArray<O, 2>, IndexedMixedGeometryArray<O, 2>);
-iter_geo_impl!(
-    IndexedMultiPolygonArray<O, 2>,
-    IndexedGeometryCollectionArray<O, 2>
-);
+iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedPointArray<2>);
+iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedLineStringArray<2>);
+iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedPolygonArray<2>);
+iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiPointArray<2>);
+iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiLineStringArray<2>);
+iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiPolygonArray<2>);
+iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMixedGeometryArray<2>);
+iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedGeometryCollectionArray<2>);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
@@ -171,7 +150,7 @@ impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedPointArray<2> {
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: PointTrait<T = f64>> IntersectsPoint<G> for $struct_name {
+        impl<G: PointTrait<T = f64>> IntersectsPoint<G> for $struct_name {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
@@ -182,47 +161,43 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O, 2>);
-impl_intersects!(IndexedPolygonArray<O, 2>);
-impl_intersects!(IndexedMultiPointArray<O, 2>);
-impl_intersects!(IndexedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedLineStringArray<2>);
+impl_intersects!(IndexedPolygonArray<2>);
+impl_intersects!(IndexedMultiPointArray<2>);
+impl_intersects!(IndexedMultiLineStringArray<2>);
+impl_intersects!(IndexedMultiPolygonArray<2>);
+impl_intersects!(IndexedMixedGeometryArray<2>);
+impl_intersects!(IndexedGeometryCollectionArray<2>);
 
 impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = point_to_geo(rhs);
-        self.map(|chunk| IntersectsPoint::intersects(chunk, &rhs))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| IntersectsPoint::intersects(chunk, &rhs)).try_into().unwrap()
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: PointTrait<T = f64>> IntersectsPoint<G> for $struct_name {
+        impl<G: PointTrait<T = f64>> IntersectsPoint<G> for $struct_name {
             type Output = ChunkedArray<BooleanArray>;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = point_to_geo(rhs);
-                self.map(|chunk| IntersectsPoint::intersects(chunk, &rhs))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| IntersectsPoint::intersects(chunk, &rhs)).try_into().unwrap()
             }
         }
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedChunkedLineStringArray<2>);
+impl_intersects!(IndexedChunkedPolygonArray<2>);
+impl_intersects!(IndexedChunkedMultiPointArray<2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
 
 pub trait IntersectsLineString<Rhs> {
     type Output;
@@ -235,72 +210,60 @@ impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedPointArray<
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = line_string_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-            geom.to_geo().intersects(&rhs)
-        })
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> IntersectsLineString<G>
-            for $struct_name
-        {
+        impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for $struct_name {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = line_string_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-                    geom.to_geo().intersects(&rhs)
-                })
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
             }
         }
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O, 2>);
-impl_intersects!(IndexedPolygonArray<O, 2>);
-impl_intersects!(IndexedMultiPointArray<O, 2>);
-impl_intersects!(IndexedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedLineStringArray<2>);
+impl_intersects!(IndexedPolygonArray<2>);
+impl_intersects!(IndexedMultiPointArray<2>);
+impl_intersects!(IndexedMultiLineStringArray<2>);
+impl_intersects!(IndexedMultiPolygonArray<2>);
+impl_intersects!(IndexedMixedGeometryArray<2>);
+impl_intersects!(IndexedGeometryCollectionArray<2>);
 
 impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = line_string_to_geo(rhs);
-        self.map(|chunk| IntersectsLineString::intersects(chunk, &rhs))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| IntersectsLineString::intersects(chunk, &rhs)).try_into().unwrap()
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>> IntersectsLineString<G>
-            for $struct_name
-        {
+        impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for $struct_name {
             type Output = ChunkedArray<BooleanArray>;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = line_string_to_geo(rhs);
-                self.map(|chunk| IntersectsLineString::intersects(chunk, &rhs))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| IntersectsLineString::intersects(chunk, &rhs)).try_into().unwrap()
             }
         }
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedChunkedLineStringArray<2>);
+impl_intersects!(IndexedChunkedPolygonArray<2>);
+impl_intersects!(IndexedChunkedMultiPointArray<2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
 
 pub trait IntersectsPolygon<Rhs> {
     type Output;
@@ -313,68 +276,60 @@ impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedPointArray<2> {
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = polygon_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-            geom.to_geo().intersects(&rhs)
-        })
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> IntersectsPolygon<G> for $struct_name {
+        impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for $struct_name {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = polygon_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-                    geom.to_geo().intersects(&rhs)
-                })
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
             }
         }
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O, 2>);
-impl_intersects!(IndexedPolygonArray<O, 2>);
-impl_intersects!(IndexedMultiPointArray<O, 2>);
-impl_intersects!(IndexedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedLineStringArray<2>);
+impl_intersects!(IndexedPolygonArray<2>);
+impl_intersects!(IndexedMultiPointArray<2>);
+impl_intersects!(IndexedMultiLineStringArray<2>);
+impl_intersects!(IndexedMultiPolygonArray<2>);
+impl_intersects!(IndexedMixedGeometryArray<2>);
+impl_intersects!(IndexedGeometryCollectionArray<2>);
 
 impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = polygon_to_geo(rhs);
-        self.map(|chunk| IntersectsPolygon::intersects(chunk, &rhs))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| IntersectsPolygon::intersects(chunk, &rhs)).try_into().unwrap()
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> IntersectsPolygon<G> for $struct_name {
+        impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for $struct_name {
             type Output = ChunkedArray<BooleanArray>;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = polygon_to_geo(rhs);
-                self.map(|chunk| IntersectsPolygon::intersects(chunk, &rhs))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| IntersectsPolygon::intersects(chunk, &rhs)).try_into().unwrap()
             }
         }
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedChunkedLineStringArray<2>);
+impl_intersects!(IndexedChunkedPolygonArray<2>);
+impl_intersects!(IndexedChunkedMultiPointArray<2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
 
 pub trait IntersectsMultiPoint<Rhs> {
     type Output;
@@ -387,72 +342,60 @@ impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedPointArray<
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_point_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-            geom.to_geo().intersects(&rhs)
-        })
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G>
-            for $struct_name
-        {
+        impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for $struct_name {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_point_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-                    geom.to_geo().intersects(&rhs)
-                })
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
             }
         }
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O, 2>);
-impl_intersects!(IndexedPolygonArray<O, 2>);
-impl_intersects!(IndexedMultiPointArray<O, 2>);
-impl_intersects!(IndexedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedLineStringArray<2>);
+impl_intersects!(IndexedPolygonArray<2>);
+impl_intersects!(IndexedMultiPointArray<2>);
+impl_intersects!(IndexedMultiLineStringArray<2>);
+impl_intersects!(IndexedMultiPolygonArray<2>);
+impl_intersects!(IndexedMixedGeometryArray<2>);
+impl_intersects!(IndexedGeometryCollectionArray<2>);
 
 impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_point_to_geo(rhs);
-        self.map(|chunk| IntersectsMultiPoint::intersects(chunk, &rhs))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| IntersectsMultiPoint::intersects(chunk, &rhs)).try_into().unwrap()
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G>
-            for $struct_name
-        {
+        impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for $struct_name {
             type Output = ChunkedArray<BooleanArray>;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_point_to_geo(rhs);
-                self.map(|chunk| IntersectsMultiPoint::intersects(chunk, &rhs))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| IntersectsMultiPoint::intersects(chunk, &rhs)).try_into().unwrap()
             }
         }
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedChunkedLineStringArray<2>);
+impl_intersects!(IndexedChunkedPolygonArray<2>);
+impl_intersects!(IndexedChunkedMultiPointArray<2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
 
 pub trait IntersectsMultiLineString<Rhs> {
     type Output;
@@ -465,74 +408,60 @@ impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedP
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_line_string_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-            geom.to_geo().intersects(&rhs)
-        })
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G>
-            for $struct_name
-        {
+        impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for $struct_name {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_line_string_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-                    geom.to_geo().intersects(&rhs)
-                })
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
             }
         }
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O, 2>);
-impl_intersects!(IndexedPolygonArray<O, 2>);
-impl_intersects!(IndexedMultiPointArray<O, 2>);
-impl_intersects!(IndexedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedLineStringArray<2>);
+impl_intersects!(IndexedPolygonArray<2>);
+impl_intersects!(IndexedMultiPointArray<2>);
+impl_intersects!(IndexedMultiLineStringArray<2>);
+impl_intersects!(IndexedMultiPolygonArray<2>);
+impl_intersects!(IndexedMixedGeometryArray<2>);
+impl_intersects!(IndexedGeometryCollectionArray<2>);
 
-impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G>
-    for IndexedChunkedPointArray<2>
-{
+impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_line_string_to_geo(rhs);
-        self.map(|chunk| IntersectsMultiLineString::intersects(chunk, &rhs))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| IntersectsMultiLineString::intersects(chunk, &rhs)).try_into().unwrap()
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G>
-            for $struct_name
-        {
+        impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for $struct_name {
             type Output = ChunkedArray<BooleanArray>;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_line_string_to_geo(rhs);
-                self.map(|chunk| IntersectsMultiLineString::intersects(chunk, &rhs))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| IntersectsMultiLineString::intersects(chunk, &rhs)).try_into().unwrap()
             }
         }
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedChunkedLineStringArray<2>);
+impl_intersects!(IndexedChunkedPolygonArray<2>);
+impl_intersects!(IndexedChunkedMultiPointArray<2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
 
 pub trait IntersectsMultiPolygon<Rhs> {
     type Output;
@@ -545,72 +474,60 @@ impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedPointAr
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_polygon_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-            geom.to_geo().intersects(&rhs)
-        })
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G>
-            for $struct_name
-        {
+        impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for $struct_name {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_polygon_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-                    geom.to_geo().intersects(&rhs)
-                })
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
             }
         }
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O, 2>);
-impl_intersects!(IndexedPolygonArray<O, 2>);
-impl_intersects!(IndexedMultiPointArray<O, 2>);
-impl_intersects!(IndexedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedLineStringArray<2>);
+impl_intersects!(IndexedPolygonArray<2>);
+impl_intersects!(IndexedMultiPointArray<2>);
+impl_intersects!(IndexedMultiLineStringArray<2>);
+impl_intersects!(IndexedMultiPolygonArray<2>);
+impl_intersects!(IndexedMixedGeometryArray<2>);
+impl_intersects!(IndexedGeometryCollectionArray<2>);
 
 impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_polygon_to_geo(rhs);
-        self.map(|chunk| IntersectsMultiPolygon::intersects(chunk, &rhs))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| IntersectsMultiPolygon::intersects(chunk, &rhs)).try_into().unwrap()
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G>
-            for $struct_name
-        {
+        impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for $struct_name {
             type Output = ChunkedArray<BooleanArray>;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_polygon_to_geo(rhs);
-                self.map(|chunk| IntersectsMultiPolygon::intersects(chunk, &rhs))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| IntersectsMultiPolygon::intersects(chunk, &rhs)).try_into().unwrap()
             }
         }
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedChunkedLineStringArray<2>);
+impl_intersects!(IndexedChunkedPolygonArray<2>);
+impl_intersects!(IndexedChunkedMultiPointArray<2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
 
 pub trait IntersectsGeometry<Rhs> {
     type Output;
@@ -623,68 +540,60 @@ impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedPointArray<2> {
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = geometry_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-            geom.to_geo().intersects(&rhs)
-        })
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> IntersectsGeometry<G> for $struct_name {
+        impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for $struct_name {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = geometry_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-                    geom.to_geo().intersects(&rhs)
-                })
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
             }
         }
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O, 2>);
-impl_intersects!(IndexedPolygonArray<O, 2>);
-impl_intersects!(IndexedMultiPointArray<O, 2>);
-impl_intersects!(IndexedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedLineStringArray<2>);
+impl_intersects!(IndexedPolygonArray<2>);
+impl_intersects!(IndexedMultiPointArray<2>);
+impl_intersects!(IndexedMultiLineStringArray<2>);
+impl_intersects!(IndexedMultiPolygonArray<2>);
+impl_intersects!(IndexedMixedGeometryArray<2>);
+impl_intersects!(IndexedGeometryCollectionArray<2>);
 
 impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = geometry_to_geo(rhs);
-        self.map(|chunk| IntersectsGeometry::intersects(chunk, &rhs))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| IntersectsGeometry::intersects(chunk, &rhs)).try_into().unwrap()
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> IntersectsGeometry<G> for $struct_name {
+        impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for $struct_name {
             type Output = ChunkedArray<BooleanArray>;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = geometry_to_geo(rhs);
-                self.map(|chunk| IntersectsGeometry::intersects(chunk, &rhs))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| IntersectsGeometry::intersects(chunk, &rhs)).try_into().unwrap()
             }
         }
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedChunkedLineStringArray<2>);
+impl_intersects!(IndexedChunkedPolygonArray<2>);
+impl_intersects!(IndexedChunkedMultiPointArray<2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
 
 pub trait IntersectsGeometryCollection<Rhs> {
     type Output;
@@ -697,71 +606,57 @@ impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for In
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = geometry_collection_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-            geom.to_geo().intersects(&rhs)
-        })
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>>
-            IntersectsGeometryCollection<G> for $struct_name
-        {
+        impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for $struct_name {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = geometry_collection_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
-                    geom.to_geo().intersects(&rhs)
-                })
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
             }
         }
     };
 }
 
-impl_intersects!(IndexedLineStringArray<O, 2>);
-impl_intersects!(IndexedPolygonArray<O, 2>);
-impl_intersects!(IndexedMultiPointArray<O, 2>);
-impl_intersects!(IndexedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedLineStringArray<2>);
+impl_intersects!(IndexedPolygonArray<2>);
+impl_intersects!(IndexedMultiPointArray<2>);
+impl_intersects!(IndexedMultiLineStringArray<2>);
+impl_intersects!(IndexedMultiPolygonArray<2>);
+impl_intersects!(IndexedMixedGeometryArray<2>);
+impl_intersects!(IndexedGeometryCollectionArray<2>);
 
-impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G>
-    for IndexedChunkedPointArray<2>
-{
+impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for IndexedChunkedPointArray<2> {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = geometry_collection_to_geo(rhs);
-        self.map(|chunk| IntersectsGeometryCollection::intersects(chunk, &rhs))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| IntersectsGeometryCollection::intersects(chunk, &rhs)).try_into().unwrap()
     }
 }
 
 macro_rules! impl_intersects {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>>
-            IntersectsGeometryCollection<G> for $struct_name
-        {
+        impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for $struct_name {
             type Output = ChunkedArray<BooleanArray>;
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = geometry_collection_to_geo(rhs);
-                self.map(|chunk| IntersectsGeometryCollection::intersects(chunk, &rhs))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| IntersectsGeometryCollection::intersects(chunk, &rhs)).try_into().unwrap()
             }
         }
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPointArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<O, 2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<O, 2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<O, 2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<O, 2>);
+impl_intersects!(IndexedChunkedLineStringArray<2>);
+impl_intersects!(IndexedChunkedPolygonArray<2>);
+impl_intersects!(IndexedChunkedMultiPointArray<2>);
+impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
+impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
+impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
+impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);

--- a/src/algorithm/geo/intersects.rs
+++ b/src/algorithm/geo/intersects.rs
@@ -4,7 +4,7 @@ use crate::indexed::array::*;
 use crate::indexed::chunked::*;
 use crate::io::geo::{geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo, multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo};
 use crate::trait_::NativeScalar;
-use arrow_array::{BooleanArray, OffsetSizeTrait};
+use arrow_array::BooleanArray;
 use geo::{BoundingRect, Intersects as _Intersects};
 
 /// Checks if the geometry Self intersects the geometry Rhs.

--- a/src/algorithm/geo/intersects.rs
+++ b/src/algorithm/geo/intersects.rs
@@ -1,8 +1,14 @@
 use crate::chunked_array::ChunkedArray;
-use crate::geo_traits::{GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait};
+use crate::geo_traits::{
+    GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
+    MultiPolygonTrait, PointTrait, PolygonTrait,
+};
 use crate::indexed::array::*;
 use crate::indexed::chunked::*;
-use crate::io::geo::{geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo, multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo};
+use crate::io::geo::{
+    geometry_collection_to_geo, geometry_to_geo, line_string_to_geo, multi_line_string_to_geo,
+    multi_point_to_geo, multi_polygon_to_geo, point_to_geo, polygon_to_geo,
+};
 use crate::trait_::NativeScalar;
 use arrow_array::BooleanArray;
 use geo::{BoundingRect, Intersects as _Intersects};
@@ -53,7 +59,10 @@ impl Intersects for IndexedPointArray<2> {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &Self) -> Self::Output {
-        self.try_binary_boolean(rhs, |left, right| Ok(left.to_geo().intersects(&right.to_geo()))).unwrap()
+        self.try_binary_boolean(rhs, |left, right| {
+            Ok(left.to_geo().intersects(&right.to_geo()))
+        })
+        .unwrap()
     }
 }
 
@@ -64,7 +73,10 @@ macro_rules! iter_geo_impl {
             type Output = BooleanArray;
 
             fn intersects(&self, rhs: &$second) -> Self::Output {
-                self.try_binary_boolean(rhs, |left, right| Ok(left.to_geo().intersects(&right.to_geo()))).unwrap()
+                self.try_binary_boolean(rhs, |left, right| {
+                    Ok(left.to_geo().intersects(&right.to_geo()))
+                })
+                .unwrap()
             }
         }
     };
@@ -114,10 +126,16 @@ iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedPointArray<2>);
 iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedLineStringArray<2>);
 iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedPolygonArray<2>);
 iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMultiPointArray<2>);
-iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMultiLineStringArray<2>);
+iter_geo_impl!(
+    IndexedMultiLineStringArray<2>,
+    IndexedMultiLineStringArray<2>
+);
 iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMultiPolygonArray<2>);
 iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMixedGeometryArray<2>);
-iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedGeometryCollectionArray<2>);
+iter_geo_impl!(
+    IndexedMultiLineStringArray<2>,
+    IndexedGeometryCollectionArray<2>
+);
 
 // Implementations on MultiPolygonArray
 iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedPointArray<2>);
@@ -127,7 +145,10 @@ iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiPointArray<2>);
 iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiLineStringArray<2>);
 iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiPolygonArray<2>);
 iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMixedGeometryArray<2>);
-iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedGeometryCollectionArray<2>);
+iter_geo_impl!(
+    IndexedMultiPolygonArray<2>,
+    IndexedGeometryCollectionArray<2>
+);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
@@ -174,7 +195,9 @@ impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedChunkedPointArray<2> 
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = point_to_geo(rhs);
-        self.map(|chunk| IntersectsPoint::intersects(chunk, &rhs)).try_into().unwrap()
+        self.map(|chunk| IntersectsPoint::intersects(chunk, &rhs))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -185,7 +208,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = point_to_geo(rhs);
-                self.map(|chunk| IntersectsPoint::intersects(chunk, &rhs)).try_into().unwrap()
+                self.map(|chunk| IntersectsPoint::intersects(chunk, &rhs))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -210,7 +235,9 @@ impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedPointArray<
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = line_string_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+            geom.to_geo().intersects(&rhs)
+        })
     }
 }
 
@@ -221,7 +248,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = line_string_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+                    geom.to_geo().intersects(&rhs)
+                })
             }
         }
     };
@@ -240,7 +269,9 @@ impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedChunkedPoin
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = line_string_to_geo(rhs);
-        self.map(|chunk| IntersectsLineString::intersects(chunk, &rhs)).try_into().unwrap()
+        self.map(|chunk| IntersectsLineString::intersects(chunk, &rhs))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -251,7 +282,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = line_string_to_geo(rhs);
-                self.map(|chunk| IntersectsLineString::intersects(chunk, &rhs)).try_into().unwrap()
+                self.map(|chunk| IntersectsLineString::intersects(chunk, &rhs))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -276,7 +309,9 @@ impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedPointArray<2> {
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = polygon_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+            geom.to_geo().intersects(&rhs)
+        })
     }
 }
 
@@ -287,7 +322,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = polygon_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+                    geom.to_geo().intersects(&rhs)
+                })
             }
         }
     };
@@ -306,7 +343,9 @@ impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedChunkedPointArray
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = polygon_to_geo(rhs);
-        self.map(|chunk| IntersectsPolygon::intersects(chunk, &rhs)).try_into().unwrap()
+        self.map(|chunk| IntersectsPolygon::intersects(chunk, &rhs))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -317,7 +356,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = polygon_to_geo(rhs);
-                self.map(|chunk| IntersectsPolygon::intersects(chunk, &rhs)).try_into().unwrap()
+                self.map(|chunk| IntersectsPolygon::intersects(chunk, &rhs))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -342,7 +383,9 @@ impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedPointArray<
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_point_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+            geom.to_geo().intersects(&rhs)
+        })
     }
 }
 
@@ -353,7 +396,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_point_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+                    geom.to_geo().intersects(&rhs)
+                })
             }
         }
     };
@@ -372,7 +417,9 @@ impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedChunkedPoin
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_point_to_geo(rhs);
-        self.map(|chunk| IntersectsMultiPoint::intersects(chunk, &rhs)).try_into().unwrap()
+        self.map(|chunk| IntersectsMultiPoint::intersects(chunk, &rhs))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -383,7 +430,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_point_to_geo(rhs);
-                self.map(|chunk| IntersectsMultiPoint::intersects(chunk, &rhs)).try_into().unwrap()
+                self.map(|chunk| IntersectsMultiPoint::intersects(chunk, &rhs))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -408,7 +457,9 @@ impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedP
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_line_string_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+            geom.to_geo().intersects(&rhs)
+        })
     }
 }
 
@@ -419,7 +470,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_line_string_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+                    geom.to_geo().intersects(&rhs)
+                })
             }
         }
     };
@@ -433,12 +486,16 @@ impl_intersects!(IndexedMultiPolygonArray<2>);
 impl_intersects!(IndexedMixedGeometryArray<2>);
 impl_intersects!(IndexedGeometryCollectionArray<2>);
 
-impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedChunkedPointArray<2> {
+impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G>
+    for IndexedChunkedPointArray<2>
+{
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_line_string_to_geo(rhs);
-        self.map(|chunk| IntersectsMultiLineString::intersects(chunk, &rhs)).try_into().unwrap()
+        self.map(|chunk| IntersectsMultiLineString::intersects(chunk, &rhs))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -449,7 +506,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_line_string_to_geo(rhs);
-                self.map(|chunk| IntersectsMultiLineString::intersects(chunk, &rhs)).try_into().unwrap()
+                self.map(|chunk| IntersectsMultiLineString::intersects(chunk, &rhs))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -474,7 +533,9 @@ impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedPointAr
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_polygon_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+            geom.to_geo().intersects(&rhs)
+        })
     }
 }
 
@@ -485,7 +546,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_polygon_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+                    geom.to_geo().intersects(&rhs)
+                })
             }
         }
     };
@@ -504,7 +567,9 @@ impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedChunked
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = multi_polygon_to_geo(rhs);
-        self.map(|chunk| IntersectsMultiPolygon::intersects(chunk, &rhs)).try_into().unwrap()
+        self.map(|chunk| IntersectsMultiPolygon::intersects(chunk, &rhs))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -515,7 +580,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = multi_polygon_to_geo(rhs);
-                self.map(|chunk| IntersectsMultiPolygon::intersects(chunk, &rhs)).try_into().unwrap()
+                self.map(|chunk| IntersectsMultiPolygon::intersects(chunk, &rhs))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -540,7 +607,9 @@ impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedPointArray<2> {
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = geometry_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+            geom.to_geo().intersects(&rhs)
+        })
     }
 }
 
@@ -551,7 +620,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = geometry_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+                    geom.to_geo().intersects(&rhs)
+                })
             }
         }
     };
@@ -570,7 +641,9 @@ impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedChunkedPointArr
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = geometry_to_geo(rhs);
-        self.map(|chunk| IntersectsGeometry::intersects(chunk, &rhs)).try_into().unwrap()
+        self.map(|chunk| IntersectsGeometry::intersects(chunk, &rhs))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -581,7 +654,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = geometry_to_geo(rhs);
-                self.map(|chunk| IntersectsGeometry::intersects(chunk, &rhs)).try_into().unwrap()
+                self.map(|chunk| IntersectsGeometry::intersects(chunk, &rhs))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -606,7 +681,9 @@ impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for In
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = geometry_collection_to_geo(rhs);
-        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+        self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+            geom.to_geo().intersects(&rhs)
+        })
     }
 }
 
@@ -617,7 +694,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = geometry_collection_to_geo(rhs);
-                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| geom.to_geo().intersects(&rhs))
+                self.unary_boolean(&rhs.bounding_rect().unwrap(), |geom| {
+                    geom.to_geo().intersects(&rhs)
+                })
             }
         }
     };
@@ -631,12 +710,16 @@ impl_intersects!(IndexedMultiPolygonArray<2>);
 impl_intersects!(IndexedMixedGeometryArray<2>);
 impl_intersects!(IndexedGeometryCollectionArray<2>);
 
-impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for IndexedChunkedPointArray<2> {
+impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G>
+    for IndexedChunkedPointArray<2>
+{
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
         let rhs = geometry_collection_to_geo(rhs);
-        self.map(|chunk| IntersectsGeometryCollection::intersects(chunk, &rhs)).try_into().unwrap()
+        self.map(|chunk| IntersectsGeometryCollection::intersects(chunk, &rhs))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -647,7 +730,9 @@ macro_rules! impl_intersects {
 
             fn intersects(&self, rhs: &G) -> Self::Output {
                 let rhs = geometry_collection_to_geo(rhs);
-                self.map(|chunk| IntersectsGeometryCollection::intersects(chunk, &rhs)).try_into().unwrap()
+                self.map(|chunk| IntersectsGeometryCollection::intersects(chunk, &rhs))
+                    .try_into()
+                    .unwrap()
             }
         }
     };

--- a/src/algorithm/geo/line_interpolate_point.rs
+++ b/src/algorithm/geo/line_interpolate_point.rs
@@ -49,16 +49,18 @@ impl LineInterpolatePoint<&Float64Array> for LineStringArray<2> {
     fn line_interpolate_point(&self, p: &Float64Array) -> Self::Output {
         let mut output_array = PointBuilder::with_capacity(self.len());
 
-        self.iter_geo().zip(p).for_each(|(first, second)| match (first, second) {
-            (Some(first), Some(fraction)) => {
-                if let Some(val) = first.line_interpolate_point(fraction) {
-                    output_array.push_point(Some(&val))
-                } else {
-                    output_array.push_empty()
+        self.iter_geo()
+            .zip(p)
+            .for_each(|(first, second)| match (first, second) {
+                (Some(first), Some(fraction)) => {
+                    if let Some(val) = first.line_interpolate_point(fraction) {
+                        output_array.push_point(Some(&val))
+                    } else {
+                        output_array.push_empty()
+                    }
                 }
-            }
-            _ => output_array.push_null(),
-        });
+                _ => output_array.push_null(),
+            });
 
         output_array.into()
     }
@@ -82,7 +84,9 @@ impl LineInterpolatePoint<&[Float64Array]> for ChunkedLineStringArray<2> {
     type Output = ChunkedPointArray<2>;
 
     fn line_interpolate_point(&self, p: &[Float64Array]) -> Self::Output {
-        ChunkedPointArray::new(self.binary_map(p, |(left, right)| left.line_interpolate_point(right)))
+        ChunkedPointArray::new(
+            self.binary_map(p, |(left, right)| left.line_interpolate_point(right)),
+        )
     }
 }
 

--- a/src/algorithm/geo/line_interpolate_point.rs
+++ b/src/algorithm/geo/line_interpolate_point.rs
@@ -43,7 +43,7 @@ pub trait LineInterpolatePoint<Rhs> {
     fn line_interpolate_point(&self, fraction: Rhs) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> LineInterpolatePoint<&Float64Array> for LineStringArray<O, 2> {
+impl LineInterpolatePoint<&Float64Array> for LineStringArray<2> {
     type Output = PointArray<2>;
 
     fn line_interpolate_point(&self, p: &Float64Array) -> Self::Output {
@@ -75,15 +75,12 @@ impl LineInterpolatePoint<&Float64Array> for &dyn NativeArray {
 
         match self.data_type() {
             LineString(_, XY) => Ok(self.as_line_string::<2>().line_interpolate_point(fraction)),
-            LargeLineString(_, XY) => Ok(self
-                .as_large_line_string::<2>()
-                .line_interpolate_point(fraction)),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl<O: OffsetSizeTrait> LineInterpolatePoint<&[Float64Array]> for ChunkedLineStringArray<O, 2> {
+impl LineInterpolatePoint<&[Float64Array]> for ChunkedLineStringArray<2> {
     type Output = ChunkedPointArray<2>;
 
     fn line_interpolate_point(&self, p: &[Float64Array]) -> Self::Output {
@@ -102,15 +99,12 @@ impl LineInterpolatePoint<&[Float64Array]> for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             LineString(_, XY) => Ok(self.as_line_string::<2>().line_interpolate_point(fraction)),
-            LargeLineString(_, XY) => Ok(self
-                .as_large_line_string::<2>()
-                .line_interpolate_point(fraction)),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl<O: OffsetSizeTrait> LineInterpolatePoint<f64> for LineStringArray<O, 2> {
+impl LineInterpolatePoint<f64> for LineStringArray<2> {
     type Output = PointArray<2>;
 
     fn line_interpolate_point(&self, p: f64) -> Self::Output {
@@ -141,15 +135,12 @@ impl LineInterpolatePoint<f64> for &dyn NativeArray {
 
         match self.data_type() {
             LineString(_, XY) => Ok(self.as_line_string::<2>().line_interpolate_point(fraction)),
-            LargeLineString(_, XY) => Ok(self
-                .as_large_line_string::<2>()
-                .line_interpolate_point(fraction)),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl<O: OffsetSizeTrait> LineInterpolatePoint<f64> for ChunkedLineStringArray<O, 2> {
+impl LineInterpolatePoint<f64> for ChunkedLineStringArray<2> {
     type Output = ChunkedPointArray<2>;
 
     fn line_interpolate_point(&self, fraction: f64) -> Self::Output {
@@ -166,9 +157,6 @@ impl LineInterpolatePoint<f64> for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             LineString(_, XY) => Ok(self.as_line_string::<2>().line_interpolate_point(fraction)),
-            LargeLineString(_, XY) => Ok(self
-                .as_large_line_string::<2>()
-                .line_interpolate_point(fraction)),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/line_locate_point.rs
+++ b/src/algorithm/geo/line_locate_point.rs
@@ -31,16 +31,18 @@ impl LineLocatePoint<&PointArray<2>> for LineStringArray<2> {
     fn line_locate_point(&self, rhs: &PointArray<2>) -> Float64Array {
         let mut output_array = Float64Builder::with_capacity(self.len());
 
-        self.iter_geo().zip(rhs.iter_geo()).for_each(|(first, second)| match (first, second) {
-            (Some(first), Some(second)) => {
-                if let Some(val) = first.line_locate_point(&second) {
-                    output_array.append_value(val)
-                } else {
-                    output_array.append_value(f64::NAN)
+        self.iter_geo()
+            .zip(rhs.iter_geo())
+            .for_each(|(first, second)| match (first, second) {
+                (Some(first), Some(second)) => {
+                    if let Some(val) = first.line_locate_point(&second) {
+                        output_array.append_value(val)
+                    } else {
+                        output_array.append_value(f64::NAN)
+                    }
                 }
-            }
-            _ => output_array.append_null(),
-        });
+                _ => output_array.append_null(),
+            });
 
         output_array.finish()
     }
@@ -54,7 +56,9 @@ impl LineLocatePoint<&dyn NativeArray> for &dyn NativeArray {
         use NativeType::*;
 
         let result = match (self.data_type(), rhs.data_type()) {
-            (LineString(_, XY), Point(_, XY)) => LineLocatePoint::line_locate_point(self.as_line_string::<2>(), rhs.as_point::<2>()),
+            (LineString(_, XY), Point(_, XY)) => {
+                LineLocatePoint::line_locate_point(self.as_line_string::<2>(), rhs.as_point::<2>())
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -65,7 +69,9 @@ impl LineLocatePoint<&[PointArray<2>]> for ChunkedLineStringArray<2> {
     type Output = ChunkedArray<Float64Array>;
 
     fn line_locate_point(&self, rhs: &[PointArray<2>]) -> ChunkedArray<Float64Array> {
-        let chunks = self.binary_map(rhs, |(left, right)| LineLocatePoint::line_locate_point(left, right));
+        let chunks = self.binary_map(rhs, |(left, right)| {
+            LineLocatePoint::line_locate_point(left, right)
+        });
         ChunkedArray::new(chunks)
     }
 }
@@ -78,7 +84,10 @@ impl LineLocatePoint<&dyn ChunkedNativeArray> for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result = match (self.data_type(), rhs.data_type()) {
-            (LineString(_, XY), Point(_, XY)) => LineLocatePoint::line_locate_point(self.as_line_string::<2>(), &rhs.as_point::<2>().chunks),
+            (LineString(_, XY), Point(_, XY)) => LineLocatePoint::line_locate_point(
+                self.as_line_string::<2>(),
+                &rhs.as_point::<2>().chunks,
+            ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -121,7 +130,9 @@ impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            LineString(_, XY) => LineLocatePointScalar::line_locate_point(self.as_line_string::<2>(), rhs),
+            LineString(_, XY) => {
+                LineLocatePointScalar::line_locate_point(self.as_line_string::<2>(), rhs)
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -146,7 +157,9 @@ impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for &dyn ChunkedNativeArra
         use NativeType::*;
 
         let result = match self.data_type() {
-            LineString(_, XY) => LineLocatePointScalar::line_locate_point(self.as_line_string::<2>(), rhs),
+            LineString(_, XY) => {
+                LineLocatePointScalar::line_locate_point(self.as_line_string::<2>(), rhs)
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/line_locate_point.rs
+++ b/src/algorithm/geo/line_locate_point.rs
@@ -8,7 +8,7 @@ use crate::io::geo::point_to_geo;
 use crate::trait_::ArrayAccessor;
 use crate::{ArrayBase, NativeArray};
 use arrow_array::builder::Float64Builder;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::LineLocatePoint as _LineLocatePoint;
 
 /// Returns a (option of the) fraction of the line's total length

--- a/src/algorithm/geo/minimum_rotated_rect.rs
+++ b/src/algorithm/geo/minimum_rotated_rect.rs
@@ -5,7 +5,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::MinimumRotatedRect as _MinimumRotatedRect;
 
 /// Return the minimum bounding rectangle(MBR) of geometry

--- a/src/algorithm/geo/minimum_rotated_rect.rs
+++ b/src/algorithm/geo/minimum_rotated_rect.rs
@@ -32,15 +32,15 @@ use geo::MinimumRotatedRect as _MinimumRotatedRect;
 ///     ])
 /// );
 /// ```
-pub trait MinimumRotatedRect<O: OffsetSizeTrait> {
+pub trait MinimumRotatedRect {
     type Output;
 
     fn minimum_rotated_rect(&self) -> Self::Output;
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for PointArray<2> {
-    type Output = PolygonArray<O, 2>;
+impl MinimumRotatedRect for PointArray<2> {
+    type Output = PolygonArray<2>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         // The number of output geoms is the same as the input
@@ -56,11 +56,7 @@ impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for PointArray<2> {
 
         let mut output_array = PolygonBuilder::with_capacity(capacity);
 
-        self.iter_geo().for_each(|maybe_g| {
-            output_array
-                .push_polygon(maybe_g.and_then(|g| g.minimum_rotated_rect()).as_ref())
-                .unwrap()
-        });
+        self.iter_geo().for_each(|maybe_g| output_array.push_polygon(maybe_g.and_then(|g| g.minimum_rotated_rect()).as_ref()).unwrap());
 
         output_array.into()
     }
@@ -69,10 +65,8 @@ impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<OOutput: OffsetSizeTrait, OInput: OffsetSizeTrait> MinimumRotatedRect<OOutput>
-            for $type
-        {
-            type Output = PolygonArray<OOutput, 2>;
+        impl MinimumRotatedRect for $type {
+            type Output = PolygonArray<2>;
 
             fn minimum_rotated_rect(&self) -> Self::Output {
                 // The number of output geoms is the same as the input
@@ -88,11 +82,7 @@ macro_rules! iter_geo_impl {
 
                 let mut output_array = PolygonBuilder::with_capacity(capacity);
 
-                self.iter_geo().for_each(|maybe_g| {
-                    output_array
-                        .push_polygon(maybe_g.and_then(|g| g.minimum_rotated_rect()).as_ref())
-                        .unwrap()
-                });
+                self.iter_geo().for_each(|maybe_g| output_array.push_polygon(maybe_g.and_then(|g| g.minimum_rotated_rect()).as_ref()).unwrap());
 
                 output_array.into()
             }
@@ -100,16 +90,16 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<OInput, 2>);
-iter_geo_impl!(PolygonArray<OInput, 2>);
-iter_geo_impl!(MultiPointArray<OInput, 2>);
-iter_geo_impl!(MultiLineStringArray<OInput, 2>);
-iter_geo_impl!(MultiPolygonArray<OInput, 2>);
-iter_geo_impl!(MixedGeometryArray<OInput, 2>);
-iter_geo_impl!(GeometryCollectionArray<OInput, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(MixedGeometryArray<2>);
+iter_geo_impl!(GeometryCollectionArray<2>);
 
-impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for &dyn NativeArray {
-    type Output = Result<PolygonArray<O, 2>>;
+impl MinimumRotatedRect for &dyn NativeArray {
+    type Output = Result<PolygonArray<2>>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         use Dimension::*;
@@ -118,40 +108,28 @@ impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for &dyn NativeArray {
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().minimum_rotated_rect(),
             LineString(_, XY) => self.as_line_string::<2>().minimum_rotated_rect(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().minimum_rotated_rect(),
             Polygon(_, XY) => self.as_polygon::<2>().minimum_rotated_rect(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().minimum_rotated_rect(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().minimum_rotated_rect(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().minimum_rotated_rect(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().minimum_rotated_rect(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .minimum_rotated_rect(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().minimum_rotated_rect(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().minimum_rotated_rect(),
             Mixed(_, XY) => self.as_mixed::<2>().minimum_rotated_rect(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().minimum_rotated_rect(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().minimum_rotated_rect(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .minimum_rotated_rect(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl<O: OffsetSizeTrait, G: NativeArray> MinimumRotatedRect<O> for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedGeometryArray<PolygonArray<O, 2>>>;
+impl<G: NativeArray> MinimumRotatedRect for ChunkedGeometryArray<G> {
+    type Output = Result<ChunkedGeometryArray<PolygonArray<2>>>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().minimum_rotated_rect())?
-            .try_into()
+        self.try_map(|chunk| chunk.as_ref().minimum_rotated_rect())?.try_into()
     }
 }
 
-impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPolygonArray<O, 2>>;
+impl MinimumRotatedRect for &dyn ChunkedNativeArray {
+    type Output = Result<ChunkedPolygonArray<2>>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         use Dimension::*;
@@ -160,23 +138,12 @@ impl<O: OffsetSizeTrait> MinimumRotatedRect<O> for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().minimum_rotated_rect(),
             LineString(_, XY) => self.as_line_string::<2>().minimum_rotated_rect(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().minimum_rotated_rect(),
             Polygon(_, XY) => self.as_polygon::<2>().minimum_rotated_rect(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().minimum_rotated_rect(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().minimum_rotated_rect(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().minimum_rotated_rect(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().minimum_rotated_rect(),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .minimum_rotated_rect(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().minimum_rotated_rect(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().minimum_rotated_rect(),
             Mixed(_, XY) => self.as_mixed::<2>().minimum_rotated_rect(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().minimum_rotated_rect(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().minimum_rotated_rect(),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .minimum_rotated_rect(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geo/minimum_rotated_rect.rs
+++ b/src/algorithm/geo/minimum_rotated_rect.rs
@@ -55,7 +55,11 @@ impl MinimumRotatedRect for PointArray<2> {
 
         let mut output_array = PolygonBuilder::with_capacity(capacity);
 
-        self.iter_geo().for_each(|maybe_g| output_array.push_polygon(maybe_g.and_then(|g| g.minimum_rotated_rect()).as_ref()).unwrap());
+        self.iter_geo().for_each(|maybe_g| {
+            output_array
+                .push_polygon(maybe_g.and_then(|g| g.minimum_rotated_rect()).as_ref())
+                .unwrap()
+        });
 
         output_array.into()
     }
@@ -81,7 +85,11 @@ macro_rules! iter_geo_impl {
 
                 let mut output_array = PolygonBuilder::with_capacity(capacity);
 
-                self.iter_geo().for_each(|maybe_g| output_array.push_polygon(maybe_g.and_then(|g| g.minimum_rotated_rect()).as_ref()).unwrap());
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array
+                        .push_polygon(maybe_g.and_then(|g| g.minimum_rotated_rect()).as_ref())
+                        .unwrap()
+                });
 
                 output_array.into()
             }
@@ -123,7 +131,8 @@ impl<G: NativeArray> MinimumRotatedRect for ChunkedGeometryArray<G> {
     type Output = Result<ChunkedGeometryArray<PolygonArray<2>>>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
-        self.try_map(|chunk| chunk.as_ref().minimum_rotated_rect())?.try_into()
+        self.try_map(|chunk| chunk.as_ref().minimum_rotated_rect())?
+            .try_into()
     }
 }
 

--- a/src/algorithm/geo/remove_repeated_points.rs
+++ b/src/algorithm/geo/remove_repeated_points.rs
@@ -44,7 +44,9 @@ macro_rules! iter_geo_impl {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
                 self.iter_geo().for_each(|maybe_g| {
-                    output_array.$push_func(maybe_g.map(|geom| geom.remove_repeated_points()).as_ref()).unwrap();
+                    output_array
+                        .$push_func(maybe_g.map(|geom| geom.remove_repeated_points()).as_ref())
+                        .unwrap();
                 });
 
                 output_array.finish()
@@ -56,8 +58,16 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
+iter_geo_impl!(
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
+    push_multi_line_string
+);
+iter_geo_impl!(
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
+    push_multi_polygon
+);
 // iter_geo_impl!(MixedGeometryArray<2>, MixedGeometryBuilder<2>, push_geometry);
 // iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
 
@@ -73,7 +83,9 @@ impl RemoveRepeatedPoints for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().remove_repeated_points()),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().remove_repeated_points()),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().remove_repeated_points()),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().remove_repeated_points()),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string::<2>().remove_repeated_points())
+            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().remove_repeated_points()),
             // Mixed(_, XY) => self.as_mixed::<2>().remove_repeated_points(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().remove_repeated_points(),
@@ -97,7 +109,9 @@ macro_rules! impl_chunked {
             type Output = $struct_name;
 
             fn remove_repeated_points(&self) -> Self::Output {
-                self.map(|chunk| chunk.remove_repeated_points()).try_into().unwrap()
+                self.map(|chunk| chunk.remove_repeated_points())
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -121,7 +135,9 @@ impl RemoveRepeatedPoints for &dyn ChunkedNativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().remove_repeated_points()),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().remove_repeated_points()),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().remove_repeated_points()),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().remove_repeated_points()),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string::<2>().remove_repeated_points())
+            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().remove_repeated_points()),
             // Mixed(_, XY) => self.as_mixed::<2>().remove_repeated_points(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().remove_repeated_points(),

--- a/src/algorithm/geo/remove_repeated_points.rs
+++ b/src/algorithm/geo/remove_repeated_points.rs
@@ -6,7 +6,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::RemoveRepeatedPoints as _RemoveRepeatedPoints;
 
 /// Remove repeated points from a `MultiPoint` and repeated consecutive coordinates
@@ -45,9 +44,7 @@ macro_rules! iter_geo_impl {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
                 self.iter_geo().for_each(|maybe_g| {
-                    output_array
-                        .$push_func(maybe_g.map(|geom| geom.remove_repeated_points()).as_ref())
-                        .unwrap();
+                    output_array.$push_func(maybe_g.map(|geom| geom.remove_repeated_points()).as_ref()).unwrap();
                 });
 
                 output_array.finish()
@@ -59,16 +56,8 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
-    push_multi_line_string
-);
-iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
-    push_multi_polygon
-);
+iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
+iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
 // iter_geo_impl!(MixedGeometryArray<2>, MixedGeometryBuilder<2>, push_geometry);
 // iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
 
@@ -84,9 +73,7 @@ impl RemoveRepeatedPoints for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().remove_repeated_points()),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().remove_repeated_points()),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().remove_repeated_points()),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().remove_repeated_points())
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().remove_repeated_points()),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().remove_repeated_points()),
             // Mixed(_, XY) => self.as_mixed::<2>().remove_repeated_points(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().remove_repeated_points(),
@@ -110,9 +97,7 @@ macro_rules! impl_chunked {
             type Output = $struct_name;
 
             fn remove_repeated_points(&self) -> Self::Output {
-                self.map(|chunk| chunk.remove_repeated_points())
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| chunk.remove_repeated_points()).try_into().unwrap()
             }
         }
     };
@@ -136,9 +121,7 @@ impl RemoveRepeatedPoints for &dyn ChunkedNativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().remove_repeated_points()),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().remove_repeated_points()),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().remove_repeated_points()),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().remove_repeated_points())
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().remove_repeated_points()),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().remove_repeated_points()),
             // Mixed(_, XY) => self.as_mixed::<2>().remove_repeated_points(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().remove_repeated_points(),

--- a/src/algorithm/geo/remove_repeated_points.rs
+++ b/src/algorithm/geo/remove_repeated_points.rs
@@ -38,7 +38,7 @@ impl RemoveRepeatedPoints for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $builder_type:ty, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> RemoveRepeatedPoints for $type {
+        impl RemoveRepeatedPoints for $type {
             type Output = Self;
 
             fn remove_repeated_points(&self) -> Self::Output {
@@ -56,21 +56,21 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
+iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
+iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
+iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringBuilder<O, 2>,
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonBuilder<O, 2>,
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
     push_multi_polygon
 );
-// iter_geo_impl!(MixedGeometryArray<O, 2>, MixedGeometryBuilder<O, 2>, push_geometry);
-// iter_geo_impl!(GeometryCollectionArray<O, 2>, geo::GeometryCollection);
+// iter_geo_impl!(MixedGeometryArray<2>, MixedGeometryBuilder<2>, push_geometry);
+// iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
 
 impl RemoveRepeatedPoints for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -82,32 +82,14 @@ impl RemoveRepeatedPoints for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().remove_repeated_points()),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().remove_repeated_points()),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().remove_repeated_points())
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().remove_repeated_points()),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().remove_repeated_points()),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().remove_repeated_points()),
-            LargeMultiPoint(_, XY) => {
-                Arc::new(self.as_large_multi_point::<2>().remove_repeated_points())
-            }
             MultiLineString(_, XY) => {
                 Arc::new(self.as_multi_line_string::<2>().remove_repeated_points())
             }
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
-                    .remove_repeated_points(),
-            ),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().remove_repeated_points()),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().remove_repeated_points())
-            }
             // Mixed(_, XY) => self.as_mixed::<2>().remove_repeated_points(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().remove_repeated_points(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().remove_repeated_points(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().remove_repeated_points()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -124,7 +106,7 @@ impl RemoveRepeatedPoints for ChunkedPointArray<2> {
 
 macro_rules! impl_chunked {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait> RemoveRepeatedPoints for $struct_name {
+        impl RemoveRepeatedPoints for $struct_name {
             type Output = $struct_name;
 
             fn remove_repeated_points(&self) -> Self::Output {
@@ -136,11 +118,11 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<O, 2>);
-impl_chunked!(ChunkedPolygonArray<O, 2>);
-impl_chunked!(ChunkedMultiPointArray<O, 2>);
-impl_chunked!(ChunkedMultiLineStringArray<O, 2>);
-impl_chunked!(ChunkedMultiPolygonArray<O, 2>);
+impl_chunked!(ChunkedLineStringArray<2>);
+impl_chunked!(ChunkedPolygonArray<2>);
+impl_chunked!(ChunkedMultiPointArray<2>);
+impl_chunked!(ChunkedMultiLineStringArray<2>);
+impl_chunked!(ChunkedMultiPolygonArray<2>);
 
 impl RemoveRepeatedPoints for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -152,32 +134,14 @@ impl RemoveRepeatedPoints for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().remove_repeated_points()),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().remove_repeated_points()),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().remove_repeated_points())
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().remove_repeated_points()),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().remove_repeated_points()),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().remove_repeated_points()),
-            LargeMultiPoint(_, XY) => {
-                Arc::new(self.as_large_multi_point::<2>().remove_repeated_points())
-            }
             MultiLineString(_, XY) => {
                 Arc::new(self.as_multi_line_string::<2>().remove_repeated_points())
             }
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
-                    .remove_repeated_points(),
-            ),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().remove_repeated_points()),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().remove_repeated_points())
-            }
             // Mixed(_, XY) => self.as_mixed::<2>().remove_repeated_points(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().remove_repeated_points(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().remove_repeated_points(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().remove_repeated_points()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/rotate.rs
+++ b/src/algorithm/geo/rotate.rs
@@ -103,18 +103,30 @@ impl Rotate<Float64Array> for PointArray<2> {
 
     fn rotate_around_centroid(&self, degrees: &Float64Array) -> Self {
         let centroids = self.centroid();
-        let transforms: Vec<AffineTransform> = centroids.iter_geo_values().zip(degrees.values().iter()).map(|(point, angle)| AffineTransform::rotate(*angle, point)).collect();
+        let transforms: Vec<AffineTransform> = centroids
+            .iter_geo_values()
+            .zip(degrees.values().iter())
+            .map(|(point, angle)| AffineTransform::rotate(*angle, point))
+            .collect();
         self.affine_transform(transforms.as_slice())
     }
 
     fn rotate_around_center(&self, degrees: &Float64Array) -> Self {
         let centers = self.center();
-        let transforms: Vec<AffineTransform> = centers.iter_geo_values().zip(degrees.values().iter()).map(|(point, angle)| AffineTransform::rotate(*angle, point)).collect();
+        let transforms: Vec<AffineTransform> = centers
+            .iter_geo_values()
+            .zip(degrees.values().iter())
+            .map(|(point, angle)| AffineTransform::rotate(*angle, point))
+            .collect();
         self.affine_transform(transforms.as_slice())
     }
 
     fn rotate_around_point(&self, degrees: &Float64Array, point: geo::Point) -> Self {
-        let transforms: Vec<AffineTransform> = degrees.values().iter().map(|degrees| AffineTransform::rotate(*degrees, point)).collect();
+        let transforms: Vec<AffineTransform> = degrees
+            .values()
+            .iter()
+            .map(|degrees| AffineTransform::rotate(*degrees, point))
+            .collect();
         self.affine_transform(transforms.as_slice())
     }
 }
@@ -127,18 +139,30 @@ macro_rules! iter_geo_impl {
 
             fn rotate_around_centroid(&self, degrees: &Float64Array) -> $type {
                 let centroids = self.centroid();
-                let transforms: Vec<AffineTransform> = centroids.iter_geo_values().zip(degrees.values().iter()).map(|(point, angle)| AffineTransform::rotate(*angle, point)).collect();
+                let transforms: Vec<AffineTransform> = centroids
+                    .iter_geo_values()
+                    .zip(degrees.values().iter())
+                    .map(|(point, angle)| AffineTransform::rotate(*angle, point))
+                    .collect();
                 self.affine_transform(transforms.as_slice())
             }
 
             fn rotate_around_center(&self, degrees: &Float64Array) -> Self {
                 let centers = self.center();
-                let transforms: Vec<AffineTransform> = centers.iter_geo_values().zip(degrees.values().iter()).map(|(point, angle)| AffineTransform::rotate(*angle, point)).collect();
+                let transforms: Vec<AffineTransform> = centers
+                    .iter_geo_values()
+                    .zip(degrees.values().iter())
+                    .map(|(point, angle)| AffineTransform::rotate(*angle, point))
+                    .collect();
                 self.affine_transform(transforms.as_slice())
             }
 
             fn rotate_around_point(&self, degrees: &Float64Array, point: geo::Point) -> Self {
-                let transforms: Vec<AffineTransform> = degrees.values().iter().map(|degrees| AffineTransform::rotate(*degrees, point)).collect();
+                let transforms: Vec<AffineTransform> = degrees
+                    .values()
+                    .iter()
+                    .map(|degrees| AffineTransform::rotate(*degrees, point))
+                    .collect();
                 self.affine_transform(transforms.as_slice())
             }
         }
@@ -161,13 +185,19 @@ impl Rotate<f64> for PointArray<2> {
 
     fn rotate_around_centroid(&self, degrees: &f64) -> Self {
         let centroids = self.centroid();
-        let transforms: Vec<AffineTransform> = centroids.iter_geo_values().map(|point| AffineTransform::rotate(*degrees, point)).collect();
+        let transforms: Vec<AffineTransform> = centroids
+            .iter_geo_values()
+            .map(|point| AffineTransform::rotate(*degrees, point))
+            .collect();
         self.affine_transform(transforms.as_slice())
     }
 
     fn rotate_around_center(&self, degrees: &f64) -> Self {
         let centers = self.center();
-        let transforms: Vec<AffineTransform> = centers.iter_geo_values().map(|point| AffineTransform::rotate(*degrees, point)).collect();
+        let transforms: Vec<AffineTransform> = centers
+            .iter_geo_values()
+            .map(|point| AffineTransform::rotate(*degrees, point))
+            .collect();
         self.affine_transform(transforms.as_slice())
     }
 
@@ -185,13 +215,19 @@ macro_rules! iter_geo_impl_scalar {
 
             fn rotate_around_centroid(&self, degrees: &f64) -> $type {
                 let centroids = self.centroid();
-                let transforms: Vec<AffineTransform> = centroids.iter_geo_values().map(|point| AffineTransform::rotate(*degrees, point)).collect();
+                let transforms: Vec<AffineTransform> = centroids
+                    .iter_geo_values()
+                    .map(|point| AffineTransform::rotate(*degrees, point))
+                    .collect();
                 self.affine_transform(transforms.as_slice())
             }
 
             fn rotate_around_center(&self, degrees: &f64) -> Self {
                 let centers = self.center();
-                let transforms: Vec<AffineTransform> = centers.iter_geo_values().map(|point| AffineTransform::rotate(*degrees, point)).collect();
+                let transforms: Vec<AffineTransform> = centers
+                    .iter_geo_values()
+                    .map(|point| AffineTransform::rotate(*degrees, point))
+                    .collect();
                 self.affine_transform(transforms.as_slice())
             }
 

--- a/src/algorithm/geo/rotate.rs
+++ b/src/algorithm/geo/rotate.rs
@@ -7,7 +7,7 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::Result;
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::AffineTransform;
 
 /// Rotate geometries around a point by an angle, in degrees.

--- a/src/algorithm/geo/rotate.rs
+++ b/src/algorithm/geo/rotate.rs
@@ -103,30 +103,18 @@ impl Rotate<Float64Array> for PointArray<2> {
 
     fn rotate_around_centroid(&self, degrees: &Float64Array) -> Self {
         let centroids = self.centroid();
-        let transforms: Vec<AffineTransform> = centroids
-            .iter_geo_values()
-            .zip(degrees.values().iter())
-            .map(|(point, angle)| AffineTransform::rotate(*angle, point))
-            .collect();
+        let transforms: Vec<AffineTransform> = centroids.iter_geo_values().zip(degrees.values().iter()).map(|(point, angle)| AffineTransform::rotate(*angle, point)).collect();
         self.affine_transform(transforms.as_slice())
     }
 
     fn rotate_around_center(&self, degrees: &Float64Array) -> Self {
         let centers = self.center();
-        let transforms: Vec<AffineTransform> = centers
-            .iter_geo_values()
-            .zip(degrees.values().iter())
-            .map(|(point, angle)| AffineTransform::rotate(*angle, point))
-            .collect();
+        let transforms: Vec<AffineTransform> = centers.iter_geo_values().zip(degrees.values().iter()).map(|(point, angle)| AffineTransform::rotate(*angle, point)).collect();
         self.affine_transform(transforms.as_slice())
     }
 
     fn rotate_around_point(&self, degrees: &Float64Array, point: geo::Point) -> Self {
-        let transforms: Vec<AffineTransform> = degrees
-            .values()
-            .iter()
-            .map(|degrees| AffineTransform::rotate(*degrees, point))
-            .collect();
+        let transforms: Vec<AffineTransform> = degrees.values().iter().map(|degrees| AffineTransform::rotate(*degrees, point)).collect();
         self.affine_transform(transforms.as_slice())
     }
 }
@@ -134,46 +122,34 @@ impl Rotate<Float64Array> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Rotate<Float64Array> for $type {
+        impl Rotate<Float64Array> for $type {
             type Output = Self;
 
             fn rotate_around_centroid(&self, degrees: &Float64Array) -> $type {
                 let centroids = self.centroid();
-                let transforms: Vec<AffineTransform> = centroids
-                    .iter_geo_values()
-                    .zip(degrees.values().iter())
-                    .map(|(point, angle)| AffineTransform::rotate(*angle, point))
-                    .collect();
+                let transforms: Vec<AffineTransform> = centroids.iter_geo_values().zip(degrees.values().iter()).map(|(point, angle)| AffineTransform::rotate(*angle, point)).collect();
                 self.affine_transform(transforms.as_slice())
             }
 
             fn rotate_around_center(&self, degrees: &Float64Array) -> Self {
                 let centers = self.center();
-                let transforms: Vec<AffineTransform> = centers
-                    .iter_geo_values()
-                    .zip(degrees.values().iter())
-                    .map(|(point, angle)| AffineTransform::rotate(*angle, point))
-                    .collect();
+                let transforms: Vec<AffineTransform> = centers.iter_geo_values().zip(degrees.values().iter()).map(|(point, angle)| AffineTransform::rotate(*angle, point)).collect();
                 self.affine_transform(transforms.as_slice())
             }
 
             fn rotate_around_point(&self, degrees: &Float64Array, point: geo::Point) -> Self {
-                let transforms: Vec<AffineTransform> = degrees
-                    .values()
-                    .iter()
-                    .map(|degrees| AffineTransform::rotate(*degrees, point))
-                    .collect();
+                let transforms: Vec<AffineTransform> = degrees.values().iter().map(|degrees| AffineTransform::rotate(*degrees, point)).collect();
                 self.affine_transform(transforms.as_slice())
             }
         }
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
@@ -185,19 +161,13 @@ impl Rotate<f64> for PointArray<2> {
 
     fn rotate_around_centroid(&self, degrees: &f64) -> Self {
         let centroids = self.centroid();
-        let transforms: Vec<AffineTransform> = centroids
-            .iter_geo_values()
-            .map(|point| AffineTransform::rotate(*degrees, point))
-            .collect();
+        let transforms: Vec<AffineTransform> = centroids.iter_geo_values().map(|point| AffineTransform::rotate(*degrees, point)).collect();
         self.affine_transform(transforms.as_slice())
     }
 
     fn rotate_around_center(&self, degrees: &f64) -> Self {
         let centers = self.center();
-        let transforms: Vec<AffineTransform> = centers
-            .iter_geo_values()
-            .map(|point| AffineTransform::rotate(*degrees, point))
-            .collect();
+        let transforms: Vec<AffineTransform> = centers.iter_geo_values().map(|point| AffineTransform::rotate(*degrees, point)).collect();
         self.affine_transform(transforms.as_slice())
     }
 
@@ -210,24 +180,18 @@ impl Rotate<f64> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl_scalar {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Rotate<f64> for $type {
+        impl Rotate<f64> for $type {
             type Output = Self;
 
             fn rotate_around_centroid(&self, degrees: &f64) -> $type {
                 let centroids = self.centroid();
-                let transforms: Vec<AffineTransform> = centroids
-                    .iter_geo_values()
-                    .map(|point| AffineTransform::rotate(*degrees, point))
-                    .collect();
+                let transforms: Vec<AffineTransform> = centroids.iter_geo_values().map(|point| AffineTransform::rotate(*degrees, point)).collect();
                 self.affine_transform(transforms.as_slice())
             }
 
             fn rotate_around_center(&self, degrees: &f64) -> Self {
                 let centers = self.center();
-                let transforms: Vec<AffineTransform> = centers
-                    .iter_geo_values()
-                    .map(|point| AffineTransform::rotate(*degrees, point))
-                    .collect();
+                let transforms: Vec<AffineTransform> = centers.iter_geo_values().map(|point| AffineTransform::rotate(*degrees, point)).collect();
                 self.affine_transform(transforms.as_slice())
             }
 
@@ -239,11 +203,11 @@ macro_rules! iter_geo_impl_scalar {
     };
 }
 
-iter_geo_impl_scalar!(LineStringArray<O, 2>);
-iter_geo_impl_scalar!(PolygonArray<O, 2>);
-iter_geo_impl_scalar!(MultiPointArray<O, 2>);
-iter_geo_impl_scalar!(MultiLineStringArray<O, 2>);
-iter_geo_impl_scalar!(MultiPolygonArray<O, 2>);
+iter_geo_impl_scalar!(LineStringArray<2>);
+iter_geo_impl_scalar!(PolygonArray<2>);
+iter_geo_impl_scalar!(MultiPointArray<2>);
+iter_geo_impl_scalar!(MultiLineStringArray<2>);
+iter_geo_impl_scalar!(MultiPolygonArray<2>);
 
 impl Rotate<f64> for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -261,25 +225,13 @@ impl Rotate<f64> for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
             // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };
@@ -300,25 +252,13 @@ impl Rotate<f64> for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
             // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };
@@ -339,25 +279,13 @@ impl Rotate<f64> for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
             // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };
@@ -382,25 +310,13 @@ impl Rotate<Float64Array> for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
             // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };
@@ -421,25 +337,13 @@ impl Rotate<Float64Array> for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
             // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };
@@ -460,25 +364,13 @@ impl Rotate<Float64Array> for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
             // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };

--- a/src/algorithm/geo/scale.rs
+++ b/src/algorithm/geo/scale.rs
@@ -153,7 +153,7 @@ impl Scale for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $builder_type:ty, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> Scale for $type {
+        impl Scale for $type {
             type Output = Self;
 
             fn scale_xy(
@@ -210,17 +210,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
+iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
+iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
+iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringBuilder<O, 2>,
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonBuilder<O, 2>,
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
     push_multi_polygon
 );
 
@@ -244,25 +244,13 @@ impl Scale for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
             // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };
@@ -291,25 +279,13 @@ impl Scale for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
             // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };

--- a/src/algorithm/geo/scale.rs
+++ b/src/algorithm/geo/scale.rs
@@ -63,7 +63,11 @@ pub trait Scale: Sized {
     /// ]);
     /// ```
     #[must_use]
-    fn scale_xy(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>) -> Self::Output;
+    fn scale_xy(
+        &self,
+        x_factor: &BroadcastablePrimitive<Float64Type>,
+        y_factor: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self::Output;
 
     /// Scale geometries around a point of `origin`.
     ///
@@ -87,25 +91,59 @@ pub trait Scale: Sized {
     /// ]);
     /// ```
     #[must_use]
-    fn scale_around_point(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self::Output;
+    fn scale_around_point(
+        &self,
+        x_factor: &BroadcastablePrimitive<Float64Type>,
+        y_factor: &BroadcastablePrimitive<Float64Type>,
+        origin: geo::Point,
+    ) -> Self::Output;
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
 impl Scale for PointArray<2> {
     type Output = Self;
 
-    fn scale_xy(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>) -> Self {
+    fn scale_xy(
+        &self,
+        x_factor: &BroadcastablePrimitive<Float64Type>,
+        y_factor: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.push_point(maybe_g.map(|geom| geom.scale_xy(x_factor.unwrap(), y_factor.unwrap())).as_ref()));
+        self.iter_geo()
+            .zip(x_factor)
+            .zip(y_factor)
+            .for_each(|((maybe_g, x_factor), y_factor)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| geom.scale_xy(x_factor.unwrap(), y_factor.unwrap()))
+                        .as_ref(),
+                )
+            });
 
         output_array.finish()
     }
 
-    fn scale_around_point(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self {
+    fn scale_around_point(
+        &self,
+        x_factor: &BroadcastablePrimitive<Float64Type>,
+        y_factor: &BroadcastablePrimitive<Float64Type>,
+        origin: geo::Point,
+    ) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.push_point(maybe_g.map(|geom| geom.scale_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)).as_ref()));
+        self.iter_geo()
+            .zip(x_factor)
+            .zip(y_factor)
+            .for_each(|((maybe_g, x_factor), y_factor)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| {
+                            geom.scale_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)
+                        })
+                        .as_ref(),
+                )
+            });
 
         output_array.finish()
     }
@@ -117,18 +155,53 @@ macro_rules! iter_geo_impl {
         impl Scale for $type {
             type Output = Self;
 
-            fn scale_xy(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>) -> Self {
+            fn scale_xy(
+                &self,
+                x_factor: &BroadcastablePrimitive<Float64Type>,
+                y_factor: &BroadcastablePrimitive<Float64Type>,
+            ) -> Self {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.$push_func(maybe_g.map(|geom| geom.scale_xy(x_factor.unwrap(), y_factor.unwrap())).as_ref()).unwrap());
+                self.iter_geo().zip(x_factor).zip(y_factor).for_each(
+                    |((maybe_g, x_factor), y_factor)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| geom.scale_xy(x_factor.unwrap(), y_factor.unwrap()))
+                                    .as_ref(),
+                            )
+                            .unwrap()
+                    },
+                );
 
                 output_array.finish()
             }
 
-            fn scale_around_point(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self {
+            fn scale_around_point(
+                &self,
+                x_factor: &BroadcastablePrimitive<Float64Type>,
+                y_factor: &BroadcastablePrimitive<Float64Type>,
+                origin: geo::Point,
+            ) -> Self {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.$push_func(maybe_g.map(|geom| geom.scale_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)).as_ref()).unwrap());
+                self.iter_geo().zip(x_factor).zip(y_factor).for_each(
+                    |((maybe_g, x_factor), y_factor)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| {
+                                        geom.scale_around_point(
+                                            x_factor.unwrap(),
+                                            y_factor.unwrap(),
+                                            origin,
+                                        )
+                                    })
+                                    .as_ref(),
+                            )
+                            .unwrap()
+                    },
+                );
 
                 output_array.finish()
             }
@@ -139,13 +212,25 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
+iter_geo_impl!(
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
+    push_multi_line_string
+);
+iter_geo_impl!(
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
+    push_multi_polygon
+);
 
 impl Scale for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn scale_xy(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>) -> Self::Output {
+    fn scale_xy(
+        &self,
+        x_factor: &BroadcastablePrimitive<Float64Type>,
+        y_factor: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self::Output {
         macro_rules! impl_method {
             ($method:ident) => {{
                 Arc::new(self.$method().scale_xy(x_factor, y_factor))
@@ -172,10 +257,18 @@ impl Scale for &dyn NativeArray {
         Ok(result)
     }
 
-    fn scale_around_point(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self::Output {
+    fn scale_around_point(
+        &self,
+        x_factor: &BroadcastablePrimitive<Float64Type>,
+        y_factor: &BroadcastablePrimitive<Float64Type>,
+        origin: geo::Point,
+    ) -> Self::Output {
         macro_rules! impl_method {
             ($method:ident) => {{
-                Arc::new(self.$method().scale_around_point(x_factor, y_factor, origin))
+                Arc::new(
+                    self.$method()
+                        .scale_around_point(x_factor, y_factor, origin),
+                )
             }};
         }
 

--- a/src/algorithm/geo/simplify.rs
+++ b/src/algorithm/geo/simplify.rs
@@ -39,7 +39,7 @@ pub trait Simplify {
     ///     (x: 17.3, y: 3.2),
     ///     (x: 27.8, y: 0.1),
     /// ];
-    /// let line_string_array: LineStringArray<i32, 2> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray<2> = vec![line_string].as_slice().into();
     ///
     /// let simplified_array = line_string_array.simplify(&1.0);
     ///
@@ -67,7 +67,7 @@ impl Simplify for PointArray<2> {
 /// Implementation that returns the identity
 macro_rules! identity_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Simplify for $type {
+        impl Simplify for $type {
             type Output = Self;
 
             fn simplify(&self, _epsilon: &f64) -> Self {
@@ -77,19 +77,16 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(MultiPointArray<O, 2>);
+identity_impl!(MultiPointArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: OffsetSizeTrait> Simplify for $type {
+        impl Simplify for $type {
             type Output = Self;
 
             fn simplify(&self, epsilon: &f64) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self
-                    .iter_geo()
-                    .map(|maybe_g| maybe_g.map(|geom| geom.simplify(epsilon)))
-                    .collect();
+                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.simplify(epsilon))).collect();
 
                 output_geoms.into()
             }
@@ -97,12 +94,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
-iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<O, 2>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<O, 2>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray<2>, geo::LineString);
+iter_geo_impl!(PolygonArray<2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray<2>, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
 
 impl Simplify for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -114,25 +111,12 @@ impl Simplify for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().simplify(epsilon)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify(epsilon)),
-            LargeLineString(_, XY) => Arc::new(self.as_large_line_string::<2>().simplify(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify(epsilon)),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().simplify(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify(epsilon)),
-            LargeMultiPoint(_, XY) => Arc::new(self.as_large_multi_point::<2>().simplify(epsilon)),
             MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify(epsilon)),
-            LargeMultiLineString(_, XY) => {
-                Arc::new(self.as_large_multi_line_string::<2>().simplify(epsilon))
-            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify(epsilon)),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().simplify(epsilon))
-            }
             // Mixed(_, XY) => self.as_mixed::<2>().simplify(epsilon),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().simplify(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().simplify()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -143,32 +127,28 @@ impl Simplify for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify(&self, epsilon: &f64) -> Self::Output {
-        self.map(|chunk| chunk.simplify(epsilon))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| chunk.simplify(epsilon)).try_into().unwrap()
     }
 }
 
 /// Implementation that iterates over chunks
 macro_rules! chunked_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Simplify for $type {
+        impl Simplify for $type {
             type Output = Self;
 
             fn simplify(&self, epsilon: &f64) -> Self {
-                self.map(|chunk| chunk.simplify(epsilon))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| chunk.simplify(epsilon)).try_into().unwrap()
             }
         }
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<2>>);
 
 impl Simplify for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -180,25 +160,12 @@ impl Simplify for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().simplify(epsilon)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify(epsilon)),
-            LargeLineString(_, XY) => Arc::new(self.as_large_line_string::<2>().simplify(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify(epsilon)),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().simplify(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify(epsilon)),
-            LargeMultiPoint(_, XY) => Arc::new(self.as_large_multi_point::<2>().simplify(epsilon)),
             MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify(epsilon)),
-            LargeMultiLineString(_, XY) => {
-                Arc::new(self.as_large_multi_line_string::<2>().simplify(epsilon))
-            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify(epsilon)),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().simplify(epsilon))
-            }
             // Mixed(_, XY) => self.as_mixed::<2>().simplify(epsilon),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().simplify(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().simplify()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -221,7 +188,7 @@ mod tests {
             (x: 17.3, y: 3.2 ),
             (x: 27.8, y: 0.1 ),
         ];
-        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
         let result_array = input_array.simplify(&1.0);
 
         let expected = line_string![
@@ -244,7 +211,7 @@ mod tests {
             (x: 10., y: 0.),
             (x: 0., y: 0.),
         ];
-        let input_array: PolygonArray<i64, 2> = vec![input_geom].as_slice().into();
+        let input_array: PolygonArray<2> = vec![input_geom].as_slice().into();
         let result_array = input_array.simplify(&2.0);
 
         let expected = polygon![

--- a/src/algorithm/geo/simplify.rs
+++ b/src/algorithm/geo/simplify.rs
@@ -85,7 +85,10 @@ macro_rules! iter_geo_impl {
             type Output = Self;
 
             fn simplify(&self, epsilon: &f64) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.simplify(epsilon))).collect();
+                let output_geoms: Vec<Option<$geo_type>> = self
+                    .iter_geo()
+                    .map(|maybe_g| maybe_g.map(|geom| geom.simplify(epsilon)))
+                    .collect();
 
                 output_geoms.into()
             }
@@ -126,7 +129,9 @@ impl Simplify for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify(&self, epsilon: &f64) -> Self::Output {
-        self.map(|chunk| chunk.simplify(epsilon)).try_into().unwrap()
+        self.map(|chunk| chunk.simplify(epsilon))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -137,7 +142,9 @@ macro_rules! chunked_impl {
             type Output = Self;
 
             fn simplify(&self, epsilon: &f64) -> Self {
-                self.map(|chunk| chunk.simplify(epsilon)).try_into().unwrap()
+                self.map(|chunk| chunk.simplify(epsilon))
+                    .try_into()
+                    .unwrap()
             }
         }
     };

--- a/src/algorithm/geo/simplify.rs
+++ b/src/algorithm/geo/simplify.rs
@@ -6,7 +6,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::Simplify as _Simplify;
 
 /// Simplifies a geometry.

--- a/src/algorithm/geo/simplify_vw.rs
+++ b/src/algorithm/geo/simplify_vw.rs
@@ -38,7 +38,7 @@ pub trait SimplifyVw {
     ///     (x: 7.0, y: 25.0),
     ///     (x: 10.0, y: 10.0),
     /// ];
-    /// let line_string_array: LineStringArray<i32, 2> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray<2> = vec![line_string].as_slice().into();
     ///
     /// let simplified_array = line_string_array.simplify_vw(&30.0);
     ///
@@ -65,7 +65,7 @@ impl SimplifyVw for PointArray<2> {
 /// Implementation that returns the identity
 macro_rules! identity_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> SimplifyVw for $type {
+        impl SimplifyVw for $type {
             type Output = Self;
 
             fn simplify_vw(&self, _epsilon: &f64) -> Self {
@@ -75,12 +75,12 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(MultiPointArray<O, 2>);
+identity_impl!(MultiPointArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: OffsetSizeTrait> SimplifyVw for $type {
+        impl SimplifyVw for $type {
             type Output = Self;
 
             fn simplify_vw(&self, epsilon: &f64) -> Self {
@@ -95,12 +95,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
-iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<O, 2>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<O, 2>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray<2>, geo::LineString);
+iter_geo_impl!(PolygonArray<2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray<2>, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
 
 impl SimplifyVw for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -112,31 +112,14 @@ impl SimplifyVw for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().simplify_vw(epsilon)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw(epsilon)),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().simplify_vw(epsilon))
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw(epsilon)),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().simplify_vw(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw(epsilon)),
-            LargeMultiPoint(_, XY) => {
-                Arc::new(self.as_large_multi_point::<2>().simplify_vw(epsilon))
-            }
             MultiLineString(_, XY) => {
                 Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon))
             }
-            LargeMultiLineString(_, XY) => {
-                Arc::new(self.as_large_multi_line_string::<2>().simplify_vw(epsilon))
-            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw(epsilon)),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().simplify_vw(epsilon))
-            }
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw(epsilon),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().simplify_vw(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().simplify_vw()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -156,7 +139,7 @@ impl SimplifyVw for ChunkedGeometryArray<PointArray<2>> {
 /// Implementation that iterates over chunks
 macro_rules! chunked_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> SimplifyVw for $type {
+        impl SimplifyVw for $type {
             type Output = Self;
 
             fn simplify_vw(&self, epsilon: &f64) -> Self {
@@ -168,11 +151,11 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<2>>);
 
 impl SimplifyVw for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -184,31 +167,14 @@ impl SimplifyVw for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().simplify_vw(epsilon)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw(epsilon)),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().simplify_vw(epsilon))
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw(epsilon)),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().simplify_vw(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw(epsilon)),
-            LargeMultiPoint(_, XY) => {
-                Arc::new(self.as_large_multi_point::<2>().simplify_vw(epsilon))
-            }
             MultiLineString(_, XY) => {
                 Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon))
             }
-            LargeMultiLineString(_, XY) => {
-                Arc::new(self.as_large_multi_line_string::<2>().simplify_vw(epsilon))
-            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw(epsilon)),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().simplify_vw(epsilon))
-            }
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw(epsilon),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().simplify_vw(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().simplify_vw()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/simplify_vw.rs
+++ b/src/algorithm/geo/simplify_vw.rs
@@ -83,7 +83,10 @@ macro_rules! iter_geo_impl {
             type Output = Self;
 
             fn simplify_vw(&self, epsilon: &f64) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw(epsilon))).collect();
+                let output_geoms: Vec<Option<$geo_type>> = self
+                    .iter_geo()
+                    .map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw(epsilon)))
+                    .collect();
 
                 output_geoms.into()
             }
@@ -110,7 +113,9 @@ impl SimplifyVw for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw(epsilon)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon)),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon))
+            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw(epsilon)),
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw(),
@@ -124,7 +129,9 @@ impl SimplifyVw for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify_vw(&self, epsilon: &f64) -> Self::Output {
-        self.map(|chunk| chunk.simplify_vw(epsilon)).try_into().unwrap()
+        self.map(|chunk| chunk.simplify_vw(epsilon))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -135,7 +142,9 @@ macro_rules! chunked_impl {
             type Output = Self;
 
             fn simplify_vw(&self, epsilon: &f64) -> Self {
-                self.map(|chunk| chunk.simplify_vw(epsilon)).try_into().unwrap()
+                self.map(|chunk| chunk.simplify_vw(epsilon))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -159,7 +168,9 @@ impl SimplifyVw for &dyn ChunkedNativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw(epsilon)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon)),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon))
+            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw(epsilon)),
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw(),

--- a/src/algorithm/geo/simplify_vw.rs
+++ b/src/algorithm/geo/simplify_vw.rs
@@ -6,7 +6,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::SimplifyVw as _SimplifyVw;
 
 /// Simplifies a geometry.
@@ -84,10 +83,7 @@ macro_rules! iter_geo_impl {
             type Output = Self;
 
             fn simplify_vw(&self, epsilon: &f64) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self
-                    .iter_geo()
-                    .map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw(epsilon)))
-                    .collect();
+                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw(epsilon))).collect();
 
                 output_geoms.into()
             }
@@ -114,9 +110,7 @@ impl SimplifyVw for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw(epsilon)),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon)),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw(epsilon)),
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw(),
@@ -130,9 +124,7 @@ impl SimplifyVw for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify_vw(&self, epsilon: &f64) -> Self::Output {
-        self.map(|chunk| chunk.simplify_vw(epsilon))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| chunk.simplify_vw(epsilon)).try_into().unwrap()
     }
 }
 
@@ -143,9 +135,7 @@ macro_rules! chunked_impl {
             type Output = Self;
 
             fn simplify_vw(&self, epsilon: &f64) -> Self {
-                self.map(|chunk| chunk.simplify_vw(epsilon))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| chunk.simplify_vw(epsilon)).try_into().unwrap()
             }
         }
     };
@@ -169,9 +159,7 @@ impl SimplifyVw for &dyn ChunkedNativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw(epsilon)),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon)),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw(epsilon)),
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw(),

--- a/src/algorithm/geo/simplify_vw_preserve.rs
+++ b/src/algorithm/geo/simplify_vw_preserve.rs
@@ -77,7 +77,10 @@ macro_rules! iter_geo_impl {
             type Output = Self;
 
             fn simplify_vw_preserve(&self, epsilon: &f64) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw_preserve(epsilon))).collect();
+                let output_geoms: Vec<Option<$geo_type>> = self
+                    .iter_geo()
+                    .map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw_preserve(epsilon)))
+                    .collect();
 
                 output_geoms.into()
             }
@@ -104,8 +107,13 @@ impl SimplifyVwPreserve for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw_preserve(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw_preserve(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw_preserve(epsilon)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify_vw_preserve(epsilon)),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon)),
+            MultiLineString(_, XY) => Arc::new(
+                self.as_multi_line_string::<2>()
+                    .simplify_vw_preserve(epsilon),
+            ),
+            MultiPolygon(_, XY) => {
+                Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon))
+            }
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw_preserve(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw_preserve(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
@@ -118,7 +126,9 @@ impl SimplifyVwPreserve for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify_vw_preserve(&self, epsilon: &f64) -> Self::Output {
-        self.map(|chunk| chunk.simplify_vw_preserve(epsilon)).try_into().unwrap()
+        self.map(|chunk| chunk.simplify_vw_preserve(epsilon))
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -129,7 +139,9 @@ macro_rules! chunked_impl {
             type Output = Self;
 
             fn simplify_vw_preserve(&self, epsilon: &f64) -> Self {
-                self.map(|chunk| chunk.simplify_vw_preserve(epsilon)).try_into().unwrap()
+                self.map(|chunk| chunk.simplify_vw_preserve(epsilon))
+                    .try_into()
+                    .unwrap()
             }
         }
     };
@@ -153,8 +165,13 @@ impl SimplifyVwPreserve for &dyn ChunkedNativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw_preserve(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw_preserve(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw_preserve(epsilon)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify_vw_preserve(epsilon)),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon)),
+            MultiLineString(_, XY) => Arc::new(
+                self.as_multi_line_string::<2>()
+                    .simplify_vw_preserve(epsilon),
+            ),
+            MultiPolygon(_, XY) => {
+                Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon))
+            }
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw_preserve(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw_preserve(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),

--- a/src/algorithm/geo/simplify_vw_preserve.rs
+++ b/src/algorithm/geo/simplify_vw_preserve.rs
@@ -59,7 +59,7 @@ impl SimplifyVwPreserve for PointArray<2> {
 /// Implementation that returns the identity
 macro_rules! identity_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> SimplifyVwPreserve for $type {
+        impl SimplifyVwPreserve for $type {
             type Output = Self;
 
             fn simplify_vw_preserve(&self, _epsilon: &f64) -> Self {
@@ -69,12 +69,12 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(MultiPointArray<O, 2>);
+identity_impl!(MultiPointArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: OffsetSizeTrait> SimplifyVwPreserve for $type {
+        impl SimplifyVwPreserve for $type {
             type Output = Self;
 
             fn simplify_vw_preserve(&self, epsilon: &f64) -> Self {
@@ -89,12 +89,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, geo::LineString);
-iter_geo_impl!(PolygonArray<O, 2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<O, 2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<O, 2>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<O, 2>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray<2>, geo::LineString);
+iter_geo_impl!(PolygonArray<2>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray<2>, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
 
 impl SimplifyVwPreserve for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -106,40 +106,17 @@ impl SimplifyVwPreserve for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().simplify_vw_preserve(epsilon)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw_preserve(epsilon)),
-            LargeLineString(_, XY) => Arc::new(
-                self.as_large_line_string::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw_preserve(epsilon)),
-            LargePolygon(_, XY) => {
-                Arc::new(self.as_large_polygon::<2>().simplify_vw_preserve(epsilon))
-            }
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw_preserve(epsilon)),
-            LargeMultiPoint(_, XY) => Arc::new(
-                self.as_large_multi_point::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
             MultiLineString(_, XY) => Arc::new(
                 self.as_multi_line_string::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
                     .simplify_vw_preserve(epsilon),
             ),
             MultiPolygon(_, XY) => {
                 Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon))
             }
-            LargeMultiPolygon(_, XY) => Arc::new(
-                self.as_large_multi_polygon::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw_preserve(epsilon),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().simplify_vw_preserve(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw_preserve(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().simplify_vw_preserve()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -159,7 +136,7 @@ impl SimplifyVwPreserve for ChunkedGeometryArray<PointArray<2>> {
 /// Implementation that iterates over chunks
 macro_rules! chunked_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> SimplifyVwPreserve for $type {
+        impl SimplifyVwPreserve for $type {
             type Output = Self;
 
             fn simplify_vw_preserve(&self, epsilon: &f64) -> Self {
@@ -171,11 +148,11 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<2>>);
 
 impl SimplifyVwPreserve for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -187,40 +164,17 @@ impl SimplifyVwPreserve for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().simplify_vw_preserve(epsilon)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw_preserve(epsilon)),
-            LargeLineString(_, XY) => Arc::new(
-                self.as_large_line_string::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw_preserve(epsilon)),
-            LargePolygon(_, XY) => {
-                Arc::new(self.as_large_polygon::<2>().simplify_vw_preserve(epsilon))
-            }
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw_preserve(epsilon)),
-            LargeMultiPoint(_, XY) => Arc::new(
-                self.as_large_multi_point::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
             MultiLineString(_, XY) => Arc::new(
                 self.as_multi_line_string::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
                     .simplify_vw_preserve(epsilon),
             ),
             MultiPolygon(_, XY) => {
                 Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon))
             }
-            LargeMultiPolygon(_, XY) => Arc::new(
-                self.as_large_multi_polygon::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw_preserve(epsilon),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().simplify_vw_preserve(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw_preserve(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().simplify_vw_preserve()
-            // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/geo/simplify_vw_preserve.rs
+++ b/src/algorithm/geo/simplify_vw_preserve.rs
@@ -6,7 +6,6 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo::SimplifyVwPreserve as _SimplifyVwPreserve;
 
 /// Simplifies a geometry, attempting to preserve its topology by removing self-intersections
@@ -78,10 +77,7 @@ macro_rules! iter_geo_impl {
             type Output = Self;
 
             fn simplify_vw_preserve(&self, epsilon: &f64) -> Self {
-                let output_geoms: Vec<Option<$geo_type>> = self
-                    .iter_geo()
-                    .map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw_preserve(epsilon)))
-                    .collect();
+                let output_geoms: Vec<Option<$geo_type>> = self.iter_geo().map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw_preserve(epsilon))).collect();
 
                 output_geoms.into()
             }
@@ -108,13 +104,8 @@ impl SimplifyVwPreserve for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw_preserve(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw_preserve(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw_preserve(epsilon)),
-            MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
-            MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify_vw_preserve(epsilon)),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon)),
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw_preserve(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw_preserve(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
@@ -127,9 +118,7 @@ impl SimplifyVwPreserve for ChunkedGeometryArray<PointArray<2>> {
     type Output = Self;
 
     fn simplify_vw_preserve(&self, epsilon: &f64) -> Self::Output {
-        self.map(|chunk| chunk.simplify_vw_preserve(epsilon))
-            .try_into()
-            .unwrap()
+        self.map(|chunk| chunk.simplify_vw_preserve(epsilon)).try_into().unwrap()
     }
 }
 
@@ -140,9 +129,7 @@ macro_rules! chunked_impl {
             type Output = Self;
 
             fn simplify_vw_preserve(&self, epsilon: &f64) -> Self {
-                self.map(|chunk| chunk.simplify_vw_preserve(epsilon))
-                    .try_into()
-                    .unwrap()
+                self.map(|chunk| chunk.simplify_vw_preserve(epsilon)).try_into().unwrap()
             }
         }
     };
@@ -166,13 +153,8 @@ impl SimplifyVwPreserve for &dyn ChunkedNativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw_preserve(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw_preserve(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw_preserve(epsilon)),
-            MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string::<2>()
-                    .simplify_vw_preserve(epsilon),
-            ),
-            MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify_vw_preserve(epsilon)),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon)),
             // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw_preserve(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw_preserve(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),

--- a/src/algorithm/geo/skew.rs
+++ b/src/algorithm/geo/skew.rs
@@ -79,7 +79,11 @@ pub trait Skew {
     /// approx::assert_relative_eq!(skewed, expected_output, epsilon = 1e-2);
     /// ```
     #[must_use]
-    fn skew_xy(&self, degrees_x: &BroadcastablePrimitive<Float64Type>, degrees_y: &BroadcastablePrimitive<Float64Type>) -> Self::Output;
+    fn skew_xy(
+        &self,
+        degrees_x: &BroadcastablePrimitive<Float64Type>,
+        degrees_y: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self::Output;
 
     /// An affine transformation which skews a geometry around a point of `origin`, sheared by an
     /// angle along the x and y dimensions.
@@ -113,25 +117,59 @@ pub trait Skew {
     /// approx::assert_relative_eq!(skewed, expected_output, epsilon = 1e-2);
     /// ```
     #[must_use]
-    fn skew_around_point(&self, degrees_x: &BroadcastablePrimitive<Float64Type>, degrees_y: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self::Output;
+    fn skew_around_point(
+        &self,
+        degrees_x: &BroadcastablePrimitive<Float64Type>,
+        degrees_y: &BroadcastablePrimitive<Float64Type>,
+        origin: geo::Point,
+    ) -> Self::Output;
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
 impl Skew for PointArray<2> {
     type Output = Self;
 
-    fn skew_xy(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>) -> Self {
+    fn skew_xy(
+        &self,
+        x_factor: &BroadcastablePrimitive<Float64Type>,
+        y_factor: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.push_point(maybe_g.map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap())).as_ref()));
+        self.iter_geo()
+            .zip(x_factor)
+            .zip(y_factor)
+            .for_each(|((maybe_g, x_factor), y_factor)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap()))
+                        .as_ref(),
+                )
+            });
 
         output_array.finish()
     }
 
-    fn skew_around_point(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self {
+    fn skew_around_point(
+        &self,
+        x_factor: &BroadcastablePrimitive<Float64Type>,
+        y_factor: &BroadcastablePrimitive<Float64Type>,
+        origin: geo::Point,
+    ) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.push_point(maybe_g.map(|geom| geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)).as_ref()));
+        self.iter_geo()
+            .zip(x_factor)
+            .zip(y_factor)
+            .for_each(|((maybe_g, x_factor), y_factor)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| {
+                            geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)
+                        })
+                        .as_ref(),
+                )
+            });
 
         output_array.finish()
     }
@@ -143,18 +181,53 @@ macro_rules! iter_geo_impl {
         impl Skew for $type {
             type Output = Self;
 
-            fn skew_xy(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>) -> Self {
+            fn skew_xy(
+                &self,
+                x_factor: &BroadcastablePrimitive<Float64Type>,
+                y_factor: &BroadcastablePrimitive<Float64Type>,
+            ) -> Self {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.$push_func(maybe_g.map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap())).as_ref()).unwrap());
+                self.iter_geo().zip(x_factor).zip(y_factor).for_each(
+                    |((maybe_g, x_factor), y_factor)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap()))
+                                    .as_ref(),
+                            )
+                            .unwrap()
+                    },
+                );
 
                 output_array.finish()
             }
 
-            fn skew_around_point(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self {
+            fn skew_around_point(
+                &self,
+                x_factor: &BroadcastablePrimitive<Float64Type>,
+                y_factor: &BroadcastablePrimitive<Float64Type>,
+                origin: geo::Point,
+            ) -> Self {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.$push_func(maybe_g.map(|geom| geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)).as_ref()).unwrap());
+                self.iter_geo().zip(x_factor).zip(y_factor).for_each(
+                    |((maybe_g, x_factor), y_factor)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| {
+                                        geom.skew_around_point(
+                                            x_factor.unwrap(),
+                                            y_factor.unwrap(),
+                                            origin,
+                                        )
+                                    })
+                                    .as_ref(),
+                            )
+                            .unwrap()
+                    },
+                );
 
                 output_array.finish()
             }
@@ -165,13 +238,25 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
+iter_geo_impl!(
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
+    push_multi_line_string
+);
+iter_geo_impl!(
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
+    push_multi_polygon
+);
 
 impl Skew for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn skew_xy(&self, degrees_x: &BroadcastablePrimitive<Float64Type>, degrees_y: &BroadcastablePrimitive<Float64Type>) -> Self::Output {
+    fn skew_xy(
+        &self,
+        degrees_x: &BroadcastablePrimitive<Float64Type>,
+        degrees_y: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self::Output {
         macro_rules! impl_method {
             ($method:ident) => {{
                 Arc::new(self.$method().skew_xy(degrees_x, degrees_y))
@@ -199,10 +284,18 @@ impl Skew for &dyn NativeArray {
         Ok(result)
     }
 
-    fn skew_around_point(&self, degrees_x: &BroadcastablePrimitive<Float64Type>, degrees_y: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self::Output {
+    fn skew_around_point(
+        &self,
+        degrees_x: &BroadcastablePrimitive<Float64Type>,
+        degrees_y: &BroadcastablePrimitive<Float64Type>,
+        origin: geo::Point,
+    ) -> Self::Output {
         macro_rules! impl_method {
             ($method:ident) => {{
-                Arc::new(self.$method().skew_around_point(degrees_x, degrees_y, origin))
+                Arc::new(
+                    self.$method()
+                        .skew_around_point(degrees_x, degrees_y, origin),
+                )
             }};
         }
 

--- a/src/algorithm/geo/skew.rs
+++ b/src/algorithm/geo/skew.rs
@@ -179,7 +179,7 @@ impl Skew for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $builder_type:ty, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> Skew for $type {
+        impl Skew for $type {
             type Output = Self;
 
             fn skew_xy(
@@ -236,17 +236,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
+iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
+iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
+iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringBuilder<O, 2>,
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonBuilder<O, 2>,
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
     push_multi_polygon
 );
 
@@ -270,25 +270,14 @@ impl Skew for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
             //     impl_method!(as_large_geometry_collection)
             // }
-            // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };
@@ -317,25 +306,12 @@ impl Skew for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
-            // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };

--- a/src/algorithm/geo/skew.rs
+++ b/src/algorithm/geo/skew.rs
@@ -8,7 +8,6 @@ use crate::error::Result;
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
 use arrow_array::types::Float64Type;
-use arrow_array::OffsetSizeTrait;
 use geo::Skew as _Skew;
 
 /// An affine transformation which skews a geometry, sheared by angles along x and y dimensions.
@@ -80,11 +79,7 @@ pub trait Skew {
     /// approx::assert_relative_eq!(skewed, expected_output, epsilon = 1e-2);
     /// ```
     #[must_use]
-    fn skew_xy(
-        &self,
-        degrees_x: &BroadcastablePrimitive<Float64Type>,
-        degrees_y: &BroadcastablePrimitive<Float64Type>,
-    ) -> Self::Output;
+    fn skew_xy(&self, degrees_x: &BroadcastablePrimitive<Float64Type>, degrees_y: &BroadcastablePrimitive<Float64Type>) -> Self::Output;
 
     /// An affine transformation which skews a geometry around a point of `origin`, sheared by an
     /// angle along the x and y dimensions.
@@ -118,59 +113,25 @@ pub trait Skew {
     /// approx::assert_relative_eq!(skewed, expected_output, epsilon = 1e-2);
     /// ```
     #[must_use]
-    fn skew_around_point(
-        &self,
-        degrees_x: &BroadcastablePrimitive<Float64Type>,
-        degrees_y: &BroadcastablePrimitive<Float64Type>,
-        origin: geo::Point,
-    ) -> Self::Output;
+    fn skew_around_point(&self, degrees_x: &BroadcastablePrimitive<Float64Type>, degrees_y: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self::Output;
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
 impl Skew for PointArray<2> {
     type Output = Self;
 
-    fn skew_xy(
-        &self,
-        x_factor: &BroadcastablePrimitive<Float64Type>,
-        y_factor: &BroadcastablePrimitive<Float64Type>,
-    ) -> Self {
+    fn skew_xy(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo()
-            .zip(x_factor)
-            .zip(y_factor)
-            .for_each(|((maybe_g, x_factor), y_factor)| {
-                output_array.push_point(
-                    maybe_g
-                        .map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap()))
-                        .as_ref(),
-                )
-            });
+        self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.push_point(maybe_g.map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap())).as_ref()));
 
         output_array.finish()
     }
 
-    fn skew_around_point(
-        &self,
-        x_factor: &BroadcastablePrimitive<Float64Type>,
-        y_factor: &BroadcastablePrimitive<Float64Type>,
-        origin: geo::Point,
-    ) -> Self {
+    fn skew_around_point(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo()
-            .zip(x_factor)
-            .zip(y_factor)
-            .for_each(|((maybe_g, x_factor), y_factor)| {
-                output_array.push_point(
-                    maybe_g
-                        .map(|geom| {
-                            geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)
-                        })
-                        .as_ref(),
-                )
-            });
+        self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.push_point(maybe_g.map(|geom| geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)).as_ref()));
 
         output_array.finish()
     }
@@ -182,53 +143,18 @@ macro_rules! iter_geo_impl {
         impl Skew for $type {
             type Output = Self;
 
-            fn skew_xy(
-                &self,
-                x_factor: &BroadcastablePrimitive<Float64Type>,
-                y_factor: &BroadcastablePrimitive<Float64Type>,
-            ) -> Self {
+            fn skew_xy(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>) -> Self {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().zip(x_factor).zip(y_factor).for_each(
-                    |((maybe_g, x_factor), y_factor)| {
-                        output_array
-                            .$push_func(
-                                maybe_g
-                                    .map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap()))
-                                    .as_ref(),
-                            )
-                            .unwrap()
-                    },
-                );
+                self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.$push_func(maybe_g.map(|geom| geom.skew_xy(x_factor.unwrap(), y_factor.unwrap())).as_ref()).unwrap());
 
                 output_array.finish()
             }
 
-            fn skew_around_point(
-                &self,
-                x_factor: &BroadcastablePrimitive<Float64Type>,
-                y_factor: &BroadcastablePrimitive<Float64Type>,
-                origin: geo::Point,
-            ) -> Self {
+            fn skew_around_point(&self, x_factor: &BroadcastablePrimitive<Float64Type>, y_factor: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().zip(x_factor).zip(y_factor).for_each(
-                    |((maybe_g, x_factor), y_factor)| {
-                        output_array
-                            .$push_func(
-                                maybe_g
-                                    .map(|geom| {
-                                        geom.skew_around_point(
-                                            x_factor.unwrap(),
-                                            y_factor.unwrap(),
-                                            origin,
-                                        )
-                                    })
-                                    .as_ref(),
-                            )
-                            .unwrap()
-                    },
-                );
+                self.iter_geo().zip(x_factor).zip(y_factor).for_each(|((maybe_g, x_factor), y_factor)| output_array.$push_func(maybe_g.map(|geom| geom.skew_around_point(x_factor.unwrap(), y_factor.unwrap(), origin)).as_ref()).unwrap());
 
                 output_array.finish()
             }
@@ -239,25 +165,13 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
-    push_multi_line_string
-);
-iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
-    push_multi_polygon
-);
+iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
+iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
 
 impl Skew for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn skew_xy(
-        &self,
-        degrees_x: &BroadcastablePrimitive<Float64Type>,
-        degrees_y: &BroadcastablePrimitive<Float64Type>,
-    ) -> Self::Output {
+    fn skew_xy(&self, degrees_x: &BroadcastablePrimitive<Float64Type>, degrees_y: &BroadcastablePrimitive<Float64Type>) -> Self::Output {
         macro_rules! impl_method {
             ($method:ident) => {{
                 Arc::new(self.$method().skew_xy(degrees_x, degrees_y))
@@ -285,18 +199,10 @@ impl Skew for &dyn NativeArray {
         Ok(result)
     }
 
-    fn skew_around_point(
-        &self,
-        degrees_x: &BroadcastablePrimitive<Float64Type>,
-        degrees_y: &BroadcastablePrimitive<Float64Type>,
-        origin: geo::Point,
-    ) -> Self::Output {
+    fn skew_around_point(&self, degrees_x: &BroadcastablePrimitive<Float64Type>, degrees_y: &BroadcastablePrimitive<Float64Type>, origin: geo::Point) -> Self::Output {
         macro_rules! impl_method {
             ($method:ident) => {{
-                Arc::new(
-                    self.$method()
-                        .skew_around_point(degrees_x, degrees_y, origin),
-                )
+                Arc::new(self.$method().skew_around_point(degrees_x, degrees_y, origin))
             }};
         }
 

--- a/src/algorithm/geo/translate.rs
+++ b/src/algorithm/geo/translate.rs
@@ -81,7 +81,7 @@ impl Translate for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $builder_type:ty, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> Translate for $type {
+        impl Translate for $type {
             type Output = Self;
 
             fn translate(
@@ -111,17 +111,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
+iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
+iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
+iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringBuilder<O, 2>,
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonBuilder<O, 2>,
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
     push_multi_polygon
 );
 
@@ -145,25 +145,12 @@ impl Translate for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => impl_method!(as_point),
             LineString(_, XY) => impl_method!(as_line_string),
-            LargeLineString(_, XY) => impl_method!(as_large_line_string),
             Polygon(_, XY) => impl_method!(as_polygon),
-            LargePolygon(_, XY) => impl_method!(as_large_polygon),
             MultiPoint(_, XY) => impl_method!(as_multi_point),
-            LargeMultiPoint(_, XY) => impl_method!(as_large_multi_point),
             MultiLineString(_, XY) => impl_method!(as_multi_line_string),
-            LargeMultiLineString(_, XY) => {
-                impl_method!(as_large_multi_line_string)
-            }
             MultiPolygon(_, XY) => impl_method!(as_multi_polygon),
-            LargeMultiPolygon(_, XY) => impl_method!(as_large_multi_polygon),
             // Mixed(_, XY) => impl_method!(as_mixed),
-            // LargeMixed(_, XY) => impl_method!(as_large_mixed),
             // GeometryCollection(_, XY) => impl_method!(as_geometry_collection),
-            // LargeGeometryCollection(_, XY) => {
-            //     impl_method!(as_large_geometry_collection)
-            // }
-            // WKB => impl_method!(as_wkb),
-            // LargeWKB => impl_method!(as_large_wkb),
             // Rect(XY) => impl_method!(as_rect),
             _ => todo!("unsupported data type"),
         };

--- a/src/algorithm/geo/translate.rs
+++ b/src/algorithm/geo/translate.rs
@@ -44,17 +44,34 @@ pub trait Translate {
     /// ]);
     /// ```
     #[must_use]
-    fn translate(&self, x_offset: &BroadcastablePrimitive<Float64Type>, y_offset: &BroadcastablePrimitive<Float64Type>) -> Self::Output;
+    fn translate(
+        &self,
+        x_offset: &BroadcastablePrimitive<Float64Type>,
+        y_offset: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self::Output;
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
 impl Translate for PointArray<2> {
     type Output = Self;
 
-    fn translate(&self, x_offset: &BroadcastablePrimitive<Float64Type>, y_offset: &BroadcastablePrimitive<Float64Type>) -> Self {
+    fn translate(
+        &self,
+        x_offset: &BroadcastablePrimitive<Float64Type>,
+        y_offset: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self {
         let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
 
-        self.iter_geo().zip(x_offset).zip(y_offset).for_each(|((maybe_g, x_offset), y_offset)| output_array.push_point(maybe_g.map(|geom| geom.translate(x_offset.unwrap(), y_offset.unwrap())).as_ref()));
+        self.iter_geo()
+            .zip(x_offset)
+            .zip(y_offset)
+            .for_each(|((maybe_g, x_offset), y_offset)| {
+                output_array.push_point(
+                    maybe_g
+                        .map(|geom| geom.translate(x_offset.unwrap(), y_offset.unwrap()))
+                        .as_ref(),
+                )
+            });
 
         output_array.finish()
     }
@@ -66,10 +83,26 @@ macro_rules! iter_geo_impl {
         impl Translate for $type {
             type Output = Self;
 
-            fn translate(&self, x_offset: &BroadcastablePrimitive<Float64Type>, y_offset: &BroadcastablePrimitive<Float64Type>) -> Self {
+            fn translate(
+                &self,
+                x_offset: &BroadcastablePrimitive<Float64Type>,
+                y_offset: &BroadcastablePrimitive<Float64Type>,
+            ) -> Self {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
-                self.iter_geo().zip(x_offset).zip(y_offset).for_each(|((maybe_g, x_offset), y_offset)| output_array.$push_func(maybe_g.map(|geom| geom.translate(x_offset.unwrap(), y_offset.unwrap())).as_ref()).unwrap());
+                self.iter_geo().zip(x_offset).zip(y_offset).for_each(
+                    |((maybe_g, x_offset), y_offset)| {
+                        output_array
+                            .$push_func(
+                                maybe_g
+                                    .map(|geom| {
+                                        geom.translate(x_offset.unwrap(), y_offset.unwrap())
+                                    })
+                                    .as_ref(),
+                            )
+                            .unwrap()
+                    },
+                );
 
                 output_array.finish()
             }
@@ -80,13 +113,25 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
+iter_geo_impl!(
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
+    push_multi_line_string
+);
+iter_geo_impl!(
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
+    push_multi_polygon
+);
 
 impl Translate for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn translate(&self, x_offset: &BroadcastablePrimitive<Float64Type>, y_offset: &BroadcastablePrimitive<Float64Type>) -> Self::Output {
+    fn translate(
+        &self,
+        x_offset: &BroadcastablePrimitive<Float64Type>,
+        y_offset: &BroadcastablePrimitive<Float64Type>,
+    ) -> Self::Output {
         macro_rules! impl_method {
             ($method:ident) => {{
                 Arc::new(self.$method().translate(x_offset, y_offset))

--- a/src/algorithm/geo/vincenty_length.rs
+++ b/src/algorithm/geo/vincenty_length.rs
@@ -36,7 +36,7 @@ pub trait VincentyLength {
     ///     // Osaka
     ///     (135.5244559, 34.687455)
     /// ]);
-    /// let linestring_array: LineStringArray<i32, 2> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray<2> = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.vincenty_length().unwrap();
     ///
@@ -62,7 +62,7 @@ impl VincentyLength for PointArray<2> {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> VincentyLength for $type {
+        impl VincentyLength for $type {
             type Output = Result<Float64Array>;
 
             fn vincenty_length(&self) -> Self::Output {
@@ -72,12 +72,12 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(MultiPointArray<O, 2>);
+zero_impl!(MultiPointArray<2>);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> VincentyLength for $type {
+        impl VincentyLength for $type {
             type Output = Result<Float64Array>;
 
             fn vincenty_length(&self) -> Self::Output {
@@ -87,8 +87,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>);
 
 impl VincentyLength for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -100,21 +100,12 @@ impl VincentyLength for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().vincenty_length(),
             LineString(_, XY) => self.as_line_string::<2>().vincenty_length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().vincenty_length(),
             // Polygon(_, XY) => self.as_polygon::<2>().vincenty_length(),
-            // LargePolygon(_, XY) => self.as_large_polygon::<2>().vincenty_length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().vincenty_length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().vincenty_length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().vincenty_length(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().vincenty_length(),
             // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().vincenty_length(),
-            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().vincenty_length(),
             // Mixed(_, XY) => self.as_mixed::<2>().vincenty_length(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().vincenty_length(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().vincenty_length(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().vincenty_length()
-            // }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -131,7 +122,7 @@ impl VincentyLength for ChunkedGeometryArray<PointArray<2>> {
 /// Implementation that iterates over chunks
 macro_rules! chunked_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> VincentyLength for $type {
+        impl VincentyLength for $type {
             type Output = Result<ChunkedArray<Float64Array>>;
 
             fn vincenty_length(&self) -> Self::Output {
@@ -141,9 +132,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
 
 impl VincentyLength for &dyn ChunkedNativeArray {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -155,21 +146,12 @@ impl VincentyLength for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().vincenty_length(),
             LineString(_, XY) => self.as_line_string::<2>().vincenty_length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().vincenty_length(),
             // Polygon(_, XY) => self.as_polygon::<2>().vincenty_length(),
-            // LargePolygon(_, XY) => self.as_large_polygon::<2>().vincenty_length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().vincenty_length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().vincenty_length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().vincenty_length(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().vincenty_length(),
             // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().vincenty_length(),
-            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().vincenty_length(),
             // Mixed(_, XY) => self.as_mixed::<2>().vincenty_length(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().vincenty_length(),
             // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().vincenty_length(),
-            // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().vincenty_length()
-            // }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -190,7 +172,7 @@ mod tests {
             // London
             (x: -0.1278, y: 51.5074),
         ];
-        let input_array: LineStringArray<i64, 2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
         let result_array = input_array.vincenty_length().unwrap();
 
         // Meters

--- a/src/algorithm/geo/vincenty_length.rs
+++ b/src/algorithm/geo/vincenty_length.rs
@@ -6,7 +6,7 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geo::VincentyLength as _VincentyLength;
 
 /// Determine the length of a geometry using [Vincenty’s formulae].

--- a/src/algorithm/geo/within.rs
+++ b/src/algorithm/geo/within.rs
@@ -3,7 +3,7 @@ use crate::scalar::*;
 use crate::trait_::ArrayAccessor;
 use crate::trait_::NativeScalar;
 use arrow_array::builder::BooleanBuilder;
-use arrow_array::{BooleanArray, OffsetSizeTrait};
+use arrow_array::BooleanArray;
 use geo::Within as _Within;
 
 /// Tests if a geometry is completely within another geometry.

--- a/src/algorithm/geo/within.rs
+++ b/src/algorithm/geo/within.rs
@@ -55,10 +55,12 @@ impl Within for PointArray<2> {
 
         let mut output_array = BooleanBuilder::with_capacity(self.len());
 
-        self.iter_geo().zip(rhs.iter_geo()).for_each(|(first, second)| match (first, second) {
-            (Some(first), Some(second)) => output_array.append_value(first.is_within(&second)),
-            _ => output_array.append_null(),
-        });
+        self.iter_geo()
+            .zip(rhs.iter_geo())
+            .for_each(|(first, second)| match (first, second) {
+                (Some(first), Some(second)) => output_array.append_value(first.is_within(&second)),
+                _ => output_array.append_null(),
+            });
 
         output_array.finish()
     }
@@ -73,10 +75,14 @@ macro_rules! iter_geo_impl {
 
                 let mut output_array = BooleanBuilder::with_capacity(self.len());
 
-                self.iter_geo().zip(rhs.iter_geo()).for_each(|(first, second)| match (first, second) {
-                    (Some(first), Some(second)) => output_array.append_value(first.is_within(&second)),
-                    _ => output_array.append_null(),
-                });
+                self.iter_geo()
+                    .zip(rhs.iter_geo())
+                    .for_each(|(first, second)| match (first, second) {
+                        (Some(first), Some(second)) => {
+                            output_array.append_value(first.is_within(&second))
+                        }
+                        _ => output_array.append_null(),
+                    });
 
                 output_array.finish()
             }

--- a/src/algorithm/geo/within.rs
+++ b/src/algorithm/geo/within.rs
@@ -55,12 +55,10 @@ impl Within for PointArray<2> {
 
         let mut output_array = BooleanBuilder::with_capacity(self.len());
 
-        self.iter_geo()
-            .zip(rhs.iter_geo())
-            .for_each(|(first, second)| match (first, second) {
-                (Some(first), Some(second)) => output_array.append_value(first.is_within(&second)),
-                _ => output_array.append_null(),
-            });
+        self.iter_geo().zip(rhs.iter_geo()).for_each(|(first, second)| match (first, second) {
+            (Some(first), Some(second)) => output_array.append_value(first.is_within(&second)),
+            _ => output_array.append_null(),
+        });
 
         output_array.finish()
     }
@@ -69,20 +67,16 @@ impl Within for PointArray<2> {
 // Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($first:ty, $second:ty) => {
-        impl<'a, O: OffsetSizeTrait> Within<$second> for $first {
+        impl<'a> Within<$second> for $first {
             fn is_within(&self, rhs: &$second) -> BooleanArray {
                 assert_eq!(self.len(), rhs.len());
 
                 let mut output_array = BooleanBuilder::with_capacity(self.len());
 
-                self.iter_geo()
-                    .zip(rhs.iter_geo())
-                    .for_each(|(first, second)| match (first, second) {
-                        (Some(first), Some(second)) => {
-                            output_array.append_value(first.is_within(&second))
-                        }
-                        _ => output_array.append_null(),
-                    });
+                self.iter_geo().zip(rhs.iter_geo()).for_each(|(first, second)| match (first, second) {
+                    (Some(first), Some(second)) => output_array.append_value(first.is_within(&second)),
+                    _ => output_array.append_null(),
+                });
 
                 output_array.finish()
             }
@@ -91,51 +85,51 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray<2>, LineStringArray<O, 2>);
-iter_geo_impl!(PointArray<2>, PolygonArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiPointArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(PointArray<2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(PointArray<2>, LineStringArray<2>);
+iter_geo_impl!(PointArray<2>, PolygonArray<2>);
+iter_geo_impl!(PointArray<2>, MultiPointArray<2>);
+iter_geo_impl!(PointArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(PointArray<2>, MultiPolygonArray<2>);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<O, 2>, PointArray<2>);
-iter_geo_impl!(LineStringArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(LineStringArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(LineStringArray<2>, PointArray<2>);
+iter_geo_impl!(LineStringArray<2>, LineStringArray<2>);
+iter_geo_impl!(LineStringArray<2>, PolygonArray<2>);
+iter_geo_impl!(LineStringArray<2>, MultiPointArray<2>);
+iter_geo_impl!(LineStringArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(LineStringArray<2>, MultiPolygonArray<2>);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<O, 2>, PointArray<2>);
-iter_geo_impl!(PolygonArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(PolygonArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(PolygonArray<2>, PointArray<2>);
+iter_geo_impl!(PolygonArray<2>, LineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>, PolygonArray<2>);
+iter_geo_impl!(PolygonArray<2>, MultiPointArray<2>);
+iter_geo_impl!(PolygonArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(PolygonArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<O, 2>, PointArray<2>);
-iter_geo_impl!(MultiPointArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiPointArray<2>, PointArray<2>);
+iter_geo_impl!(MultiPointArray<2>, LineStringArray<2>);
+iter_geo_impl!(MultiPointArray<2>, PolygonArray<2>);
+iter_geo_impl!(MultiPointArray<2>, MultiPointArray<2>);
+iter_geo_impl!(MultiPointArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(MultiPointArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<O, 2>, PointArray<2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiLineStringArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiLineStringArray<2>, PointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, LineStringArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, PolygonArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, MultiPointArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(MultiLineStringArray<2>, MultiPolygonArray<2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<O, 2>, PointArray<2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, LineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, PolygonArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPointArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, MultiLineStringArray<O, 2>);
-iter_geo_impl!(MultiPolygonArray<O, 2>, MultiPolygonArray<O, 2>);
+iter_geo_impl!(MultiPolygonArray<2>, PointArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, LineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, PolygonArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, MultiPointArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, MultiLineStringArray<2>);
+iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonArray<2>);
 
 // ┌──────────────────────────────────────────┐
 // │ Implementations for RHS geoarrow scalars │
@@ -158,7 +152,7 @@ impl<'a> Within<Point<'a, 2>> for PointArray<2> {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl_geoarrow_scalar {
     ($first:ty, $second:ty) => {
-        impl<'a, O: OffsetSizeTrait> Within<$second> for $first {
+        impl<'a> Within<$second> for $first {
             fn is_within(&self, rhs: &$second) -> BooleanArray {
                 let mut output_array = BooleanBuilder::with_capacity(self.len());
                 let rhs_geo = rhs.to_geo();
@@ -175,51 +169,51 @@ macro_rules! iter_geo_impl_geoarrow_scalar {
 }
 
 // Implementations on PointArray
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, LineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, Polygon<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiPoint<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiLineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, LineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, Polygon<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, MultiPoint<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, MultiLineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, LineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, Polygon<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, MultiPoint<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, MultiLineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, LineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, Polygon<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, MultiPoint<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, MultiLineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, LineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, Polygon<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, MultiPoint<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, MultiLineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, MultiPolygon<'a, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, LineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, Polygon<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, MultiPoint<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, MultiLineString<'a, O, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<O, 2>, MultiPolygon<'a, O, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, MultiPolygon<'a, 2>);
 
 // ┌─────────────────────────────────────┐
 // │ Implementations for RHS geo scalars │
@@ -252,7 +246,7 @@ non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::MultiPolygon);
 
 macro_rules! iter_geo_impl_geo_scalar {
     ($first:ty, $second:ty) => {
-        impl<'a, O: OffsetSizeTrait> Within<$second> for $first {
+        impl<'a> Within<$second> for $first {
             fn is_within(&self, rhs: &$second) -> BooleanArray {
                 let mut output_array = BooleanBuilder::with_capacity(self.len());
 
@@ -268,41 +262,41 @@ macro_rules! iter_geo_impl_geo_scalar {
 }
 
 // Implementations on LineStringArray
-iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::Point);
-iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::LineString);
-iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(LineStringArray<O, 2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::Point);
+iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::LineString);
+iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::MultiPolygon);
 
 // Implementations on PolygonArray
-iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::Point);
-iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::LineString);
-iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(PolygonArray<O, 2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::Point);
+iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::LineString);
+iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::MultiPolygon);
 
 // Implementations on MultiPointArray
-iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiPointArray<O, 2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::Point);
+iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::MultiPolygon);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<O, 2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::Point);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::MultiPolygon);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<O, 2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::Point);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::MultiPolygon);

--- a/src/algorithm/geo_index/rtree.rs
+++ b/src/algorithm/geo_index/rtree.rs
@@ -1,4 +1,8 @@
-use crate::algorithm::native::bounding_rect::{bounding_rect_geometry, bounding_rect_geometry_collection, bounding_rect_linestring, bounding_rect_multilinestring, bounding_rect_multipoint, bounding_rect_multipolygon, bounding_rect_polygon, bounding_rect_rect};
+use crate::algorithm::native::bounding_rect::{
+    bounding_rect_geometry, bounding_rect_geometry_collection, bounding_rect_linestring,
+    bounding_rect_multilinestring, bounding_rect_multipoint, bounding_rect_multipolygon,
+    bounding_rect_polygon, bounding_rect_rect,
+};
 use crate::array::*;
 use crate::chunked_array::*;
 use crate::datatypes::{Dimension, NativeType};
@@ -77,7 +81,10 @@ impl_rtree!(MultiPointArray<2>, bounding_rect_multipoint);
 impl_rtree!(MultiLineStringArray<2>, bounding_rect_multilinestring);
 impl_rtree!(MultiPolygonArray<2>, bounding_rect_multipolygon);
 impl_rtree!(MixedGeometryArray<2>, bounding_rect_geometry);
-impl_rtree!(GeometryCollectionArray<2>, bounding_rect_geometry_collection);
+impl_rtree!(
+    GeometryCollectionArray<2>,
+    bounding_rect_geometry_collection
+);
 
 impl RTree for &dyn NativeArray {
     type Output = OwnedRTree<f64>;
@@ -88,13 +95,25 @@ impl RTree for &dyn NativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().create_rtree_with_node_size(node_size),
-            LineString(_, XY) => self.as_line_string::<2>().create_rtree_with_node_size(node_size),
-            Polygon(_, XY) => self.as_polygon::<2>().create_rtree_with_node_size(node_size),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().create_rtree_with_node_size(node_size),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().create_rtree_with_node_size(node_size),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().create_rtree_with_node_size(node_size),
+            LineString(_, XY) => self
+                .as_line_string::<2>()
+                .create_rtree_with_node_size(node_size),
+            Polygon(_, XY) => self
+                .as_polygon::<2>()
+                .create_rtree_with_node_size(node_size),
+            MultiPoint(_, XY) => self
+                .as_multi_point::<2>()
+                .create_rtree_with_node_size(node_size),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .create_rtree_with_node_size(node_size),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .create_rtree_with_node_size(node_size),
             Mixed(_, XY) => self.as_mixed::<2>().create_rtree_with_node_size(node_size),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().create_rtree_with_node_size(node_size),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .create_rtree_with_node_size(node_size),
             Rect(XY) => self.as_rect::<2>().create_rtree_with_node_size(node_size),
             _ => todo!(),
         }
@@ -118,13 +137,25 @@ impl RTree for &dyn ChunkedNativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().create_rtree_with_node_size(node_size),
-            LineString(_, XY) => self.as_line_string::<2>().create_rtree_with_node_size(node_size),
-            Polygon(_, XY) => self.as_polygon::<2>().create_rtree_with_node_size(node_size),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().create_rtree_with_node_size(node_size),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().create_rtree_with_node_size(node_size),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().create_rtree_with_node_size(node_size),
+            LineString(_, XY) => self
+                .as_line_string::<2>()
+                .create_rtree_with_node_size(node_size),
+            Polygon(_, XY) => self
+                .as_polygon::<2>()
+                .create_rtree_with_node_size(node_size),
+            MultiPoint(_, XY) => self
+                .as_multi_point::<2>()
+                .create_rtree_with_node_size(node_size),
+            MultiLineString(_, XY) => self
+                .as_multi_line_string::<2>()
+                .create_rtree_with_node_size(node_size),
+            MultiPolygon(_, XY) => self
+                .as_multi_polygon::<2>()
+                .create_rtree_with_node_size(node_size),
             Mixed(_, XY) => self.as_mixed::<2>().create_rtree_with_node_size(node_size),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().create_rtree_with_node_size(node_size),
+            GeometryCollection(_, XY) => self
+                .as_geometry_collection::<2>()
+                .create_rtree_with_node_size(node_size),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
 

--- a/src/algorithm/geo_index/rtree.rs
+++ b/src/algorithm/geo_index/rtree.rs
@@ -6,7 +6,6 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::PointTrait;
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::OffsetSizeTrait;
 use geo_index::rtree::sort::HilbertSort;
 use geo_index::rtree::{OwnedRTree, RTreeBuilder};
 

--- a/src/algorithm/geo_index/rtree.rs
+++ b/src/algorithm/geo_index/rtree.rs
@@ -1,8 +1,4 @@
-use crate::algorithm::native::bounding_rect::{
-    bounding_rect_geometry, bounding_rect_geometry_collection, bounding_rect_linestring,
-    bounding_rect_multilinestring, bounding_rect_multipoint, bounding_rect_multipolygon,
-    bounding_rect_polygon, bounding_rect_rect,
-};
+use crate::algorithm::native::bounding_rect::{bounding_rect_geometry, bounding_rect_geometry_collection, bounding_rect_linestring, bounding_rect_multilinestring, bounding_rect_multipoint, bounding_rect_multipolygon, bounding_rect_polygon, bounding_rect_rect};
 use crate::array::*;
 use crate::chunked_array::*;
 use crate::datatypes::{Dimension, NativeType};
@@ -58,7 +54,7 @@ impl RTree for RectArray<2> {
 
 macro_rules! impl_rtree {
     ($struct_name:ty, $bounding_rect_fn:ident) => {
-        impl<O: OffsetSizeTrait> RTree for $struct_name {
+        impl RTree for $struct_name {
             type Output = OwnedRTree<f64>;
 
             fn create_rtree_with_node_size(&self, node_size: usize) -> Self::Output {
@@ -76,16 +72,13 @@ macro_rules! impl_rtree {
     };
 }
 
-impl_rtree!(LineStringArray<O, 2>, bounding_rect_linestring);
-impl_rtree!(PolygonArray<O, 2>, bounding_rect_polygon);
-impl_rtree!(MultiPointArray<O, 2>, bounding_rect_multipoint);
-impl_rtree!(MultiLineStringArray<O, 2>, bounding_rect_multilinestring);
-impl_rtree!(MultiPolygonArray<O, 2>, bounding_rect_multipolygon);
-impl_rtree!(MixedGeometryArray<O, 2>, bounding_rect_geometry);
-impl_rtree!(
-    GeometryCollectionArray<O, 2>,
-    bounding_rect_geometry_collection
-);
+impl_rtree!(LineStringArray<2>, bounding_rect_linestring);
+impl_rtree!(PolygonArray<2>, bounding_rect_polygon);
+impl_rtree!(MultiPointArray<2>, bounding_rect_multipoint);
+impl_rtree!(MultiLineStringArray<2>, bounding_rect_multilinestring);
+impl_rtree!(MultiPolygonArray<2>, bounding_rect_multipolygon);
+impl_rtree!(MixedGeometryArray<2>, bounding_rect_geometry);
+impl_rtree!(GeometryCollectionArray<2>, bounding_rect_geometry_collection);
 
 impl RTree for &dyn NativeArray {
     type Output = OwnedRTree<f64>;
@@ -96,46 +89,13 @@ impl RTree for &dyn NativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().create_rtree_with_node_size(node_size),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .create_rtree_with_node_size(node_size),
-            Polygon(_, XY) => self
-                .as_polygon::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .create_rtree_with_node_size(node_size),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
-                .create_rtree_with_node_size(node_size),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .create_rtree_with_node_size(node_size),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .create_rtree_with_node_size(node_size),
+            LineString(_, XY) => self.as_line_string::<2>().create_rtree_with_node_size(node_size),
+            Polygon(_, XY) => self.as_polygon::<2>().create_rtree_with_node_size(node_size),
+            MultiPoint(_, XY) => self.as_multi_point::<2>().create_rtree_with_node_size(node_size),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().create_rtree_with_node_size(node_size),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().create_rtree_with_node_size(node_size),
             Mixed(_, XY) => self.as_mixed::<2>().create_rtree_with_node_size(node_size),
-            LargeMixed(_, XY) => self
-                .as_large_mixed::<2>()
-                .create_rtree_with_node_size(node_size),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .create_rtree_with_node_size(node_size),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().create_rtree_with_node_size(node_size),
             Rect(XY) => self.as_rect::<2>().create_rtree_with_node_size(node_size),
             _ => todo!(),
         }
@@ -159,46 +119,13 @@ impl RTree for &dyn ChunkedNativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point::<2>().create_rtree_with_node_size(node_size),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeLineString(_, XY) => self
-                .as_large_line_string::<2>()
-                .create_rtree_with_node_size(node_size),
-            Polygon(_, XY) => self
-                .as_polygon::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargePolygon(_, XY) => self
-                .as_large_polygon::<2>()
-                .create_rtree_with_node_size(node_size),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeMultiPoint(_, XY) => self
-                .as_large_multi_point::<2>()
-                .create_rtree_with_node_size(node_size),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeMultiLineString(_, XY) => self
-                .as_large_multi_line_string::<2>()
-                .create_rtree_with_node_size(node_size),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeMultiPolygon(_, XY) => self
-                .as_large_multi_polygon::<2>()
-                .create_rtree_with_node_size(node_size),
+            LineString(_, XY) => self.as_line_string::<2>().create_rtree_with_node_size(node_size),
+            Polygon(_, XY) => self.as_polygon::<2>().create_rtree_with_node_size(node_size),
+            MultiPoint(_, XY) => self.as_multi_point::<2>().create_rtree_with_node_size(node_size),
+            MultiLineString(_, XY) => self.as_multi_line_string::<2>().create_rtree_with_node_size(node_size),
+            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().create_rtree_with_node_size(node_size),
             Mixed(_, XY) => self.as_mixed::<2>().create_rtree_with_node_size(node_size),
-            LargeMixed(_, XY) => self
-                .as_large_mixed::<2>()
-                .create_rtree_with_node_size(node_size),
-            GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
-                .create_rtree_with_node_size(node_size),
-            LargeGeometryCollection(_, XY) => self
-                .as_large_geometry_collection::<2>()
-                .create_rtree_with_node_size(node_size),
+            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().create_rtree_with_node_size(node_size),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
 

--- a/src/algorithm/geos/area.rs
+++ b/src/algorithm/geos/area.rs
@@ -6,7 +6,7 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geos::Geom;
 
 /// Unsigned planar area of a geometry.

--- a/src/algorithm/geos/area.rs
+++ b/src/algorithm/geos/area.rs
@@ -28,7 +28,7 @@ impl Area for PointArray<2> {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Area for $type {
+        impl Area for $type {
             type Output = Result<Float64Array>;
 
             fn area(&self) -> Self::Output {
@@ -38,13 +38,13 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(LineStringArray<O, 2>);
-zero_impl!(MultiPointArray<O, 2>);
-zero_impl!(MultiLineStringArray<O, 2>);
+zero_impl!(LineStringArray<2>);
+zero_impl!(MultiPointArray<2>);
+zero_impl!(MultiLineStringArray<2>);
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Area for $type {
+        impl Area for $type {
             type Output = Result<Float64Array>;
 
             fn area(&self) -> Self::Output {
@@ -54,11 +54,10 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(PolygonArray<O, 2>);
-iter_geos_impl!(MultiPolygonArray<O, 2>);
-iter_geos_impl!(MixedGeometryArray<O, 2>);
-iter_geos_impl!(GeometryCollectionArray<O, 2>);
-iter_geos_impl!(WKBArray<O>);
+iter_geos_impl!(PolygonArray<2>);
+iter_geos_impl!(MultiPolygonArray<2>);
+iter_geos_impl!(MixedGeometryArray<2>);
+iter_geos_impl!(GeometryCollectionArray<2>);
 
 impl Area for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -70,19 +69,12 @@ impl Area for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().area(),
             LineString(_, XY) => self.as_line_string::<2>().area(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().area(),
             Polygon(_, XY) => self.as_polygon::<2>().area(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().area(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().area(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().area(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().area(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().area(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().area(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().area(),
             Mixed(_, XY) => self.as_mixed::<2>().area(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().area(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().area(),
-            LargeGeometryCollection(_, XY) => self.as_large_geometry_collection::<2>().area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geos/buffer.rs
+++ b/src/algorithm/geos/buffer.rs
@@ -2,7 +2,6 @@ use crate::array::{PointArray, PolygonArray, PolygonBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSPolygon;
 use crate::trait_::{ArrayAccessor, NativeScalar};
-use arrow_array::OffsetSizeTrait;
 use geos::{BufferParams, Geom};
 
 pub trait Buffer {

--- a/src/algorithm/geos/buffer.rs
+++ b/src/algorithm/geos/buffer.rs
@@ -5,7 +5,7 @@ use crate::trait_::{ArrayAccessor, NativeScalar};
 use arrow_array::OffsetSizeTrait;
 use geos::{BufferParams, Geom};
 
-pub trait Buffer<O: OffsetSizeTrait> {
+pub trait Buffer {
     type Output;
 
     fn buffer(&self, width: f64, quadsegs: i32) -> Self::Output;
@@ -13,8 +13,8 @@ pub trait Buffer<O: OffsetSizeTrait> {
     fn buffer_with_params(&self, width: f64, buffer_params: &BufferParams) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> Buffer<O> for PointArray<2> {
-    type Output = Result<PolygonArray<O, 2>>;
+impl Buffer for PointArray<2> {
+    type Output = Result<PolygonArray<2>>;
 
     fn buffer(&self, width: f64, quadsegs: i32) -> Self::Output {
         let mut builder = PolygonBuilder::new();
@@ -59,7 +59,7 @@ impl<O: OffsetSizeTrait> Buffer<O> for PointArray<2> {
 // /// Implementation where the result is zero.
 // macro_rules! zero_impl {
 //     ($type:ty) => {
-//         impl<O: OffsetSizeTrait> Area for $type {
+//         impl Area for $type {
 //             fn area(&self) -> Result<PrimitiveArray<f64>> {
 //                 Ok(zeroes(self.len(), self.nulls()))
 //             }
@@ -67,9 +67,9 @@ impl<O: OffsetSizeTrait> Buffer<O> for PointArray<2> {
 //     };
 // }
 
-// zero_impl!(LineStringArray<O, 2>);
-// zero_impl!(MultiPointArray<O, 2>);
-// zero_impl!(MultiLineStringArray<O, 2>);
+// zero_impl!(LineStringArray<2>);
+// zero_impl!(MultiPointArray<2>);
+// zero_impl!(MultiLineStringArray<2>);
 
 // macro_rules! iter_geos_impl {
 //     ($type:ty) => {
@@ -80,11 +80,11 @@ impl<O: OffsetSizeTrait> Buffer<O> for PointArray<2> {
 //     };
 // }
 
-// iter_geos_impl!(PolygonArray<O, 2>);
-// iter_geos_impl!(MultiPolygonArray<O, 2>);
+// iter_geos_impl!(PolygonArray<2>);
+// iter_geos_impl!(MultiPolygonArray<2>);
 // iter_geos_impl!(WKBArray<O>);
 
-// impl<O: OffsetSizeTrait> Area for GeometryArray<O, 2> {
+// impl<O: OffsetSizeTrait> Area for GeometryArray<2> {
 //     crate::geometry_array_delegate_impl! {
 //         fn area(&self) -> Result<PrimitiveArray<f64>>;
 //     }
@@ -98,7 +98,7 @@ mod test {
     #[test]
     fn point_buffer() {
         let arr = point_array();
-        let buffered: PolygonArray<i32, 2> = arr.buffer(1., 8).unwrap();
+        let buffered: PolygonArray<2> = arr.buffer(1., 8).unwrap();
         dbg!(buffered);
     }
 }

--- a/src/algorithm/geos/is_ring.rs
+++ b/src/algorithm/geos/is_ring.rs
@@ -37,7 +37,7 @@ impl IsRing for PointArray<2> {
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> IsRing for $type {
+        impl IsRing for $type {
             type Output = Result<BooleanArray>;
 
             fn is_ring(&self) -> Self::Output {
@@ -57,13 +57,13 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(LineStringArray<O, 2>);
-iter_geos_impl!(MultiPointArray<O, 2>);
-iter_geos_impl!(MultiLineStringArray<O, 2>);
-iter_geos_impl!(PolygonArray<O, 2>);
-iter_geos_impl!(MultiPolygonArray<O, 2>);
-iter_geos_impl!(MixedGeometryArray<O, 2>);
-iter_geos_impl!(GeometryCollectionArray<O, 2>);
+iter_geos_impl!(LineStringArray<2>);
+iter_geos_impl!(MultiPointArray<2>);
+iter_geos_impl!(MultiLineStringArray<2>);
+iter_geos_impl!(PolygonArray<2>);
+iter_geos_impl!(MultiPolygonArray<2>);
+iter_geos_impl!(MixedGeometryArray<2>);
+iter_geos_impl!(GeometryCollectionArray<2>);
 
 impl IsRing for &dyn NativeArray {
     type Output = Result<BooleanArray>;
@@ -75,19 +75,12 @@ impl IsRing for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().is_ring(),
             LineString(_, XY) => self.as_line_string::<2>().is_ring(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().is_ring(),
             Polygon(_, XY) => self.as_polygon::<2>().is_ring(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().is_ring(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().is_ring(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().is_ring(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().is_ring(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().is_ring(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().is_ring(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().is_ring(),
             Mixed(_, XY) => self.as_mixed::<2>().is_ring(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().is_ring(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().is_ring(),
-            LargeGeometryCollection(_, XY) => self.as_large_geometry_collection::<2>().is_ring(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geos/is_ring.rs
+++ b/src/algorithm/geos/is_ring.rs
@@ -6,7 +6,7 @@ use crate::trait_::ArrayAccessor;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
 use arrow_array::builder::BooleanBuilder;
-use arrow_array::{BooleanArray, OffsetSizeTrait};
+use arrow_array::BooleanArray;
 use geos::Geom;
 
 /// Returns `true` if the geometry is a ring.

--- a/src/algorithm/geos/is_valid.rs
+++ b/src/algorithm/geos/is_valid.rs
@@ -37,7 +37,7 @@ impl IsValid for PointArray<2> {
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> IsValid for $type {
+        impl IsValid for $type {
             type Output = Result<BooleanArray>;
 
             fn is_valid(&self) -> Self::Output {
@@ -57,13 +57,13 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(LineStringArray<O, 2>);
-iter_geos_impl!(MultiPointArray<O, 2>);
-iter_geos_impl!(MultiLineStringArray<O, 2>);
-iter_geos_impl!(PolygonArray<O, 2>);
-iter_geos_impl!(MultiPolygonArray<O, 2>);
-iter_geos_impl!(MixedGeometryArray<O, 2>);
-iter_geos_impl!(GeometryCollectionArray<O, 2>);
+iter_geos_impl!(LineStringArray<2>);
+iter_geos_impl!(MultiPointArray<2>);
+iter_geos_impl!(MultiLineStringArray<2>);
+iter_geos_impl!(PolygonArray<2>);
+iter_geos_impl!(MultiPolygonArray<2>);
+iter_geos_impl!(MixedGeometryArray<2>);
+iter_geos_impl!(GeometryCollectionArray<2>);
 
 impl IsValid for &dyn NativeArray {
     type Output = Result<BooleanArray>;
@@ -75,23 +75,12 @@ impl IsValid for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => IsValid::is_valid(self.as_point::<2>()),
             LineString(_, XY) => IsValid::is_valid(self.as_line_string::<2>()),
-            LargeLineString(_, XY) => IsValid::is_valid(self.as_large_line_string::<2>()),
             Polygon(_, XY) => IsValid::is_valid(self.as_polygon::<2>()),
-            LargePolygon(_, XY) => IsValid::is_valid(self.as_large_polygon::<2>()),
             MultiPoint(_, XY) => IsValid::is_valid(self.as_multi_point::<2>()),
-            LargeMultiPoint(_, XY) => IsValid::is_valid(self.as_large_multi_point::<2>()),
             MultiLineString(_, XY) => IsValid::is_valid(self.as_multi_line_string::<2>()),
-            LargeMultiLineString(_, XY) => {
-                IsValid::is_valid(self.as_large_multi_line_string::<2>())
-            }
             MultiPolygon(_, XY) => IsValid::is_valid(self.as_multi_polygon::<2>()),
-            LargeMultiPolygon(_, XY) => IsValid::is_valid(self.as_large_multi_polygon::<2>()),
             Mixed(_, XY) => IsValid::is_valid(self.as_mixed::<2>()),
-            LargeMixed(_, XY) => IsValid::is_valid(self.as_large_mixed::<2>()),
             GeometryCollection(_, XY) => IsValid::is_valid(self.as_geometry_collection::<2>()),
-            LargeGeometryCollection(_, XY) => {
-                IsValid::is_valid(self.as_large_geometry_collection::<2>())
-            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/geos/is_valid.rs
+++ b/src/algorithm/geos/is_valid.rs
@@ -6,7 +6,7 @@ use crate::trait_::ArrayAccessor;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
 use arrow_array::builder::BooleanBuilder;
-use arrow_array::{BooleanArray, OffsetSizeTrait};
+use arrow_array::BooleanArray;
 use geos::Geom;
 
 /// Checks if the geometry is valid

--- a/src/algorithm/geos/length.rs
+++ b/src/algorithm/geos/length.rs
@@ -6,7 +6,7 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
-use arrow_array::{Float64Array, OffsetSizeTrait};
+use arrow_array::Float64Array;
 use geos::Geom;
 
 /// Returns the length of self. The unit depends of the SRID.

--- a/src/algorithm/geos/length.rs
+++ b/src/algorithm/geos/length.rs
@@ -27,7 +27,7 @@ impl Length for PointArray<2> {
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Length for $type {
+        impl Length for $type {
             type Output = Result<Float64Array>;
 
             fn length(&self) -> Self::Output {
@@ -37,14 +37,13 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(LineStringArray<O, 2>);
-iter_geos_impl!(MultiPointArray<O, 2>);
-iter_geos_impl!(MultiLineStringArray<O, 2>);
-iter_geos_impl!(PolygonArray<O, 2>);
-iter_geos_impl!(MultiPolygonArray<O, 2>);
-iter_geos_impl!(MixedGeometryArray<O, 2>);
-iter_geos_impl!(GeometryCollectionArray<O, 2>);
-iter_geos_impl!(WKBArray<O>);
+iter_geos_impl!(LineStringArray<2>);
+iter_geos_impl!(MultiPointArray<2>);
+iter_geos_impl!(MultiLineStringArray<2>);
+iter_geos_impl!(PolygonArray<2>);
+iter_geos_impl!(MultiPolygonArray<2>);
+iter_geos_impl!(MixedGeometryArray<2>);
+iter_geos_impl!(GeometryCollectionArray<2>);
 
 impl Length for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -56,19 +55,12 @@ impl Length for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().length(),
             LineString(_, XY) => self.as_line_string::<2>().length(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().length(),
             Polygon(_, XY) => self.as_polygon::<2>().length(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().length(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().length(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().length(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().length(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().length(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().length(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().length(),
             Mixed(_, XY) => self.as_mixed::<2>().length(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().length(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().length(),
-            LargeGeometryCollection(_, XY) => self.as_large_geometry_collection::<2>().length(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/native/binary.rs
+++ b/src/algorithm/native/binary.rs
@@ -15,7 +15,9 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
         F: Fn(Self::Item, Rhs::Item) -> bool,
     {
         if self.len() != rhs.len() {
-            return Err(GeoArrowError::General("Cannot perform binary operation on arrays of different length".to_string()));
+            return Err(GeoArrowError::General(
+                "Cannot perform binary operation on arrays of different length".to_string(),
+            ));
         }
 
         if self.is_empty() {
@@ -24,7 +26,9 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
 
         let nulls = NullBuffer::union(self.nulls(), rhs.nulls());
         let mut builder = BooleanBufferBuilder::new(self.len());
-        self.iter_values().zip(rhs.iter_values()).for_each(|(left, right)| builder.append(op(left, right)));
+        self.iter_values()
+            .zip(rhs.iter_values())
+            .for_each(|(left, right)| builder.append(op(left, right)));
         Ok(BooleanArray::new(builder.finish(), nulls))
     }
 
@@ -33,7 +37,9 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
         F: Fn(Self::Item, Rhs::Item) -> Result<bool>,
     {
         if self.len() != rhs.len() {
-            return Err(GeoArrowError::General("Cannot perform binary operation on arrays of different length".to_string()));
+            return Err(GeoArrowError::General(
+                "Cannot perform binary operation on arrays of different length".to_string(),
+            ));
         }
 
         if self.is_empty() {
@@ -44,7 +50,8 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
         if self.null_count() == 0 && rhs.null_count() == 0 {
             let mut builder = BooleanBufferBuilder::new(len);
             for idx in 0..len {
-                let (left, right) = unsafe { (self.value_unchecked(idx), rhs.value_unchecked(idx)) };
+                let (left, right) =
+                    unsafe { (self.value_unchecked(idx), rhs.value_unchecked(idx)) };
                 builder.append(op(left, right)?);
             }
             Ok(BooleanArray::new(builder.finish(), None))
@@ -55,7 +62,8 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
             buffer.append_n(len, false);
 
             nulls.try_for_each_valid_idx(|idx| {
-                let (left, right) = unsafe { (self.value_unchecked(idx), rhs.value_unchecked(idx)) };
+                let (left, right) =
+                    unsafe { (self.value_unchecked(idx), rhs.value_unchecked(idx)) };
                 buffer.set_bit(idx, op(left, right)?);
                 Ok::<_, GeoArrowError>(())
             })?;
@@ -70,7 +78,9 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
         F: Fn(Self::Item, Rhs::Item) -> Result<O::Native>,
     {
         if self.len() != rhs.len() {
-            return Err(GeoArrowError::General("Cannot perform binary operation on arrays of different length".to_string()));
+            return Err(GeoArrowError::General(
+                "Cannot perform binary operation on arrays of different length".to_string(),
+            ));
         }
 
         if self.is_empty() {
@@ -95,7 +105,10 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
             let slice = buffer.as_slice_mut();
 
             nulls.try_for_each_valid_idx(|idx| {
-                unsafe { *slice.get_unchecked_mut(idx) = op(self.value_unchecked(idx), rhs.value_unchecked(idx))? };
+                unsafe {
+                    *slice.get_unchecked_mut(idx) =
+                        op(self.value_unchecked(idx), rhs.value_unchecked(idx))?
+                };
                 Ok::<_, GeoArrowError>(())
             })?;
 

--- a/src/algorithm/native/binary.rs
+++ b/src/algorithm/native/binary.rs
@@ -15,9 +15,7 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
         F: Fn(Self::Item, Rhs::Item) -> bool,
     {
         if self.len() != rhs.len() {
-            return Err(GeoArrowError::General(
-                "Cannot perform binary operation on arrays of different length".to_string(),
-            ));
+            return Err(GeoArrowError::General("Cannot perform binary operation on arrays of different length".to_string()));
         }
 
         if self.is_empty() {
@@ -26,9 +24,7 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
 
         let nulls = NullBuffer::union(self.nulls(), rhs.nulls());
         let mut builder = BooleanBufferBuilder::new(self.len());
-        self.iter_values()
-            .zip(rhs.iter_values())
-            .for_each(|(left, right)| builder.append(op(left, right)));
+        self.iter_values().zip(rhs.iter_values()).for_each(|(left, right)| builder.append(op(left, right)));
         Ok(BooleanArray::new(builder.finish(), nulls))
     }
 
@@ -37,9 +33,7 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
         F: Fn(Self::Item, Rhs::Item) -> Result<bool>,
     {
         if self.len() != rhs.len() {
-            return Err(GeoArrowError::General(
-                "Cannot perform binary operation on arrays of different length".to_string(),
-            ));
+            return Err(GeoArrowError::General("Cannot perform binary operation on arrays of different length".to_string()));
         }
 
         if self.is_empty() {
@@ -50,8 +44,7 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
         if self.null_count() == 0 && rhs.null_count() == 0 {
             let mut builder = BooleanBufferBuilder::new(len);
             for idx in 0..len {
-                let (left, right) =
-                    unsafe { (self.value_unchecked(idx), rhs.value_unchecked(idx)) };
+                let (left, right) = unsafe { (self.value_unchecked(idx), rhs.value_unchecked(idx)) };
                 builder.append(op(left, right)?);
             }
             Ok(BooleanArray::new(builder.finish(), None))
@@ -62,8 +55,7 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
             buffer.append_n(len, false);
 
             nulls.try_for_each_valid_idx(|idx| {
-                let (left, right) =
-                    unsafe { (self.value_unchecked(idx), rhs.value_unchecked(idx)) };
+                let (left, right) = unsafe { (self.value_unchecked(idx), rhs.value_unchecked(idx)) };
                 buffer.set_bit(idx, op(left, right)?);
                 Ok::<_, GeoArrowError>(())
             })?;
@@ -78,9 +70,7 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
         F: Fn(Self::Item, Rhs::Item) -> Result<O::Native>,
     {
         if self.len() != rhs.len() {
-            return Err(GeoArrowError::General(
-                "Cannot perform binary operation on arrays of different length".to_string(),
-            ));
+            return Err(GeoArrowError::General("Cannot perform binary operation on arrays of different length".to_string()));
         }
 
         if self.is_empty() {
@@ -105,10 +95,7 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
             let slice = buffer.as_slice_mut();
 
             nulls.try_for_each_valid_idx(|idx| {
-                unsafe {
-                    *slice.get_unchecked_mut(idx) =
-                        op(self.value_unchecked(idx), rhs.value_unchecked(idx))?
-                };
+                unsafe { *slice.get_unchecked_mut(idx) = op(self.value_unchecked(idx), rhs.value_unchecked(idx))? };
                 Ok::<_, GeoArrowError>(())
             })?;
 
@@ -121,234 +108,87 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
 // Implementations on PointArray<2>
 impl<'a> Binary<'a, PointArray<2>> for PointArray<2> {}
 impl<'a> Binary<'a, PointArray<2>> for RectArray<2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for LineStringArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for PolygonArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for MultiPointArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for MultiLineStringArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for MultiPolygonArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for MixedGeometryArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PointArray<2>> for GeometryCollectionArray<O, 2> {}
+impl<'a> Binary<'a, PointArray<2>> for LineStringArray<2> {}
+impl<'a> Binary<'a, PointArray<2>> for PolygonArray<2> {}
+impl<'a> Binary<'a, PointArray<2>> for MultiPointArray<2> {}
+impl<'a> Binary<'a, PointArray<2>> for MultiLineStringArray<2> {}
+impl<'a> Binary<'a, PointArray<2>> for MultiPolygonArray<2> {}
+impl<'a> Binary<'a, PointArray<2>> for MixedGeometryArray<2> {}
+impl<'a> Binary<'a, PointArray<2>> for GeometryCollectionArray<2> {}
 
 // Implementations on LineStringArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, LineStringArray<O, 2>> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, LineStringArray<O, 2>> for RectArray<2> {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
-    for LineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
-    for PolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
-    for MultiPointArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
-    for MultiLineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
-    for MultiPolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
-    for MixedGeometryArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, LineStringArray<O1, 2>>
-    for GeometryCollectionArray<O2, 2>
-{
-}
+impl<'a> Binary<'a, LineStringArray<2>> for PointArray<2> {}
+impl<'a> Binary<'a, LineStringArray<2>> for RectArray<2> {}
+impl<'a> Binary<'a, LineStringArray<2>> for LineStringArray<2> {}
+impl<'a> Binary<'a, LineStringArray<2>> for PolygonArray<2> {}
+impl<'a> Binary<'a, LineStringArray<2>> for MultiPointArray<2> {}
+impl<'a> Binary<'a, LineStringArray<2>> for MultiLineStringArray<2> {}
+impl<'a> Binary<'a, LineStringArray<2>> for MultiPolygonArray<2> {}
+impl<'a> Binary<'a, LineStringArray<2>> for MixedGeometryArray<2> {}
+impl<'a> Binary<'a, LineStringArray<2>> for GeometryCollectionArray<2> {}
 
 // Implementations on PolygonArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, PolygonArray<O, 2>> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, PolygonArray<O, 2>> for RectArray<2> {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
-    for LineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
-    for PolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
-    for MultiPointArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
-    for MultiLineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
-    for MultiPolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
-    for MixedGeometryArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, PolygonArray<O1, 2>>
-    for GeometryCollectionArray<O2, 2>
-{
-}
+impl<'a> Binary<'a, PolygonArray<2>> for PointArray<2> {}
+impl<'a> Binary<'a, PolygonArray<2>> for RectArray<2> {}
+impl<'a> Binary<'a, PolygonArray<2>> for LineStringArray<2> {}
+impl<'a> Binary<'a, PolygonArray<2>> for PolygonArray<2> {}
+impl<'a> Binary<'a, PolygonArray<2>> for MultiPointArray<2> {}
+impl<'a> Binary<'a, PolygonArray<2>> for MultiLineStringArray<2> {}
+impl<'a> Binary<'a, PolygonArray<2>> for MultiPolygonArray<2> {}
+impl<'a> Binary<'a, PolygonArray<2>> for MixedGeometryArray<2> {}
+impl<'a> Binary<'a, PolygonArray<2>> for GeometryCollectionArray<2> {}
 
 // Implementations on MultiPointArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPointArray<O, 2>> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPointArray<O, 2>> for RectArray<2> {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
-    for LineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
-    for PolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
-    for MultiPointArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
-    for MultiLineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
-    for MultiPolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
-    for MixedGeometryArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPointArray<O1, 2>>
-    for GeometryCollectionArray<O2, 2>
-{
-}
+impl<'a> Binary<'a, MultiPointArray<2>> for PointArray<2> {}
+impl<'a> Binary<'a, MultiPointArray<2>> for RectArray<2> {}
+impl<'a> Binary<'a, MultiPointArray<2>> for LineStringArray<2> {}
+impl<'a> Binary<'a, MultiPointArray<2>> for PolygonArray<2> {}
+impl<'a> Binary<'a, MultiPointArray<2>> for MultiPointArray<2> {}
+impl<'a> Binary<'a, MultiPointArray<2>> for MultiLineStringArray<2> {}
+impl<'a> Binary<'a, MultiPointArray<2>> for MultiPolygonArray<2> {}
+impl<'a> Binary<'a, MultiPointArray<2>> for MixedGeometryArray<2> {}
+impl<'a> Binary<'a, MultiPointArray<2>> for GeometryCollectionArray<2> {}
 
 // Implementations on MultiLineStringArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O, 2>> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O, 2>> for RectArray<2> {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
-    for LineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
-    for PolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
-    for MultiPointArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
-    for MultiLineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
-    for MultiPolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
-    for MixedGeometryArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiLineStringArray<O1, 2>>
-    for GeometryCollectionArray<O2, 2>
-{
-}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for PointArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for RectArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for LineStringArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for PolygonArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for MultiPointArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for MultiLineStringArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for MultiPolygonArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for MixedGeometryArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray<2>> for GeometryCollectionArray<2> {}
 
 // Implementations on MultiPolygonArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O, 2>> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O, 2>> for RectArray<2> {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
-    for LineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
-    for PolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
-    for MultiPointArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
-    for MultiLineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
-    for MultiPolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
-    for MixedGeometryArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MultiPolygonArray<O1, 2>>
-    for GeometryCollectionArray<O2, 2>
-{
-}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for PointArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for RectArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for LineStringArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for PolygonArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for MultiPointArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for MultiLineStringArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for MultiPolygonArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for MixedGeometryArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray<2>> for GeometryCollectionArray<2> {}
 
 // Implementations on MixedGeometryArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O, 2>> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O, 2>> for RectArray<2> {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
-    for LineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
-    for PolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
-    for MultiPointArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
-    for MultiLineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
-    for MultiPolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
-    for MixedGeometryArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, MixedGeometryArray<O1, 2>>
-    for GeometryCollectionArray<O2, 2>
-{
-}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for PointArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for RectArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for LineStringArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for PolygonArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for MultiPointArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for MultiLineStringArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for MultiPolygonArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for MixedGeometryArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray<2>> for GeometryCollectionArray<2> {}
 
 // Implementations on GeometryCollectionArray
-impl<'a, O: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O, 2>> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O, 2>> for RectArray<2> {}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
-    for LineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
-    for PolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
-    for MultiPointArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
-    for MultiLineStringArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
-    for MultiPolygonArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
-    for MixedGeometryArray<O2, 2>
-{
-}
-impl<'a, O1: OffsetSizeTrait, O2: OffsetSizeTrait> Binary<'a, GeometryCollectionArray<O1, 2>>
-    for GeometryCollectionArray<O2, 2>
-{
-}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for PointArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for RectArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for LineStringArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for PolygonArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for MultiPointArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for MultiLineStringArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for MultiPolygonArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for MixedGeometryArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray<2>> for GeometryCollectionArray<2> {}

--- a/src/algorithm/native/binary.rs
+++ b/src/algorithm/native/binary.rs
@@ -1,6 +1,6 @@
 use arrow::datatypes::ArrowPrimitiveType;
 use arrow_array::builder::BooleanBuilder;
-use arrow_array::{BooleanArray, OffsetSizeTrait, PrimitiveArray};
+use arrow_array::{BooleanArray, PrimitiveArray};
 use arrow_buffer::ArrowNativeType;
 use arrow_buffer::{BooleanBufferBuilder, BufferBuilder, MutableBuffer, NullBuffer};
 use arrow_data::ArrayData;

--- a/src/algorithm/native/cast.rs
+++ b/src/algorithm/native/cast.rs
@@ -7,8 +7,6 @@
 
 use std::sync::Arc;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::*;
 use crate::chunked_array::*;
 use crate::datatypes::{Dimension, NativeType};
@@ -65,24 +63,15 @@ impl<const D: usize> Cast for PointArray<D> {
         let array = self.to_coord_type(to_type.coord_type());
         match to_type {
             Point(_, _) => Ok(Arc::new(array)),
-            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<i32, D>::from(array))),
-            LargeMultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<i64, D>::from(array))),
-            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<i32, D>::from(array))),
-            LargeMixed(_, _) => Ok(Arc::new(MixedGeometryArray::<i64, D>::from(array))),
-            GeometryCollection(_, _) => {
-                Ok(Arc::new(GeometryCollectionArray::<i32, D>::from(array)))
-            }
-            LargeGeometryCollection(_, _) => {
-                Ok(Arc::new(GeometryCollectionArray::<i64, D>::from(array)))
-            }
-            dt => Err(GeoArrowError::General(format!(
-                "invalid cast to type {dt:?}"
-            ))),
+            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<D>::from(array))),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
         }
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Cast for LineStringArray<O, D> {
+impl<const D: usize> Cast for LineStringArray<D> {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -91,82 +80,16 @@ impl<O: OffsetSizeTrait, const D: usize> Cast for LineStringArray<O, D> {
         let array = self.to_coord_type(to_type.coord_type());
 
         match to_type {
-            LineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array.to_small_offsets()?))
-                } else {
-                    Ok(Arc::new(array))
-                }
-            }
-            LargeLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array))
-                } else {
-                    Ok(Arc::new(array.to_large_offsets()))
-                }
-            }
-            MultiLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiLineStringArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(MultiLineStringArray::<O, D>::from(array)))
-                }
-            }
-            LargeMultiLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiLineStringArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(MultiLineStringArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            Mixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                }
-            }
-            LargeMixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            GeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                }
-            }
-            LargeGeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            dt => Err(GeoArrowError::General(format!(
-                "invalid cast to type {dt:?}"
-            ))),
+            LineString(_, _) => Ok(Arc::new(array)),
+            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::<D>::from(array))),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
         }
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Cast for PolygonArray<O, D> {
+impl<const D: usize> Cast for PolygonArray<D> {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -175,82 +98,16 @@ impl<O: OffsetSizeTrait, const D: usize> Cast for PolygonArray<O, D> {
         let array = self.to_coord_type(to_type.coord_type());
 
         match to_type {
-            Polygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array.to_small_offsets()?))
-                } else {
-                    Ok(Arc::new(array))
-                }
-            }
-            LargePolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array))
-                } else {
-                    Ok(Arc::new(array.to_large_offsets()))
-                }
-            }
-            MultiPolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPolygonArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(MultiPolygonArray::<O, D>::from(array)))
-                }
-            }
-            LargeMultiPolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiLineStringArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(MultiLineStringArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            Mixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                }
-            }
-            LargeMixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            GeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                }
-            }
-            LargeGeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            dt => Err(GeoArrowError::General(format!(
-                "invalid cast to type {dt:?}"
-            ))),
+            Polygon(_, _) => Ok(Arc::new(array)),
+            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::from(array))),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
         }
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Cast for MultiPointArray<O, D> {
+impl<const D: usize> Cast for MultiPointArray<D> {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -260,64 +117,15 @@ impl<O: OffsetSizeTrait, const D: usize> Cast for MultiPointArray<O, D> {
 
         match to_type {
             Point(_, _) => Ok(Arc::new(PointArray::<D>::try_from(array)?)),
-            MultiPoint(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array.to_small_offsets()?))
-                } else {
-                    Ok(Arc::new(array))
-                }
-            }
-            LargeMultiPoint(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array))
-                } else {
-                    Ok(Arc::new(array.to_large_offsets()))
-                }
-            }
-            Mixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                }
-            }
-            LargeMixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            GeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                }
-            }
-            LargeGeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            dt => Err(GeoArrowError::General(format!(
-                "invalid cast to type {dt:?}"
-            ))),
+            MultiPoint(_, _) => Ok(Arc::new(array)),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
         }
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Cast for MultiLineStringArray<O, D> {
+impl<const D: usize> Cast for MultiLineStringArray<D> {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -326,68 +134,15 @@ impl<O: OffsetSizeTrait, const D: usize> Cast for MultiLineStringArray<O, D> {
         let array = self.to_coord_type(to_type.coord_type());
 
         match to_type {
-            LineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(LineStringArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(LineStringArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(LineStringArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(LineStringArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            Mixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                }
-            }
-            LargeMixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            GeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                }
-            }
-            LargeGeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            dt => Err(GeoArrowError::General(format!(
-                "invalid cast to type {dt:?}"
-            ))),
+            LineString(_, _) => Ok(Arc::new(LineStringArray::<D>::try_from(array)?)),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
         }
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Cast for MultiPolygonArray<O, D> {
+impl<const D: usize> Cast for MultiPolygonArray<D> {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -396,68 +151,15 @@ impl<O: OffsetSizeTrait, const D: usize> Cast for MultiPolygonArray<O, D> {
         let array = self.to_coord_type(to_type.coord_type());
 
         match to_type {
-            Polygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(PolygonArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(PolygonArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargePolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(PolygonArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(PolygonArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            Mixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                }
-            }
-            LargeMixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            GeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                }
-            }
-            LargeGeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            dt => Err(GeoArrowError::General(format!(
-                "invalid cast to type {dt:?}"
-            ))),
+            Polygon(_, _) => Ok(Arc::new(PolygonArray::<D>::try_from(array)?)),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
         }
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Cast for MixedGeometryArray<O, D> {
+impl<const D: usize> Cast for MixedGeometryArray<D> {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -467,136 +169,19 @@ impl<O: OffsetSizeTrait, const D: usize> Cast for MixedGeometryArray<O, D> {
 
         match to_type {
             Point(_, _) => Ok(Arc::new(PointArray::try_from(array)?)),
-            LineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(LineStringArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(LineStringArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(LineStringArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(LineStringArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            Polygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(PolygonArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(PolygonArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargePolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(PolygonArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(PolygonArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            MultiPoint(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPointArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(MultiPointArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeMultiPoint(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPointArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(MultiPointArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            MultiLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiLineStringArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(MultiLineStringArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeMultiLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiLineStringArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(MultiLineStringArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            MultiPolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPolygonArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(MultiPolygonArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeMultiPolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPolygonArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(MultiPolygonArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            Mixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array.to_small_offsets()?))
-                } else {
-                    Ok(Arc::new(array))
-                }
-            }
-            LargeMixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array))
-                } else {
-                    Ok(Arc::new(array.to_large_offsets()))
-                }
-            }
-            GeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<i32, D>::from(
-                        array.to_small_offsets()?,
-                    )))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                }
-            }
-            LargeGeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(GeometryCollectionArray::<O, D>::from(array)))
-                } else {
-                    Ok(Arc::new(GeometryCollectionArray::<i64, D>::from(
-                        array.to_large_offsets(),
-                    )))
-                }
-            }
-            dt => Err(GeoArrowError::General(format!(
-                "invalid cast to type {dt:?}"
-            ))),
+            LineString(_, _) => Ok(Arc::new(LineStringArray::<D>::try_from(array)?)),
+            Polygon(_, _) => Ok(Arc::new(PolygonArray::<D>::try_from(array)?)),
+            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<D>::try_from(array)?)),
+            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::<D>::try_from(array)?)),
+            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::try_from(array)?)),
+            Mixed(_, _) => Ok(Arc::new(array)),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
         }
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Cast for GeometryCollectionArray<O, D> {
+impl<const D: usize> Cast for GeometryCollectionArray<D> {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -606,131 +191,14 @@ impl<O: OffsetSizeTrait, const D: usize> Cast for GeometryCollectionArray<O, D> 
 
         match to_type {
             Point(_, _) => Ok(Arc::new(PointArray::try_from(array)?)),
-            LineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(LineStringArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(LineStringArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(LineStringArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(LineStringArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            Polygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(PolygonArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(PolygonArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargePolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(PolygonArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(PolygonArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            MultiPoint(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPointArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(MultiPointArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeMultiPoint(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPointArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(MultiPointArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            MultiLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiLineStringArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(MultiLineStringArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeMultiLineString(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiLineStringArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(MultiLineStringArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            MultiPolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPolygonArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(MultiPolygonArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeMultiPolygon(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MultiPolygonArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(MultiPolygonArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            Mixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<i32, D>::try_from(
-                        array.to_small_offsets()?,
-                    )?))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::try_from(array)?))
-                }
-            }
-            LargeMixed(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(MixedGeometryArray::<O, D>::try_from(array)?))
-                } else {
-                    Ok(Arc::new(MixedGeometryArray::<i64, D>::try_from(
-                        array.to_large_offsets(),
-                    )?))
-                }
-            }
-            GeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array.to_small_offsets()?))
-                } else {
-                    Ok(Arc::new(array))
-                }
-            }
-            LargeGeometryCollection(_, _) => {
-                if O::IS_LARGE {
-                    Ok(Arc::new(array))
-                } else {
-                    Ok(Arc::new(array.to_large_offsets()))
-                }
-            }
-            dt => Err(GeoArrowError::General(format!(
-                "invalid cast to type {dt:?}"
-            ))),
+            LineString(_, _) => Ok(Arc::new(LineStringArray::<D>::try_from(array)?)),
+            Polygon(_, _) => Ok(Arc::new(PolygonArray::<D>::try_from(array)?)),
+            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<D>::try_from(array)?)),
+            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::<D>::try_from(array)?)),
+            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::try_from(array)?)),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::try_from(array)?)),
+            GeometryCollection(_, _) => Ok(Arc::new(array)),
+            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
         }
     }
 }
@@ -750,46 +218,20 @@ impl Cast for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_ref().as_point::<2>().cast(to_type),
             LineString(_, XY) => self.as_ref().as_line_string::<2>().cast(to_type),
-            LargeLineString(_, XY) => self.as_ref().as_large_line_string::<2>().cast(to_type),
             Polygon(_, XY) => self.as_ref().as_polygon::<2>().cast(to_type),
-            LargePolygon(_, XY) => self.as_ref().as_large_polygon::<2>().cast(to_type),
             MultiPoint(_, XY) => self.as_ref().as_multi_point::<2>().cast(to_type),
-            LargeMultiPoint(_, XY) => self.as_ref().as_large_multi_point::<2>().cast(to_type),
             MultiLineString(_, XY) => self.as_ref().as_multi_line_string::<2>().cast(to_type),
-            LargeMultiLineString(_, XY) => self
-                .as_ref()
-                .as_large_multi_line_string::<2>()
-                .cast(to_type),
             MultiPolygon(_, XY) => self.as_ref().as_multi_polygon::<2>().cast(to_type),
-            LargeMultiPolygon(_, XY) => self.as_ref().as_large_multi_polygon::<2>().cast(to_type),
             Mixed(_, XY) => self.as_ref().as_mixed::<2>().cast(to_type),
-            LargeMixed(_, XY) => self.as_ref().as_large_mixed::<2>().cast(to_type),
             GeometryCollection(_, XY) => self.as_ref().as_geometry_collection::<2>().cast(to_type),
-            LargeGeometryCollection(_, XY) => self
-                .as_ref()
-                .as_large_geometry_collection::<2>()
-                .cast(to_type),
             Point(_, XYZ) => self.as_ref().as_point::<3>().cast(to_type),
             LineString(_, XYZ) => self.as_ref().as_line_string::<3>().cast(to_type),
-            LargeLineString(_, XYZ) => self.as_ref().as_large_line_string::<3>().cast(to_type),
             Polygon(_, XYZ) => self.as_ref().as_polygon::<3>().cast(to_type),
-            LargePolygon(_, XYZ) => self.as_ref().as_large_polygon::<3>().cast(to_type),
             MultiPoint(_, XYZ) => self.as_ref().as_multi_point::<3>().cast(to_type),
-            LargeMultiPoint(_, XYZ) => self.as_ref().as_large_multi_point::<3>().cast(to_type),
             MultiLineString(_, XYZ) => self.as_ref().as_multi_line_string::<3>().cast(to_type),
-            LargeMultiLineString(_, XYZ) => self
-                .as_ref()
-                .as_large_multi_line_string::<3>()
-                .cast(to_type),
             MultiPolygon(_, XYZ) => self.as_ref().as_multi_polygon::<3>().cast(to_type),
-            LargeMultiPolygon(_, XYZ) => self.as_ref().as_large_multi_polygon::<3>().cast(to_type),
             Mixed(_, XYZ) => self.as_ref().as_mixed::<3>().cast(to_type),
-            LargeMixed(_, XYZ) => self.as_ref().as_large_mixed::<3>().cast(to_type),
             GeometryCollection(_, XYZ) => self.as_ref().as_geometry_collection::<3>().cast(to_type),
-            LargeGeometryCollection(_, XYZ) => self
-                .as_ref()
-                .as_large_geometry_collection::<3>()
-                .cast(to_type),
             _ => todo!(),
         }
     }
@@ -803,29 +245,10 @@ macro_rules! impl_chunked_cast_non_generic {
             fn cast(&self, to_type: &NativeType) -> Self::Output {
                 macro_rules! impl_cast {
                     ($method:ident) => {
-                        Arc::new(ChunkedGeometryArray::new(
-                            self.geometry_chunks()
-                                .iter()
-                                .map(|chunk| {
-                                    Ok(chunk.as_ref().cast(to_type)?.as_ref().$method().clone())
-                                })
-                                .collect::<Result<Vec<_>>>()?,
-                        ))
+                        Arc::new(ChunkedGeometryArray::new(self.geometry_chunks().iter().map(|chunk| Ok(chunk.as_ref().cast(to_type)?.as_ref().$method().clone())).collect::<Result<Vec<_>>>()?))
                     };
                     ($method:ident, $dim:expr) => {
-                        Arc::new(ChunkedGeometryArray::new(
-                            self.geometry_chunks()
-                                .iter()
-                                .map(|chunk| {
-                                    Ok(chunk
-                                        .as_ref()
-                                        .cast(to_type)?
-                                        .as_ref()
-                                        .$method::<$dim>()
-                                        .clone())
-                                })
-                                .collect::<Result<Vec<_>>>()?,
-                        ))
+                        Arc::new(ChunkedGeometryArray::new(self.geometry_chunks().iter().map(|chunk| Ok(chunk.as_ref().cast(to_type)?.as_ref().$method::<$dim>().clone())).collect::<Result<Vec<_>>>()?))
                     };
                 }
 
@@ -835,42 +258,20 @@ macro_rules! impl_chunked_cast_non_generic {
                 let result: Arc<dyn ChunkedNativeArray> = match to_type {
                     Point(_, XY) => impl_cast!(as_point, 2),
                     LineString(_, XY) => impl_cast!(as_line_string, 2),
-                    LargeLineString(_, XY) => impl_cast!(as_large_line_string, 2),
                     Polygon(_, XY) => impl_cast!(as_polygon, 2),
-                    LargePolygon(_, XY) => impl_cast!(as_large_polygon, 2),
                     MultiPoint(_, XY) => impl_cast!(as_multi_point, 2),
-                    LargeMultiPoint(_, XY) => impl_cast!(as_large_multi_point, 2),
                     MultiLineString(_, XY) => impl_cast!(as_multi_line_string, 2),
-                    LargeMultiLineString(_, XY) => {
-                        impl_cast!(as_large_multi_line_string, 2)
-                    }
                     MultiPolygon(_, XY) => impl_cast!(as_multi_polygon, 2),
-                    LargeMultiPolygon(_, XY) => impl_cast!(as_large_multi_polygon, 2),
                     Mixed(_, XY) => impl_cast!(as_mixed, 2),
-                    LargeMixed(_, XY) => impl_cast!(as_large_mixed, 2),
                     GeometryCollection(_, XY) => impl_cast!(as_geometry_collection, 2),
-                    LargeGeometryCollection(_, XY) => {
-                        impl_cast!(as_large_geometry_collection, 2)
-                    }
                     Point(_, XYZ) => impl_cast!(as_point, 3),
                     LineString(_, XYZ) => impl_cast!(as_line_string, 3),
-                    LargeLineString(_, XYZ) => impl_cast!(as_large_line_string, 3),
                     Polygon(_, XYZ) => impl_cast!(as_polygon, 3),
-                    LargePolygon(_, XYZ) => impl_cast!(as_large_polygon, 3),
                     MultiPoint(_, XYZ) => impl_cast!(as_multi_point, 3),
-                    LargeMultiPoint(_, XYZ) => impl_cast!(as_large_multi_point, 3),
                     MultiLineString(_, XYZ) => impl_cast!(as_multi_line_string, 3),
-                    LargeMultiLineString(_, XYZ) => {
-                        impl_cast!(as_large_multi_line_string, 3)
-                    }
                     MultiPolygon(_, XYZ) => impl_cast!(as_multi_polygon, 3),
-                    LargeMultiPolygon(_, XYZ) => impl_cast!(as_large_multi_polygon, 3),
                     Mixed(_, XYZ) => impl_cast!(as_mixed, 3),
-                    LargeMixed(_, XYZ) => impl_cast!(as_large_mixed, 3),
                     GeometryCollection(_, XYZ) => impl_cast!(as_geometry_collection, 3),
-                    LargeGeometryCollection(_, XYZ) => {
-                        impl_cast!(as_large_geometry_collection, 3)
-                    }
                     Rect(XY) => impl_cast!(as_rect, 2),
                     Rect(XYZ) => impl_cast!(as_rect, 3),
                 };
@@ -882,35 +283,16 @@ macro_rules! impl_chunked_cast_non_generic {
 
 macro_rules! impl_chunked_cast_generic {
     ($chunked_array:ty) => {
-        impl<O: OffsetSizeTrait> Cast for $chunked_array {
+        impl Cast for $chunked_array {
             type Output = Result<Arc<dyn ChunkedNativeArray>>;
 
             fn cast(&self, to_type: &NativeType) -> Self::Output {
                 macro_rules! impl_cast {
                     ($method:ident) => {
-                        Arc::new(ChunkedGeometryArray::new(
-                            self.geometry_chunks()
-                                .iter()
-                                .map(|chunk| {
-                                    Ok(chunk.as_ref().cast(to_type)?.as_ref().$method().clone())
-                                })
-                                .collect::<Result<Vec<_>>>()?,
-                        ))
+                        Arc::new(ChunkedGeometryArray::new(self.geometry_chunks().iter().map(|chunk| Ok(chunk.as_ref().cast(to_type)?.as_ref().$method().clone())).collect::<Result<Vec<_>>>()?))
                     };
                     ($method:ident, $dim:expr) => {
-                        Arc::new(ChunkedGeometryArray::new(
-                            self.geometry_chunks()
-                                .iter()
-                                .map(|chunk| {
-                                    Ok(chunk
-                                        .as_ref()
-                                        .cast(to_type)?
-                                        .as_ref()
-                                        .$method::<$dim>()
-                                        .clone())
-                                })
-                                .collect::<Result<Vec<_>>>()?,
-                        ))
+                        Arc::new(ChunkedGeometryArray::new(self.geometry_chunks().iter().map(|chunk| Ok(chunk.as_ref().cast(to_type)?.as_ref().$method::<$dim>().clone())).collect::<Result<Vec<_>>>()?))
                     };
                 }
 
@@ -920,42 +302,20 @@ macro_rules! impl_chunked_cast_generic {
                 let result: Arc<dyn ChunkedNativeArray> = match to_type {
                     Point(_, XY) => impl_cast!(as_point, 2),
                     LineString(_, XY) => impl_cast!(as_line_string, 2),
-                    LargeLineString(_, XY) => impl_cast!(as_large_line_string, 2),
                     Polygon(_, XY) => impl_cast!(as_polygon, 2),
-                    LargePolygon(_, XY) => impl_cast!(as_large_polygon, 2),
                     MultiPoint(_, XY) => impl_cast!(as_multi_point, 2),
-                    LargeMultiPoint(_, XY) => impl_cast!(as_large_multi_point, 2),
                     MultiLineString(_, XY) => impl_cast!(as_multi_line_string, 2),
-                    LargeMultiLineString(_, XY) => {
-                        impl_cast!(as_large_multi_line_string, 2)
-                    }
                     MultiPolygon(_, XY) => impl_cast!(as_multi_polygon, 2),
-                    LargeMultiPolygon(_, XY) => impl_cast!(as_large_multi_polygon, 2),
                     Mixed(_, XY) => impl_cast!(as_mixed, 2),
-                    LargeMixed(_, XY) => impl_cast!(as_large_mixed, 2),
                     GeometryCollection(_, XY) => impl_cast!(as_geometry_collection, 2),
-                    LargeGeometryCollection(_, XY) => {
-                        impl_cast!(as_large_geometry_collection, 2)
-                    }
                     Point(_, XYZ) => impl_cast!(as_point, 3),
                     LineString(_, XYZ) => impl_cast!(as_line_string, 3),
-                    LargeLineString(_, XYZ) => impl_cast!(as_large_line_string, 3),
                     Polygon(_, XYZ) => impl_cast!(as_polygon, 3),
-                    LargePolygon(_, XYZ) => impl_cast!(as_large_polygon, 3),
                     MultiPoint(_, XYZ) => impl_cast!(as_multi_point, 3),
-                    LargeMultiPoint(_, XYZ) => impl_cast!(as_large_multi_point, 3),
                     MultiLineString(_, XYZ) => impl_cast!(as_multi_line_string, 3),
-                    LargeMultiLineString(_, XYZ) => {
-                        impl_cast!(as_large_multi_line_string, 3)
-                    }
                     MultiPolygon(_, XYZ) => impl_cast!(as_multi_polygon, 3),
-                    LargeMultiPolygon(_, XYZ) => impl_cast!(as_large_multi_polygon, 3),
                     Mixed(_, XYZ) => impl_cast!(as_mixed, 3),
-                    LargeMixed(_, XYZ) => impl_cast!(as_large_mixed, 3),
                     GeometryCollection(_, XYZ) => impl_cast!(as_geometry_collection, 3),
-                    LargeGeometryCollection(_, XYZ) => {
-                        impl_cast!(as_large_geometry_collection, 3)
-                    }
                     Rect(XY) => impl_cast!(as_rect, 2),
                     Rect(XYZ) => impl_cast!(as_rect, 3),
                 };
@@ -968,19 +328,19 @@ macro_rules! impl_chunked_cast_generic {
 impl_chunked_cast_non_generic!(ChunkedPointArray<2>);
 impl_chunked_cast_non_generic!(ChunkedRectArray<2>);
 impl_chunked_cast_non_generic!(&dyn ChunkedNativeArray);
-impl_chunked_cast_generic!(ChunkedLineStringArray<O, 2>);
-impl_chunked_cast_generic!(ChunkedPolygonArray<O, 2>);
-impl_chunked_cast_generic!(ChunkedMultiPointArray<O, 2>);
-impl_chunked_cast_generic!(ChunkedMultiLineStringArray<O, 2>);
-impl_chunked_cast_generic!(ChunkedMultiPolygonArray<O, 2>);
-impl_chunked_cast_generic!(ChunkedMixedGeometryArray<O, 2>);
-impl_chunked_cast_generic!(ChunkedGeometryCollectionArray<O, 2>);
+impl_chunked_cast_generic!(ChunkedLineStringArray<2>);
+impl_chunked_cast_generic!(ChunkedPolygonArray<2>);
+impl_chunked_cast_generic!(ChunkedMultiPointArray<2>);
+impl_chunked_cast_generic!(ChunkedMultiLineStringArray<2>);
+impl_chunked_cast_generic!(ChunkedMultiPolygonArray<2>);
+impl_chunked_cast_generic!(ChunkedMixedGeometryArray<2>);
+impl_chunked_cast_generic!(ChunkedGeometryCollectionArray<2>);
 impl_chunked_cast_non_generic!(ChunkedPointArray<3>);
 impl_chunked_cast_non_generic!(ChunkedRectArray<3>);
-impl_chunked_cast_generic!(ChunkedLineStringArray<O, 3>);
-impl_chunked_cast_generic!(ChunkedPolygonArray<O, 3>);
-impl_chunked_cast_generic!(ChunkedMultiPointArray<O, 3>);
-impl_chunked_cast_generic!(ChunkedMultiLineStringArray<O, 3>);
-impl_chunked_cast_generic!(ChunkedMultiPolygonArray<O, 3>);
-impl_chunked_cast_generic!(ChunkedMixedGeometryArray<O, 3>);
-impl_chunked_cast_generic!(ChunkedGeometryCollectionArray<O, 3>);
+impl_chunked_cast_generic!(ChunkedLineStringArray<3>);
+impl_chunked_cast_generic!(ChunkedPolygonArray<3>);
+impl_chunked_cast_generic!(ChunkedMultiPointArray<3>);
+impl_chunked_cast_generic!(ChunkedMultiLineStringArray<3>);
+impl_chunked_cast_generic!(ChunkedMultiPolygonArray<3>);
+impl_chunked_cast_generic!(ChunkedMixedGeometryArray<3>);
+impl_chunked_cast_generic!(ChunkedGeometryCollectionArray<3>);

--- a/src/algorithm/native/cast.rs
+++ b/src/algorithm/native/cast.rs
@@ -66,7 +66,9 @@ impl<const D: usize> Cast for PointArray<D> {
             MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<D>::from(array))),
             Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
             GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
-            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
+            dt => Err(GeoArrowError::General(format!(
+                "invalid cast to type {dt:?}"
+            ))),
         }
     }
 }
@@ -84,7 +86,9 @@ impl<const D: usize> Cast for LineStringArray<D> {
             MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::<D>::from(array))),
             Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
             GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
-            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
+            dt => Err(GeoArrowError::General(format!(
+                "invalid cast to type {dt:?}"
+            ))),
         }
     }
 }
@@ -102,7 +106,9 @@ impl<const D: usize> Cast for PolygonArray<D> {
             MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::from(array))),
             Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
             GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
-            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
+            dt => Err(GeoArrowError::General(format!(
+                "invalid cast to type {dt:?}"
+            ))),
         }
     }
 }
@@ -120,7 +126,9 @@ impl<const D: usize> Cast for MultiPointArray<D> {
             MultiPoint(_, _) => Ok(Arc::new(array)),
             Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
             GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
-            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
+            dt => Err(GeoArrowError::General(format!(
+                "invalid cast to type {dt:?}"
+            ))),
         }
     }
 }
@@ -137,7 +145,9 @@ impl<const D: usize> Cast for MultiLineStringArray<D> {
             LineString(_, _) => Ok(Arc::new(LineStringArray::<D>::try_from(array)?)),
             Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
             GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
-            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
+            dt => Err(GeoArrowError::General(format!(
+                "invalid cast to type {dt:?}"
+            ))),
         }
     }
 }
@@ -154,7 +164,9 @@ impl<const D: usize> Cast for MultiPolygonArray<D> {
             Polygon(_, _) => Ok(Arc::new(PolygonArray::<D>::try_from(array)?)),
             Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
             GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
-            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
+            dt => Err(GeoArrowError::General(format!(
+                "invalid cast to type {dt:?}"
+            ))),
         }
     }
 }
@@ -176,7 +188,9 @@ impl<const D: usize> Cast for MixedGeometryArray<D> {
             MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::try_from(array)?)),
             Mixed(_, _) => Ok(Arc::new(array)),
             GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
-            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
+            dt => Err(GeoArrowError::General(format!(
+                "invalid cast to type {dt:?}"
+            ))),
         }
     }
 }
@@ -198,7 +212,9 @@ impl<const D: usize> Cast for GeometryCollectionArray<D> {
             MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::try_from(array)?)),
             Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::try_from(array)?)),
             GeometryCollection(_, _) => Ok(Arc::new(array)),
-            dt => Err(GeoArrowError::General(format!("invalid cast to type {dt:?}"))),
+            dt => Err(GeoArrowError::General(format!(
+                "invalid cast to type {dt:?}"
+            ))),
         }
     }
 }
@@ -245,10 +261,29 @@ macro_rules! impl_chunked_cast_non_generic {
             fn cast(&self, to_type: &NativeType) -> Self::Output {
                 macro_rules! impl_cast {
                     ($method:ident) => {
-                        Arc::new(ChunkedGeometryArray::new(self.geometry_chunks().iter().map(|chunk| Ok(chunk.as_ref().cast(to_type)?.as_ref().$method().clone())).collect::<Result<Vec<_>>>()?))
+                        Arc::new(ChunkedGeometryArray::new(
+                            self.geometry_chunks()
+                                .iter()
+                                .map(|chunk| {
+                                    Ok(chunk.as_ref().cast(to_type)?.as_ref().$method().clone())
+                                })
+                                .collect::<Result<Vec<_>>>()?,
+                        ))
                     };
                     ($method:ident, $dim:expr) => {
-                        Arc::new(ChunkedGeometryArray::new(self.geometry_chunks().iter().map(|chunk| Ok(chunk.as_ref().cast(to_type)?.as_ref().$method::<$dim>().clone())).collect::<Result<Vec<_>>>()?))
+                        Arc::new(ChunkedGeometryArray::new(
+                            self.geometry_chunks()
+                                .iter()
+                                .map(|chunk| {
+                                    Ok(chunk
+                                        .as_ref()
+                                        .cast(to_type)?
+                                        .as_ref()
+                                        .$method::<$dim>()
+                                        .clone())
+                                })
+                                .collect::<Result<Vec<_>>>()?,
+                        ))
                     };
                 }
 
@@ -289,10 +324,29 @@ macro_rules! impl_chunked_cast_generic {
             fn cast(&self, to_type: &NativeType) -> Self::Output {
                 macro_rules! impl_cast {
                     ($method:ident) => {
-                        Arc::new(ChunkedGeometryArray::new(self.geometry_chunks().iter().map(|chunk| Ok(chunk.as_ref().cast(to_type)?.as_ref().$method().clone())).collect::<Result<Vec<_>>>()?))
+                        Arc::new(ChunkedGeometryArray::new(
+                            self.geometry_chunks()
+                                .iter()
+                                .map(|chunk| {
+                                    Ok(chunk.as_ref().cast(to_type)?.as_ref().$method().clone())
+                                })
+                                .collect::<Result<Vec<_>>>()?,
+                        ))
                     };
                     ($method:ident, $dim:expr) => {
-                        Arc::new(ChunkedGeometryArray::new(self.geometry_chunks().iter().map(|chunk| Ok(chunk.as_ref().cast(to_type)?.as_ref().$method::<$dim>().clone())).collect::<Result<Vec<_>>>()?))
+                        Arc::new(ChunkedGeometryArray::new(
+                            self.geometry_chunks()
+                                .iter()
+                                .map(|chunk| {
+                                    Ok(chunk
+                                        .as_ref()
+                                        .cast(to_type)?
+                                        .as_ref()
+                                        .$method::<$dim>()
+                                        .clone())
+                                })
+                                .collect::<Result<Vec<_>>>()?,
+                        ))
                     };
                 }
 

--- a/src/algorithm/native/concatenate.rs
+++ b/src/algorithm/native/concatenate.rs
@@ -17,21 +17,18 @@ impl Concatenate for &[PointArray<2>] {
     fn concatenate(&self) -> Self::Output {
         let output_capacity = self.iter().fold(0, |sum, val| sum + val.buffer_lengths());
         let mut builder = PointBuilder::with_capacity(output_capacity);
-        self.iter()
-            .for_each(|chunk| chunk.iter().for_each(|p| builder.push_point(p.as_ref())));
+        self.iter().for_each(|chunk| chunk.iter().for_each(|p| builder.push_point(p.as_ref())));
         Ok(builder.finish())
     }
 }
 
 macro_rules! impl_concatenate {
     ($array:ty, $capacity:ty, $builder:ty, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> Concatenate for &[$array] {
+        impl Concatenate for &[$array] {
             type Output = Result<$array>;
 
             fn concatenate(&self) -> Self::Output {
-                let output_capacity = self.iter().fold(<$capacity>::new_empty(), |sum, val| {
-                    sum + val.buffer_lengths()
-                });
+                let output_capacity = self.iter().fold(<$capacity>::new_empty(), |sum, val| sum + val.buffer_lengths());
                 let mut builder = <$builder>::with_capacity(output_capacity);
                 for chunk in self.iter() {
                     for geom in chunk.iter() {
@@ -44,48 +41,13 @@ macro_rules! impl_concatenate {
     };
 }
 
-impl_concatenate!(
-    LineStringArray<O, 2>,
-    LineStringCapacity,
-    LineStringBuilder<O, 2>,
-    push_line_string
-);
-impl_concatenate!(
-    PolygonArray<O, 2>,
-    PolygonCapacity,
-    PolygonBuilder<O, 2>,
-    push_polygon
-);
-impl_concatenate!(
-    MultiPointArray<O, 2>,
-    MultiPointCapacity,
-    MultiPointBuilder<O, 2>,
-    push_multi_point
-);
-impl_concatenate!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringCapacity,
-    MultiLineStringBuilder<O, 2>,
-    push_multi_line_string
-);
-impl_concatenate!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonCapacity,
-    MultiPolygonBuilder<O, 2>,
-    push_multi_polygon
-);
-impl_concatenate!(
-    MixedGeometryArray<O, 2>,
-    MixedCapacity,
-    MixedGeometryBuilder<O, 2>,
-    push_geometry
-);
-impl_concatenate!(
-    GeometryCollectionArray<O, 2>,
-    GeometryCollectionCapacity,
-    GeometryCollectionBuilder<O, 2>,
-    push_geometry_collection
-);
+impl_concatenate!(LineStringArray<2>, LineStringCapacity, LineStringBuilder<2>, push_line_string);
+impl_concatenate!(PolygonArray<2>, PolygonCapacity, PolygonBuilder<2>, push_polygon);
+impl_concatenate!(MultiPointArray<2>, MultiPointCapacity, MultiPointBuilder<2>, push_multi_point);
+impl_concatenate!(MultiLineStringArray<2>, MultiLineStringCapacity, MultiLineStringBuilder<2>, push_multi_line_string);
+impl_concatenate!(MultiPolygonArray<2>, MultiPolygonCapacity, MultiPolygonBuilder<2>, push_multi_polygon);
+impl_concatenate!(MixedGeometryArray<2>, MixedCapacity, MixedGeometryBuilder<2>, push_geometry);
+impl_concatenate!(GeometryCollectionArray<2>, GeometryCollectionCapacity, GeometryCollectionBuilder<2>, push_geometry_collection);
 
 impl Concatenate for ChunkedPointArray<2> {
     type Output = Result<PointArray<2>>;
@@ -97,7 +59,7 @@ impl Concatenate for ChunkedPointArray<2> {
 
 macro_rules! impl_chunked_concatenate {
     ($chunked_array:ty, $output_array:ty) => {
-        impl<O: OffsetSizeTrait> Concatenate for $chunked_array {
+        impl Concatenate for $chunked_array {
             type Output = Result<$output_array>;
 
             fn concatenate(&self) -> Self::Output {
@@ -107,13 +69,10 @@ macro_rules! impl_chunked_concatenate {
     };
 }
 
-impl_chunked_concatenate!(ChunkedLineStringArray<O, 2>, LineStringArray<O, 2>);
-impl_chunked_concatenate!(ChunkedPolygonArray<O, 2>, PolygonArray<O, 2>);
-impl_chunked_concatenate!(ChunkedMultiPointArray<O, 2>, MultiPointArray<O, 2>);
-impl_chunked_concatenate!(ChunkedMultiLineStringArray<O, 2>, MultiLineStringArray<O, 2>);
-impl_chunked_concatenate!(ChunkedMultiPolygonArray<O, 2>, MultiPolygonArray<O, 2>);
-impl_chunked_concatenate!(ChunkedMixedGeometryArray<O, 2>, MixedGeometryArray<O, 2>);
-impl_chunked_concatenate!(
-    ChunkedGeometryCollectionArray<O, 2>,
-    GeometryCollectionArray<O, 2>
-);
+impl_chunked_concatenate!(ChunkedLineStringArray<2>, LineStringArray<2>);
+impl_chunked_concatenate!(ChunkedPolygonArray<2>, PolygonArray<2>);
+impl_chunked_concatenate!(ChunkedMultiPointArray<2>, MultiPointArray<2>);
+impl_chunked_concatenate!(ChunkedMultiLineStringArray<2>, MultiLineStringArray<2>);
+impl_chunked_concatenate!(ChunkedMultiPolygonArray<2>, MultiPolygonArray<2>);
+impl_chunked_concatenate!(ChunkedMixedGeometryArray<2>, MixedGeometryArray<2>);
+impl_chunked_concatenate!(ChunkedGeometryCollectionArray<2>, GeometryCollectionArray<2>);

--- a/src/algorithm/native/concatenate.rs
+++ b/src/algorithm/native/concatenate.rs
@@ -1,5 +1,3 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::*;
 use crate::chunked_array::*;
 use crate::error::Result;

--- a/src/algorithm/native/concatenate.rs
+++ b/src/algorithm/native/concatenate.rs
@@ -15,7 +15,8 @@ impl Concatenate for &[PointArray<2>] {
     fn concatenate(&self) -> Self::Output {
         let output_capacity = self.iter().fold(0, |sum, val| sum + val.buffer_lengths());
         let mut builder = PointBuilder::with_capacity(output_capacity);
-        self.iter().for_each(|chunk| chunk.iter().for_each(|p| builder.push_point(p.as_ref())));
+        self.iter()
+            .for_each(|chunk| chunk.iter().for_each(|p| builder.push_point(p.as_ref())));
         Ok(builder.finish())
     }
 }
@@ -26,7 +27,9 @@ macro_rules! impl_concatenate {
             type Output = Result<$array>;
 
             fn concatenate(&self) -> Self::Output {
-                let output_capacity = self.iter().fold(<$capacity>::new_empty(), |sum, val| sum + val.buffer_lengths());
+                let output_capacity = self.iter().fold(<$capacity>::new_empty(), |sum, val| {
+                    sum + val.buffer_lengths()
+                });
                 let mut builder = <$builder>::with_capacity(output_capacity);
                 for chunk in self.iter() {
                     for geom in chunk.iter() {
@@ -39,13 +42,48 @@ macro_rules! impl_concatenate {
     };
 }
 
-impl_concatenate!(LineStringArray<2>, LineStringCapacity, LineStringBuilder<2>, push_line_string);
-impl_concatenate!(PolygonArray<2>, PolygonCapacity, PolygonBuilder<2>, push_polygon);
-impl_concatenate!(MultiPointArray<2>, MultiPointCapacity, MultiPointBuilder<2>, push_multi_point);
-impl_concatenate!(MultiLineStringArray<2>, MultiLineStringCapacity, MultiLineStringBuilder<2>, push_multi_line_string);
-impl_concatenate!(MultiPolygonArray<2>, MultiPolygonCapacity, MultiPolygonBuilder<2>, push_multi_polygon);
-impl_concatenate!(MixedGeometryArray<2>, MixedCapacity, MixedGeometryBuilder<2>, push_geometry);
-impl_concatenate!(GeometryCollectionArray<2>, GeometryCollectionCapacity, GeometryCollectionBuilder<2>, push_geometry_collection);
+impl_concatenate!(
+    LineStringArray<2>,
+    LineStringCapacity,
+    LineStringBuilder<2>,
+    push_line_string
+);
+impl_concatenate!(
+    PolygonArray<2>,
+    PolygonCapacity,
+    PolygonBuilder<2>,
+    push_polygon
+);
+impl_concatenate!(
+    MultiPointArray<2>,
+    MultiPointCapacity,
+    MultiPointBuilder<2>,
+    push_multi_point
+);
+impl_concatenate!(
+    MultiLineStringArray<2>,
+    MultiLineStringCapacity,
+    MultiLineStringBuilder<2>,
+    push_multi_line_string
+);
+impl_concatenate!(
+    MultiPolygonArray<2>,
+    MultiPolygonCapacity,
+    MultiPolygonBuilder<2>,
+    push_multi_polygon
+);
+impl_concatenate!(
+    MixedGeometryArray<2>,
+    MixedCapacity,
+    MixedGeometryBuilder<2>,
+    push_geometry
+);
+impl_concatenate!(
+    GeometryCollectionArray<2>,
+    GeometryCollectionCapacity,
+    GeometryCollectionBuilder<2>,
+    push_geometry_collection
+);
 
 impl Concatenate for ChunkedPointArray<2> {
     type Output = Result<PointArray<2>>;
@@ -73,4 +111,7 @@ impl_chunked_concatenate!(ChunkedMultiPointArray<2>, MultiPointArray<2>);
 impl_chunked_concatenate!(ChunkedMultiLineStringArray<2>, MultiLineStringArray<2>);
 impl_chunked_concatenate!(ChunkedMultiPolygonArray<2>, MultiPolygonArray<2>);
 impl_chunked_concatenate!(ChunkedMixedGeometryArray<2>, MixedGeometryArray<2>);
-impl_chunked_concatenate!(ChunkedGeometryCollectionArray<2>, GeometryCollectionArray<2>);
+impl_chunked_concatenate!(
+    ChunkedGeometryCollectionArray<2>,
+    GeometryCollectionArray<2>
+);

--- a/src/algorithm/native/eq.rs
+++ b/src/algorithm/native/eq.rs
@@ -332,8 +332,8 @@ pub fn geometry_collection_eq<T: CoordFloat>(
 }
 
 pub(crate) fn offset_buffer_eq<O: OffsetSizeTrait>(
-    left: &OffsetBuffer<O>,
-    right: &OffsetBuffer<O>,
+    left: &OffsetBuffer<i32>,
+    right: &OffsetBuffer<i32>,
 ) -> bool {
     if left.len() != right.len() {
         return false;

--- a/src/algorithm/native/eq.rs
+++ b/src/algorithm/native/eq.rs
@@ -332,8 +332,8 @@ pub fn geometry_collection_eq<T: CoordFloat>(
 }
 
 pub(crate) fn offset_buffer_eq<O: OffsetSizeTrait>(
-    left: &OffsetBuffer<i32>,
-    right: &OffsetBuffer<i32>,
+    left: &OffsetBuffer<O>,
+    right: &OffsetBuffer<O>,
 ) -> bool {
     if left.len() != right.len() {
         return false;

--- a/src/algorithm/native/explode.rs
+++ b/src/algorithm/native/explode.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arrow::compute::take;
-use arrow_array::{Int32Array, OffsetSizeTrait, RecordBatch};
+use arrow_array::{Int32Array, RecordBatch};
 use arrow_buffer::OffsetBuffer;
 use arrow_schema::SchemaBuilder;
 

--- a/src/algorithm/native/map_coords.rs
+++ b/src/algorithm/native/map_coords.rs
@@ -6,10 +6,7 @@ use crate::array::*;
 use crate::chunked_array::*;
 use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
-use crate::geo_traits::{
-    GeometryCollectionTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait,
-    MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait,
-};
+use crate::geo_traits::{GeometryCollectionTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait};
 use crate::scalar::*;
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
@@ -56,7 +53,7 @@ impl MapCoords for Point<'_, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for LineString<'_, O, 2> {
+impl MapCoords for LineString<'_, 2> {
     type Output = geo::LineString;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -64,15 +61,12 @@ impl<O: OffsetSizeTrait> MapCoords for LineString<'_, O, 2> {
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let output_coords = self
-            .coords()
-            .map(|point| map_op(&point.coord()))
-            .collect::<std::result::Result<Vec<_>, E>>()?;
+        let output_coords = self.coords().map(|point| map_op(&point.coord())).collect::<std::result::Result<Vec<_>, E>>()?;
         Ok(geo::LineString::new(output_coords))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for Polygon<'_, O, 2> {
+impl MapCoords for Polygon<'_, 2> {
     type Output = geo::Polygon;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -81,20 +75,15 @@ impl<O: OffsetSizeTrait> MapCoords for Polygon<'_, O, 2> {
         GeoArrowError: From<E>,
     {
         if self.exterior().is_none() {
-            return Err(GeoArrowError::General(
-                "Empty polygons not yet supported in MapCoords".to_string(),
-            ));
+            return Err(GeoArrowError::General("Empty polygons not yet supported in MapCoords".to_string()));
         }
         let exterior = self.exterior().unwrap().try_map_coords(&map_op)?;
-        let interiors = self
-            .interiors()
-            .map(|int| int.try_map_coords(&map_op))
-            .collect::<Result<Vec<_>>>()?;
+        let interiors = self.interiors().map(|int| int.try_map_coords(&map_op)).collect::<Result<Vec<_>>>()?;
         Ok(geo::Polygon::new(exterior, interiors))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiPoint<'_, O, 2> {
+impl MapCoords for MultiPoint<'_, 2> {
     type Output = geo::MultiPoint;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -102,15 +91,12 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPoint<'_, O, 2> {
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let points = self
-            .points()
-            .map(|point| point.try_map_coords(&map_op))
-            .collect::<Result<Vec<_>>>()?;
+        let points = self.points().map(|point| point.try_map_coords(&map_op)).collect::<Result<Vec<_>>>()?;
         Ok(geo::MultiPoint::new(points))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiLineString<'_, O, 2> {
+impl MapCoords for MultiLineString<'_, 2> {
     type Output = geo::MultiLineString;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -118,15 +104,12 @@ impl<O: OffsetSizeTrait> MapCoords for MultiLineString<'_, O, 2> {
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let lines = self
-            .lines()
-            .map(|line_string| line_string.try_map_coords(&map_op))
-            .collect::<Result<Vec<_>>>()?;
+        let lines = self.lines().map(|line_string| line_string.try_map_coords(&map_op)).collect::<Result<Vec<_>>>()?;
         Ok(geo::MultiLineString::new(lines))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiPolygon<'_, O, 2> {
+impl MapCoords for MultiPolygon<'_, 2> {
     // TODO: support empty polygons within a multi polygon
     type Output = geo::MultiPolygon;
 
@@ -135,15 +118,12 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPolygon<'_, O, 2> {
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let polygons = self
-            .polygons()
-            .map(|polygon| polygon.try_map_coords(&map_op))
-            .collect::<Result<Vec<_>>>()?;
+        let polygons = self.polygons().map(|polygon| polygon.try_map_coords(&map_op)).collect::<Result<Vec<_>>>()?;
         Ok(geo::MultiPolygon::new(polygons))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for Geometry<'_, O, 2> {
+impl MapCoords for Geometry<'_, 2> {
     type Output = geo::Geometry;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -153,30 +133,18 @@ impl<O: OffsetSizeTrait> MapCoords for Geometry<'_, O, 2> {
     {
         match self.as_type() {
             GeometryType::Point(geom) => Ok(geo::Geometry::Point(geom.try_map_coords(&map_op)?)),
-            GeometryType::LineString(geom) => {
-                Ok(geo::Geometry::LineString(geom.try_map_coords(&map_op)?))
-            }
-            GeometryType::Polygon(geom) => {
-                Ok(geo::Geometry::Polygon(geom.try_map_coords(&map_op)?))
-            }
-            GeometryType::MultiPoint(geom) => {
-                Ok(geo::Geometry::MultiPoint(geom.try_map_coords(&map_op)?))
-            }
-            GeometryType::MultiLineString(geom) => Ok(geo::Geometry::MultiLineString(
-                geom.try_map_coords(&map_op)?,
-            )),
-            GeometryType::MultiPolygon(geom) => {
-                Ok(geo::Geometry::MultiPolygon(geom.try_map_coords(&map_op)?))
-            }
-            GeometryType::GeometryCollection(geom) => Ok(geo::Geometry::GeometryCollection(
-                geom.try_map_coords(&map_op)?,
-            )),
+            GeometryType::LineString(geom) => Ok(geo::Geometry::LineString(geom.try_map_coords(&map_op)?)),
+            GeometryType::Polygon(geom) => Ok(geo::Geometry::Polygon(geom.try_map_coords(&map_op)?)),
+            GeometryType::MultiPoint(geom) => Ok(geo::Geometry::MultiPoint(geom.try_map_coords(&map_op)?)),
+            GeometryType::MultiLineString(geom) => Ok(geo::Geometry::MultiLineString(geom.try_map_coords(&map_op)?)),
+            GeometryType::MultiPolygon(geom) => Ok(geo::Geometry::MultiPolygon(geom.try_map_coords(&map_op)?)),
+            GeometryType::GeometryCollection(geom) => Ok(geo::Geometry::GeometryCollection(geom.try_map_coords(&map_op)?)),
             GeometryType::Rect(geom) => Ok(geo::Geometry::Rect(geom.try_map_coords(&map_op)?)),
         }
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for GeometryCollection<'_, O, 2> {
+impl MapCoords for GeometryCollection<'_, 2> {
     type Output = geo::GeometryCollection;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -184,10 +152,7 @@ impl<O: OffsetSizeTrait> MapCoords for GeometryCollection<'_, O, 2> {
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let geoms = self
-            .geometries()
-            .map(|geom| geom.try_map_coords(&map_op))
-            .collect::<Result<Vec<_>>>()?;
+        let geoms = self.geometries().map(|geom| geom.try_map_coords(&map_op)).collect::<Result<Vec<_>>>()?;
         Ok(geo::GeometryCollection::new_from(geoms))
     }
 }
@@ -225,11 +190,7 @@ impl MapCoords for PointArray<2> {
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = PointBuilder::with_capacity_and_options(
-            self.buffer_lengths(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = PointBuilder::with_capacity_and_options(self.buffer_lengths(), self.coord_type(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.coord().try_map_coords(&map_op)?;
@@ -242,19 +203,15 @@ impl MapCoords for PointArray<2> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for LineStringArray<O, 2> {
-    type Output = LineStringArray<O, 2>;
+impl MapCoords for LineStringArray<2> {
+    type Output = LineStringArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = LineStringBuilder::with_capacity_and_options(
-            self.buffer_lengths(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = LineStringBuilder::with_capacity_and_options(self.buffer_lengths(), self.coord_type(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.try_map_coords(&map_op)?;
@@ -267,19 +224,15 @@ impl<O: OffsetSizeTrait> MapCoords for LineStringArray<O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for PolygonArray<O, 2> {
-    type Output = PolygonArray<O, 2>;
+impl MapCoords for PolygonArray<2> {
+    type Output = PolygonArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = PolygonBuilder::with_capacity_and_options(
-            self.buffer_lengths(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = PolygonBuilder::with_capacity_and_options(self.buffer_lengths(), self.coord_type(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.try_map_coords(&map_op)?;
@@ -292,19 +245,15 @@ impl<O: OffsetSizeTrait> MapCoords for PolygonArray<O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiPointArray<O, 2> {
-    type Output = MultiPointArray<O, 2>;
+impl MapCoords for MultiPointArray<2> {
+    type Output = MultiPointArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = MultiPointBuilder::with_capacity_and_options(
-            self.buffer_lengths(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = MultiPointBuilder::with_capacity_and_options(self.buffer_lengths(), self.coord_type(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.try_map_coords(&map_op)?;
@@ -317,19 +266,15 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPointArray<O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiLineStringArray<O, 2> {
-    type Output = MultiLineStringArray<O, 2>;
+impl MapCoords for MultiLineStringArray<2> {
+    type Output = MultiLineStringArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = MultiLineStringBuilder::with_capacity_and_options(
-            self.buffer_lengths(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = MultiLineStringBuilder::with_capacity_and_options(self.buffer_lengths(), self.coord_type(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.try_map_coords(&map_op)?;
@@ -342,19 +287,15 @@ impl<O: OffsetSizeTrait> MapCoords for MultiLineStringArray<O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MultiPolygonArray<O, 2> {
-    type Output = MultiPolygonArray<O, 2>;
+impl MapCoords for MultiPolygonArray<2> {
+    type Output = MultiPolygonArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = MultiPolygonBuilder::with_capacity_and_options(
-            self.buffer_lengths(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = MultiPolygonBuilder::with_capacity_and_options(self.buffer_lengths(), self.coord_type(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.try_map_coords(&map_op)?;
@@ -367,19 +308,15 @@ impl<O: OffsetSizeTrait> MapCoords for MultiPolygonArray<O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for MixedGeometryArray<O, 2> {
-    type Output = MixedGeometryArray<O, 2>;
+impl MapCoords for MixedGeometryArray<2> {
+    type Output = MixedGeometryArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = MixedGeometryBuilder::with_capacity_and_options(
-            self.buffer_lengths(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = MixedGeometryBuilder::with_capacity_and_options(self.buffer_lengths(), self.coord_type(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.try_map_coords(&map_op)?;
@@ -392,19 +329,15 @@ impl<O: OffsetSizeTrait> MapCoords for MixedGeometryArray<O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for GeometryCollectionArray<O, 2> {
-    type Output = GeometryCollectionArray<O, 2>;
+impl MapCoords for GeometryCollectionArray<2> {
+    type Output = GeometryCollectionArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = GeometryCollectionBuilder::with_capacity_and_options(
-            self.buffer_lengths(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = GeometryCollectionBuilder::with_capacity_and_options(self.buffer_lengths(), self.coord_type(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.try_map_coords(&map_op)?;
@@ -452,35 +385,12 @@ impl MapCoords for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().try_map_coords(map_op)?),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().try_map_coords(map_op)?),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().try_map_coords(map_op)?)
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().try_map_coords(map_op)?),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().try_map_coords(map_op)?),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().try_map_coords(map_op)?),
-            LargeMultiPoint(_, XY) => {
-                Arc::new(self.as_large_multi_point::<2>().try_map_coords(map_op)?)
-            }
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().try_map_coords(map_op)?)
-            }
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
-                    .try_map_coords(map_op)?,
-            ),
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().try_map_coords(map_op)?),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().try_map_coords(map_op)?),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().try_map_coords(map_op)?)
-            }
             Mixed(_, XY) => Arc::new(self.as_mixed::<2>().try_map_coords(map_op)?),
-            LargeMixed(_, XY) => Arc::new(self.as_large_mixed::<2>().try_map_coords(map_op)?),
-            GeometryCollection(_, XY) => {
-                Arc::new(self.as_geometry_collection::<2>().try_map_coords(map_op)?)
-            }
-            LargeGeometryCollection(_, XY) => Arc::new(
-                self.as_large_geometry_collection::<2>()
-                    .try_map_coords(map_op)?,
-            ),
+            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection::<2>().try_map_coords(map_op)?),
             Rect(XY) => Arc::new(self.as_rect::<2>().try_map_coords(map_op)?),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -496,107 +406,91 @@ impl MapCoords for ChunkedPointArray<2> {
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedLineStringArray<O, 2> {
-    type Output = ChunkedLineStringArray<O, 2>;
+impl MapCoords for ChunkedLineStringArray<2> {
+    type Output = ChunkedLineStringArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedPolygonArray<O, 2> {
-    type Output = ChunkedPolygonArray<O, 2>;
+impl MapCoords for ChunkedPolygonArray<2> {
+    type Output = ChunkedPolygonArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPointArray<O, 2> {
-    type Output = ChunkedMultiPointArray<O, 2>;
+impl MapCoords for ChunkedMultiPointArray<2> {
+    type Output = ChunkedMultiPointArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiLineStringArray<O, 2> {
-    type Output = ChunkedMultiLineStringArray<O, 2>;
+impl MapCoords for ChunkedMultiLineStringArray<2> {
+    type Output = ChunkedMultiLineStringArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedMultiPolygonArray<O, 2> {
-    type Output = ChunkedMultiPolygonArray<O, 2>;
+impl MapCoords for ChunkedMultiPolygonArray<2> {
+    type Output = ChunkedMultiPolygonArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedMixedGeometryArray<O, 2> {
-    type Output = ChunkedMixedGeometryArray<O, 2>;
+impl MapCoords for ChunkedMixedGeometryArray<2> {
+    type Output = ChunkedMixedGeometryArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
-impl<O: OffsetSizeTrait> MapCoords for ChunkedGeometryCollectionArray<O, 2> {
-    type Output = ChunkedGeometryCollectionArray<O, 2>;
+impl MapCoords for ChunkedGeometryCollectionArray<2> {
+    type Output = ChunkedGeometryCollectionArray<2>;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
@@ -608,9 +502,7 @@ impl MapCoords for ChunkedRectArray<2> {
         F: Fn(&crate::scalar::Coord<2>) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(ChunkedGeometryArray::new(
-            self.try_map(|chunk| chunk.try_map_coords(&map_op))?,
-        ))
+        Ok(ChunkedGeometryArray::new(self.try_map(|chunk| chunk.try_map_coords(&map_op))?))
     }
 }
 
@@ -628,35 +520,12 @@ impl MapCoords for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().try_map_coords(map_op)?),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().try_map_coords(map_op)?),
-            LargeLineString(_, XY) => {
-                Arc::new(self.as_large_line_string::<2>().try_map_coords(map_op)?)
-            }
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().try_map_coords(map_op)?),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().try_map_coords(map_op)?),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().try_map_coords(map_op)?),
-            LargeMultiPoint(_, XY) => {
-                Arc::new(self.as_large_multi_point::<2>().try_map_coords(map_op)?)
-            }
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().try_map_coords(map_op)?)
-            }
-            LargeMultiLineString(_, XY) => Arc::new(
-                self.as_large_multi_line_string::<2>()
-                    .try_map_coords(map_op)?,
-            ),
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().try_map_coords(map_op)?),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().try_map_coords(map_op)?),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().try_map_coords(map_op)?)
-            }
             Mixed(_, XY) => Arc::new(self.as_mixed::<2>().try_map_coords(map_op)?),
-            LargeMixed(_, XY) => Arc::new(self.as_large_mixed::<2>().try_map_coords(map_op)?),
-            GeometryCollection(_, XY) => {
-                Arc::new(self.as_geometry_collection::<2>().try_map_coords(map_op)?)
-            }
-            LargeGeometryCollection(_, XY) => Arc::new(
-                self.as_large_geometry_collection::<2>()
-                    .try_map_coords(map_op)?,
-            ),
+            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection::<2>().try_map_coords(map_op)?),
             Rect(XY) => Arc::new(self.as_rect::<2>().try_map_coords(map_op)?),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };

--- a/src/algorithm/native/map_coords.rs
+++ b/src/algorithm/native/map_coords.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::*;
 use crate::chunked_array::*;
 use crate::datatypes::{Dimension, NativeType};

--- a/src/algorithm/native/rechunk.rs
+++ b/src/algorithm/native/rechunk.rs
@@ -1,7 +1,5 @@
 use std::ops::Range;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::algorithm::native::Take;
 use crate::array::*;
 use crate::chunked_array::ChunkedGeometryArray;
@@ -44,7 +42,7 @@ impl Rechunk for PointArray<2> {
 
 macro_rules! rechunk_impl {
     ($array_type:ty) => {
-        impl<O: OffsetSizeTrait> Rechunk for $array_type {
+        impl Rechunk for $array_type {
             type Output = Result<ChunkedGeometryArray<Self>>;
 
             fn rechunk(&self, ranges: &[Range<usize>]) -> Self::Output {
@@ -58,15 +56,15 @@ macro_rules! rechunk_impl {
     };
 }
 
-rechunk_impl!(LineStringArray<O, 2>);
-rechunk_impl!(PolygonArray<O, 2>);
-rechunk_impl!(MultiPointArray<O, 2>);
-rechunk_impl!(MultiLineStringArray<O, 2>);
-rechunk_impl!(MultiPolygonArray<O, 2>);
-rechunk_impl!(MixedGeometryArray<O, 2>);
-rechunk_impl!(GeometryCollectionArray<O, 2>);
+rechunk_impl!(LineStringArray<2>);
+rechunk_impl!(PolygonArray<2>);
+rechunk_impl!(MultiPointArray<2>);
+rechunk_impl!(MultiLineStringArray<2>);
+rechunk_impl!(MultiPolygonArray<2>);
+rechunk_impl!(MixedGeometryArray<2>);
+rechunk_impl!(GeometryCollectionArray<2>);
 
-// impl<O: OffsetSizeTrait> Rechunk for LineStringArray<O, 2> {
+// impl<O: OffsetSizeTrait> Rechunk for LineStringArray<2> {
 //     type Output = Result<ChunkedGeometryArray<Self>>;
 
 //     fn rechunk(&self, ranges: &[Range<usize>]) -> Self::Output {

--- a/src/algorithm/native/take.rs
+++ b/src/algorithm/native/take.rs
@@ -23,7 +23,11 @@ impl Take for PointArray<2> {
     type Output = Self;
 
     fn take(&self, indices: &UInt32Array) -> Self::Output {
-        let mut builder = PointBuilder::with_capacity_and_options(indices.len(), self.coord_type(), self.metadata());
+        let mut builder = PointBuilder::with_capacity_and_options(
+            indices.len(),
+            self.coord_type(),
+            self.metadata(),
+        );
         for index in indices.iter() {
             if let Some(index) = index {
                 builder.push_point(self.get(index.as_usize()).as_ref())
@@ -36,7 +40,11 @@ impl Take for PointArray<2> {
     }
 
     fn take_range(&self, range: &Range<usize>) -> Self::Output {
-        let mut builder = PointBuilder::with_capacity_and_options(range.end - range.start, self.coord_type(), self.metadata());
+        let mut builder = PointBuilder::with_capacity_and_options(
+            range.end - range.start,
+            self.coord_type(),
+            self.metadata(),
+        );
         for i in range.start..range.end {
             builder.push_point(self.get(i).as_ref());
         }
@@ -58,7 +66,11 @@ macro_rules! take_impl {
                     capacity.$capacity_add_func(self.get(index.as_usize()).as_ref());
                 }
 
-                let mut builder = <$builder_type>::with_capacity_and_options(capacity, self.coord_type(), self.metadata());
+                let mut builder = <$builder_type>::with_capacity_and_options(
+                    capacity,
+                    self.coord_type(),
+                    self.metadata(),
+                );
 
                 for index in indices.iter() {
                     if let Some(index) = index {
@@ -78,7 +90,11 @@ macro_rules! take_impl {
                     capacity.$capacity_add_func(self.get(i).as_ref());
                 }
 
-                let mut builder = <$builder_type>::with_capacity_and_options(capacity, self.coord_type(), self.metadata());
+                let mut builder = <$builder_type>::with_capacity_and_options(
+                    capacity,
+                    self.coord_type(),
+                    self.metadata(),
+                );
 
                 for i in range.start..range.end {
                     builder.$push_func(self.get(i).as_ref())?;
@@ -90,11 +106,41 @@ macro_rules! take_impl {
     };
 }
 
-take_impl!(LineStringArray<2>, LineStringCapacity, LineStringBuilder<2>, add_line_string, push_line_string);
-take_impl!(PolygonArray<2>, PolygonCapacity, PolygonBuilder<2>, add_polygon, push_polygon);
-take_impl!(MultiPointArray<2>, MultiPointCapacity, MultiPointBuilder<2>, add_multi_point, push_multi_point);
-take_impl!(MultiLineStringArray<2>, MultiLineStringCapacity, MultiLineStringBuilder<2>, add_multi_line_string, push_multi_line_string);
-take_impl!(MultiPolygonArray<2>, MultiPolygonCapacity, MultiPolygonBuilder<2>, add_multi_polygon, push_multi_polygon);
+take_impl!(
+    LineStringArray<2>,
+    LineStringCapacity,
+    LineStringBuilder<2>,
+    add_line_string,
+    push_line_string
+);
+take_impl!(
+    PolygonArray<2>,
+    PolygonCapacity,
+    PolygonBuilder<2>,
+    add_polygon,
+    push_polygon
+);
+take_impl!(
+    MultiPointArray<2>,
+    MultiPointCapacity,
+    MultiPointBuilder<2>,
+    add_multi_point,
+    push_multi_point
+);
+take_impl!(
+    MultiLineStringArray<2>,
+    MultiLineStringCapacity,
+    MultiLineStringBuilder<2>,
+    add_multi_line_string,
+    push_multi_line_string
+);
+take_impl!(
+    MultiPolygonArray<2>,
+    MultiPolygonCapacity,
+    MultiPolygonBuilder<2>,
+    add_multi_polygon,
+    push_multi_polygon
+);
 
 macro_rules! take_impl_fallible {
     ($array_type:ty, $capacity_type:ty, $builder_type:ty, $capacity_add_func:ident, $push_func:ident) => {
@@ -108,7 +154,11 @@ macro_rules! take_impl_fallible {
                     capacity.$capacity_add_func(self.get(index.as_usize()).as_ref())?;
                 }
 
-                let mut builder = <$builder_type>::with_capacity_and_options(capacity, self.coord_type(), self.metadata());
+                let mut builder = <$builder_type>::with_capacity_and_options(
+                    capacity,
+                    self.coord_type(),
+                    self.metadata(),
+                );
 
                 for index in indices.iter() {
                     if let Some(index) = index {
@@ -128,7 +178,11 @@ macro_rules! take_impl_fallible {
                     capacity.$capacity_add_func(self.get(i).as_ref())?;
                 }
 
-                let mut builder = <$builder_type>::with_capacity_and_options(capacity, self.coord_type(), self.metadata());
+                let mut builder = <$builder_type>::with_capacity_and_options(
+                    capacity,
+                    self.coord_type(),
+                    self.metadata(),
+                );
 
                 for i in range.start..range.end {
                     builder.$push_func(self.get(i).as_ref())?;
@@ -140,8 +194,20 @@ macro_rules! take_impl_fallible {
     };
 }
 
-take_impl_fallible!(MixedGeometryArray<2>, MixedCapacity, MixedGeometryBuilder<2>, add_geometry, push_geometry);
-take_impl_fallible!(GeometryCollectionArray<2>, GeometryCollectionCapacity, GeometryCollectionBuilder<2>, add_geometry_collection, push_geometry_collection);
+take_impl_fallible!(
+    MixedGeometryArray<2>,
+    MixedCapacity,
+    MixedGeometryBuilder<2>,
+    add_geometry,
+    push_geometry
+);
+take_impl_fallible!(
+    GeometryCollectionArray<2>,
+    GeometryCollectionCapacity,
+    GeometryCollectionBuilder<2>,
+    add_geometry_collection,
+    push_geometry_collection
+);
 
 impl Take for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -158,7 +224,9 @@ impl Take for &dyn NativeArray {
             MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().take(indices)?),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().take(indices)?),
             Mixed(_, XY) => Arc::new(self.as_mixed::<2>().take(indices)?),
-            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection::<2>().take(indices)?),
+            GeometryCollection(_, XY) => {
+                Arc::new(self.as_geometry_collection::<2>().take(indices)?)
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -176,7 +244,9 @@ impl Take for &dyn NativeArray {
             MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().take_range(range)?),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().take_range(range)?),
             Mixed(_, XY) => Arc::new(self.as_mixed::<2>().take_range(range)?),
-            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection::<2>().take_range(range)?),
+            GeometryCollection(_, XY) => {
+                Arc::new(self.as_geometry_collection::<2>().take_range(range)?)
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/src/algorithm/native/take.rs
+++ b/src/algorithm/native/take.rs
@@ -7,7 +7,7 @@ use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
-use arrow_array::{OffsetSizeTrait, UInt32Array};
+use arrow_array::UInt32Array;
 use arrow_buffer::ArrowNativeType;
 
 /// Take elements by index from Array, creating a new Array from those indexes.

--- a/src/algorithm/native/take.rs
+++ b/src/algorithm/native/take.rs
@@ -23,11 +23,7 @@ impl Take for PointArray<2> {
     type Output = Self;
 
     fn take(&self, indices: &UInt32Array) -> Self::Output {
-        let mut builder = PointBuilder::with_capacity_and_options(
-            indices.len(),
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = PointBuilder::with_capacity_and_options(indices.len(), self.coord_type(), self.metadata());
         for index in indices.iter() {
             if let Some(index) = index {
                 builder.push_point(self.get(index.as_usize()).as_ref())
@@ -40,11 +36,7 @@ impl Take for PointArray<2> {
     }
 
     fn take_range(&self, range: &Range<usize>) -> Self::Output {
-        let mut builder = PointBuilder::with_capacity_and_options(
-            range.end - range.start,
-            self.coord_type(),
-            self.metadata(),
-        );
+        let mut builder = PointBuilder::with_capacity_and_options(range.end - range.start, self.coord_type(), self.metadata());
         for i in range.start..range.end {
             builder.push_point(self.get(i).as_ref());
         }
@@ -56,7 +48,7 @@ impl Take for PointArray<2> {
 
 macro_rules! take_impl {
     ($array_type:ty, $capacity_type:ty, $builder_type:ty, $capacity_add_func:ident, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> Take for $array_type {
+        impl Take for $array_type {
             type Output = Result<Self>;
 
             fn take(&self, indices: &UInt32Array) -> Self::Output {
@@ -66,11 +58,7 @@ macro_rules! take_impl {
                     capacity.$capacity_add_func(self.get(index.as_usize()).as_ref());
                 }
 
-                let mut builder = <$builder_type>::with_capacity_and_options(
-                    capacity,
-                    self.coord_type(),
-                    self.metadata(),
-                );
+                let mut builder = <$builder_type>::with_capacity_and_options(capacity, self.coord_type(), self.metadata());
 
                 for index in indices.iter() {
                     if let Some(index) = index {
@@ -90,11 +78,7 @@ macro_rules! take_impl {
                     capacity.$capacity_add_func(self.get(i).as_ref());
                 }
 
-                let mut builder = <$builder_type>::with_capacity_and_options(
-                    capacity,
-                    self.coord_type(),
-                    self.metadata(),
-                );
+                let mut builder = <$builder_type>::with_capacity_and_options(capacity, self.coord_type(), self.metadata());
 
                 for i in range.start..range.end {
                     builder.$push_func(self.get(i).as_ref())?;
@@ -106,45 +90,15 @@ macro_rules! take_impl {
     };
 }
 
-take_impl!(
-    LineStringArray<O, 2>,
-    LineStringCapacity,
-    LineStringBuilder<O, 2>,
-    add_line_string,
-    push_line_string
-);
-take_impl!(
-    PolygonArray<O, 2>,
-    PolygonCapacity,
-    PolygonBuilder<O, 2>,
-    add_polygon,
-    push_polygon
-);
-take_impl!(
-    MultiPointArray<O, 2>,
-    MultiPointCapacity,
-    MultiPointBuilder<O, 2>,
-    add_multi_point,
-    push_multi_point
-);
-take_impl!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringCapacity,
-    MultiLineStringBuilder<O, 2>,
-    add_multi_line_string,
-    push_multi_line_string
-);
-take_impl!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonCapacity,
-    MultiPolygonBuilder<O, 2>,
-    add_multi_polygon,
-    push_multi_polygon
-);
+take_impl!(LineStringArray<2>, LineStringCapacity, LineStringBuilder<2>, add_line_string, push_line_string);
+take_impl!(PolygonArray<2>, PolygonCapacity, PolygonBuilder<2>, add_polygon, push_polygon);
+take_impl!(MultiPointArray<2>, MultiPointCapacity, MultiPointBuilder<2>, add_multi_point, push_multi_point);
+take_impl!(MultiLineStringArray<2>, MultiLineStringCapacity, MultiLineStringBuilder<2>, add_multi_line_string, push_multi_line_string);
+take_impl!(MultiPolygonArray<2>, MultiPolygonCapacity, MultiPolygonBuilder<2>, add_multi_polygon, push_multi_polygon);
 
 macro_rules! take_impl_fallible {
     ($array_type:ty, $capacity_type:ty, $builder_type:ty, $capacity_add_func:ident, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> Take for $array_type {
+        impl Take for $array_type {
             type Output = Result<Self>;
 
             fn take(&self, indices: &UInt32Array) -> Self::Output {
@@ -154,11 +108,7 @@ macro_rules! take_impl_fallible {
                     capacity.$capacity_add_func(self.get(index.as_usize()).as_ref())?;
                 }
 
-                let mut builder = <$builder_type>::with_capacity_and_options(
-                    capacity,
-                    self.coord_type(),
-                    self.metadata(),
-                );
+                let mut builder = <$builder_type>::with_capacity_and_options(capacity, self.coord_type(), self.metadata());
 
                 for index in indices.iter() {
                     if let Some(index) = index {
@@ -178,11 +128,7 @@ macro_rules! take_impl_fallible {
                     capacity.$capacity_add_func(self.get(i).as_ref())?;
                 }
 
-                let mut builder = <$builder_type>::with_capacity_and_options(
-                    capacity,
-                    self.coord_type(),
-                    self.metadata(),
-                );
+                let mut builder = <$builder_type>::with_capacity_and_options(capacity, self.coord_type(), self.metadata());
 
                 for i in range.start..range.end {
                     builder.$push_func(self.get(i).as_ref())?;
@@ -194,20 +140,8 @@ macro_rules! take_impl_fallible {
     };
 }
 
-take_impl_fallible!(
-    MixedGeometryArray<O, 2>,
-    MixedCapacity,
-    MixedGeometryBuilder<O, 2>,
-    add_geometry,
-    push_geometry
-);
-take_impl_fallible!(
-    GeometryCollectionArray<O, 2>,
-    GeometryCollectionCapacity,
-    GeometryCollectionBuilder<O, 2>,
-    add_geometry_collection,
-    push_geometry_collection
-);
+take_impl_fallible!(MixedGeometryArray<2>, MixedCapacity, MixedGeometryBuilder<2>, add_geometry, push_geometry);
+take_impl_fallible!(GeometryCollectionArray<2>, GeometryCollectionCapacity, GeometryCollectionBuilder<2>, add_geometry_collection, push_geometry_collection);
 
 impl Take for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -219,25 +153,12 @@ impl Take for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().take(indices)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().take(indices)?),
-            LargeLineString(_, XY) => Arc::new(self.as_large_line_string::<2>().take(indices)?),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().take(indices)?),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().take(indices)?),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().take(indices)?),
-            LargeMultiPoint(_, XY) => Arc::new(self.as_large_multi_point::<2>().take(indices)?),
             MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().take(indices)?),
-            LargeMultiLineString(_, XY) => {
-                Arc::new(self.as_large_multi_line_string::<2>().take(indices)?)
-            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().take(indices)?),
-            LargeMultiPolygon(_, XY) => Arc::new(self.as_large_multi_polygon::<2>().take(indices)?),
             Mixed(_, XY) => Arc::new(self.as_mixed::<2>().take(indices)?),
-            LargeMixed(_, XY) => Arc::new(self.as_large_mixed::<2>().take(indices)?),
-            GeometryCollection(_, XY) => {
-                Arc::new(self.as_geometry_collection::<2>().take(indices)?)
-            }
-            LargeGeometryCollection(_, XY) => {
-                Arc::new(self.as_large_geometry_collection::<2>().take(indices)?)
-            }
+            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection::<2>().take(indices)?),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -250,27 +171,12 @@ impl Take for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             Point(_, XY) => Arc::new(self.as_point::<2>().take_range(range)),
             LineString(_, XY) => Arc::new(self.as_line_string::<2>().take_range(range)?),
-            LargeLineString(_, XY) => Arc::new(self.as_large_line_string::<2>().take_range(range)?),
             Polygon(_, XY) => Arc::new(self.as_polygon::<2>().take_range(range)?),
-            LargePolygon(_, XY) => Arc::new(self.as_large_polygon::<2>().take_range(range)?),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().take_range(range)?),
-            LargeMultiPoint(_, XY) => Arc::new(self.as_large_multi_point::<2>().take_range(range)?),
             MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().take_range(range)?),
-            LargeMultiLineString(_, XY) => {
-                Arc::new(self.as_large_multi_line_string::<2>().take_range(range)?)
-            }
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().take_range(range)?),
-            LargeMultiPolygon(_, XY) => {
-                Arc::new(self.as_large_multi_polygon::<2>().take_range(range)?)
-            }
             Mixed(_, XY) => Arc::new(self.as_mixed::<2>().take_range(range)?),
-            LargeMixed(_, XY) => Arc::new(self.as_large_mixed::<2>().take_range(range)?),
-            GeometryCollection(_, XY) => {
-                Arc::new(self.as_geometry_collection::<2>().take_range(range)?)
-            }
-            LargeGeometryCollection(_, XY) => {
-                Arc::new(self.as_large_geometry_collection::<2>().take_range(range)?)
-            }
+            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection::<2>().take_range(range)?),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -302,7 +208,7 @@ impl Take for ChunkedGeometryArray<PointArray<2>> {
 /// Implementation that iterates over chunks
 macro_rules! chunked_impl {
     ($type:ty) => {
-        impl<O: OffsetSizeTrait> Take for $type {
+        impl Take for $type {
             type Output = Result<$type>;
 
             fn take(&self, indices: &UInt32Array) -> Self::Output {
@@ -326,10 +232,10 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<MixedGeometryArray<O, 2>>);
-chunked_impl!(ChunkedGeometryArray<GeometryCollectionArray<O, 2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<2>>);
+chunked_impl!(ChunkedGeometryArray<MixedGeometryArray<2>>);
+chunked_impl!(ChunkedGeometryArray<GeometryCollectionArray<2>>);

--- a/src/algorithm/native/total_bounds.rs
+++ b/src/algorithm/native/total_bounds.rs
@@ -95,7 +95,9 @@ impl TotalBounds for &dyn NativeArray {
 impl<G: NativeArray> TotalBounds for ChunkedGeometryArray<G> {
     fn total_bounds(&self) -> BoundingRect {
         let bounding_rects = self.map(|chunk| chunk.as_ref().total_bounds());
-        bounding_rects.into_iter().fold(BoundingRect::default(), |acc, x| acc + x)
+        bounding_rects
+            .into_iter()
+            .fold(BoundingRect::default(), |acc, x| acc + x)
     }
 }
 
@@ -137,7 +139,10 @@ mod test {
 
     #[test]
     fn test_dyn_chunked_array() {
-        let chunked_array: Arc<dyn ChunkedNativeArray> = Arc::new(ChunkedGeometryArray::new(vec![polygon::p_array(), polygon::p_array()]));
+        let chunked_array: Arc<dyn ChunkedNativeArray> = Arc::new(ChunkedGeometryArray::new(vec![
+            polygon::p_array(),
+            polygon::p_array(),
+        ]));
         let total_bounds = chunked_array.as_ref().total_bounds();
         dbg!(total_bounds);
     }

--- a/src/algorithm/native/total_bounds.rs
+++ b/src/algorithm/native/total_bounds.rs
@@ -1,5 +1,3 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::algorithm::native::bounding_rect::BoundingRect;
 use crate::array::*;
 use crate::chunked_array::*;
@@ -97,9 +95,7 @@ impl TotalBounds for &dyn NativeArray {
 impl<G: NativeArray> TotalBounds for ChunkedGeometryArray<G> {
     fn total_bounds(&self) -> BoundingRect {
         let bounding_rects = self.map(|chunk| chunk.as_ref().total_bounds());
-        bounding_rects
-            .into_iter()
-            .fold(BoundingRect::default(), |acc, x| acc + x)
+        bounding_rects.into_iter().fold(BoundingRect::default(), |acc, x| acc + x)
     }
 }
 
@@ -141,10 +137,7 @@ mod test {
 
     #[test]
     fn test_dyn_chunked_array() {
-        let chunked_array: Arc<dyn ChunkedNativeArray> = Arc::new(ChunkedGeometryArray::new(vec![
-            polygon::p_array(),
-            polygon::p_array(),
-        ]));
+        let chunked_array: Arc<dyn ChunkedNativeArray> = Arc::new(ChunkedGeometryArray::new(vec![polygon::p_array(), polygon::p_array()]));
         let total_bounds = chunked_array.as_ref().total_bounds();
         dbg!(total_bounds);
     }

--- a/src/algorithm/native/total_bounds.rs
+++ b/src/algorithm/native/total_bounds.rs
@@ -34,7 +34,7 @@ impl<const D: usize> TotalBounds for RectArray<D> {
 
 macro_rules! impl_array {
     ($type:ty, $func:ident) => {
-        impl<O: OffsetSizeTrait, const D: usize> TotalBounds for $type {
+        impl<const D: usize> TotalBounds for $type {
             fn total_bounds(&self) -> BoundingRect {
                 let mut bounds = BoundingRect::new();
                 for geom in self.iter().flatten() {
@@ -46,13 +46,13 @@ macro_rules! impl_array {
     };
 }
 
-impl_array!(LineStringArray<O, D>, add_line_string);
-impl_array!(PolygonArray<O, D>, add_polygon);
-impl_array!(MultiPointArray<O, D>, add_multi_point);
-impl_array!(MultiLineStringArray<O, D>, add_multi_line_string);
-impl_array!(MultiPolygonArray<O, D>, add_multi_polygon);
-impl_array!(MixedGeometryArray<O, D>, add_geometry);
-impl_array!(GeometryCollectionArray<O, D>, add_geometry_collection);
+impl_array!(LineStringArray<D>, add_line_string);
+impl_array!(PolygonArray<D>, add_polygon);
+impl_array!(MultiPointArray<D>, add_multi_point);
+impl_array!(MultiLineStringArray<D>, add_multi_line_string);
+impl_array!(MultiPolygonArray<D>, add_multi_polygon);
+impl_array!(MixedGeometryArray<D>, add_geometry);
+impl_array!(GeometryCollectionArray<D>, add_geometry_collection);
 
 // impl<O: OffsetSizeTrait> TotalBounds for WKBArray<O> {
 //     fn total_bounds(&self) -> BoundingRect {
@@ -72,39 +72,21 @@ impl TotalBounds for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().total_bounds(),
             LineString(_, XY) => self.as_line_string::<2>().total_bounds(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().total_bounds(),
             Polygon(_, XY) => self.as_polygon::<2>().total_bounds(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().total_bounds(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().total_bounds(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().total_bounds(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().total_bounds(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().total_bounds(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().total_bounds(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().total_bounds(),
             Mixed(_, XY) => self.as_mixed::<2>().total_bounds(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().total_bounds(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().total_bounds(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().total_bounds()
-            }
             Rect(XY) => self.as_rect::<2>().total_bounds(),
             Point(_, XYZ) => self.as_point::<3>().total_bounds(),
             LineString(_, XYZ) => self.as_line_string::<3>().total_bounds(),
-            LargeLineString(_, XYZ) => self.as_large_line_string::<3>().total_bounds(),
             Polygon(_, XYZ) => self.as_polygon::<3>().total_bounds(),
-            LargePolygon(_, XYZ) => self.as_large_polygon::<3>().total_bounds(),
             MultiPoint(_, XYZ) => self.as_multi_point::<3>().total_bounds(),
-            LargeMultiPoint(_, XYZ) => self.as_large_multi_point::<3>().total_bounds(),
             MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().total_bounds(),
-            LargeMultiLineString(_, XYZ) => self.as_large_multi_line_string::<3>().total_bounds(),
             MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().total_bounds(),
-            LargeMultiPolygon(_, XYZ) => self.as_large_multi_polygon::<3>().total_bounds(),
             Mixed(_, XYZ) => self.as_mixed::<3>().total_bounds(),
-            LargeMixed(_, XYZ) => self.as_large_mixed::<3>().total_bounds(),
             GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().total_bounds(),
-            LargeGeometryCollection(_, XYZ) => {
-                self.as_large_geometry_collection::<3>().total_bounds()
-            }
             Rect(XYZ) => self.as_rect::<3>().total_bounds(),
             // WKB => self.as_wkb().total_bounds(),
             // LargeWKB => self.as_large_wkb().total_bounds(),
@@ -129,39 +111,22 @@ impl TotalBounds for &dyn ChunkedNativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().total_bounds(),
             LineString(_, XY) => self.as_line_string::<2>().total_bounds(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().total_bounds(),
             Polygon(_, XY) => self.as_polygon::<2>().total_bounds(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().total_bounds(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().total_bounds(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().total_bounds(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().total_bounds(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().total_bounds(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().total_bounds(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().total_bounds(),
             Mixed(_, XY) => self.as_mixed::<2>().total_bounds(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().total_bounds(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().total_bounds(),
-            LargeGeometryCollection(_, XY) => {
-                self.as_large_geometry_collection::<2>().total_bounds()
-            }
             Rect(XY) => self.as_rect::<2>().total_bounds(),
+
             Point(_, XYZ) => self.as_point::<3>().total_bounds(),
             LineString(_, XYZ) => self.as_line_string::<3>().total_bounds(),
-            LargeLineString(_, XYZ) => self.as_large_line_string::<3>().total_bounds(),
             Polygon(_, XYZ) => self.as_polygon::<3>().total_bounds(),
-            LargePolygon(_, XYZ) => self.as_large_polygon::<3>().total_bounds(),
             MultiPoint(_, XYZ) => self.as_multi_point::<3>().total_bounds(),
-            LargeMultiPoint(_, XYZ) => self.as_large_multi_point::<3>().total_bounds(),
             MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().total_bounds(),
-            LargeMultiLineString(_, XYZ) => self.as_large_multi_line_string::<3>().total_bounds(),
             MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().total_bounds(),
-            LargeMultiPolygon(_, XYZ) => self.as_large_multi_polygon::<3>().total_bounds(),
             Mixed(_, XYZ) => self.as_mixed::<3>().total_bounds(),
-            LargeMixed(_, XYZ) => self.as_large_mixed::<3>().total_bounds(),
             GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().total_bounds(),
-            LargeGeometryCollection(_, XYZ) => {
-                self.as_large_geometry_collection::<3>().total_bounds()
-            }
             Rect(XYZ) => self.as_rect::<3>().total_bounds(),
         }
     }

--- a/src/algorithm/native/type_id.rs
+++ b/src/algorithm/native/type_id.rs
@@ -52,7 +52,7 @@ impl TypeIds for PointArray<2> {
 
 macro_rules! constant_impl {
     ($type:ty, $value:expr) => {
-        impl<O: OffsetSizeTrait> TypeIds for $type {
+        impl TypeIds for $type {
             fn get_type_ids(&self) -> Int16Array {
                 let values = vec![$value; self.len()];
                 Int16Array::new(values.into(), self.nulls().cloned())
@@ -67,13 +67,13 @@ macro_rules! constant_impl {
     };
 }
 
-constant_impl!(LineStringArray<O, 2>, 1);
-constant_impl!(PolygonArray<O, 2>, 3);
-constant_impl!(MultiPointArray<O, 2>, 4);
-constant_impl!(MultiLineStringArray<O, 2>, 5);
-constant_impl!(MultiPolygonArray<O, 2>, 6);
+constant_impl!(LineStringArray<2>, 1);
+constant_impl!(PolygonArray<2>, 3);
+constant_impl!(MultiPointArray<2>, 4);
+constant_impl!(MultiLineStringArray<2>, 5);
+constant_impl!(MultiPolygonArray<2>, 6);
 
-impl<O: OffsetSizeTrait> TypeIds for MixedGeometryArray<O, 2> {
+impl TypeIds for MixedGeometryArray<2> {
     fn get_type_ids(&self) -> Int16Array {
         use crate::scalar::Geometry::*;
 

--- a/src/algorithm/native/unary.rs
+++ b/src/algorithm/native/unary.rs
@@ -106,7 +106,8 @@ pub trait UnaryPoint<'a>: ArrayAccessor<'a> + NativeArray {
     {
         let nulls = self.nulls().cloned();
         let result_geom_iter = self.iter_values().map(op);
-        let builder = PointBuilder::from_points(result_geom_iter, Some(self.coord_type()), self.metadata());
+        let builder =
+            PointBuilder::from_points(result_geom_iter, Some(self.coord_type()), self.metadata());
         let mut result = builder.finish();
         result.validity = nulls;
         result
@@ -117,7 +118,8 @@ pub trait UnaryPoint<'a>: ArrayAccessor<'a> + NativeArray {
         G: PointTrait<T = f64> + 'a,
         F: Fn(Self::Item) -> std::result::Result<G, E>,
     {
-        let mut builder = PointBuilder::with_capacity_and_options(self.len(), self.coord_type(), self.metadata());
+        let mut builder =
+            PointBuilder::with_capacity_and_options(self.len(), self.coord_type(), self.metadata());
 
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {

--- a/src/algorithm/native/unary.rs
+++ b/src/algorithm/native/unary.rs
@@ -87,13 +87,13 @@ pub trait Unary<'a>: ArrayAccessor<'a> {
 }
 
 impl<'a> Unary<'a> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for LineStringArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for PolygonArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiPointArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiLineStringArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for MultiPolygonArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for MixedGeometryArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> Unary<'a> for GeometryCollectionArray<O, 2> {}
+impl<'a> Unary<'a> for LineStringArray<2> {}
+impl<'a> Unary<'a> for PolygonArray<2> {}
+impl<'a> Unary<'a> for MultiPointArray<2> {}
+impl<'a> Unary<'a> for MultiLineStringArray<2> {}
+impl<'a> Unary<'a> for MultiPolygonArray<2> {}
+impl<'a> Unary<'a> for MixedGeometryArray<2> {}
+impl<'a> Unary<'a> for GeometryCollectionArray<2> {}
 impl<'a> Unary<'a> for RectArray<2> {}
 impl<'a, O: OffsetSizeTrait> Unary<'a> for WKBArray<O> {}
 
@@ -106,8 +106,7 @@ pub trait UnaryPoint<'a>: ArrayAccessor<'a> + NativeArray {
     {
         let nulls = self.nulls().cloned();
         let result_geom_iter = self.iter_values().map(op);
-        let builder =
-            PointBuilder::from_points(result_geom_iter, Some(self.coord_type()), self.metadata());
+        let builder = PointBuilder::from_points(result_geom_iter, Some(self.coord_type()), self.metadata());
         let mut result = builder.finish();
         result.validity = nulls;
         result
@@ -118,8 +117,7 @@ pub trait UnaryPoint<'a>: ArrayAccessor<'a> + NativeArray {
         G: PointTrait<T = f64> + 'a,
         F: Fn(Self::Item) -> std::result::Result<G, E>,
     {
-        let mut builder =
-            PointBuilder::with_capacity_and_options(self.len(), self.coord_type(), self.metadata());
+        let mut builder = PointBuilder::with_capacity_and_options(self.len(), self.coord_type(), self.metadata());
 
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
@@ -134,11 +132,11 @@ pub trait UnaryPoint<'a>: ArrayAccessor<'a> + NativeArray {
 }
 
 impl<'a> UnaryPoint<'a> for PointArray<2> {}
-impl<'a, O: OffsetSizeTrait> UnaryPoint<'a> for LineStringArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> UnaryPoint<'a> for PolygonArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> UnaryPoint<'a> for MultiPointArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> UnaryPoint<'a> for MultiLineStringArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> UnaryPoint<'a> for MultiPolygonArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> UnaryPoint<'a> for MixedGeometryArray<O, 2> {}
-impl<'a, O: OffsetSizeTrait> UnaryPoint<'a> for GeometryCollectionArray<O, 2> {}
+impl<'a> UnaryPoint<'a> for LineStringArray<2> {}
+impl<'a> UnaryPoint<'a> for PolygonArray<2> {}
+impl<'a> UnaryPoint<'a> for MultiPointArray<2> {}
+impl<'a> UnaryPoint<'a> for MultiLineStringArray<2> {}
+impl<'a> UnaryPoint<'a> for MultiPolygonArray<2> {}
+impl<'a> UnaryPoint<'a> for MixedGeometryArray<2> {}
+impl<'a> UnaryPoint<'a> for GeometryCollectionArray<2> {}
 impl<'a> UnaryPoint<'a> for RectArray<2> {}

--- a/src/algorithm/polylabel.rs
+++ b/src/algorithm/polylabel.rs
@@ -2,7 +2,9 @@ use polylabel::polylabel;
 
 use crate::algorithm::native::UnaryPoint;
 use crate::array::{AsChunkedNativeArray, AsNativeArray, PointArray, PolygonArray};
-use crate::chunked_array::{ChunkedGeometryArray, ChunkedNativeArray, ChunkedPointArray, ChunkedPolygonArray};
+use crate::chunked_array::{
+    ChunkedGeometryArray, ChunkedNativeArray, ChunkedPointArray, ChunkedPolygonArray,
+};
 use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;

--- a/src/algorithm/polylabel.rs
+++ b/src/algorithm/polylabel.rs
@@ -1,4 +1,3 @@
-use arrow_array::OffsetSizeTrait;
 use polylabel::polylabel;
 
 use crate::algorithm::native::UnaryPoint;

--- a/src/algorithm/polylabel.rs
+++ b/src/algorithm/polylabel.rs
@@ -3,9 +3,7 @@ use polylabel::polylabel;
 
 use crate::algorithm::native::UnaryPoint;
 use crate::array::{AsChunkedNativeArray, AsNativeArray, PointArray, PolygonArray};
-use crate::chunked_array::{
-    ChunkedGeometryArray, ChunkedNativeArray, ChunkedPointArray, ChunkedPolygonArray,
-};
+use crate::chunked_array::{ChunkedGeometryArray, ChunkedNativeArray, ChunkedPointArray, ChunkedPolygonArray};
 use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::NativeScalar;
@@ -26,7 +24,7 @@ pub trait Polylabel {
     fn polylabel(&self, tolerance: f64) -> Self::Output;
 }
 
-impl<O: OffsetSizeTrait> Polylabel for PolygonArray<O, 2> {
+impl Polylabel for PolygonArray<2> {
     type Output = Result<PointArray<2>>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
@@ -40,15 +38,12 @@ impl Polylabel for &dyn NativeArray {
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         match self.data_type() {
             NativeType::Polygon(_, Dimension::XY) => self.as_polygon::<2>().polylabel(tolerance),
-            NativeType::LargePolygon(_, Dimension::XY) => {
-                self.as_large_polygon::<2>().polylabel(tolerance)
-            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl<O: OffsetSizeTrait> Polylabel for ChunkedPolygonArray<O, 2> {
+impl Polylabel for ChunkedPolygonArray<2> {
     type Output = Result<ChunkedPointArray<2>>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
@@ -63,9 +58,6 @@ impl Polylabel for &dyn ChunkedNativeArray {
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         match self.data_type() {
             NativeType::Polygon(_, Dimension::XY) => self.as_polygon::<2>().polylabel(tolerance),
-            NativeType::LargePolygon(_, Dimension::XY) => {
-                self.as_large_polygon::<2>().polylabel(tolerance)
-            }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/src/algorithm/proj.rs
+++ b/src/algorithm/proj.rs
@@ -3,7 +3,6 @@
 use crate::array::*;
 use crate::error::Result;
 use crate::trait_::ArrayAccessor;
-use arrow_array::OffsetSizeTrait;
 use proj::{Proj, Transform};
 
 /// Reproject an array using PROJ
@@ -54,16 +53,8 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
-    push_multi_line_string
-);
-iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
-    push_multi_polygon
-);
+iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
+iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
 
 #[cfg(test)]
 mod test {

--- a/src/algorithm/proj.rs
+++ b/src/algorithm/proj.rs
@@ -32,7 +32,7 @@ impl Reproject for PointArray<2> {
 
 macro_rules! iter_geo_impl {
     ($type:ty, $builder_type:ty, $push_func:ident) => {
-        impl<O: OffsetSizeTrait> Reproject for $type {
+        impl Reproject for $type {
             fn reproject(&self, proj: &Proj) -> Result<Self> {
                 let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
 
@@ -51,17 +51,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<O, 2>, LineStringBuilder<O, 2>, push_line_string);
-iter_geo_impl!(PolygonArray<O, 2>, PolygonBuilder<O, 2>, push_polygon);
-iter_geo_impl!(MultiPointArray<O, 2>, MultiPointBuilder<O, 2>, push_multi_point);
+iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
+iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
+iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<O, 2>,
-    MultiLineStringBuilder<O, 2>,
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<O, 2>,
-    MultiPolygonBuilder<O, 2>,
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
     push_multi_polygon
 );
 

--- a/src/algorithm/proj.rs
+++ b/src/algorithm/proj.rs
@@ -53,8 +53,16 @@ macro_rules! iter_geo_impl {
 iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
 iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
 iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
-iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringBuilder<2>, push_multi_line_string);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonBuilder<2>, push_multi_polygon);
+iter_geo_impl!(
+    MultiLineStringArray<2>,
+    MultiLineStringBuilder<2>,
+    push_multi_line_string
+);
+iter_geo_impl!(
+    MultiPolygonArray<2>,
+    MultiPolygonBuilder<2>,
+    push_multi_polygon
+);
 
 #[cfg(test)]
 mod test {

--- a/src/algorithm/rstar.rs
+++ b/src/algorithm/rstar.rs
@@ -34,7 +34,7 @@ impl<'a> RTree<'a> for RectArray<2> {
 
 macro_rules! iter_cached_impl {
     ($type:ty, $scalar_type:ty) => {
-        impl<'a, O: OffsetSizeTrait> RTree<'a> for $type {
+        impl<'a> RTree<'a> for $type {
             type RTreeObject = CachedEnvelope<$scalar_type>;
 
             fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject> {
@@ -44,17 +44,10 @@ macro_rules! iter_cached_impl {
     };
 }
 
-iter_cached_impl!(LineStringArray<O, 2>, crate::scalar::LineString<'a, O, 2>);
-iter_cached_impl!(PolygonArray<O, 2>, crate::scalar::Polygon<'a, O, 2>);
-iter_cached_impl!(MultiPointArray<O, 2>, crate::scalar::MultiPoint<'a, O, 2>);
-iter_cached_impl!(
-    MultiLineStringArray<O, 2>,
-    crate::scalar::MultiLineString<'a, O, 2>
-);
-iter_cached_impl!(MultiPolygonArray<O, 2>, crate::scalar::MultiPolygon<'a, O, 2>);
-iter_cached_impl!(WKBArray<O>, crate::scalar::WKB<'a, O>);
-iter_cached_impl!(MixedGeometryArray<O, 2>, crate::scalar::Geometry<'a, O, 2>);
-iter_cached_impl!(
-    GeometryCollectionArray<O, 2>,
-    crate::scalar::GeometryCollection<'a, O, 2>
-);
+iter_cached_impl!(LineStringArray<2>, crate::scalar::LineString<'a, 2>);
+iter_cached_impl!(PolygonArray<2>, crate::scalar::Polygon<'a, 2>);
+iter_cached_impl!(MultiPointArray<2>, crate::scalar::MultiPoint<'a, 2>);
+iter_cached_impl!(MultiLineStringArray<2>, crate::scalar::MultiLineString<'a, 2>);
+iter_cached_impl!(MultiPolygonArray<2>, crate::scalar::MultiPolygon<'a, 2>);
+iter_cached_impl!(MixedGeometryArray<2>, crate::scalar::Geometry<'a, 2>);
+iter_cached_impl!(GeometryCollectionArray<2>, crate::scalar::GeometryCollection<'a, 2>);

--- a/src/algorithm/rstar.rs
+++ b/src/algorithm/rstar.rs
@@ -2,7 +2,6 @@
 
 use crate::array::*;
 use crate::trait_::ArrayAccessor;
-use arrow_array::OffsetSizeTrait;
 use rstar::primitives::CachedEnvelope;
 
 /// Construct an R-Tree from a geometry array.

--- a/src/algorithm/rstar.rs
+++ b/src/algorithm/rstar.rs
@@ -46,7 +46,13 @@ macro_rules! iter_cached_impl {
 iter_cached_impl!(LineStringArray<2>, crate::scalar::LineString<'a, 2>);
 iter_cached_impl!(PolygonArray<2>, crate::scalar::Polygon<'a, 2>);
 iter_cached_impl!(MultiPointArray<2>, crate::scalar::MultiPoint<'a, 2>);
-iter_cached_impl!(MultiLineStringArray<2>, crate::scalar::MultiLineString<'a, 2>);
+iter_cached_impl!(
+    MultiLineStringArray<2>,
+    crate::scalar::MultiLineString<'a, 2>
+);
 iter_cached_impl!(MultiPolygonArray<2>, crate::scalar::MultiPolygon<'a, 2>);
 iter_cached_impl!(MixedGeometryArray<2>, crate::scalar::Geometry<'a, 2>);
-iter_cached_impl!(GeometryCollectionArray<2>, crate::scalar::GeometryCollection<'a, 2>);
+iter_cached_impl!(
+    GeometryCollectionArray<2>,
+    crate::scalar::GeometryCollection<'a, 2>
+);

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -39,7 +39,11 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
             false => SerializedType::WKB,
         };
 
-        Self { data_type, metadata, array }
+        Self {
+            data_type,
+            metadata,
+            array,
+        }
     }
 
     /// Returns true if the array is empty
@@ -50,14 +54,17 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
     /// Infer the minimal NativeType that this WKBArray can be casted to.
     #[allow(dead_code)]
     // TODO: is this obsolete with new from_wkb approach that uses downcasting?
-    pub(crate) fn infer_geo_data_type(&self, large_type: bool, coord_type: CoordType) -> Result<NativeType> {
+    pub(crate) fn infer_geo_data_type(&self, coord_type: CoordType) -> Result<NativeType> {
         use crate::io::wkb::reader::r#type::infer_geometry_type;
-        infer_geometry_type(self.iter().flatten(), large_type, coord_type)
+        infer_geometry_type(self.iter().flatten(), coord_type)
     }
 
     /// The lengths of each buffer contained in this array.
     pub fn buffer_lengths(&self) -> WKBCapacity {
-        WKBCapacity::new(self.array.offsets().last().unwrap().to_usize().unwrap(), self.len())
+        WKBCapacity::new(
+            self.array.offsets().last().unwrap().to_usize().unwrap(),
+            self.len(),
+        )
     }
 
     /// The number of bytes occupied by this array.
@@ -75,8 +82,15 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
-        Self { array: self.array.slice(offset, length), data_type: self.data_type, metadata: self.metadata() }
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        Self {
+            array: self.array.slice(offset, length),
+            data_type: self.data_type,
+            metadata: self.metadata(),
+        }
     }
 
     pub fn owned_slice(&self, _offset: usize, _length: usize) -> Self {
@@ -121,7 +135,9 @@ impl<O: OffsetSizeTrait> ArrayBase for WKBArray<O> {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        self.data_type.to_field_with_metadata("geometry", true, &self.metadata).into()
+        self.data_type
+            .to_field_with_metadata("geometry", true, &self.metadata)
+            .into()
     }
 
     fn extension_name(&self) -> &str {
@@ -180,7 +196,11 @@ impl<O: OffsetSizeTrait> IntoArrow for WKBArray<O> {
     type ArrowArray = GenericBinaryArray<O>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        GenericBinaryArray::new(self.array.offsets().clone(), self.array.values().clone(), self.array.nulls().cloned())
+        GenericBinaryArray::new(
+            self.array.offsets().clone(),
+            self.array.values().clone(),
+            self.array.nulls().cloned(),
+        )
     }
 }
 
@@ -203,7 +223,10 @@ impl TryFrom<&dyn Array> for WKBArray<i32> {
                 let geom_array: WKBArray<i64> = downcasted.clone().into();
                 geom_array.try_into()
             }
-            _ => Err(GeoArrowError::General(format!("Unexpected type: {:?}", value.data_type()))),
+            _ => Err(GeoArrowError::General(format!(
+                "Unexpected type: {:?}",
+                value.data_type()
+            ))),
         }
     }
 }
@@ -221,7 +244,10 @@ impl TryFrom<&dyn Array> for WKBArray<i64> {
                 let downcasted = value.as_binary::<i64>();
                 Ok(downcasted.clone().into())
             }
-            _ => Err(GeoArrowError::General(format!("Unexpected type: {:?}", value.data_type()))),
+            _ => Err(GeoArrowError::General(format!(
+                "Unexpected type: {:?}",
+                value.data_type()
+            ))),
         }
     }
 }
@@ -250,7 +276,10 @@ impl From<WKBArray<i32>> for WKBArray<i64> {
     fn from(value: WKBArray<i32>) -> Self {
         let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
-        Self::new(LargeBinaryArray::new(offsets_buffer_i32_to_i64(&offsets), values, nulls), value.metadata)
+        Self::new(
+            LargeBinaryArray::new(offsets_buffer_i32_to_i64(&offsets), values, nulls),
+            value.metadata,
+        )
     }
 }
 
@@ -260,7 +289,10 @@ impl TryFrom<WKBArray<i64>> for WKBArray<i32> {
     fn try_from(value: WKBArray<i64>) -> Result<Self> {
         let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
-        Ok(Self::new(BinaryArray::new(offsets_buffer_i64_to_i32(&offsets)?, values, nulls), value.metadata))
+        Ok(Self::new(
+            BinaryArray::new(offsets_buffer_i64_to_i32(&offsets)?, values, nulls),
+            value.metadata,
+        ))
     }
 }
 

--- a/src/array/binary/array.rs
+++ b/src/array/binary/array.rs
@@ -74,7 +74,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
         let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
-        validity_len + self.buffer_lengths().num_bytes::<O>()
+        validity_len + self.buffer_lengths().num_bytes()
     }
 
     pub fn into_inner(self) -> GenericBinaryArray<O> {

--- a/src/array/cast.rs
+++ b/src/array/cast.rs
@@ -13,143 +13,70 @@ pub trait AsNativeArray {
     }
 
     /// Downcast this to a [`LineStringArray`] with `i32` offsets returning `None` if not possible
-    fn as_line_string_opt<const D: usize>(&self) -> Option<&LineStringArray<i32, D>>;
+    fn as_line_string_opt<const D: usize>(&self) -> Option<&LineStringArray<D>>;
 
     /// Downcast this to a [`LineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_line_string<const D: usize>(&self) -> &LineStringArray<i32, D> {
+    fn as_line_string<const D: usize>(&self) -> &LineStringArray<D> {
         self.as_line_string_opt::<D>().unwrap()
     }
 
-    /// Downcast this to a [`LineStringArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_line_string_opt<const D: usize>(&self) -> Option<&LineStringArray<i64, D>>;
-
-    /// Downcast this to a [`LineStringArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_line_string<const D: usize>(&self) -> &LineStringArray<i64, D> {
-        self.as_large_line_string_opt::<D>().unwrap()
-    }
-
     /// Downcast this to a [`PolygonArray`] with `i32` offsets returning `None` if not possible
-    fn as_polygon_opt<const D: usize>(&self) -> Option<&PolygonArray<i32, D>>;
+    fn as_polygon_opt<const D: usize>(&self) -> Option<&PolygonArray<D>>;
 
     /// Downcast this to a [`PolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_polygon<const D: usize>(&self) -> &PolygonArray<i32, D> {
+    fn as_polygon<const D: usize>(&self) -> &PolygonArray<D> {
         self.as_polygon_opt::<D>().unwrap()
     }
 
-    /// Downcast this to a [`PolygonArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_polygon_opt<const D: usize>(&self) -> Option<&PolygonArray<i64, D>>;
-
-    /// Downcast this to a [`PolygonArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_polygon<const D: usize>(&self) -> &PolygonArray<i64, D> {
-        self.as_large_polygon_opt::<D>().unwrap()
-    }
-
     /// Downcast this to a [`MultiPointArray`] with `i32` offsets returning `None` if not possible
-    fn as_multi_point_opt<const D: usize>(&self) -> Option<&MultiPointArray<i32, D>>;
+    fn as_multi_point_opt<const D: usize>(&self) -> Option<&MultiPointArray<D>>;
 
     /// Downcast this to a [`MultiPointArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_point<const D: usize>(&self) -> &MultiPointArray<i32, D> {
+    fn as_multi_point<const D: usize>(&self) -> &MultiPointArray<D> {
         self.as_multi_point_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`MultiPointArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_multi_point_opt<const D: usize>(&self) -> Option<&MultiPointArray<i64, D>>;
-
-    /// Downcast this to a [`MultiPointArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_multi_point<const D: usize>(&self) -> &MultiPointArray<i64, D> {
-        self.as_large_multi_point_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`MultiLineStringArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&MultiLineStringArray<i32, D>>;
+    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&MultiLineStringArray<D>>;
 
     /// Downcast this to a [`MultiLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_line_string<const D: usize>(&self) -> &MultiLineStringArray<i32, D> {
+    fn as_multi_line_string<const D: usize>(&self) -> &MultiLineStringArray<D> {
         self.as_multi_line_string_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`MultiLineStringArray`] with `i64` offsets returning `None` if not
-    /// possible
-    fn as_large_multi_line_string_opt<const D: usize>(
-        &self,
-    ) -> Option<&MultiLineStringArray<i64, D>>;
-
-    /// Downcast this to a [`MultiLineStringArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_multi_line_string<const D: usize>(&self) -> &MultiLineStringArray<i64, D> {
-        self.as_large_multi_line_string_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`MultiPolygonArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&MultiPolygonArray<i32, D>>;
+    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&MultiPolygonArray<D>>;
 
     /// Downcast this to a [`MultiPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_polygon<const D: usize>(&self) -> &MultiPolygonArray<i32, D> {
+    fn as_multi_polygon<const D: usize>(&self) -> &MultiPolygonArray<D> {
         self.as_multi_polygon_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`MultiPolygonArray`] with `i64` offsets returning `None` if not
-    /// possible
-    fn as_large_multi_polygon_opt<const D: usize>(&self) -> Option<&MultiPolygonArray<i64, D>>;
-
-    /// Downcast this to a [`MultiPolygonArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_multi_polygon<const D: usize>(&self) -> &MultiPolygonArray<i64, D> {
-        self.as_large_multi_polygon_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`MixedGeometryArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_mixed_opt<const D: usize>(&self) -> Option<&MixedGeometryArray<i32, D>>;
+    fn as_mixed_opt<const D: usize>(&self) -> Option<&MixedGeometryArray<D>>;
 
     /// Downcast this to a [`MixedGeometryArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_mixed<const D: usize>(&self) -> &MixedGeometryArray<i32, D> {
+    fn as_mixed<const D: usize>(&self) -> &MixedGeometryArray<D> {
         self.as_mixed_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`MixedGeometryArray`] with `i64` offsets returning `None` if not
-    /// possible
-    fn as_large_mixed_opt<const D: usize>(&self) -> Option<&MixedGeometryArray<i64, D>>;
-
-    /// Downcast this to a [`MixedGeometryArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_mixed<const D: usize>(&self) -> &MixedGeometryArray<i64, D> {
-        self.as_large_mixed_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`GeometryCollectionArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&GeometryCollectionArray<i32, D>>;
+    fn as_geometry_collection_opt<const D: usize>(&self) -> Option<&GeometryCollectionArray<D>>;
 
     /// Downcast this to a [`GeometryCollectionArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_geometry_collection<const D: usize>(&self) -> &GeometryCollectionArray<i32, D> {
+    fn as_geometry_collection<const D: usize>(&self) -> &GeometryCollectionArray<D> {
         self.as_geometry_collection_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`GeometryCollectionArray`] with `i64` offsets returning `None` if not
-    /// possible
-    fn as_large_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&GeometryCollectionArray<i64, D>>;
-
-    /// Downcast this to a [`GeometryCollectionArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_geometry_collection<const D: usize>(&self) -> &GeometryCollectionArray<i64, D> {
-        self.as_large_geometry_collection_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`RectArray`] returning `None` if not possible
@@ -169,81 +96,38 @@ impl AsNativeArray for &dyn NativeArray {
     }
 
     #[inline]
-    fn as_line_string_opt<const D: usize>(&self) -> Option<&LineStringArray<i32, D>> {
-        self.as_any().downcast_ref::<LineStringArray<i32, D>>()
+    fn as_line_string_opt<const D: usize>(&self) -> Option<&LineStringArray<D>> {
+        self.as_any().downcast_ref::<LineStringArray<D>>()
     }
 
     #[inline]
-    fn as_large_line_string_opt<const D: usize>(&self) -> Option<&LineStringArray<i64, D>> {
-        self.as_any().downcast_ref::<LineStringArray<i64, D>>()
+    fn as_polygon_opt<const D: usize>(&self) -> Option<&PolygonArray<D>> {
+        self.as_any().downcast_ref::<PolygonArray<D>>()
     }
 
     #[inline]
-    fn as_polygon_opt<const D: usize>(&self) -> Option<&PolygonArray<i32, D>> {
-        self.as_any().downcast_ref::<PolygonArray<i32, D>>()
+    fn as_multi_point_opt<const D: usize>(&self) -> Option<&MultiPointArray<D>> {
+        self.as_any().downcast_ref::<MultiPointArray<D>>()
     }
 
     #[inline]
-    fn as_large_polygon_opt<const D: usize>(&self) -> Option<&PolygonArray<i64, D>> {
-        self.as_any().downcast_ref::<PolygonArray<i64, D>>()
+    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&MultiLineStringArray<D>> {
+        self.as_any().downcast_ref::<MultiLineStringArray<D>>()
     }
 
     #[inline]
-    fn as_multi_point_opt<const D: usize>(&self) -> Option<&MultiPointArray<i32, D>> {
-        self.as_any().downcast_ref::<MultiPointArray<i32, D>>()
+    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&MultiPolygonArray<D>> {
+        self.as_any().downcast_ref::<MultiPolygonArray<D>>()
     }
 
     #[inline]
-    fn as_large_multi_point_opt<const D: usize>(&self) -> Option<&MultiPointArray<i64, D>> {
-        self.as_any().downcast_ref::<MultiPointArray<i64, D>>()
+    fn as_mixed_opt<const D: usize>(&self) -> Option<&MixedGeometryArray<D>> {
+        self.as_any().downcast_ref::<MixedGeometryArray<D>>()
     }
 
     #[inline]
-    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&MultiLineStringArray<i32, D>> {
-        self.as_any().downcast_ref::<MultiLineStringArray<i32, D>>()
-    }
-
-    #[inline]
-    fn as_large_multi_line_string_opt<const D: usize>(
-        &self,
-    ) -> Option<&MultiLineStringArray<i64, D>> {
-        self.as_any().downcast_ref::<MultiLineStringArray<i64, D>>()
-    }
-
-    #[inline]
-    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&MultiPolygonArray<i32, D>> {
-        self.as_any().downcast_ref::<MultiPolygonArray<i32, D>>()
-    }
-
-    #[inline]
-    fn as_large_multi_polygon_opt<const D: usize>(&self) -> Option<&MultiPolygonArray<i64, D>> {
-        self.as_any().downcast_ref::<MultiPolygonArray<i64, D>>()
-    }
-
-    #[inline]
-    fn as_mixed_opt<const D: usize>(&self) -> Option<&MixedGeometryArray<i32, D>> {
-        self.as_any().downcast_ref::<MixedGeometryArray<i32, D>>()
-    }
-
-    #[inline]
-    fn as_large_mixed_opt<const D: usize>(&self) -> Option<&MixedGeometryArray<i64, D>> {
-        self.as_any().downcast_ref::<MixedGeometryArray<i64, D>>()
-    }
-
-    #[inline]
-    fn as_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&GeometryCollectionArray<i32, D>> {
-        self.as_any()
-            .downcast_ref::<GeometryCollectionArray<i32, D>>()
-    }
-
-    #[inline]
-    fn as_large_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&GeometryCollectionArray<i64, D>> {
-        self.as_any()
-            .downcast_ref::<GeometryCollectionArray<i64, D>>()
+    fn as_geometry_collection_opt<const D: usize>(&self) -> Option<&GeometryCollectionArray<D>> {
+        self.as_any().downcast_ref::<GeometryCollectionArray<D>>()
     }
 
     #[inline]
@@ -296,149 +180,70 @@ pub trait AsChunkedNativeArray {
     }
 
     /// Downcast this to a [`ChunkedLineStringArray`] with `i32` offsets returning `None` if not possible
-    fn as_line_string_opt<const D: usize>(&self) -> Option<&ChunkedLineStringArray<i32, D>>;
+    fn as_line_string_opt<const D: usize>(&self) -> Option<&ChunkedLineStringArray<D>>;
 
     /// Downcast this to a [`ChunkedLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_line_string<const D: usize>(&self) -> &ChunkedLineStringArray<i32, D> {
+    fn as_line_string<const D: usize>(&self) -> &ChunkedLineStringArray<D> {
         self.as_line_string_opt::<D>().unwrap()
     }
 
-    /// Downcast this to a [`ChunkedLineStringArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_line_string_opt<const D: usize>(&self) -> Option<&ChunkedLineStringArray<i64, D>>;
-
-    /// Downcast this to a [`ChunkedLineStringArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_line_string<const D: usize>(&self) -> &ChunkedLineStringArray<i64, D> {
-        self.as_large_line_string_opt::<D>().unwrap()
-    }
-
     /// Downcast this to a [`ChunkedPolygonArray`] with `i32` offsets returning `None` if not possible
-    fn as_polygon_opt<const D: usize>(&self) -> Option<&ChunkedPolygonArray<i32, D>>;
+    fn as_polygon_opt<const D: usize>(&self) -> Option<&ChunkedPolygonArray<D>>;
 
     /// Downcast this to a [`ChunkedPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_polygon<const D: usize>(&self) -> &ChunkedPolygonArray<i32, D> {
+    fn as_polygon<const D: usize>(&self) -> &ChunkedPolygonArray<D> {
         self.as_polygon_opt::<D>().unwrap()
     }
 
-    /// Downcast this to a [`ChunkedPolygonArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_polygon_opt<const D: usize>(&self) -> Option<&ChunkedPolygonArray<i64, D>>;
-
-    /// Downcast this to a [`ChunkedPolygonArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_polygon<const D: usize>(&self) -> &ChunkedPolygonArray<i64, D> {
-        self.as_large_polygon_opt::<D>().unwrap()
-    }
-
     /// Downcast this to a [`ChunkedMultiPointArray`] with `i32` offsets returning `None` if not possible
-    fn as_multi_point_opt<const D: usize>(&self) -> Option<&ChunkedMultiPointArray<i32, D>>;
+    fn as_multi_point_opt<const D: usize>(&self) -> Option<&ChunkedMultiPointArray<D>>;
 
     /// Downcast this to a [`ChunkedMultiPointArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_point<const D: usize>(&self) -> &ChunkedMultiPointArray<i32, D> {
+    fn as_multi_point<const D: usize>(&self) -> &ChunkedMultiPointArray<D> {
         self.as_multi_point_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`ChunkedMultiPointArray`] with `i64` offsets returning `None` if not possible
-    fn as_large_multi_point_opt<const D: usize>(&self) -> Option<&ChunkedMultiPointArray<i64, D>>;
-
-    /// Downcast this to a [`ChunkedMultiPointArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_multi_point<const D: usize>(&self) -> &ChunkedMultiPointArray<i64, D> {
-        self.as_large_multi_point_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_line_string_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedMultiLineStringArray<i32, D>>;
+    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&ChunkedMultiLineStringArray<D>>;
 
     /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_line_string<const D: usize>(&self) -> &ChunkedMultiLineStringArray<i32, D> {
+    fn as_multi_line_string<const D: usize>(&self) -> &ChunkedMultiLineStringArray<D> {
         self.as_multi_line_string_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i64` offsets returning `None` if not
-    /// possible
-    fn as_large_multi_line_string_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedMultiLineStringArray<i64, D>>;
-
-    /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_multi_line_string<const D: usize>(&self) -> &ChunkedMultiLineStringArray<i64, D> {
-        self.as_large_multi_line_string_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&ChunkedMultiPolygonArray<i32, D>>;
+    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&ChunkedMultiPolygonArray<D>>;
 
     /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_polygon<const D: usize>(&self) -> &ChunkedMultiPolygonArray<i32, D> {
+    fn as_multi_polygon<const D: usize>(&self) -> &ChunkedMultiPolygonArray<D> {
         self.as_multi_polygon_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i64` offsets returning `None` if not
-    /// possible
-    fn as_large_multi_polygon_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedMultiPolygonArray<i64, D>>;
-
-    /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_multi_polygon<const D: usize>(&self) -> &ChunkedMultiPolygonArray<i64, D> {
-        self.as_large_multi_polygon_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_mixed_opt<const D: usize>(&self) -> Option<&ChunkedMixedGeometryArray<i32, D>>;
+    fn as_mixed_opt<const D: usize>(&self) -> Option<&ChunkedMixedGeometryArray<D>>;
 
     /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_mixed<const D: usize>(&self) -> &ChunkedMixedGeometryArray<i32, D> {
+    fn as_mixed<const D: usize>(&self) -> &ChunkedMixedGeometryArray<D> {
         self.as_mixed_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i64` offsets returning `None` if not
-    /// possible
-    fn as_large_mixed_opt<const D: usize>(&self) -> Option<&ChunkedMixedGeometryArray<i64, D>>;
-
-    /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_mixed<const D: usize>(&self) -> &ChunkedMixedGeometryArray<i64, D> {
-        self.as_large_mixed_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedGeometryCollectionArray<i32, D>>;
+    fn as_geometry_collection_opt<const D: usize>(&self) -> Option<&ChunkedGeometryCollectionArray<D>>;
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_geometry_collection<const D: usize>(&self) -> &ChunkedGeometryCollectionArray<i32, D> {
+    fn as_geometry_collection<const D: usize>(&self) -> &ChunkedGeometryCollectionArray<D> {
         self.as_geometry_collection_opt::<D>().unwrap()
-    }
-
-    /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i64` offsets returning `None` if not
-    /// possible
-    fn as_large_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedGeometryCollectionArray<i64, D>>;
-
-    /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i64` offsets panicking if not possible
-    #[inline]
-    fn as_large_geometry_collection<const D: usize>(
-        &self,
-    ) -> &ChunkedGeometryCollectionArray<i64, D> {
-        self.as_large_geometry_collection_opt::<D>().unwrap()
     }
 
     /// Downcast this to a [`ChunkedRectArray`] returning `None` if not possible
@@ -458,95 +263,38 @@ impl AsChunkedNativeArray for &dyn ChunkedNativeArray {
     }
 
     #[inline]
-    fn as_line_string_opt<const D: usize>(&self) -> Option<&ChunkedLineStringArray<i32, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedLineStringArray<i32, D>>()
+    fn as_line_string_opt<const D: usize>(&self) -> Option<&ChunkedLineStringArray<D>> {
+        self.as_any().downcast_ref::<ChunkedLineStringArray<D>>()
     }
 
     #[inline]
-    fn as_large_line_string_opt<const D: usize>(&self) -> Option<&ChunkedLineStringArray<i64, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedLineStringArray<i64, D>>()
+    fn as_polygon_opt<const D: usize>(&self) -> Option<&ChunkedPolygonArray<D>> {
+        self.as_any().downcast_ref::<ChunkedPolygonArray<D>>()
     }
 
     #[inline]
-    fn as_polygon_opt<const D: usize>(&self) -> Option<&ChunkedPolygonArray<i32, D>> {
-        self.as_any().downcast_ref::<ChunkedPolygonArray<i32, D>>()
+    fn as_multi_point_opt<const D: usize>(&self) -> Option<&ChunkedMultiPointArray<D>> {
+        self.as_any().downcast_ref::<ChunkedMultiPointArray<D>>()
     }
 
     #[inline]
-    fn as_large_polygon_opt<const D: usize>(&self) -> Option<&ChunkedPolygonArray<i64, D>> {
-        self.as_any().downcast_ref::<ChunkedPolygonArray<i64, D>>()
+    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&ChunkedMultiLineStringArray<D>> {
+        self.as_any().downcast_ref::<ChunkedMultiLineStringArray<D>>()
     }
 
     #[inline]
-    fn as_multi_point_opt<const D: usize>(&self) -> Option<&ChunkedMultiPointArray<i32, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMultiPointArray<i32, D>>()
+    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&ChunkedMultiPolygonArray<D>> {
+        self.as_any().downcast_ref::<ChunkedMultiPolygonArray<D>>()
     }
 
     #[inline]
-    fn as_large_multi_point_opt<const D: usize>(&self) -> Option<&ChunkedMultiPointArray<i64, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMultiPointArray<i64, D>>()
+    fn as_mixed_opt<const D: usize>(&self) -> Option<&ChunkedMixedGeometryArray<D>> {
+        self.as_any().downcast_ref::<ChunkedMixedGeometryArray<D>>()
     }
 
     #[inline]
-    fn as_multi_line_string_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedMultiLineStringArray<i32, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMultiLineStringArray<i32, D>>()
-    }
-
-    #[inline]
-    fn as_large_multi_line_string_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedMultiLineStringArray<i64, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMultiLineStringArray<i64, D>>()
-    }
-
-    #[inline]
-    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&ChunkedMultiPolygonArray<i32, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMultiPolygonArray<i32, D>>()
-    }
-
-    #[inline]
-    fn as_large_multi_polygon_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedMultiPolygonArray<i64, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMultiPolygonArray<i64, D>>()
-    }
-
-    #[inline]
-    fn as_mixed_opt<const D: usize>(&self) -> Option<&ChunkedMixedGeometryArray<i32, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMixedGeometryArray<i32, D>>()
-    }
-
-    #[inline]
-    fn as_large_mixed_opt<const D: usize>(&self) -> Option<&ChunkedMixedGeometryArray<i64, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedMixedGeometryArray<i64, D>>()
-    }
-
-    #[inline]
-    fn as_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedGeometryCollectionArray<i32, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedGeometryCollectionArray<i32, D>>()
-    }
-
-    #[inline]
-    fn as_large_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedGeometryCollectionArray<i64, D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedGeometryCollectionArray<i64, D>>()
+    fn as_geometry_collection_opt<const D: usize>(&self) -> Option<&ChunkedGeometryCollectionArray<D>> {
+        self.as_any().downcast_ref::<ChunkedGeometryCollectionArray<D>>()
     }
 
     #[inline]

--- a/src/array/cast.rs
+++ b/src/array/cast.rs
@@ -238,7 +238,9 @@ pub trait AsChunkedNativeArray {
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_geometry_collection_opt<const D: usize>(&self) -> Option<&ChunkedGeometryCollectionArray<D>>;
+    fn as_geometry_collection_opt<const D: usize>(
+        &self,
+    ) -> Option<&ChunkedGeometryCollectionArray<D>>;
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i32` offsets panicking if not possible
     #[inline]
@@ -279,7 +281,8 @@ impl AsChunkedNativeArray for &dyn ChunkedNativeArray {
 
     #[inline]
     fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&ChunkedMultiLineStringArray<D>> {
-        self.as_any().downcast_ref::<ChunkedMultiLineStringArray<D>>()
+        self.as_any()
+            .downcast_ref::<ChunkedMultiLineStringArray<D>>()
     }
 
     #[inline]
@@ -293,8 +296,11 @@ impl AsChunkedNativeArray for &dyn ChunkedNativeArray {
     }
 
     #[inline]
-    fn as_geometry_collection_opt<const D: usize>(&self) -> Option<&ChunkedGeometryCollectionArray<D>> {
-        self.as_any().downcast_ref::<ChunkedGeometryCollectionArray<D>>()
+    fn as_geometry_collection_opt<const D: usize>(
+        &self,
+    ) -> Option<&ChunkedGeometryCollectionArray<D>> {
+        self.as_any()
+            .downcast_ref::<ChunkedGeometryCollectionArray<D>>()
     }
 
     #[inline]

--- a/src/array/dynamic.rs
+++ b/src/array/dynamic.rs
@@ -37,60 +37,32 @@ impl NativeArrayDyn {
                 XYZ => Arc::new(PointArray::<3>::try_from((array, field))?),
             },
             LineString(_, dim) => match dim {
-                XY => Arc::new(LineStringArray::<i32, 2>::try_from((array, field))?),
-                XYZ => Arc::new(LineStringArray::<i32, 3>::try_from((array, field))?),
-            },
-            LargeLineString(_, dim) => match dim {
-                XY => Arc::new(LineStringArray::<i64, 2>::try_from((array, field))?),
-                XYZ => Arc::new(LineStringArray::<i64, 3>::try_from((array, field))?),
+                XY => Arc::new(LineStringArray::<2>::try_from((array, field))?),
+                XYZ => Arc::new(LineStringArray::<3>::try_from((array, field))?),
             },
             Polygon(_, dim) => match dim {
-                XY => Arc::new(PolygonArray::<i32, 2>::try_from((array, field))?),
-                XYZ => Arc::new(PolygonArray::<i32, 3>::try_from((array, field))?),
-            },
-            LargePolygon(_, dim) => match dim {
-                XY => Arc::new(PolygonArray::<i64, 2>::try_from((array, field))?),
-                XYZ => Arc::new(PolygonArray::<i64, 3>::try_from((array, field))?),
+                XY => Arc::new(PolygonArray::<2>::try_from((array, field))?),
+                XYZ => Arc::new(PolygonArray::<3>::try_from((array, field))?),
             },
             MultiPoint(_, dim) => match dim {
-                XY => Arc::new(MultiPointArray::<i32, 2>::try_from((array, field))?),
-                XYZ => Arc::new(MultiPointArray::<i32, 3>::try_from((array, field))?),
-            },
-            LargeMultiPoint(_, dim) => match dim {
-                XY => Arc::new(MultiPointArray::<i64, 2>::try_from((array, field))?),
-                XYZ => Arc::new(MultiPointArray::<i64, 3>::try_from((array, field))?),
+                XY => Arc::new(MultiPointArray::<2>::try_from((array, field))?),
+                XYZ => Arc::new(MultiPointArray::<3>::try_from((array, field))?),
             },
             MultiLineString(_, dim) => match dim {
-                XY => Arc::new(MultiLineStringArray::<i32, 2>::try_from((array, field))?),
-                XYZ => Arc::new(MultiLineStringArray::<i32, 3>::try_from((array, field))?),
-            },
-            LargeMultiLineString(_, dim) => match dim {
-                XY => Arc::new(MultiLineStringArray::<i64, 2>::try_from((array, field))?),
-                XYZ => Arc::new(MultiLineStringArray::<i64, 3>::try_from((array, field))?),
+                XY => Arc::new(MultiLineStringArray::<2>::try_from((array, field))?),
+                XYZ => Arc::new(MultiLineStringArray::<3>::try_from((array, field))?),
             },
             MultiPolygon(_, dim) => match dim {
-                XY => Arc::new(MultiPolygonArray::<i32, 2>::try_from((array, field))?),
-                XYZ => Arc::new(MultiPolygonArray::<i32, 3>::try_from((array, field))?),
-            },
-            LargeMultiPolygon(_, dim) => match dim {
-                XY => Arc::new(MultiPolygonArray::<i64, 2>::try_from((array, field))?),
-                XYZ => Arc::new(MultiPolygonArray::<i64, 3>::try_from((array, field))?),
+                XY => Arc::new(MultiPolygonArray::<2>::try_from((array, field))?),
+                XYZ => Arc::new(MultiPolygonArray::<3>::try_from((array, field))?),
             },
             Mixed(_, dim) => match dim {
-                XY => Arc::new(MixedGeometryArray::<i32, 2>::try_from((array, field))?),
-                XYZ => Arc::new(MixedGeometryArray::<i32, 3>::try_from((array, field))?),
-            },
-            LargeMixed(_, dim) => match dim {
-                XY => Arc::new(MixedGeometryArray::<i64, 2>::try_from((array, field))?),
-                XYZ => Arc::new(MixedGeometryArray::<i64, 3>::try_from((array, field))?),
+                XY => Arc::new(MixedGeometryArray::<2>::try_from((array, field))?),
+                XYZ => Arc::new(MixedGeometryArray::<3>::try_from((array, field))?),
             },
             GeometryCollection(_, dim) => match dim {
-                XY => Arc::new(GeometryCollectionArray::<i32, 2>::try_from((array, field))?),
-                XYZ => Arc::new(GeometryCollectionArray::<i32, 3>::try_from((array, field))?),
-            },
-            LargeGeometryCollection(_, dim) => match dim {
-                XY => Arc::new(GeometryCollectionArray::<i64, 2>::try_from((array, field))?),
-                XYZ => Arc::new(GeometryCollectionArray::<i64, 3>::try_from((array, field))?),
+                XY => Arc::new(GeometryCollectionArray::<2>::try_from((array, field))?),
+                XYZ => Arc::new(GeometryCollectionArray::<3>::try_from((array, field))?),
             },
             // WKB => Arc::new(WKBArray::<i32>::try_from((array, field))?),
             // LargeWKB => Arc::new(WKBArray::<i64>::try_from((array, field))?),

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -7,14 +7,8 @@ use arrow_schema::{DataType, Field};
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::geometrycollection::{GeometryCollectionBuilder, GeometryCollectionCapacity};
 use crate::array::metadata::ArrayMetadata;
-use crate::array::util::{
-    offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32,
-    offsets_buffer_to_i64,
-};
-use crate::array::{
-    CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, MultiLineStringArray,
-    MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray,
-};
+use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32, offsets_buffer_to_i64};
+use crate::array::{CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::GeometryCollectionTrait;
@@ -27,46 +21,32 @@ use crate::{ArrayBase, NativeArray};
 /// This is semantically equivalent to `Vec<Option<GeometryCollection>>` due to the internal
 /// validity bitmap.
 #[derive(Debug, Clone)]
-pub struct GeometryCollectionArray<O: OffsetSizeTrait, const D: usize> {
+pub struct GeometryCollectionArray<const D: usize> {
     // Always NativeType::GeometryCollection or NativeType::LargeGeometryCollection
     data_type: NativeType,
 
     metadata: Arc<ArrayMetadata>,
 
-    pub(crate) array: MixedGeometryArray<O, D>,
+    pub(crate) array: MixedGeometryArray<D>,
 
     /// Offsets into the mixed geometry array where each geometry starts
-    pub(crate) geom_offsets: OffsetBuffer<O>,
+    pub(crate) geom_offsets: OffsetBuffer<i32>,
 
     /// Validity bitmap
     pub(crate) validity: Option<NullBuffer>,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionArray<O, D> {
+impl<const D: usize> GeometryCollectionArray<D> {
     /// Create a new GeometryCollectionArray from parts
     ///
     /// # Implementation
     ///
     /// This function is `O(1)`.
-    pub fn new(
-        array: MixedGeometryArray<O, D>,
-        geom_offsets: OffsetBuffer<O>,
-        validity: Option<NullBuffer>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    pub fn new(array: MixedGeometryArray<D>, geom_offsets: OffsetBuffer<i32>, validity: Option<NullBuffer>, metadata: Arc<ArrayMetadata>) -> Self {
         let coord_type = array.coord_type();
-        let data_type = match O::IS_LARGE {
-            true => NativeType::LargeGeometryCollection(coord_type, D.try_into().unwrap()),
-            false => NativeType::GeometryCollection(coord_type, D.try_into().unwrap()),
-        };
+        let data_type = NativeType::GeometryCollection(coord_type, D.try_into().unwrap());
 
-        Self {
-            data_type,
-            array,
-            geom_offsets,
-            validity,
-            metadata,
-        }
+        Self { data_type, array, geom_offsets, validity, metadata }
     }
 
     fn geometries_field(&self) -> Arc<Field> {
@@ -75,16 +55,13 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionArray<O, D> {
 
     /// The lengths of each buffer contained in this array.
     pub fn buffer_lengths(&self) -> GeometryCollectionCapacity {
-        GeometryCollectionCapacity::new(
-            self.array.buffer_lengths(),
-            self.geom_offsets.last().unwrap().to_usize().unwrap(),
-        )
+        GeometryCollectionCapacity::new(self.array.buffer_lengths(), self.geom_offsets.last().unwrap().to_usize().unwrap())
     }
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
         let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
-        validity_len + self.buffer_lengths().num_bytes::<O>()
+        validity_len + self.buffer_lengths().num_bytes()
     }
 
     /// Slices this [`GeometryCollectionArray`] in place.
@@ -107,10 +84,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionArray<O, D> {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        assert!(
-            offset + length <= self.len(),
-            "offset + length may not exceed length of array"
-        );
+        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
         // Note: we **only** slice the geom_offsets and not any actual data
         Self {
             data_type: self.data_type,
@@ -130,34 +104,19 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionArray<O, D> {
     }
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
-        Self::new(
-            self.array.into_coord_type(coord_type),
-            self.geom_offsets,
-            self.validity,
-            self.metadata,
-        )
+        Self::new(self.array.into_coord_type(coord_type), self.geom_offsets, self.validity, self.metadata)
     }
 
     pub fn to_small_offsets(&self) -> Result<GeometryCollectionArray<i32, D>> {
-        Ok(GeometryCollectionArray::new(
-            self.array.to_small_offsets()?,
-            offsets_buffer_to_i32(&self.geom_offsets)?,
-            self.validity.clone(),
-            self.metadata.clone(),
-        ))
+        Ok(GeometryCollectionArray::new(self.array.to_small_offsets()?, offsets_buffer_to_i32(&self.geom_offsets)?, self.validity.clone(), self.metadata.clone()))
     }
 
     pub fn to_large_offsets(&self) -> GeometryCollectionArray<i64, D> {
-        GeometryCollectionArray::new(
-            self.array.to_large_offsets(),
-            offsets_buffer_to_i64(&self.geom_offsets),
-            self.validity.clone(),
-            self.metadata.clone(),
-        )
+        GeometryCollectionArray::new(self.array.to_large_offsets(), offsets_buffer_to_i64(&self.geom_offsets), self.validity.clone(), self.metadata.clone())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> ArrayBase for GeometryCollectionArray<O, D> {
+impl<const D: usize> ArrayBase for GeometryCollectionArray<D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -167,9 +126,7 @@ impl<O: OffsetSizeTrait, const D: usize> ArrayBase for GeometryCollectionArray<O
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        self.data_type
-            .to_field_with_metadata("geometry", true, &self.metadata)
-            .into()
+        self.data_type.to_field_with_metadata("geometry", true, &self.metadata).into()
     }
 
     fn extension_name(&self) -> &str {
@@ -202,7 +159,7 @@ impl<O: OffsetSizeTrait, const D: usize> ArrayBase for GeometryCollectionArray<O
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> NativeArray for GeometryCollectionArray<O, D> {
+impl<const D: usize> NativeArray for GeometryCollectionArray<D> {
     fn data_type(&self) -> NativeType {
         self.data_type
     }
@@ -234,9 +191,7 @@ impl<O: OffsetSizeTrait, const D: usize> NativeArray for GeometryCollectionArray
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D>
-    for GeometryCollectionArray<O, D>
-{
+impl<const D: usize> GeometryArraySelfMethods<D> for GeometryCollectionArray<D> {
     fn with_coords(self, _coords: CoordBuffer<D>) -> Self {
         todo!()
     }
@@ -246,8 +201,8 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D>
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> ArrayAccessor<'a> for GeometryCollectionArray<O, D> {
-    type Item = GeometryCollection<'a, O, D>;
+impl<'a, const D: usize> ArrayAccessor<'a> for GeometryCollectionArray<D> {
+    type Item = GeometryCollection<'a, D>;
     type ItemGeo = geo::GeometryCollection;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -255,8 +210,8 @@ impl<'a, O: OffsetSizeTrait, const D: usize> ArrayAccessor<'a> for GeometryColle
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> IntoArrow for GeometryCollectionArray<O, D> {
-    type ArrowArray = GenericListArray<O>;
+impl<const D: usize> IntoArrow for GeometryCollectionArray<D> {
+    type ArrowArray = GenericListArray<i32>;
 
     fn into_arrow(self) -> Self::ArrowArray {
         let geometries_field = self.geometries_field();
@@ -266,41 +221,19 @@ impl<O: OffsetSizeTrait, const D: usize> IntoArrow for GeometryCollectionArray<O
     }
 }
 
-impl<const D: usize> TryFrom<&GenericListArray<i32>> for GeometryCollectionArray<i32, D> {
+impl<const D: usize> TryFrom<&GenericListArray<i32>> for GeometryCollectionArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &GenericListArray<i32>) -> Result<Self> {
-        let geoms: MixedGeometryArray<i32, D> = value.values().as_ref().try_into()?;
+        let geoms: MixedGeometryArray<D> = value.values().as_ref().try_into()?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
-        Ok(Self::new(
-            geoms,
-            geom_offsets.clone(),
-            validity.cloned(),
-            Default::default(),
-        ))
+        Ok(Self::new(geoms, geom_offsets.clone(), validity.cloned(), Default::default()))
     }
 }
 
-impl<const D: usize> TryFrom<&GenericListArray<i64>> for GeometryCollectionArray<i64, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: &GenericListArray<i64>) -> Result<Self> {
-        let geoms: MixedGeometryArray<i64, D> = value.values().as_ref().try_into()?;
-        let geom_offsets = value.offsets();
-        let validity = value.nulls();
-
-        Ok(Self::new(
-            geoms,
-            geom_offsets.clone(),
-            validity.cloned(),
-            Default::default(),
-        ))
-    }
-}
-
-impl<const D: usize> TryFrom<&dyn Array> for GeometryCollectionArray<i32, D> {
+impl<const D: usize> TryFrom<&dyn Array> for GeometryCollectionArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
@@ -314,37 +247,12 @@ impl<const D: usize> TryFrom<&dyn Array> for GeometryCollectionArray<i32, D> {
                 let geom_array: GeometryCollectionArray<i64, D> = downcasted.try_into()?;
                 geom_array.try_into()
             }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
-            ))),
+            _ => Err(GeoArrowError::General(format!("Unexpected type: {:?}", value.data_type()))),
         }
     }
 }
 
-impl<const D: usize> TryFrom<&dyn Array> for GeometryCollectionArray<i64, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: &dyn Array) -> Result<Self> {
-        match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_any().downcast_ref::<ListArray>().unwrap();
-                let geom_array: GeometryCollectionArray<i32, D> = downcasted.try_into()?;
-                Ok(geom_array.into())
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_any().downcast_ref::<LargeListArray>().unwrap();
-                downcasted.try_into()
-            }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
-            ))),
-        }
-    }
-}
-
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray<i32, D> {
+impl<const D: usize> TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray<D> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -354,75 +262,37 @@ impl<const D: usize> TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray<i
     }
 }
 
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray<i64, D> {
-    type Error = GeoArrowError;
-
-    fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let mut arr: Self = arr.try_into()?;
-        arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
-        Ok(arr)
-    }
-}
-
-impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<&[G]>
-    for GeometryCollectionArray<O, 2>
-{
+impl<G: GeometryCollectionTrait<T = f64>> From<&[G]> for GeometryCollectionArray<2> {
     fn from(other: &[G]) -> Self {
-        let mut_arr: GeometryCollectionBuilder<O, 2> = other.into();
+        let mut_arr: GeometryCollectionBuilder<2> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> From<Vec<Option<G>>>
-    for GeometryCollectionArray<O, 2>
-{
+impl<G: GeometryCollectionTrait<T = f64>> From<Vec<Option<G>>> for GeometryCollectionArray<2> {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: GeometryCollectionBuilder<O, 2> = other.into();
+        let mut_arr: GeometryCollectionBuilder<2> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for GeometryCollectionArray<O, 2> {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for GeometryCollectionArray<2> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
-        let mut_arr: GeometryCollectionBuilder<O, 2> = value.try_into()?;
+        let mut_arr: GeometryCollectionBuilder<2> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }
 
-impl<const D: usize> From<GeometryCollectionArray<i32, D>> for GeometryCollectionArray<i64, D> {
-    fn from(value: GeometryCollectionArray<i32, D>) -> Self {
-        Self::new(
-            value.array.into(),
-            offsets_buffer_i32_to_i64(&value.geom_offsets),
-            value.validity,
-            value.metadata,
-        )
-    }
-}
-
-impl<const D: usize> TryFrom<GeometryCollectionArray<i64, D>> for GeometryCollectionArray<i32, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: GeometryCollectionArray<i64, D>) -> Result<Self> {
-        Ok(Self::new(
-            value.array.try_into()?,
-            offsets_buffer_i64_to_i32(&value.geom_offsets)?,
-            value.validity,
-            value.metadata,
-        ))
-    }
-}
-
 /// Default to an empty array
-impl<O: OffsetSizeTrait, const D: usize> Default for GeometryCollectionArray<O, D> {
+impl<const D: usize> Default for GeometryCollectionArray<D> {
     fn default() -> Self {
         GeometryCollectionBuilder::default().into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> PartialEq for GeometryCollectionArray<O, D> {
+impl<const D: usize> PartialEq for GeometryCollectionArray<D> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;
@@ -440,54 +310,42 @@ impl<O: OffsetSizeTrait, const D: usize> PartialEq for GeometryCollectionArray<O
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<PointArray<D>> for GeometryCollectionArray<O, D> {
+impl<const D: usize> From<PointArray<D>> for GeometryCollectionArray<D> {
     fn from(value: PointArray<D>) -> Self {
-        MixedGeometryArray::<O, D>::from(value).into()
+        MixedGeometryArray::<D>::from(value).into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<LineStringArray<O, D>>
-    for GeometryCollectionArray<O, D>
-{
-    fn from(value: LineStringArray<O, D>) -> Self {
-        MixedGeometryArray::<O, D>::from(value).into()
+impl<const D: usize> From<LineStringArray<D>> for GeometryCollectionArray<D> {
+    fn from(value: LineStringArray<D>) -> Self {
+        MixedGeometryArray::<D>::from(value).into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<PolygonArray<O, D>>
-    for GeometryCollectionArray<O, D>
-{
-    fn from(value: PolygonArray<O, D>) -> Self {
-        MixedGeometryArray::<O, D>::from(value).into()
+impl<const D: usize> From<PolygonArray<D>> for GeometryCollectionArray<D> {
+    fn from(value: PolygonArray<D>) -> Self {
+        MixedGeometryArray::<D>::from(value).into()
     }
 }
-impl<O: OffsetSizeTrait, const D: usize> From<MultiPointArray<O, D>>
-    for GeometryCollectionArray<O, D>
-{
-    fn from(value: MultiPointArray<O, D>) -> Self {
-        MixedGeometryArray::<O, D>::from(value).into()
+impl<const D: usize> From<MultiPointArray<D>> for GeometryCollectionArray<D> {
+    fn from(value: MultiPointArray<D>) -> Self {
+        MixedGeometryArray::<D>::from(value).into()
     }
 }
-impl<O: OffsetSizeTrait, const D: usize> From<MultiLineStringArray<O, D>>
-    for GeometryCollectionArray<O, D>
-{
-    fn from(value: MultiLineStringArray<O, D>) -> Self {
-        MixedGeometryArray::<O, D>::from(value).into()
+impl<const D: usize> From<MultiLineStringArray<D>> for GeometryCollectionArray<D> {
+    fn from(value: MultiLineStringArray<D>) -> Self {
+        MixedGeometryArray::<D>::from(value).into()
     }
 }
-impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygonArray<O, D>>
-    for GeometryCollectionArray<O, D>
-{
-    fn from(value: MultiPolygonArray<O, D>) -> Self {
-        MixedGeometryArray::<O, D>::from(value).into()
+impl<const D: usize> From<MultiPolygonArray<D>> for GeometryCollectionArray<D> {
+    fn from(value: MultiPolygonArray<D>) -> Self {
+        MixedGeometryArray::<D>::from(value).into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<MixedGeometryArray<O, D>>
-    for GeometryCollectionArray<O, D>
-{
+impl<const D: usize> From<MixedGeometryArray<D>> for GeometryCollectionArray<D> {
     // TODO: We should construct the correct validity buffer from the union's underlying arrays.
-    fn from(value: MixedGeometryArray<O, D>) -> Self {
+    fn from(value: MixedGeometryArray<D>) -> Self {
         let metadata = value.metadata.clone();
         let geom_offsets = OffsetBuffer::from_lengths(vec![1; value.len()]);
         GeometryCollectionArray::new(value, geom_offsets, None, metadata)

--- a/src/array/geometrycollection/array.rs
+++ b/src/array/geometrycollection/array.rs
@@ -7,7 +7,6 @@ use arrow_schema::{DataType, Field};
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::geometrycollection::{GeometryCollectionBuilder, GeometryCollectionCapacity};
 use crate::array::metadata::ArrayMetadata;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32, offsets_buffer_to_i64};
 use crate::array::{CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};
@@ -105,14 +104,6 @@ impl<const D: usize> GeometryCollectionArray<D> {
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
         Self::new(self.array.into_coord_type(coord_type), self.geom_offsets, self.validity, self.metadata)
-    }
-
-    pub fn to_small_offsets(&self) -> Result<GeometryCollectionArray<i32, D>> {
-        Ok(GeometryCollectionArray::new(self.array.to_small_offsets()?, offsets_buffer_to_i32(&self.geom_offsets)?, self.validity.clone(), self.metadata.clone()))
-    }
-
-    pub fn to_large_offsets(&self) -> GeometryCollectionArray<i64, D> {
-        GeometryCollectionArray::new(self.array.to_large_offsets(), offsets_buffer_to_i64(&self.geom_offsets), self.validity.clone(), self.metadata.clone())
     }
 }
 

--- a/src/array/geometrycollection/builder.rs
+++ b/src/array/geometrycollection/builder.rs
@@ -8,7 +8,10 @@ use crate::array::metadata::ArrayMetadata;
 use crate::array::offset_builder::OffsetsBuilder;
 use crate::array::{CoordType, GeometryCollectionArray, MixedGeometryBuilder, WKBArray};
 use crate::error::{GeoArrowError, Result};
-use crate::geo_traits::{GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait};
+use crate::geo_traits::{
+    GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
+    MultiPolygonTrait, PointTrait, PolygonTrait,
+};
 use crate::io::wkb::reader::WKBGeometry;
 use crate::scalar::WKB;
 use crate::trait_::{ArrayAccessor, GeometryArrayBuilder, IntoArrow};
@@ -42,10 +45,18 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
         Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options(capacity: GeometryCollectionCapacity, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn with_capacity_and_options(
+        capacity: GeometryCollectionCapacity,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         // Should we be storing array metadata on child arrays?
         Self {
-            geoms: MixedGeometryBuilder::with_capacity_and_options(capacity.mixed_capacity, coord_type, metadata.clone()),
+            geoms: MixedGeometryBuilder::with_capacity_and_options(
+                capacity.mixed_capacity,
+                coord_type,
+                metadata.clone(),
+            ),
             geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity),
             validity: NullBufferBuilder::new(capacity.geom_capacity),
             metadata,
@@ -80,7 +91,13 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
     }
 
     /// Extract the low-level APIs from the [`GeometryCollectionBuilder`].
-    pub fn into_inner(self) -> (MixedGeometryBuilder<D>, OffsetsBuilder<i32>, NullBufferBuilder) {
+    pub fn into_inner(
+        self,
+    ) -> (
+        MixedGeometryBuilder<D>,
+        OffsetsBuilder<i32>,
+        NullBufferBuilder,
+    ) {
         (self.geoms, self.geom_offsets, self.validity)
     }
 
@@ -88,22 +105,36 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
         self.into()
     }
 
-    pub fn with_capacity_from_iter(geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>) -> Result<Self> {
+    pub fn with_capacity_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+    ) -> Result<Self> {
         Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options_from_iter(geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+    pub fn with_capacity_and_options_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
         let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
-        Ok(Self::with_capacity_and_options(counter, coord_type, metadata))
+        Ok(Self::with_capacity_and_options(
+            counter, coord_type, metadata,
+        ))
     }
 
-    pub fn reserve_from_iter(&mut self, geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>) -> Result<()> {
+    pub fn reserve_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+    ) -> Result<()> {
         let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
         self.reserve(counter);
         Ok(())
     }
 
-    pub fn reserve_exact_from_iter(&mut self, geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>) -> Result<()> {
+    pub fn reserve_exact_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+    ) -> Result<()> {
         let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
         self.reserve_exact(counter);
         Ok(())
@@ -111,7 +142,11 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
 
     /// Push a Point onto the end of this builder
     #[inline]
-    pub fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>, prefer_multi: bool) -> Result<()> {
+    pub fn push_point(
+        &mut self,
+        value: Option<&impl PointTrait<T = f64>>,
+        prefer_multi: bool,
+    ) -> Result<()> {
         if prefer_multi {
             self.geoms.push_point_as_multi_point(value)?;
         } else {
@@ -124,7 +159,11 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
 
     /// Push a LineString onto the end of this builder
     #[inline]
-    pub fn push_line_string(&mut self, value: Option<&impl LineStringTrait<T = f64>>, prefer_multi: bool) -> Result<()> {
+    pub fn push_line_string(
+        &mut self,
+        value: Option<&impl LineStringTrait<T = f64>>,
+        prefer_multi: bool,
+    ) -> Result<()> {
         if prefer_multi {
             self.geoms.push_line_string_as_multi_line_string(value)?;
         } else {
@@ -137,7 +176,11 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
 
     /// Push a Polygon onto the end of this builder
     #[inline]
-    pub fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>, prefer_multi: bool) -> Result<()> {
+    pub fn push_polygon(
+        &mut self,
+        value: Option<&impl PolygonTrait<T = f64>>,
+        prefer_multi: bool,
+    ) -> Result<()> {
         if prefer_multi {
             self.geoms.push_polygon_as_multi_polygon(value)?;
         } else {
@@ -150,7 +193,10 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
 
     /// Push a MultiPoint onto the end of this builder
     #[inline]
-    pub fn push_multi_point(&mut self, value: Option<&impl MultiPointTrait<T = f64>>) -> Result<()> {
+    pub fn push_multi_point(
+        &mut self,
+        value: Option<&impl MultiPointTrait<T = f64>>,
+    ) -> Result<()> {
         self.geoms.push_multi_point(value)?;
         self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
@@ -159,7 +205,10 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
 
     /// Push a MultiLineString onto the end of this builder
     #[inline]
-    pub fn push_multi_line_string(&mut self, value: Option<&impl MultiLineStringTrait<T = f64>>) -> Result<()> {
+    pub fn push_multi_line_string(
+        &mut self,
+        value: Option<&impl MultiLineStringTrait<T = f64>>,
+    ) -> Result<()> {
         self.geoms.push_multi_line_string(value)?;
         self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
@@ -168,7 +217,10 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
 
     /// Push a MultiPolygon onto the end of this builder
     #[inline]
-    pub fn push_multi_polygon(&mut self, value: Option<&impl MultiPolygonTrait<T = f64>>) -> Result<()> {
+    pub fn push_multi_polygon(
+        &mut self,
+        value: Option<&impl MultiPolygonTrait<T = f64>>,
+    ) -> Result<()> {
         self.geoms.push_multi_polygon(value)?;
         self.geom_offsets.try_push_usize(1)?;
         self.validity.append(value.is_some());
@@ -177,17 +229,29 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
 
     /// Push a Geometry onto the end of this builder
     #[inline]
-    pub fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>, prefer_multi: bool) -> Result<()> {
+    pub fn push_geometry(
+        &mut self,
+        value: Option<&impl GeometryTrait<T = f64>>,
+        prefer_multi: bool,
+    ) -> Result<()> {
         if let Some(g) = value {
             match g.as_type() {
-                crate::geo_traits::GeometryType::Point(p) => self.push_point(Some(p), prefer_multi)?,
+                crate::geo_traits::GeometryType::Point(p) => {
+                    self.push_point(Some(p), prefer_multi)?
+                }
                 crate::geo_traits::GeometryType::LineString(p) => {
                     self.push_line_string(Some(p), prefer_multi)?;
                 }
-                crate::geo_traits::GeometryType::Polygon(p) => self.push_polygon(Some(p), prefer_multi)?,
+                crate::geo_traits::GeometryType::Polygon(p) => {
+                    self.push_polygon(Some(p), prefer_multi)?
+                }
                 crate::geo_traits::GeometryType::MultiPoint(p) => self.push_multi_point(Some(p))?,
-                crate::geo_traits::GeometryType::MultiLineString(p) => self.push_multi_line_string(Some(p))?,
-                crate::geo_traits::GeometryType::MultiPolygon(p) => self.push_multi_polygon(Some(p))?,
+                crate::geo_traits::GeometryType::MultiLineString(p) => {
+                    self.push_multi_line_string(Some(p))?
+                }
+                crate::geo_traits::GeometryType::MultiPolygon(p) => {
+                    self.push_multi_polygon(Some(p))?
+                }
                 crate::geo_traits::GeometryType::GeometryCollection(p) => {
                     if prefer_multi {
                         self.push_geometry_collection_preferring_multi(Some(p))?
@@ -207,7 +271,10 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
 
     /// Push a GeometryCollection onto the end of this builder
     #[inline]
-    pub fn push_geometry_collection(&mut self, value: Option<&impl GeometryCollectionTrait<T = f64>>) -> Result<()> {
+    pub fn push_geometry_collection(
+        &mut self,
+        value: Option<&impl GeometryCollectionTrait<T = f64>>,
+    ) -> Result<()> {
         if let Some(gc) = value {
             let num_geoms = gc.num_geometries();
             for g in gc.geometries() {
@@ -221,7 +288,10 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
     }
 
     #[inline]
-    pub fn push_geometry_collection_preferring_multi(&mut self, value: Option<&impl GeometryCollectionTrait<T = f64>>) -> Result<()> {
+    pub fn push_geometry_collection_preferring_multi(
+        &mut self,
+        value: Option<&impl GeometryCollectionTrait<T = f64>>,
+    ) -> Result<()> {
         if let Some(gc) = value {
             let num_geoms = gc.num_geometries();
             for g in gc.geometries() {
@@ -234,8 +304,21 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
         Ok(())
     }
 
-    pub fn extend_from_iter(&mut self, geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait<T = f64> + 'a)>>, prefer_multi: bool) {
-        geoms.into_iter().try_for_each(|maybe_gc| if prefer_multi { self.push_geometry_collection_preferring_multi(maybe_gc) } else { self.push_geometry_collection(maybe_gc) }).unwrap();
+    pub fn extend_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait<T = f64> + 'a)>>,
+        prefer_multi: bool,
+    ) {
+        geoms
+            .into_iter()
+            .try_for_each(|maybe_gc| {
+                if prefer_multi {
+                    self.push_geometry_collection_preferring_multi(maybe_gc)
+                } else {
+                    self.push_geometry_collection(maybe_gc)
+                }
+            })
+            .unwrap();
     }
 
     #[inline]
@@ -251,38 +334,77 @@ impl<'a, const D: usize> GeometryCollectionBuilder<D> {
         self.validity.append(false);
     }
 
-    pub fn from_geometry_collections(geoms: &[impl GeometryCollectionTrait<T = f64>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(Some), coord_type.unwrap_or_default(), metadata)?;
+    pub fn from_geometry_collections(
+        geoms: &[impl GeometryCollectionTrait<T = f64>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+            metadata,
+        )?;
         array.extend_from_iter(geoms.iter().map(Some), prefer_multi);
         Ok(array)
     }
 
-    pub fn from_nullable_geometry_collections(geoms: &[Option<impl GeometryCollectionTrait<T = f64>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(|x| x.as_ref()), coord_type.unwrap_or_default(), metadata)?;
+    pub fn from_nullable_geometry_collections(
+        geoms: &[Option<impl GeometryCollectionTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(|x| x.as_ref()),
+            coord_type.unwrap_or_default(),
+            metadata,
+        )?;
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()), prefer_multi);
         Ok(array)
     }
 
-    pub fn from_geometries(geoms: &[impl GeometryTrait<T = f64>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+    pub fn from_geometries(
+        geoms: &[impl GeometryTrait<T = f64>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
         let capacity = GeometryCollectionCapacity::from_geometries(geoms.iter().map(Some))?;
-        let mut array = Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default(), metadata);
+        let mut array =
+            Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default(), metadata);
         for geom in geoms {
             array.push_geometry(Some(geom), prefer_multi)?;
         }
         Ok(array)
     }
 
-    pub fn from_nullable_geometries(geoms: &[Option<impl GeometryTrait<T = f64>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let capacity = GeometryCollectionCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
-        let mut array = Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default(), metadata);
+    pub fn from_nullable_geometries(
+        geoms: &[Option<impl GeometryTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let capacity =
+            GeometryCollectionCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
+        let mut array =
+            Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default(), metadata);
         for geom in geoms {
             array.push_geometry(geom.as_ref(), prefer_multi)?;
         }
         Ok(array)
     }
 
-    pub(crate) fn from_wkb<W: OffsetSizeTrait>(wkb_objects: &[Option<WKB<'_, W>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let wkb_objects2: Vec<Option<WKBGeometry>> = wkb_objects.iter().map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object())).collect();
+    pub(crate) fn from_wkb<W: OffsetSizeTrait>(
+        wkb_objects: &[Option<WKB<'_, W>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let wkb_objects2: Vec<Option<WKBGeometry>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
+            .collect();
         Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata, prefer_multi)
     }
 }
@@ -292,7 +414,11 @@ impl<const D: usize> GeometryArrayBuilder for GeometryCollectionBuilder<D> {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let capacity = GeometryCollectionCapacity::new(Default::default(), geom_capacity);
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
@@ -344,7 +470,12 @@ impl<const D: usize> Default for GeometryCollectionBuilder<D> {
 impl<const D: usize> From<GeometryCollectionBuilder<D>> for GeometryCollectionArray<D> {
     fn from(mut other: GeometryCollectionBuilder<D>) -> Self {
         let validity = other.validity.finish();
-        Self::new(other.geoms.into(), other.geom_offsets.into(), validity, other.metadata)
+        Self::new(
+            other.geoms.into(),
+            other.geom_offsets.into(),
+            validity,
+            other.metadata,
+        )
     }
 }
 
@@ -356,13 +487,20 @@ impl<const D: usize> From<GeometryCollectionBuilder<D>> for GenericListArray<i32
 
 impl<G: GeometryCollectionTrait<T = f64>> From<&[G]> for GeometryCollectionBuilder<2> {
     fn from(geoms: &[G]) -> Self {
-        Self::from_geometry_collections(geoms, Default::default(), Default::default(), true).unwrap()
+        Self::from_geometry_collections(geoms, Default::default(), Default::default(), true)
+            .unwrap()
     }
 }
 
 impl<G: GeometryCollectionTrait<T = f64>> From<Vec<Option<G>>> for GeometryCollectionBuilder<2> {
     fn from(geoms: Vec<Option<G>>) -> Self {
-        Self::from_nullable_geometry_collections(&geoms, Default::default(), Default::default(), true).unwrap()
+        Self::from_nullable_geometry_collections(
+            &geoms,
+            Default::default(),
+            Default::default(),
+            true,
+        )
+        .unwrap()
     }
 }
 

--- a/src/array/geometrycollection/capacity.rs
+++ b/src/array/geometrycollection/capacity.rs
@@ -2,7 +2,10 @@ use std::ops::Add;
 
 use crate::array::mixed::MixedCapacity;
 use crate::error::Result;
-use crate::geo_traits::{GeometryCollectionTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait};
+use crate::geo_traits::{
+    GeometryCollectionTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait,
+    MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
+};
 
 /// A counter for the buffer sizes of a
 /// [`GeometryCollectionArray`][crate::array::GeometryCollectionArray].
@@ -17,7 +20,10 @@ pub struct GeometryCollectionCapacity {
 impl GeometryCollectionCapacity {
     /// Create a new capacity with known sizes.
     pub fn new(mixed_capacity: MixedCapacity, geom_capacity: usize) -> Self {
-        Self { mixed_capacity, geom_capacity }
+        Self {
+            mixed_capacity,
+            geom_capacity,
+        }
     }
 
     /// Create a new empty capacity.
@@ -88,7 +94,10 @@ impl GeometryCollectionCapacity {
 
     /// Add a GeometryCollection to this capacity counter.
     #[inline]
-    pub fn add_geometry_collection<'a>(&mut self, geom: Option<&'a (impl GeometryCollectionTrait + 'a)>) -> Result<()> {
+    pub fn add_geometry_collection<'a>(
+        &mut self,
+        geom: Option<&'a (impl GeometryCollectionTrait + 'a)>,
+    ) -> Result<()> {
         if let Some(geom) = geom {
             self.add_valid_geometry_collection(geom)?;
         }
@@ -97,7 +106,9 @@ impl GeometryCollectionCapacity {
     }
 
     /// Create a capacity counter from an iterator of GeometryCollections.
-    pub fn from_geometry_collections<'a>(geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>) -> Result<Self> {
+    pub fn from_geometry_collections<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
+    ) -> Result<Self> {
         let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry_collection(maybe_geom)?;
@@ -106,7 +117,9 @@ impl GeometryCollectionCapacity {
     }
 
     /// Create a capacity counter from an iterator of Geometries.
-    pub fn from_owned_geometries<'a>(geoms: impl Iterator<Item = Option<(impl GeometryCollectionTrait + 'a)>>) -> Result<Self> {
+    pub fn from_owned_geometries<'a>(
+        geoms: impl Iterator<Item = Option<(impl GeometryCollectionTrait + 'a)>>,
+    ) -> Result<Self> {
         let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry_collection(maybe_geom.as_ref())?;
@@ -115,7 +128,9 @@ impl GeometryCollectionCapacity {
     }
 
     /// Create a capacity counter from an iterator of Geometries.
-    pub fn from_geometries<'a>(geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>) -> Result<Self> {
+    pub fn from_geometries<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<Self> {
         let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry(maybe_geom)?;

--- a/src/array/geometrycollection/capacity.rs
+++ b/src/array/geometrycollection/capacity.rs
@@ -144,7 +144,7 @@ impl GeometryCollectionCapacity {
     pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
         let offsets_byte_width = if O::IS_LARGE { 8 } else { 4 };
         let num_offsets = self.geom_capacity;
-        (offsets_byte_width * num_offsets) + self.mixed_capacity.num_bytes::<O>()
+        (offsets_byte_width * num_offsets) + self.mixed_capacity.num_bytes()
     }
 }
 

--- a/src/array/geometrycollection/capacity.rs
+++ b/src/array/geometrycollection/capacity.rs
@@ -1,13 +1,8 @@
 use std::ops::Add;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::mixed::MixedCapacity;
 use crate::error::Result;
-use crate::geo_traits::{
-    GeometryCollectionTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait,
-    MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
-};
+use crate::geo_traits::{GeometryCollectionTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait};
 
 /// A counter for the buffer sizes of a
 /// [`GeometryCollectionArray`][crate::array::GeometryCollectionArray].
@@ -22,10 +17,7 @@ pub struct GeometryCollectionCapacity {
 impl GeometryCollectionCapacity {
     /// Create a new capacity with known sizes.
     pub fn new(mixed_capacity: MixedCapacity, geom_capacity: usize) -> Self {
-        Self {
-            mixed_capacity,
-            geom_capacity,
-        }
+        Self { mixed_capacity, geom_capacity }
     }
 
     /// Create a new empty capacity.
@@ -96,10 +88,7 @@ impl GeometryCollectionCapacity {
 
     /// Add a GeometryCollection to this capacity counter.
     #[inline]
-    pub fn add_geometry_collection<'a>(
-        &mut self,
-        geom: Option<&'a (impl GeometryCollectionTrait + 'a)>,
-    ) -> Result<()> {
+    pub fn add_geometry_collection<'a>(&mut self, geom: Option<&'a (impl GeometryCollectionTrait + 'a)>) -> Result<()> {
         if let Some(geom) = geom {
             self.add_valid_geometry_collection(geom)?;
         }
@@ -108,9 +97,7 @@ impl GeometryCollectionCapacity {
     }
 
     /// Create a capacity counter from an iterator of GeometryCollections.
-    pub fn from_geometry_collections<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>,
-    ) -> Result<Self> {
+    pub fn from_geometry_collections<'a>(geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait + 'a)>>) -> Result<Self> {
         let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry_collection(maybe_geom)?;
@@ -119,9 +106,7 @@ impl GeometryCollectionCapacity {
     }
 
     /// Create a capacity counter from an iterator of Geometries.
-    pub fn from_owned_geometries<'a>(
-        geoms: impl Iterator<Item = Option<(impl GeometryCollectionTrait + 'a)>>,
-    ) -> Result<Self> {
+    pub fn from_owned_geometries<'a>(geoms: impl Iterator<Item = Option<(impl GeometryCollectionTrait + 'a)>>) -> Result<Self> {
         let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry_collection(maybe_geom.as_ref())?;
@@ -130,9 +115,7 @@ impl GeometryCollectionCapacity {
     }
 
     /// Create a capacity counter from an iterator of Geometries.
-    pub fn from_geometries<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
-    ) -> Result<Self> {
+    pub fn from_geometries<'a>(geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>) -> Result<Self> {
         let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry(maybe_geom)?;
@@ -141,8 +124,8 @@ impl GeometryCollectionCapacity {
     }
 
     /// The number of bytes an array with this capacity would occupy.
-    pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
-        let offsets_byte_width = if O::IS_LARGE { 8 } else { 4 };
+    pub fn num_bytes(&self) -> usize {
+        let offsets_byte_width = 4;
         let num_offsets = self.geom_capacity;
         (offsets_byte_width * num_offsets) + self.mixed_capacity.num_bytes()
     }

--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -5,7 +5,7 @@ use crate::algorithm::native::downcast::can_downcast_multi;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::linestring::LineStringCapacity;
 use crate::array::metadata::ArrayMetadata;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32, offsets_buffer_to_i64, OffsetBufferUtils};
+use crate::array::util::OffsetBufferUtils;
 use crate::array::{CoordBuffer, CoordType, GeometryCollectionArray, MixedGeometryArray, MultiLineStringArray, MultiPointArray, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};
@@ -167,14 +167,6 @@ impl<const D: usize> LineStringArray<D> {
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
         Self::new(self.coords.into_coord_type(coord_type), self.geom_offsets, self.validity, self.metadata)
-    }
-
-    pub fn to_small_offsets(&self) -> Result<LineStringArray<i32, D>> {
-        Ok(LineStringArray::new(self.coords.clone(), offsets_buffer_to_i32(&self.geom_offsets)?, self.validity.clone(), self.metadata.clone()))
-    }
-
-    pub fn to_large_offsets(&self) -> LineStringArray<i64, D> {
-        LineStringArray::new(self.coords.clone(), offsets_buffer_to_i64(&self.geom_offsets), self.validity.clone(), self.metadata.clone())
     }
 }
 

--- a/src/array/linestring/builder.rs
+++ b/src/array/linestring/builder.rs
@@ -2,14 +2,9 @@ use crate::array::linestring::capacity::LineStringCapacity;
 use crate::array::metadata::ArrayMetadata;
 // use super::array::check;
 use crate::array::offset_builder::OffsetsBuilder;
-use crate::array::{
-    CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, LineStringArray,
-    MultiPointBuilder, SeparatedCoordBufferBuilder, WKBArray,
-};
+use crate::array::{CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, LineStringArray, MultiPointBuilder, SeparatedCoordBufferBuilder, WKBArray};
 use crate::error::{GeoArrowError, Result};
-use crate::geo_traits::{
-    CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait,
-};
+use crate::geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
 use crate::io::wkb::reader::WKBLineString;
 use crate::scalar::WKB;
 use crate::trait_::{ArrayAccessor, GeometryArrayBuilder, IntoArrow};
@@ -22,19 +17,19 @@ use std::sync::Arc;
 ///
 /// Converting an [`LineStringBuilder`] into a [`LineStringArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct LineStringBuilder<O: OffsetSizeTrait, const D: usize> {
+pub struct LineStringBuilder<const D: usize> {
     metadata: Arc<ArrayMetadata>,
 
     pub(crate) coords: CoordBufferBuilder<D>,
 
     /// Offsets into the coordinate array where each geometry starts
-    pub(crate) geom_offsets: OffsetsBuilder<O>,
+    pub(crate) geom_offsets: OffsetsBuilder<i32>,
 
     /// Validity is only defined at the geometry level
     pub(crate) validity: NullBufferBuilder,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> LineStringBuilder<O, D> {
+impl<const D: usize> LineStringBuilder<D> {
     /// Creates a new empty [`LineStringBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -49,25 +44,12 @@ impl<O: OffsetSizeTrait, const D: usize> LineStringBuilder<O, D> {
         Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options(
-        capacity: LineStringCapacity,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    pub fn with_capacity_and_options(capacity: LineStringCapacity, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
         let coords = match coord_type {
-            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
-                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity()),
-            ),
-            CoordType::Separated => CoordBufferBuilder::Separated(
-                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity()),
-            ),
+            CoordType::Interleaved => CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity())),
+            CoordType::Separated => CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity())),
         };
-        Self {
-            coords,
-            geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity()),
-            validity: NullBufferBuilder::new(capacity.geom_capacity()),
-            metadata,
-        }
+        Self { coords, geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity()), validity: NullBufferBuilder::new(capacity.geom_capacity()), metadata }
     }
 
     /// Reserves capacity for at least `additional` more LineStrings to be inserted
@@ -109,27 +91,17 @@ impl<O: OffsetSizeTrait, const D: usize> LineStringBuilder<O, D> {
     ///
     /// - The validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
-    pub fn try_new(
-        coords: CoordBufferBuilder<D>,
-        geom_offsets: OffsetsBuilder<O>,
-        validity: NullBufferBuilder,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self> {
+    pub fn try_new(coords: CoordBufferBuilder<D>, geom_offsets: OffsetsBuilder<i32>, validity: NullBufferBuilder, metadata: Arc<ArrayMetadata>) -> Result<Self> {
         // check(
         //     &coords.clone().into(),
         //     validity.as_ref().map(|x| x.len()),
         //     &geom_offsets.clone().into(),
         // )?;
-        Ok(Self {
-            coords,
-            geom_offsets,
-            validity,
-            metadata,
-        })
+        Ok(Self { coords, geom_offsets, validity, metadata })
     }
 
     /// Extract the low-level APIs from the [`LineStringBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder<D>, OffsetsBuilder<O>, NullBufferBuilder) {
+    pub fn into_inner(self) -> (CoordBufferBuilder<D>, OffsetsBuilder<i32>, NullBufferBuilder) {
         (self.coords, self.geom_offsets, self.validity)
     }
 
@@ -152,65 +124,37 @@ impl<O: OffsetSizeTrait, const D: usize> LineStringBuilder<O, D> {
         Arc::new(self.into_arrow())
     }
 
-    pub fn finish(self) -> LineStringArray<O, D> {
+    pub fn finish(self) -> LineStringArray<D> {
         self.into()
     }
 
-    pub fn with_capacity_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
-    ) -> Self {
+    pub fn with_capacity_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>) -> Self {
         Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    pub fn with_capacity_and_options_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
         let counter = LineStringCapacity::from_line_strings(geoms);
         Self::with_capacity_and_options(counter, coord_type, metadata)
     }
 
-    pub fn reserve_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
-    ) {
+    pub fn reserve_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>) {
         let counter = LineStringCapacity::from_line_strings(geoms);
         self.reserve(counter)
     }
 
-    pub fn reserve_exact_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>,
-    ) {
+    pub fn reserve_exact_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait + 'a)>>) {
         let counter = LineStringCapacity::from_line_strings(geoms);
         self.reserve_exact(counter)
     }
 
-    pub fn from_line_strings(
-        geoms: &[impl LineStringTrait<T = f64>],
-        coord_type: Option<CoordType>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(Some),
-            coord_type.unwrap_or_default(),
-            metadata,
-        );
+    pub fn from_line_strings(geoms: &[impl LineStringTrait<T = f64>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(Some), coord_type.unwrap_or_default(), metadata);
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }
 
-    pub fn from_nullable_line_strings(
-        geoms: &[Option<impl LineStringTrait<T = f64>>],
-        coord_type: Option<CoordType>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(|x| x.as_ref()),
-            coord_type.unwrap_or_default(),
-            metadata,
-        );
+    pub fn from_nullable_line_strings(geoms: &[Option<impl LineStringTrait<T = f64>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(|x| x.as_ref()), coord_type.unwrap_or_default(), metadata);
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
     }
@@ -221,10 +165,7 @@ impl<O: OffsetSizeTrait, const D: usize> LineStringBuilder<O, D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_line_string(
-        &mut self,
-        value: Option<&impl LineStringTrait<T = f64>>,
-    ) -> Result<()> {
+    pub fn push_line_string(&mut self, value: Option<&impl LineStringTrait<T = f64>>) -> Result<()> {
         if let Some(line_string) = value {
             let num_coords = line_string.num_coords();
             for coord in line_string.coords() {
@@ -237,14 +178,8 @@ impl<O: OffsetSizeTrait, const D: usize> LineStringBuilder<O, D> {
         Ok(())
     }
 
-    pub fn extend_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait<T = f64> + 'a)>>,
-    ) {
-        geoms
-            .into_iter()
-            .try_for_each(|maybe_multi_point| self.push_line_string(maybe_multi_point))
-            .unwrap();
+    pub fn extend_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl LineStringTrait<T = f64> + 'a)>>) {
+        geoms.into_iter().try_for_each(|maybe_multi_point| self.push_line_string(maybe_multi_point)).unwrap();
     }
 
     /// Push a raw coordinate to the underlying coordinate array.
@@ -278,37 +213,18 @@ impl<O: OffsetSizeTrait, const D: usize> LineStringBuilder<O, D> {
         Ok(())
     }
 
-    pub(crate) fn from_wkb<W: OffsetSizeTrait>(
-        wkb_objects: &[Option<WKB<'_, W>>],
-        coord_type: Option<CoordType>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self> {
-        let wkb_objects2: Vec<Option<WKBLineString>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| {
-                maybe_wkb
-                    .as_ref()
-                    .map(|wkb| wkb.to_wkb_object().into_line_string())
-            })
-            .collect();
-        Ok(Self::from_nullable_line_strings(
-            &wkb_objects2,
-            coord_type,
-            metadata,
-        ))
+    pub(crate) fn from_wkb<W: OffsetSizeTrait>(wkb_objects: &[Option<WKB<'_, W>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+        let wkb_objects2: Vec<Option<WKBLineString>> = wkb_objects.iter().map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object().into_line_string())).collect();
+        Ok(Self::from_nullable_line_strings(&wkb_objects2, coord_type, metadata))
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for LineStringBuilder<O, D> {
+impl<const D: usize> GeometryArrayBuilder for LineStringBuilder<D> {
     fn new() -> Self {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(
-        geom_capacity: usize,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
         let capacity = LineStringCapacity::new(0, geom_capacity);
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
@@ -342,56 +258,47 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for LineStringBuil
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> IntoArrow for LineStringBuilder<O, D> {
-    type ArrowArray = GenericListArray<O>;
+impl<const D: usize> IntoArrow for LineStringBuilder<D> {
+    type ArrowArray = GenericListArray<i32>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let linestring_arr: LineStringArray<O, D> = self.into();
+        let linestring_arr: LineStringArray<D> = self.into();
         linestring_arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Default for LineStringBuilder<O, D> {
+impl<const D: usize> Default for LineStringBuilder<D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<LineStringBuilder<O, D>> for LineStringArray<O, D> {
-    fn from(mut other: LineStringBuilder<O, D>) -> Self {
+impl<const D: usize> From<LineStringBuilder<D>> for LineStringArray<D> {
+    fn from(mut other: LineStringBuilder<D>) -> Self {
         let validity = other.validity.finish();
-        Self::new(
-            other.coords.into(),
-            other.geom_offsets.into(),
-            validity,
-            other.metadata,
-        )
+        Self::new(other.coords.into(), other.geom_offsets.into(), validity, other.metadata)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<LineStringBuilder<O, D>> for GenericListArray<O> {
-    fn from(arr: LineStringBuilder<O, D>) -> Self {
+impl<O: OffsetSizeTrait, const D: usize> From<LineStringBuilder<D>> for GenericListArray<O> {
+    fn from(arr: LineStringBuilder<D>) -> Self {
         arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>, const D: usize> From<&[G]>
-    for LineStringBuilder<O, D>
-{
+impl<G: LineStringTrait<T = f64>, const D: usize> From<&[G]> for LineStringBuilder<D> {
     fn from(geoms: &[G]) -> Self {
         Self::from_line_strings(geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, G: LineStringTrait<T = f64>, const D: usize> From<Vec<Option<G>>>
-    for LineStringBuilder<O, D>
-{
+impl<G: LineStringTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for LineStringBuilder<D> {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_line_strings(&geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for LineStringBuilder<O, D> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for LineStringBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -403,14 +310,8 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for LineStringBuil
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<O: OffsetSizeTrait, const D: usize> From<LineStringBuilder<O, D>> for MultiPointBuilder<O, D> {
-    fn from(value: LineStringBuilder<O, D>) -> Self {
-        Self::try_new(
-            value.coords,
-            value.geom_offsets,
-            value.validity,
-            value.metadata,
-        )
-        .unwrap()
+impl<const D: usize> From<LineStringBuilder<D>> for MultiPointBuilder<D> {
+    fn from(value: LineStringBuilder<D>) -> Self {
+        Self::try_new(value.coords, value.geom_offsets, value.validity, value.metadata).unwrap()
     }
 }

--- a/src/array/linestring/capacity.rs
+++ b/src/array/linestring/capacity.rs
@@ -1,7 +1,5 @@
 use std::ops::Add;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{GeometryTrait, GeometryType, LineStringTrait};
 
@@ -81,8 +79,8 @@ impl LineStringCapacity {
     }
 
     /// The number of bytes an array with this capacity would occupy.
-    pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
-        let offsets_byte_width = if O::IS_LARGE { 8 } else { 4 };
+    pub fn num_bytes(&self) -> usize {
+        let offsets_byte_width = 4;
         let num_offsets = self.geom_capacity;
         (offsets_byte_width * num_offsets) + (self.coord_capacity * 2 * 8)
     }

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -9,7 +9,10 @@ use crate::algorithm::native::downcast::can_downcast_multi;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::mixed::builder::MixedGeometryBuilder;
 use crate::array::mixed::MixedCapacity;
-use crate::array::{CoordType, GeometryCollectionArray, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray};
+use crate::array::{
+    CoordType, GeometryCollectionArray, LineStringArray, MultiLineStringArray, MultiPointArray,
+    MultiPolygonArray, PointArray, PolygonArray, WKBArray,
+};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::GeometryTrait;
@@ -143,7 +146,17 @@ impl<const D: usize> MixedGeometryArray<D> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     #[allow(clippy::too_many_arguments)]
-    pub fn new(type_ids: ScalarBuffer<i8>, offsets: ScalarBuffer<i32>, points: PointArray<D>, line_strings: LineStringArray<D>, polygons: PolygonArray<D>, multi_points: MultiPointArray<D>, multi_line_strings: MultiLineStringArray<D>, multi_polygons: MultiPolygonArray<D>, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn new(
+        type_ids: ScalarBuffer<i8>,
+        offsets: ScalarBuffer<i32>,
+        points: PointArray<D>,
+        line_strings: LineStringArray<D>,
+        polygons: PolygonArray<D>,
+        multi_points: MultiPointArray<D>,
+        multi_line_strings: MultiLineStringArray<D>,
+        multi_polygons: MultiPolygonArray<D>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let mut coord_types = HashSet::new();
         coord_types.insert(points.coord_type());
         coord_types.insert(line_strings.coord_type());
@@ -156,12 +169,31 @@ impl<const D: usize> MixedGeometryArray<D> {
         let coord_type = coord_types.into_iter().next().unwrap();
         let data_type = NativeType::Mixed(coord_type, D.try_into().unwrap());
 
-        Self { data_type, type_ids, offsets, points, line_strings, polygons, multi_points, multi_line_strings, multi_polygons, slice_offset: 0, metadata }
+        Self {
+            data_type,
+            type_ids,
+            offsets,
+            points,
+            line_strings,
+            polygons,
+            multi_points,
+            multi_line_strings,
+            multi_polygons,
+            slice_offset: 0,
+            metadata,
+        }
     }
 
     /// The lengths of each buffer contained in this array.
     pub fn buffer_lengths(&self) -> MixedCapacity {
-        MixedCapacity::new(self.points.buffer_lengths(), self.line_strings.buffer_lengths(), self.polygons.buffer_lengths(), self.multi_points.buffer_lengths(), self.multi_line_strings.buffer_lengths(), self.multi_polygons.buffer_lengths())
+        MixedCapacity::new(
+            self.points.buffer_lengths(),
+            self.line_strings.buffer_lengths(),
+            self.polygons.buffer_lengths(),
+            self.multi_points.buffer_lengths(),
+            self.multi_line_strings.buffer_lengths(),
+            self.multi_polygons.buffer_lengths(),
+        )
     }
 
     pub fn has_points(&self) -> bool {
@@ -189,27 +221,57 @@ impl<const D: usize> MixedGeometryArray<D> {
     }
 
     pub fn has_only_points(&self) -> bool {
-        self.has_points() && !self.has_line_strings() && !self.has_polygons() && !self.has_multi_points() && !self.has_multi_line_strings() && !self.has_multi_polygons()
+        self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
     }
 
     pub fn has_only_line_strings(&self) -> bool {
-        !self.has_points() && self.has_line_strings() && !self.has_polygons() && !self.has_multi_points() && !self.has_multi_line_strings() && !self.has_multi_polygons()
+        !self.has_points()
+            && self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
     }
 
     pub fn has_only_polygons(&self) -> bool {
-        !self.has_points() && !self.has_line_strings() && self.has_polygons() && !self.has_multi_points() && !self.has_multi_line_strings() && !self.has_multi_polygons()
+        !self.has_points()
+            && !self.has_line_strings()
+            && self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
     }
 
     pub fn has_only_multi_points(&self) -> bool {
-        !self.has_points() && !self.has_line_strings() && !self.has_polygons() && self.has_multi_points() && !self.has_multi_line_strings() && !self.has_multi_polygons()
+        !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && !self.has_multi_polygons()
     }
 
     pub fn has_only_multi_line_strings(&self) -> bool {
-        !self.has_points() && !self.has_line_strings() && !self.has_polygons() && !self.has_multi_points() && self.has_multi_line_strings() && !self.has_multi_polygons()
+        !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && self.has_multi_line_strings()
+            && !self.has_multi_polygons()
     }
 
     pub fn has_only_multi_polygons(&self) -> bool {
-        !self.has_points() && !self.has_line_strings() && !self.has_polygons() && !self.has_multi_points() && !self.has_multi_line_strings() && self.has_multi_polygons()
+        !self.has_points()
+            && !self.has_line_strings()
+            && !self.has_polygons()
+            && !self.has_multi_points()
+            && !self.has_multi_line_strings()
+            && self.has_multi_polygons()
     }
 
     /// The number of bytes occupied by this array.
@@ -228,7 +290,10 @@ impl<const D: usize> MixedGeometryArray<D> {
     /// This function panics iff `offset + length >= self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
         Self {
             data_type: self.data_type,
             type_ids: self.type_ids.slice(offset, length),
@@ -253,7 +318,17 @@ impl<const D: usize> MixedGeometryArray<D> {
     }
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
-        Self::new(self.type_ids, self.offsets, self.points.into_coord_type(coord_type), self.line_strings.into_coord_type(coord_type), self.polygons.into_coord_type(coord_type), self.multi_points.into_coord_type(coord_type), self.multi_line_strings.into_coord_type(coord_type), self.multi_polygons.into_coord_type(coord_type), self.metadata)
+        Self::new(
+            self.type_ids,
+            self.offsets,
+            self.points.into_coord_type(coord_type),
+            self.line_strings.into_coord_type(coord_type),
+            self.polygons.into_coord_type(coord_type),
+            self.multi_points.into_coord_type(coord_type),
+            self.multi_line_strings.into_coord_type(coord_type),
+            self.multi_polygons.into_coord_type(coord_type),
+            self.metadata,
+        )
     }
 }
 
@@ -267,7 +342,10 @@ impl<const D: usize> ArrayBase for MixedGeometryArray<D> {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        Arc::new(self.data_type.to_field_with_metadata("geometry", true, &self.metadata))
+        Arc::new(
+            self.data_type
+                .to_field_with_metadata("geometry", true, &self.metadata),
+        )
     }
 
     fn extension_name(&self) -> &str {
@@ -383,9 +461,22 @@ impl<const D: usize> IntoArrow for MixedGeometryArray<D> {
             _ => unreachable!(),
         };
 
-        let child_arrays = vec![self.points.into_array_ref(), self.line_strings.into_array_ref(), self.polygons.into_array_ref(), self.multi_points.into_array_ref(), self.multi_line_strings.into_array_ref(), self.multi_polygons.into_array_ref()];
+        let child_arrays = vec![
+            self.points.into_array_ref(),
+            self.line_strings.into_array_ref(),
+            self.polygons.into_array_ref(),
+            self.multi_points.into_array_ref(),
+            self.multi_line_strings.into_array_ref(),
+            self.multi_polygons.into_array_ref(),
+        ];
 
-        UnionArray::try_new(union_fields, self.type_ids, Some(self.offsets), child_arrays).unwrap()
+        UnionArray::try_new(
+            union_fields,
+            self.type_ids,
+            Some(self.offsets),
+            child_arrays,
+        )
+        .unwrap()
     }
 }
 
@@ -412,44 +503,67 @@ impl<const D: usize> TryFrom<&UnionArray> for MixedGeometryArray<D> {
                                 points = Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             2 => {
-                                line_strings = Some(value.child(type_id).as_ref().try_into().unwrap());
+                                line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             3 => {
                                 polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             4 => {
-                                multi_points = Some(value.child(type_id).as_ref().try_into().unwrap());
+                                multi_points =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             5 => {
-                                multi_line_strings = Some(value.child(type_id).as_ref().try_into().unwrap());
+                                multi_line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             6 => {
-                                multi_polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
+                                multi_polygons =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            _ => return Err(GeoArrowError::General(format!("Unexpected type_id {} for dimension {}", type_id, D))),
+                            _ => {
+                                return Err(GeoArrowError::General(format!(
+                                    "Unexpected type_id {} for dimension {}",
+                                    type_id, D
+                                )))
+                            }
                         },
                         3 => match type_id {
                             11 => {
                                 points = Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             12 => {
-                                line_strings = Some(value.child(type_id).as_ref().try_into().unwrap());
+                                line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             13 => {
                                 polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             14 => {
-                                multi_points = Some(value.child(type_id).as_ref().try_into().unwrap());
+                                multi_points =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             15 => {
-                                multi_line_strings = Some(value.child(type_id).as_ref().try_into().unwrap());
+                                multi_line_strings =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
                             16 => {
-                                multi_polygons = Some(value.child(type_id).as_ref().try_into().unwrap());
+                                multi_polygons =
+                                    Some(value.child(type_id).as_ref().try_into().unwrap());
                             }
-                            _ => return Err(GeoArrowError::General(format!("Unexpected type_id {} for dimension {}", type_id, D))),
+                            _ => {
+                                return Err(GeoArrowError::General(format!(
+                                    "Unexpected type_id {} for dimension {}",
+                                    type_id, D
+                                )))
+                            }
                         },
-                        _ => return Err(GeoArrowError::General(format!("Unexpected type_id {} for dimension {}", type_id, D))),
+                        _ => {
+                            return Err(GeoArrowError::General(format!(
+                                "Unexpected type_id {} for dimension {}",
+                                type_id, D
+                            )))
+                        }
                     }
                 }
             }
@@ -460,7 +574,17 @@ impl<const D: usize> TryFrom<&UnionArray> for MixedGeometryArray<D> {
         // This is after checking for dense union
         let offsets = value.offsets().unwrap().clone();
 
-        Ok(Self::new(type_ids, offsets, points.unwrap_or_default(), line_strings.unwrap_or_default(), polygons.unwrap_or_default(), multi_points.unwrap_or_default(), multi_line_strings.unwrap_or_default(), multi_polygons.unwrap_or_default(), Default::default()))
+        Ok(Self::new(
+            type_ids,
+            offsets,
+            points.unwrap_or_default(),
+            line_strings.unwrap_or_default(),
+            polygons.unwrap_or_default(),
+            multi_points.unwrap_or_default(),
+            multi_line_strings.unwrap_or_default(),
+            multi_polygons.unwrap_or_default(),
+            Default::default(),
+        ))
     }
 }
 
@@ -473,7 +597,10 @@ impl<const D: usize> TryFrom<&dyn Array> for MixedGeometryArray<D> {
                 let downcasted = value.as_any().downcast_ref::<UnionArray>().unwrap();
                 downcasted.try_into()
             }
-            _ => Err(GeoArrowError::General(format!("Unexpected type: {:?}", value.data_type()))),
+            _ => Err(GeoArrowError::General(format!(
+                "Unexpected type: {:?}",
+                value.data_type()
+            ))),
         }
     }
 }
@@ -523,7 +650,17 @@ impl<const D: usize> From<PointArray<D>> for MixedGeometryArray<D> {
             _ => panic!(),
         };
         let metadata = value.metadata.clone();
-        Self::new(ScalarBuffer::from(type_ids), ScalarBuffer::from_iter(0..value.len() as i32), value, Default::default(), Default::default(), Default::default(), Default::default(), Default::default(), metadata)
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            value,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            metadata,
+        )
     }
 }
 
@@ -535,7 +672,17 @@ impl<const D: usize> From<LineStringArray<D>> for MixedGeometryArray<D> {
             _ => panic!(),
         };
         let metadata = value.metadata.clone();
-        Self::new(ScalarBuffer::from(type_ids), ScalarBuffer::from_iter(0..value.len() as i32), Default::default(), value, Default::default(), Default::default(), Default::default(), Default::default(), metadata)
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            value,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            metadata,
+        )
     }
 }
 
@@ -547,7 +694,17 @@ impl<const D: usize> From<PolygonArray<D>> for MixedGeometryArray<D> {
             _ => panic!(),
         };
         let metadata = value.metadata.clone();
-        Self::new(ScalarBuffer::from(type_ids), ScalarBuffer::from_iter(0..value.len() as i32), Default::default(), Default::default(), value, Default::default(), Default::default(), Default::default(), metadata)
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            Default::default(),
+            value,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            metadata,
+        )
     }
 }
 
@@ -559,7 +716,17 @@ impl<const D: usize> From<MultiPointArray<D>> for MixedGeometryArray<D> {
             _ => panic!(),
         };
         let metadata = value.metadata.clone();
-        Self::new(ScalarBuffer::from(type_ids), ScalarBuffer::from_iter(0..value.len() as i32), Default::default(), Default::default(), Default::default(), value, Default::default(), Default::default(), metadata)
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            value,
+            Default::default(),
+            Default::default(),
+            metadata,
+        )
     }
 }
 
@@ -571,7 +738,17 @@ impl<const D: usize> From<MultiLineStringArray<D>> for MixedGeometryArray<D> {
             _ => panic!(),
         };
         let metadata = value.metadata.clone();
-        Self::new(ScalarBuffer::from(type_ids), ScalarBuffer::from_iter(0..value.len() as i32), Default::default(), Default::default(), Default::default(), Default::default(), value, Default::default(), metadata)
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            value,
+            Default::default(),
+            metadata,
+        )
     }
 }
 
@@ -583,7 +760,17 @@ impl<const D: usize> From<MultiPolygonArray<D>> for MixedGeometryArray<D> {
             _ => panic!(),
         };
         let metadata = value.metadata.clone();
-        Self::new(ScalarBuffer::from(type_ids), ScalarBuffer::from_iter(0..value.len() as i32), Default::default(), Default::default(), Default::default(), Default::default(), Default::default(), value, metadata)
+        Self::new(
+            ScalarBuffer::from(type_ids),
+            ScalarBuffer::from_iter(0..value.len() as i32),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            value,
+            metadata,
+        )
     }
 }
 
@@ -596,7 +783,9 @@ impl<const D: usize> TryFrom<GeometryCollectionArray<D>> for MixedGeometryArray<
         }
 
         if value.null_count() > 0 {
-            return Err(GeoArrowError::General("Unable to cast with nulls".to_string()));
+            return Err(GeoArrowError::General(
+                "Unable to cast with nulls".to_string(),
+            ));
         }
 
         Ok(value.array)
@@ -618,22 +807,51 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate_points() {
-        let geoms: Vec<geo::Geometry> = vec![geo::Geometry::Point(point::p0()), geo::Geometry::Point(point::p1()), geo::Geometry::Point(point::p2())];
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::Point(point::p0()),
+            geo::Geometry::Point(point::p1()),
+            geo::Geometry::Point(point::p2()),
+        ];
         let arr: MixedGeometryArray<2> = geoms.as_slice().try_into().unwrap();
 
-        assert_eq!(arr.value_as_geo(0), geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()])));
-        assert_eq!(arr.value_as_geo(1), geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p1()])));
-        assert_eq!(arr.value_as_geo(2), geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p2()])));
+        assert_eq!(
+            arr.value_as_geo(0),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()]))
+        );
+        assert_eq!(
+            arr.value_as_geo(1),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p1()]))
+        );
+        assert_eq!(
+            arr.value_as_geo(2),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p2()]))
+        );
     }
 
     #[test]
     fn geo_roundtrip_accurate_all() {
-        let geoms: Vec<geo::Geometry> = vec![geo::Geometry::Point(point::p0()), geo::Geometry::LineString(linestring::ls0()), geo::Geometry::Polygon(polygon::p0()), geo::Geometry::MultiPoint(multipoint::mp0()), geo::Geometry::MultiLineString(multilinestring::ml0()), geo::Geometry::MultiPolygon(multipolygon::mp0())];
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::Point(point::p0()),
+            geo::Geometry::LineString(linestring::ls0()),
+            geo::Geometry::Polygon(polygon::p0()),
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiLineString(multilinestring::ml0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
         let arr: MixedGeometryArray<2> = geoms.as_slice().try_into().unwrap();
 
-        assert_eq!(arr.value_as_geo(0), geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()])));
-        assert_eq!(arr.value_as_geo(1), geo::Geometry::MultiLineString(geo::MultiLineString(vec![linestring::ls0()])));
-        assert_eq!(arr.value_as_geo(2), geo::Geometry::MultiPolygon(geo::MultiPolygon(vec![polygon::p0()])));
+        assert_eq!(
+            arr.value_as_geo(0),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()]))
+        );
+        assert_eq!(
+            arr.value_as_geo(1),
+            geo::Geometry::MultiLineString(geo::MultiLineString(vec![linestring::ls0()]))
+        );
+        assert_eq!(
+            arr.value_as_geo(2),
+            geo::Geometry::MultiPolygon(geo::MultiPolygon(vec![polygon::p0()]))
+        );
         assert_eq!(arr.value_as_geo(3), geoms[3]);
         assert_eq!(arr.value_as_geo(4), geoms[4]);
         assert_eq!(arr.value_as_geo(5), geoms[5]);
@@ -641,16 +859,32 @@ mod test {
 
     #[test]
     fn arrow_roundtrip() {
-        let geoms: Vec<geo::Geometry> = vec![geo::Geometry::Point(point::p0()), geo::Geometry::LineString(linestring::ls0()), geo::Geometry::Polygon(polygon::p0()), geo::Geometry::MultiPoint(multipoint::mp0()), geo::Geometry::MultiLineString(multilinestring::ml0()), geo::Geometry::MultiPolygon(multipolygon::mp0())];
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::Point(point::p0()),
+            geo::Geometry::LineString(linestring::ls0()),
+            geo::Geometry::Polygon(polygon::p0()),
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiLineString(multilinestring::ml0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
         let arr: MixedGeometryArray<2> = geoms.as_slice().try_into().unwrap();
 
         // Round trip to/from arrow-rs
         let arrow_array = arr.into_arrow();
         let round_trip_arr: MixedGeometryArray<2> = (&arrow_array).try_into().unwrap();
 
-        assert_eq!(round_trip_arr.value_as_geo(0), geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()])));
-        assert_eq!(round_trip_arr.value_as_geo(1), geo::Geometry::MultiLineString(geo::MultiLineString(vec![linestring::ls0()])));
-        assert_eq!(round_trip_arr.value_as_geo(2), geo::Geometry::MultiPolygon(geo::MultiPolygon(vec![polygon::p0()])));
+        assert_eq!(
+            round_trip_arr.value_as_geo(0),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()]))
+        );
+        assert_eq!(
+            round_trip_arr.value_as_geo(1),
+            geo::Geometry::MultiLineString(geo::MultiLineString(vec![linestring::ls0()]))
+        );
+        assert_eq!(
+            round_trip_arr.value_as_geo(2),
+            geo::Geometry::MultiPolygon(geo::MultiPolygon(vec![polygon::p0()]))
+        );
         assert_eq!(round_trip_arr.value_as_geo(3), geoms[3]);
         assert_eq!(round_trip_arr.value_as_geo(4), geoms[4]);
         assert_eq!(round_trip_arr.value_as_geo(5), geoms[5]);
@@ -658,7 +892,11 @@ mod test {
 
     #[test]
     fn arrow_roundtrip_not_all_types() {
-        let geoms: Vec<geo::Geometry> = vec![geo::Geometry::MultiPoint(multipoint::mp0()), geo::Geometry::MultiLineString(multilinestring::ml0()), geo::Geometry::MultiPolygon(multipolygon::mp0())];
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiLineString(multilinestring::ml0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
         let arr: MixedGeometryArray<2> = geoms.as_slice().try_into().unwrap();
 
         // Round trip to/from arrow-rs
@@ -672,7 +910,10 @@ mod test {
 
     #[test]
     fn arrow_roundtrip_not_all_types2() {
-        let geoms: Vec<geo::Geometry> = vec![geo::Geometry::MultiPoint(multipoint::mp0()), geo::Geometry::MultiPolygon(multipolygon::mp0())];
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
         let arr: MixedGeometryArray<2> = geoms.as_slice().try_into().unwrap();
 
         // Round trip to/from arrow-rs

--- a/src/array/mixed/builder.rs
+++ b/src/array/mixed/builder.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::mixed::array::GeometryType;
 use crate::array::mixed::MixedCapacity;
-use crate::array::{CoordType, LineStringBuilder, MixedGeometryArray, MultiLineStringBuilder, MultiPointBuilder, MultiPolygonBuilder, PointBuilder, PolygonBuilder, WKBArray};
+use crate::array::{
+    CoordType, LineStringBuilder, MixedGeometryArray, MultiLineStringBuilder, MultiPointBuilder,
+    MultiPolygonBuilder, PointBuilder, PolygonBuilder, WKBArray,
+};
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::*;
 use crate::io::wkb::reader::WKBGeometry;
@@ -56,17 +59,45 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
         Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options(capacity: MixedCapacity, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn with_capacity_and_options(
+        capacity: MixedCapacity,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         // Don't store array metadata on child arrays
         Self {
             metadata,
             types: vec![],
-            points: PointBuilder::with_capacity_and_options(capacity.point, coord_type, Default::default()),
-            line_strings: LineStringBuilder::with_capacity_and_options(capacity.line_string, coord_type, Default::default()),
-            polygons: PolygonBuilder::with_capacity_and_options(capacity.polygon, coord_type, Default::default()),
-            multi_points: MultiPointBuilder::with_capacity_and_options(capacity.multi_point, coord_type, Default::default()),
-            multi_line_strings: MultiLineStringBuilder::with_capacity_and_options(capacity.multi_line_string, coord_type, Default::default()),
-            multi_polygons: MultiPolygonBuilder::with_capacity_and_options(capacity.multi_polygon, coord_type, Default::default()),
+            points: PointBuilder::with_capacity_and_options(
+                capacity.point,
+                coord_type,
+                Default::default(),
+            ),
+            line_strings: LineStringBuilder::with_capacity_and_options(
+                capacity.line_string,
+                coord_type,
+                Default::default(),
+            ),
+            polygons: PolygonBuilder::with_capacity_and_options(
+                capacity.polygon,
+                coord_type,
+                Default::default(),
+            ),
+            multi_points: MultiPointBuilder::with_capacity_and_options(
+                capacity.multi_point,
+                coord_type,
+                Default::default(),
+            ),
+            multi_line_strings: MultiLineStringBuilder::with_capacity_and_options(
+                capacity.multi_line_string,
+                coord_type,
+                Default::default(),
+            ),
+            multi_polygons: MultiPolygonBuilder::with_capacity_and_options(
+                capacity.multi_polygon,
+                coord_type,
+                Default::default(),
+            ),
             offsets: vec![],
         }
     }
@@ -91,7 +122,8 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
         self.line_strings.reserve_exact(capacity.line_string);
         self.polygons.reserve_exact(capacity.polygon);
         self.multi_points.reserve_exact(capacity.multi_point);
-        self.multi_line_strings.reserve_exact(capacity.multi_line_string);
+        self.multi_line_strings
+            .reserve_exact(capacity.multi_line_string);
         self.multi_polygons.reserve_exact(capacity.multi_polygon);
     }
 
@@ -128,22 +160,36 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
         self.into()
     }
 
-    pub fn with_capacity_from_iter(geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>) -> Result<Self> {
+    pub fn with_capacity_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<Self> {
         Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options_from_iter(geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+    pub fn with_capacity_and_options_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
         let counter = MixedCapacity::from_geometries(geoms)?;
-        Ok(Self::with_capacity_and_options(counter, coord_type, metadata))
+        Ok(Self::with_capacity_and_options(
+            counter, coord_type, metadata,
+        ))
     }
 
-    pub fn reserve_from_iter(&mut self, geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>) -> Result<()> {
+    pub fn reserve_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<()> {
         let counter = MixedCapacity::from_geometries(geoms)?;
         self.reserve(counter);
         Ok(())
     }
 
-    pub fn reserve_exact_from_iter(&mut self, geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>) -> Result<()> {
+    pub fn reserve_exact_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<()> {
         let counter = MixedCapacity::from_geometries(geoms)?;
         self.reserve_exact(counter);
         Ok(())
@@ -165,7 +211,10 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
     /// Add a new Point to the end of this array, storing it in the MultiPointBuilder child
     /// array.
     #[inline]
-    pub fn push_point_as_multi_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
+    pub fn push_point_as_multi_point(
+        &mut self,
+        value: Option<&impl PointTrait<T = f64>>,
+    ) -> Result<()> {
         self.add_multi_point_type();
         self.multi_points.push_point(value)
     }
@@ -177,14 +226,18 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_line_string(&mut self, value: Option<&impl LineStringTrait<T = f64>>) -> Result<()> {
+    pub fn push_line_string(
+        &mut self,
+        value: Option<&impl LineStringTrait<T = f64>>,
+    ) -> Result<()> {
         self.add_line_string_type();
         self.line_strings.push_line_string(value)
     }
 
     #[inline]
     pub(crate) fn add_line_string_type(&mut self) {
-        self.offsets.push(self.line_strings.len().try_into().unwrap());
+        self.offsets
+            .push(self.line_strings.len().try_into().unwrap());
         self.types.push(GeometryType::LineString.default_ordering());
     }
 
@@ -195,7 +248,10 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_line_string_as_multi_line_string(&mut self, value: Option<&impl LineStringTrait<T = f64>>) -> Result<()> {
+    pub fn push_line_string_as_multi_line_string(
+        &mut self,
+        value: Option<&impl LineStringTrait<T = f64>>,
+    ) -> Result<()> {
         self.add_multi_line_string_type();
         self.multi_line_strings.push_line_string(value)
     }
@@ -225,7 +281,10 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_polygon_as_multi_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
+    pub fn push_polygon_as_multi_polygon(
+        &mut self,
+        value: Option<&impl PolygonTrait<T = f64>>,
+    ) -> Result<()> {
         self.add_multi_polygon_type();
         self.multi_polygons.push_polygon(value)
     }
@@ -236,14 +295,18 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_point(&mut self, value: Option<&impl MultiPointTrait<T = f64>>) -> Result<()> {
+    pub fn push_multi_point(
+        &mut self,
+        value: Option<&impl MultiPointTrait<T = f64>>,
+    ) -> Result<()> {
         self.add_multi_point_type();
         self.multi_points.push_multi_point(value)
     }
 
     #[inline]
     pub(crate) fn add_multi_point_type(&mut self) {
-        self.offsets.push(self.multi_points.len().try_into().unwrap());
+        self.offsets
+            .push(self.multi_points.len().try_into().unwrap());
         self.types.push(GeometryType::MultiPoint.default_ordering());
     }
 
@@ -253,15 +316,20 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_line_string(&mut self, value: Option<&impl MultiLineStringTrait<T = f64>>) -> Result<()> {
+    pub fn push_multi_line_string(
+        &mut self,
+        value: Option<&impl MultiLineStringTrait<T = f64>>,
+    ) -> Result<()> {
         self.add_multi_line_string_type();
         self.multi_line_strings.push_multi_line_string(value)
     }
 
     #[inline]
     pub(crate) fn add_multi_line_string_type(&mut self) {
-        self.offsets.push(self.multi_line_strings.len().try_into().unwrap());
-        self.types.push(GeometryType::MultiLineString.default_ordering());
+        self.offsets
+            .push(self.multi_line_strings.len().try_into().unwrap());
+        self.types
+            .push(GeometryType::MultiLineString.default_ordering());
     }
 
     /// Add a new MultiPolygon to the end of this array.
@@ -270,15 +338,20 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_polygon(&mut self, value: Option<&impl MultiPolygonTrait<T = f64>>) -> Result<()> {
+    pub fn push_multi_polygon(
+        &mut self,
+        value: Option<&impl MultiPolygonTrait<T = f64>>,
+    ) -> Result<()> {
         self.add_multi_polygon_type();
         self.multi_polygons.push_multi_polygon(value)
     }
 
     #[inline]
     pub(crate) fn add_multi_polygon_type(&mut self) {
-        self.offsets.push(self.multi_polygons.len().try_into().unwrap());
-        self.types.push(GeometryType::MultiPolygon.default_ordering());
+        self.offsets
+            .push(self.multi_polygons.len().try_into().unwrap());
+        self.types
+            .push(GeometryType::MultiPolygon.default_ordering());
     }
 
     #[inline]
@@ -287,12 +360,19 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
     }
 
     #[inline]
-    pub fn push_geometry_preferring_multi(&mut self, value: Option<&'a impl GeometryTrait<T = f64>>) -> Result<()> {
+    pub fn push_geometry_preferring_multi(
+        &mut self,
+        value: Option<&'a impl GeometryTrait<T = f64>>,
+    ) -> Result<()> {
         self._push_geometry(value, true)
     }
 
     #[inline]
-    fn _push_geometry(&mut self, value: Option<&'a impl GeometryTrait<T = f64>>, prefer_multi: bool) -> Result<()> {
+    fn _push_geometry(
+        &mut self,
+        value: Option<&'a impl GeometryTrait<T = f64>>,
+        prefer_multi: bool,
+    ) -> Result<()> {
         if let Some(geom) = value {
             match geom.as_type() {
                 crate::geo_traits::GeometryType::Point(g) => {
@@ -317,13 +397,19 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
                     }
                 }
                 crate::geo_traits::GeometryType::MultiPoint(p) => self.push_multi_point(Some(p))?,
-                crate::geo_traits::GeometryType::MultiLineString(p) => self.push_multi_line_string(Some(p))?,
-                crate::geo_traits::GeometryType::MultiPolygon(p) => self.push_multi_polygon(Some(p))?,
+                crate::geo_traits::GeometryType::MultiLineString(p) => {
+                    self.push_multi_line_string(Some(p))?
+                }
+                crate::geo_traits::GeometryType::MultiPolygon(p) => {
+                    self.push_multi_polygon(Some(p))?
+                }
                 crate::geo_traits::GeometryType::GeometryCollection(gc) => {
                     if gc.num_geometries() == 1 {
                         self._push_geometry(Some(&gc.geometry(0).unwrap()), prefer_multi)?
                     } else {
-                        return Err(GeoArrowError::General("nested geometry collections not supported".to_string()));
+                        return Err(GeoArrowError::General(
+                            "nested geometry collections not supported".to_string(),
+                        ));
                     }
                 }
                 crate::geo_traits::GeometryType::Rect(_) => todo!(),
@@ -339,26 +425,65 @@ impl<'a, const D: usize> MixedGeometryBuilder<D> {
         todo!("push null geometry")
     }
 
-    pub fn extend_from_iter(&mut self, geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = f64> + 'a)>>, prefer_multi: bool) {
-        geoms.into_iter().try_for_each(|maybe_geom| if prefer_multi { self.push_geometry_preferring_multi(maybe_geom) } else { self.push_geometry(maybe_geom) }).unwrap();
+    pub fn extend_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = f64> + 'a)>>,
+        prefer_multi: bool,
+    ) {
+        geoms
+            .into_iter()
+            .try_for_each(|maybe_geom| {
+                if prefer_multi {
+                    self.push_geometry_preferring_multi(maybe_geom)
+                } else {
+                    self.push_geometry(maybe_geom)
+                }
+            })
+            .unwrap();
     }
 
     /// Create this builder from a slice of Geometries.
-    pub fn from_geometries(geoms: &[impl GeometryTrait<T = f64>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(Some), coord_type.unwrap_or_default(), metadata)?;
+    pub fn from_geometries(
+        geoms: &[impl GeometryTrait<T = f64>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+            metadata,
+        )?;
         array.extend_from_iter(geoms.iter().map(Some), prefer_multi);
         Ok(array)
     }
 
     /// Create this builder from a slice of nullable Geometries.
-    pub fn from_nullable_geometries(geoms: &[Option<impl GeometryTrait<T = f64>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(|x| x.as_ref()), coord_type.unwrap_or_default(), metadata)?;
+    pub fn from_nullable_geometries(
+        geoms: &[Option<impl GeometryTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(|x| x.as_ref()),
+            coord_type.unwrap_or_default(),
+            metadata,
+        )?;
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()), prefer_multi);
         Ok(array)
     }
 
-    pub(crate) fn from_wkb<W: OffsetSizeTrait>(wkb_objects: &[Option<WKB<'_, W>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let wkb_objects2: Vec<Option<WKBGeometry>> = wkb_objects.iter().map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object())).collect();
+    pub(crate) fn from_wkb<W: OffsetSizeTrait>(
+        wkb_objects: &[Option<WKB<'_, W>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let wkb_objects2: Vec<Option<WKBGeometry>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object()))
+            .collect();
         Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata, prefer_multi)
     }
 }
@@ -379,7 +504,17 @@ impl<const D: usize> IntoArrow for MixedGeometryBuilder<D> {
 
 impl<const D: usize> From<MixedGeometryBuilder<D>> for MixedGeometryArray<D> {
     fn from(other: MixedGeometryBuilder<D>) -> Self {
-        Self::new(other.types.into(), other.offsets.into(), other.points.into(), other.line_strings.into(), other.polygons.into(), other.multi_points.into(), other.multi_line_strings.into(), other.multi_polygons.into(), other.metadata)
+        Self::new(
+            other.types.into(),
+            other.offsets.into(),
+            other.points.into(),
+            other.line_strings.into(),
+            other.polygons.into(),
+            other.multi_points.into(),
+            other.multi_line_strings.into(),
+            other.multi_polygons.into(),
+            other.metadata,
+        )
     }
 }
 
@@ -403,7 +538,11 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MixedGeometryB
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> std::result::Result<Self, Self::Error> {
-        assert_eq!(value.nulls().map_or(0, |validity| validity.null_count()), 0, "Parsing a WKBArray with null elements not supported",);
+        assert_eq!(
+            value.nulls().map_or(0, |validity| validity.null_count()),
+            0,
+            "Parsing a WKBArray with null elements not supported",
+        );
 
         let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
@@ -429,7 +568,11 @@ impl<const D: usize> GeometryArrayBuilder for MixedGeometryBuilder<D> {
         Arc::new(self.into_arrow())
     }
 
-    fn with_geom_capacity_and_options(_geom_capacity: usize, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    fn with_geom_capacity_and_options(
+        _geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         // We don't know where to allocate the capacity
         Self::with_capacity_and_options(Default::default(), coord_type, metadata)
     }

--- a/src/array/mixed/capacity.rs
+++ b/src/array/mixed/capacity.rs
@@ -1,7 +1,5 @@
 use std::ops::Add;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::linestring::LineStringCapacity;
 use crate::array::multilinestring::MultiLineStringCapacity;
 use crate::array::multipoint::MultiPointCapacity;
@@ -221,13 +219,13 @@ impl MixedCapacity {
     }
 
     /// The number of bytes an array with this capacity would occupy.
-    pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
+    pub fn num_bytes(&self) -> usize {
         let mut count = self.point * 2 * 8;
-        count += self.line_string.num_bytes::<O>();
-        count += self.polygon.num_bytes::<O>();
-        count += self.multi_point.num_bytes::<O>();
-        count += self.multi_line_string.num_bytes::<O>();
-        count += self.multi_polygon.num_bytes::<O>();
+        count += self.line_string.num_bytes();
+        count += self.polygon.num_bytes();
+        count += self.multi_point.num_bytes();
+        count += self.multi_line_string.num_bytes();
+        count += self.multi_polygon.num_bytes();
         count
     }
 }

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -3,14 +3,8 @@ use std::sync::Arc;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::multilinestring::MultiLineStringCapacity;
-use crate::array::util::{
-    offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32,
-    offsets_buffer_to_i64, OffsetBufferUtils,
-};
-use crate::array::{
-    CoordBuffer, CoordType, GeometryCollectionArray, LineStringArray, MixedGeometryArray,
-    PolygonArray, WKBArray,
-};
+use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32, offsets_buffer_to_i64, OffsetBufferUtils};
+use crate::array::{CoordBuffer, CoordType, GeometryCollectionArray, LineStringArray, MixedGeometryArray, PolygonArray, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiLineStringTrait;
@@ -29,7 +23,7 @@ use super::MultiLineStringBuilder;
 /// This is semantically equivalent to `Vec<Option<MultiLineString>>` due to the internal validity
 /// bitmap.
 #[derive(Debug, Clone)]
-pub struct MultiLineStringArray<O: OffsetSizeTrait, const D: usize> {
+pub struct MultiLineStringArray<const D: usize> {
     // Always NativeType::MultiLineString or NativeType::LargeMultiLineString
     data_type: NativeType,
 
@@ -38,43 +32,32 @@ pub struct MultiLineStringArray<O: OffsetSizeTrait, const D: usize> {
     pub(crate) coords: CoordBuffer<D>,
 
     /// Offsets into the ring array where each geometry starts
-    pub(crate) geom_offsets: OffsetBuffer<O>,
+    pub(crate) geom_offsets: OffsetBuffer<i32>,
 
     /// Offsets into the coordinate array where each ring starts
-    pub(crate) ring_offsets: OffsetBuffer<O>,
+    pub(crate) ring_offsets: OffsetBuffer<i32>,
 
     /// Validity bitmap
     pub(crate) validity: Option<NullBuffer>,
 }
 
-pub(super) fn check<O: OffsetSizeTrait, const D: usize>(
-    coords: &CoordBuffer<D>,
-    geom_offsets: &OffsetBuffer<O>,
-    ring_offsets: &OffsetBuffer<O>,
-    validity_len: Option<usize>,
-) -> Result<()> {
+pub(super) fn check<const D: usize>(coords: &CoordBuffer<D>, geom_offsets: &OffsetBuffer<i32>, ring_offsets: &OffsetBuffer<i32>, validity_len: Option<usize>) -> Result<()> {
     if validity_len.map_or(false, |len| len != geom_offsets.len_proxy()) {
-        return Err(GeoArrowError::General(
-            "validity mask length must match the number of values".to_string(),
-        ));
+        return Err(GeoArrowError::General("validity mask length must match the number of values".to_string()));
     }
 
     if ring_offsets.last().to_usize().unwrap() != coords.len() {
-        return Err(GeoArrowError::General(
-            "largest ring offset must match coords length".to_string(),
-        ));
+        return Err(GeoArrowError::General("largest ring offset must match coords length".to_string()));
     }
 
     if geom_offsets.last().to_usize().unwrap() != ring_offsets.len_proxy() {
-        return Err(GeoArrowError::General(
-            "largest geometry offset must match ring offsets length".to_string(),
-        ));
+        return Err(GeoArrowError::General("largest geometry offset must match ring offsets length".to_string()));
     }
 
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
+impl<const D: usize> MultiLineStringArray<D> {
     /// Create a new MultiLineStringArray from parts
     ///
     /// # Implementation
@@ -86,13 +69,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
-    pub fn new(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
-        validity: Option<NullBuffer>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, validity: Option<NullBuffer>, metadata: Arc<ArrayMetadata>) -> Self {
         Self::try_new(coords, geom_offsets, ring_offsets, validity, metadata).unwrap()
     }
 
@@ -107,34 +84,13 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
-    pub fn try_new(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
-        validity: Option<NullBuffer>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self> {
-        check(
-            &coords,
-            &geom_offsets,
-            &ring_offsets,
-            validity.as_ref().map(|v| v.len()),
-        )?;
+    pub fn try_new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, validity: Option<NullBuffer>, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+        check(&coords, &geom_offsets, &ring_offsets, validity.as_ref().map(|v| v.len()))?;
 
         let coord_type = coords.coord_type();
-        let data_type = match O::IS_LARGE {
-            true => NativeType::LargeMultiLineString(coord_type, D.try_into()?),
-            false => NativeType::MultiLineString(coord_type, D.try_into()?),
-        };
+        let data_type = NativeType::MultiLineString(coord_type, D.try_into()?);
 
-        Ok(Self {
-            data_type,
-            coords,
-            geom_offsets,
-            ring_offsets,
-            validity,
-            metadata,
-        })
+        Ok(Self { data_type, coords, geom_offsets, ring_offsets, validity, metadata })
     }
 
     fn vertices_field(&self) -> Arc<Field> {
@@ -142,37 +98,30 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
     }
 
     fn linestrings_field(&self) -> Arc<Field> {
-        match O::IS_LARGE {
-            true => Field::new_large_list("linestrings", self.vertices_field(), false).into(),
-            false => Field::new_list("linestrings", self.vertices_field(), false).into(),
-        }
+        Field::new_list("linestrings", self.vertices_field(), false).into()
     }
 
     pub fn coords(&self) -> &CoordBuffer<D> {
         &self.coords
     }
 
-    pub fn geom_offsets(&self) -> &OffsetBuffer<O> {
+    pub fn geom_offsets(&self) -> &OffsetBuffer<i32> {
         &self.geom_offsets
     }
 
-    pub fn ring_offsets(&self) -> &OffsetBuffer<O> {
+    pub fn ring_offsets(&self) -> &OffsetBuffer<i32> {
         &self.ring_offsets
     }
 
     /// The lengths of each buffer contained in this array.
     pub fn buffer_lengths(&self) -> MultiLineStringCapacity {
-        MultiLineStringCapacity::new(
-            self.ring_offsets.last().to_usize().unwrap(),
-            self.geom_offsets.last().to_usize().unwrap(),
-            self.len(),
-        )
+        MultiLineStringCapacity::new(self.ring_offsets.last().to_usize().unwrap(), self.geom_offsets.last().to_usize().unwrap(), self.len())
     }
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
         let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
-        validity_len + self.buffer_lengths().num_bytes::<O>()
+        validity_len + self.buffer_lengths().num_bytes()
     }
 
     /// Slices this [`MultiLineStringArray`] in place.
@@ -180,10 +129,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        assert!(
-            offset + length <= self.len(),
-            "offset + length may not exceed length of array"
-        );
+        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
         // Note: we **only** slice the geom_offsets and not any actual data. Otherwise the offsets
         // would be in the wrong location.
         Self {
@@ -197,10 +143,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
     }
 
     pub fn owned_slice(&self, offset: usize, length: usize) -> Self {
-        assert!(
-            offset + length <= self.len(),
-            "offset + length may not exceed length of array"
-        );
+        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
         assert!(length >= 1, "length must be at least 1");
 
         // Find the start and end of the ring offsets
@@ -213,24 +156,12 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
 
         // Slice the geom_offsets
         let geom_offsets = owned_slice_offsets(&self.geom_offsets, offset, length);
-        let ring_offsets = owned_slice_offsets(
-            &self.ring_offsets,
-            start_ring_idx,
-            end_ring_idx - start_ring_idx,
-        );
-        let coords = self
-            .coords
-            .owned_slice(start_coord_idx, end_coord_idx - start_coord_idx);
+        let ring_offsets = owned_slice_offsets(&self.ring_offsets, start_ring_idx, end_ring_idx - start_ring_idx);
+        let coords = self.coords.owned_slice(start_coord_idx, end_coord_idx - start_coord_idx);
 
         let validity = owned_slice_validity(self.nulls(), offset, length);
 
-        Self::new(
-            coords,
-            geom_offsets,
-            ring_offsets,
-            validity,
-            self.metadata(),
-        )
+        Self::new(coords, geom_offsets, ring_offsets, validity, self.metadata())
     }
 
     pub fn to_coord_type(&self, coord_type: CoordType) -> Self {
@@ -238,37 +169,19 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringArray<O, D> {
     }
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
-        Self::new(
-            self.coords.into_coord_type(coord_type),
-            self.geom_offsets,
-            self.ring_offsets,
-            self.validity,
-            self.metadata,
-        )
+        Self::new(self.coords.into_coord_type(coord_type), self.geom_offsets, self.ring_offsets, self.validity, self.metadata)
     }
 
     pub fn to_small_offsets(&self) -> Result<MultiLineStringArray<i32, D>> {
-        Ok(MultiLineStringArray::new(
-            self.coords.clone(),
-            offsets_buffer_to_i32(&self.geom_offsets)?,
-            offsets_buffer_to_i32(&self.ring_offsets)?,
-            self.validity.clone(),
-            self.metadata.clone(),
-        ))
+        Ok(MultiLineStringArray::new(self.coords.clone(), offsets_buffer_to_i32(&self.geom_offsets)?, offsets_buffer_to_i32(&self.ring_offsets)?, self.validity.clone(), self.metadata.clone()))
     }
 
     pub fn to_large_offsets(&self) -> MultiLineStringArray<i64, D> {
-        MultiLineStringArray::new(
-            self.coords.clone(),
-            offsets_buffer_to_i64(&self.geom_offsets),
-            offsets_buffer_to_i64(&self.ring_offsets),
-            self.validity.clone(),
-            self.metadata.clone(),
-        )
+        MultiLineStringArray::new(self.coords.clone(), offsets_buffer_to_i64(&self.geom_offsets), offsets_buffer_to_i64(&self.ring_offsets), self.validity.clone(), self.metadata.clone())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> ArrayBase for MultiLineStringArray<O, D> {
+impl<const D: usize> ArrayBase for MultiLineStringArray<D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -278,9 +191,7 @@ impl<O: OffsetSizeTrait, const D: usize> ArrayBase for MultiLineStringArray<O, D
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        self.data_type
-            .to_field_with_metadata("geometry", true, &self.metadata)
-            .into()
+        self.data_type.to_field_with_metadata("geometry", true, &self.metadata).into()
     }
 
     fn extension_name(&self) -> &str {
@@ -312,7 +223,7 @@ impl<O: OffsetSizeTrait, const D: usize> ArrayBase for MultiLineStringArray<O, D
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> NativeArray for MultiLineStringArray<O, D> {
+impl<const D: usize> NativeArray for MultiLineStringArray<D> {
     fn data_type(&self) -> NativeType {
         self.data_type
     }
@@ -344,34 +255,20 @@ impl<O: OffsetSizeTrait, const D: usize> NativeArray for MultiLineStringArray<O,
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D>
-    for MultiLineStringArray<O, D>
-{
+impl<const D: usize> GeometryArraySelfMethods<D> for MultiLineStringArray<D> {
     fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
-        Self::new(
-            coords,
-            self.geom_offsets,
-            self.ring_offsets,
-            self.validity,
-            self.metadata,
-        )
+        Self::new(coords, self.geom_offsets, self.ring_offsets, self.validity, self.metadata)
     }
 
     fn into_coord_type(self, coord_type: CoordType) -> Self {
-        Self::new(
-            self.coords.into_coord_type(coord_type),
-            self.geom_offsets,
-            self.ring_offsets,
-            self.validity,
-            self.metadata,
-        )
+        Self::new(self.coords.into_coord_type(coord_type), self.geom_offsets, self.ring_offsets, self.validity, self.metadata)
     }
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait, const D: usize> ArrayAccessor<'a> for MultiLineStringArray<O, D> {
-    type Item = MultiLineString<'a, O, D>;
+impl<'a, const D: usize> ArrayAccessor<'a> for MultiLineStringArray<D> {
+    type Item = MultiLineString<'a, D>;
     type ItemGeo = geo::MultiLineString;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -379,27 +276,20 @@ impl<'a, O: OffsetSizeTrait, const D: usize> ArrayAccessor<'a> for MultiLineStri
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiLineStringArray<O, D> {
-    type ArrowArray = GenericListArray<O>;
+impl<const D: usize> IntoArrow for MultiLineStringArray<D> {
+    type ArrowArray = GenericListArray<i32>;
 
     fn into_arrow(self) -> Self::ArrowArray {
         let vertices_field = self.vertices_field();
         let linestrings_field = self.linestrings_field();
         let validity = self.validity;
         let coord_array = self.coords.into_array_ref();
-        let ring_array = Arc::new(GenericListArray::new(
-            vertices_field,
-            self.ring_offsets,
-            coord_array,
-            None,
-        ));
+        let ring_array = Arc::new(GenericListArray::new(vertices_field, self.ring_offsets, coord_array, None));
         GenericListArray::new(linestrings_field, self.geom_offsets, ring_array, validity)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>>
-    for MultiLineStringArray<O, D>
-{
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>> for MultiLineStringArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(geom_array: &GenericListArray<O>) -> Result<Self> {
@@ -407,25 +297,16 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>>
         let validity = geom_array.nulls();
 
         let rings_dyn_array = geom_array.values();
-        let rings_array = rings_dyn_array
-            .as_any()
-            .downcast_ref::<GenericListArray<O>>()
-            .unwrap();
+        let rings_array = rings_dyn_array.as_any().downcast_ref::<GenericListArray<O>>().unwrap();
 
         let ring_offsets = rings_array.offsets();
         let coords: CoordBuffer<D> = rings_array.values().as_ref().try_into()?;
 
-        Ok(Self::new(
-            coords,
-            geom_offsets.clone(),
-            ring_offsets.clone(),
-            validity.cloned(),
-            Default::default(),
-        ))
+        Ok(Self::new(coords, geom_offsets.clone(), ring_offsets.clone(), validity.cloned(), Default::default()))
     }
 }
 
-impl<const D: usize> TryFrom<&dyn Array> for MultiLineStringArray<i32, D> {
+impl<const D: usize> TryFrom<&dyn Array> for MultiLineStringArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
@@ -439,37 +320,12 @@ impl<const D: usize> TryFrom<&dyn Array> for MultiLineStringArray<i32, D> {
                 let geom_array: MultiLineStringArray<i64, D> = downcasted.try_into()?;
                 geom_array.try_into()
             }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
-            ))),
+            _ => Err(GeoArrowError::General(format!("Unexpected type: {:?}", value.data_type()))),
         }
     }
 }
 
-impl<const D: usize> TryFrom<&dyn Array> for MultiLineStringArray<i64, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: &dyn Array) -> Result<Self> {
-        match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_any().downcast_ref::<ListArray>().unwrap();
-                let geom_array: MultiLineStringArray<i32, D> = downcasted.try_into()?;
-                Ok(geom_array.into())
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_any().downcast_ref::<LargeListArray>().unwrap();
-                downcasted.try_into()
-            }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
-            ))),
-        }
-    }
-}
-
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiLineStringArray<i32, D> {
+impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiLineStringArray<D> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -479,61 +335,39 @@ impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiLineStringArray<i32,
     }
 }
 
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiLineStringArray<i64, D> {
-    type Error = GeoArrowError;
-
-    fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let mut arr: Self = arr.try_into()?;
-        arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
-        Ok(arr)
-    }
-}
-
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>, const D: usize> From<Vec<Option<G>>>
-    for MultiLineStringArray<O, D>
-{
+impl<G: MultiLineStringTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiLineStringArray<D> {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: MultiLineStringBuilder<O, D> = other.into();
+        let mut_arr: MultiLineStringBuilder<D> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>, const D: usize> From<&[G]>
-    for MultiLineStringArray<O, D>
-{
+impl<G: MultiLineStringTrait<T = f64>, const D: usize> From<&[G]> for MultiLineStringArray<D> {
     fn from(other: &[G]) -> Self {
-        let mut_arr: MultiLineStringBuilder<O, D> = other.into();
+        let mut_arr: MultiLineStringBuilder<D> = other.into();
         mut_arr.into()
     }
 }
 
 /// Polygon and MultiLineString have the same layout, so enable conversions between the two to
 /// change the semantic type
-impl<O: OffsetSizeTrait, const D: usize> From<MultiLineStringArray<O, D>> for PolygonArray<O, D> {
-    fn from(value: MultiLineStringArray<O, D>) -> Self {
-        Self::new(
-            value.coords,
-            value.geom_offsets,
-            value.ring_offsets,
-            value.validity,
-            value.metadata,
-        )
+impl<const D: usize> From<MultiLineStringArray<D>> for PolygonArray<D> {
+    fn from(value: MultiLineStringArray<D>) -> Self {
+        Self::new(value.coords, value.geom_offsets, value.ring_offsets, value.validity, value.metadata)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiLineStringArray<O, D> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiLineStringArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
-        let mut_arr: MultiLineStringBuilder<O, D> = value.try_into()?;
+        let mut_arr: MultiLineStringBuilder<D> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<LineStringArray<O, D>>
-    for MultiLineStringArray<O, D>
-{
-    fn from(value: LineStringArray<O, D>) -> Self {
+impl<const D: usize> From<LineStringArray<D>> for MultiLineStringArray<D> {
+    fn from(value: LineStringArray<D>) -> Self {
         let coords = value.coords;
         let geom_offsets = OffsetBuffer::from_lengths(vec![1; coords.len()]);
         let ring_offsets = value.geom_offsets;
@@ -542,40 +376,14 @@ impl<O: OffsetSizeTrait, const D: usize> From<LineStringArray<O, D>>
     }
 }
 
-impl<const D: usize> From<MultiLineStringArray<i32, D>> for MultiLineStringArray<i64, D> {
-    fn from(value: MultiLineStringArray<i32, D>) -> Self {
-        Self::new(
-            value.coords,
-            offsets_buffer_i32_to_i64(&value.geom_offsets),
-            offsets_buffer_i32_to_i64(&value.ring_offsets),
-            value.validity,
-            value.metadata,
-        )
-    }
-}
-
-impl<const D: usize> TryFrom<MultiLineStringArray<i64, D>> for MultiLineStringArray<i32, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: MultiLineStringArray<i64, D>) -> Result<Self> {
-        Ok(Self::new(
-            value.coords,
-            offsets_buffer_i64_to_i32(&value.geom_offsets)?,
-            offsets_buffer_i64_to_i32(&value.ring_offsets)?,
-            value.validity,
-            value.metadata,
-        ))
-    }
-}
-
 /// Default to an empty array
-impl<O: OffsetSizeTrait, const D: usize> Default for MultiLineStringArray<O, D> {
+impl<const D: usize> Default for MultiLineStringArray<D> {
     fn default() -> Self {
         MultiLineStringBuilder::default().into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> PartialEq for MultiLineStringArray<O, D> {
+impl<const D: usize> PartialEq for MultiLineStringArray<D> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;
@@ -597,17 +405,11 @@ impl<O: OffsetSizeTrait, const D: usize> PartialEq for MultiLineStringArray<O, D
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
-    for MultiLineStringArray<O, D>
-{
+impl<const D: usize> TryFrom<MixedGeometryArray<D>> for MultiLineStringArray<D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: MixedGeometryArray<O, D>) -> Result<Self> {
-        if value.has_points()
-            || value.has_polygons()
-            || value.has_multi_points()
-            || value.has_multi_polygons()
-        {
+    fn try_from(value: MixedGeometryArray<D>) -> Result<Self> {
+        if value.has_points() || value.has_polygons() || value.has_multi_points() || value.has_multi_polygons() {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
@@ -622,48 +424,37 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
         let mut capacity = value.multi_line_strings.buffer_lengths();
         capacity += value.line_strings.buffer_lengths();
 
-        let mut builder = MultiLineStringBuilder::<O, D>::with_capacity_and_options(
-            capacity,
-            value.coord_type(),
-            value.metadata(),
-        );
-        value
-            .iter()
-            .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
+        let mut builder = MultiLineStringBuilder::<D>::with_capacity_and_options(capacity, value.coord_type(), value.metadata());
+        value.iter().try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>>
-    for MultiLineStringArray<O, D>
-{
+impl<const D: usize> TryFrom<GeometryCollectionArray<D>> for MultiLineStringArray<D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self> {
+    fn try_from(value: GeometryCollectionArray<D>) -> Result<Self> {
         MixedGeometryArray::try_from(value)?.try_into()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::test::geoarrow_data::{
-        example_multilinestring_interleaved, example_multilinestring_separated,
-        example_multilinestring_wkb,
-    };
+    use crate::test::geoarrow_data::{example_multilinestring_interleaved, example_multilinestring_separated, example_multilinestring_wkb};
     use crate::test::multilinestring::{ml0, ml1};
 
     use super::*;
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: MultiLineStringArray<i64, 2> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
         assert_eq!(arr.value_as_geo(0), ml0());
         assert_eq!(arr.value_as_geo(1), ml1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: MultiLineStringArray<i64, 2> = vec![Some(ml0()), Some(ml1()), None].into();
+        let arr: MultiLineStringArray<2> = vec![Some(ml0()), Some(ml1()), None].into();
         assert_eq!(arr.get_as_geo(0), Some(ml0()));
         assert_eq!(arr.get_as_geo(1), Some(ml1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -671,7 +462,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiLineStringArray<i64, 2> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
         let sliced = arr.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(ml1()));
@@ -679,7 +470,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: MultiLineStringArray<i64, 2> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -700,7 +491,7 @@ mod test {
         let geom_arr = example_multilinestring_interleaved();
 
         let wkb_arr = example_multilinestring_wkb();
-        let parsed_geom_arr: MultiLineStringArray<i64, 2> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiLineStringArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }
@@ -710,7 +501,7 @@ mod test {
         let geom_arr = example_multilinestring_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_multilinestring_wkb();
-        let parsed_geom_arr: MultiLineStringArray<i64, 2> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiLineStringArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::multilinestring::MultiLineStringCapacity;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32, offsets_buffer_to_i64, OffsetBufferUtils};
+use crate::array::util::OffsetBufferUtils;
 use crate::array::{CoordBuffer, CoordType, GeometryCollectionArray, LineStringArray, MixedGeometryArray, PolygonArray, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};
@@ -170,14 +170,6 @@ impl<const D: usize> MultiLineStringArray<D> {
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
         Self::new(self.coords.into_coord_type(coord_type), self.geom_offsets, self.ring_offsets, self.validity, self.metadata)
-    }
-
-    pub fn to_small_offsets(&self) -> Result<MultiLineStringArray<i32, D>> {
-        Ok(MultiLineStringArray::new(self.coords.clone(), offsets_buffer_to_i32(&self.geom_offsets)?, offsets_buffer_to_i32(&self.ring_offsets)?, self.validity.clone(), self.metadata.clone()))
-    }
-
-    pub fn to_large_offsets(&self) -> MultiLineStringArray<i64, D> {
-        MultiLineStringArray::new(self.coords.clone(), offsets_buffer_to_i64(&self.geom_offsets), offsets_buffer_to_i64(&self.ring_offsets), self.validity.clone(), self.metadata.clone())
     }
 }
 

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -4,9 +4,14 @@ use crate::array::metadata::ArrayMetadata;
 use crate::array::multilinestring::MultiLineStringCapacity;
 // use super::array::check;
 use crate::array::offset_builder::OffsetsBuilder;
-use crate::array::{CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, MultiLineStringArray, PolygonBuilder, SeparatedCoordBufferBuilder, WKBArray};
+use crate::array::{
+    CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, MultiLineStringArray,
+    PolygonBuilder, SeparatedCoordBufferBuilder, WKBArray,
+};
 use crate::error::{GeoArrowError, Result};
-use crate::geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
+use crate::geo_traits::{
+    CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait,
+};
 use crate::io::wkb::reader::WKBMaybeMultiLineString;
 use crate::scalar::WKB;
 use crate::trait_::{ArrayAccessor, GeometryArrayBuilder, IntoArrow};
@@ -33,7 +38,12 @@ pub struct MultiLineStringBuilder<const D: usize> {
     pub(crate) validity: NullBufferBuilder,
 }
 
-pub type MultiLineStringInner<const D: usize> = (CoordBufferBuilder<D>, OffsetsBuilder<i32>, OffsetsBuilder<i32>, NullBufferBuilder);
+pub type MultiLineStringInner<const D: usize> = (
+    CoordBufferBuilder<D>,
+    OffsetsBuilder<i32>,
+    OffsetsBuilder<i32>,
+    NullBufferBuilder,
+);
 
 impl<const D: usize> MultiLineStringBuilder<D> {
     /// Creates a new empty [`MultiLineStringBuilder`].
@@ -50,10 +60,18 @@ impl<const D: usize> MultiLineStringBuilder<D> {
         Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options(capacity: MultiLineStringCapacity, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn with_capacity_and_options(
+        capacity: MultiLineStringCapacity,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let coords = match coord_type {
-            CoordType::Interleaved => CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity)),
-            CoordType::Separated => CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity)),
+            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
+                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
+            ),
+            CoordType::Separated => CoordBufferBuilder::Separated(
+                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
+            ),
         };
         Self {
             coords,
@@ -105,19 +123,36 @@ impl<const D: usize> MultiLineStringBuilder<D> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
-    pub fn try_new(coords: CoordBufferBuilder<D>, geom_offsets: OffsetsBuilder<i32>, ring_offsets: OffsetsBuilder<i32>, validity: NullBufferBuilder, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+    pub fn try_new(
+        coords: CoordBufferBuilder<D>,
+        geom_offsets: OffsetsBuilder<i32>,
+        ring_offsets: OffsetsBuilder<i32>,
+        validity: NullBufferBuilder,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
         // check(
         //     &coords.clone().into(),
         //     &geom_offsets.clone().into(),
         //     &ring_offsets.clone().into(),
         //     validity.as_ref().map(|x| x.len()),
         // )?;
-        Ok(Self { coords, geom_offsets, ring_offsets, validity, metadata })
+        Ok(Self {
+            coords,
+            geom_offsets,
+            ring_offsets,
+            validity,
+            metadata,
+        })
     }
 
     /// Extract the low-level APIs from the [`MultiLineStringBuilder`].
     pub fn into_inner(self) -> MultiLineStringInner<D> {
-        (self.coords, self.geom_offsets, self.ring_offsets, self.validity)
+        (
+            self.coords,
+            self.geom_offsets,
+            self.ring_offsets,
+            self.validity,
+        )
     }
 
     pub fn into_array_ref(self) -> Arc<dyn Array> {
@@ -153,21 +188,33 @@ impl<const D: usize> MultiLineStringBuilder<D> {
         self.into()
     }
 
-    pub fn with_capacity_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>) -> Self {
+    pub fn with_capacity_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) -> Self {
         Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn with_capacity_and_options_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
         Self::with_capacity_and_options(counter, coord_type, metadata)
     }
 
-    pub fn reserve_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>) {
+    pub fn reserve_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) {
         let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
         self.reserve(counter)
     }
 
-    pub fn reserve_exact_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>) {
+    pub fn reserve_exact_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait + 'a)>>,
+    ) {
         let counter = MultiLineStringCapacity::from_multi_line_strings(geoms);
         self.reserve_exact(counter)
     }
@@ -178,7 +225,10 @@ impl<const D: usize> MultiLineStringBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_line_string(&mut self, value: Option<&impl LineStringTrait<T = f64>>) -> Result<()> {
+    pub fn push_line_string(
+        &mut self,
+        value: Option<&impl LineStringTrait<T = f64>>,
+    ) -> Result<()> {
         if let Some(line_string) = value {
             // Total number of linestrings in this multilinestring
             let num_line_strings = 1;
@@ -189,7 +239,9 @@ impl<const D: usize> MultiLineStringBuilder<D> {
             // - Add ring's # of coords to self.ring_offsets
             // - Push ring's coords to self.coords
 
-            self.ring_offsets.try_push_usize(line_string.num_coords()).unwrap();
+            self.ring_offsets
+                .try_push_usize(line_string.num_coords())
+                .unwrap();
 
             for coord in line_string.coords() {
                 self.coords.push_coord(&coord);
@@ -208,7 +260,10 @@ impl<const D: usize> MultiLineStringBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_line_string(&mut self, value: Option<&impl MultiLineStringTrait<T = f64>>) -> Result<()> {
+    pub fn push_multi_line_string(
+        &mut self,
+        value: Option<&impl MultiLineStringTrait<T = f64>>,
+    ) -> Result<()> {
         if let Some(multi_line_string) = value {
             // Total number of linestrings in this multilinestring
             let num_line_strings = multi_line_string.num_lines();
@@ -221,7 +276,9 @@ impl<const D: usize> MultiLineStringBuilder<D> {
 
             // Number of coords for each ring
             for line_string in multi_line_string.lines() {
-                self.ring_offsets.try_push_usize(line_string.num_coords()).unwrap();
+                self.ring_offsets
+                    .try_push_usize(line_string.num_coords())
+                    .unwrap();
 
                 for coord in line_string.coords() {
                     self.coords.push_coord(&coord);
@@ -249,8 +306,14 @@ impl<const D: usize> MultiLineStringBuilder<D> {
         Ok(())
     }
 
-    pub fn extend_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait<T = f64> + 'a)>>) {
-        geoms.into_iter().try_for_each(|maybe_multi_point| self.push_multi_line_string(maybe_multi_point)).unwrap();
+    pub fn extend_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiLineStringTrait<T = f64> + 'a)>>,
+    ) {
+        geoms
+            .into_iter()
+            .try_for_each(|maybe_multi_point| self.push_multi_line_string(maybe_multi_point))
+            .unwrap();
     }
 
     /// Push a raw coordinate to the underlying coordinate array.
@@ -273,21 +336,52 @@ impl<const D: usize> MultiLineStringBuilder<D> {
         self.validity.append(false);
     }
 
-    pub fn from_multi_line_strings(geoms: &[impl MultiLineStringTrait<T = f64>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(Some), coord_type.unwrap_or_default(), metadata);
+    pub fn from_multi_line_strings(
+        geoms: &[impl MultiLineStringTrait<T = f64>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }
 
-    pub fn from_nullable_multi_line_strings(geoms: &[Option<impl MultiLineStringTrait<T = f64>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(|x| x.as_ref()), coord_type.unwrap_or_default(), metadata);
+    pub fn from_nullable_multi_line_strings(
+        geoms: &[Option<impl MultiLineStringTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(|x| x.as_ref()),
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
     }
 
-    pub(crate) fn from_wkb<W: OffsetSizeTrait>(wkb_objects: &[Option<WKB<'_, W>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Result<Self> {
-        let wkb_objects2: Vec<Option<WKBMaybeMultiLineString>> = wkb_objects.iter().map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object().into_maybe_multi_line_string())).collect();
-        Ok(Self::from_nullable_multi_line_strings(&wkb_objects2, coord_type, metadata))
+    pub(crate) fn from_wkb<W: OffsetSizeTrait>(
+        wkb_objects: &[Option<WKB<'_, W>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
+        let wkb_objects2: Vec<Option<WKBMaybeMultiLineString>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_line_string())
+            })
+            .collect();
+        Ok(Self::from_nullable_multi_line_strings(
+            &wkb_objects2,
+            coord_type,
+            metadata,
+        ))
     }
 }
 
@@ -296,7 +390,11 @@ impl<const D: usize> GeometryArrayBuilder for MultiLineStringBuilder<D> {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let capacity = MultiLineStringCapacity::new(0, 0, geom_capacity);
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
@@ -352,7 +450,13 @@ impl<const D: usize> From<MultiLineStringBuilder<D>> for MultiLineStringArray<D>
         let geom_offsets: OffsetBuffer<i32> = other.geom_offsets.into();
         let ring_offsets: OffsetBuffer<i32> = other.ring_offsets.into();
 
-        Self::new(other.coords.into(), geom_offsets, ring_offsets, validity, other.metadata)
+        Self::new(
+            other.coords.into(),
+            geom_offsets,
+            ring_offsets,
+            validity,
+            other.metadata,
+        )
     }
 }
 
@@ -362,7 +466,9 @@ impl<G: MultiLineStringTrait<T = f64>, const D: usize> From<&[G]> for MultiLineS
     }
 }
 
-impl<G: MultiLineStringTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiLineStringBuilder<D> {
+impl<G: MultiLineStringTrait<T = f64>, const D: usize> From<Vec<Option<G>>>
+    for MultiLineStringBuilder<D>
+{
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_multi_line_strings(&geoms, Default::default(), Default::default())
     }
@@ -382,6 +488,13 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiLineStrin
 /// change the semantic type
 impl<const D: usize> From<MultiLineStringBuilder<D>> for PolygonBuilder<D> {
     fn from(value: MultiLineStringBuilder<D>) -> Self {
-        Self::try_new(value.coords, value.geom_offsets, value.ring_offsets, value.validity, value.metadata).unwrap()
+        Self::try_new(
+            value.coords,
+            value.geom_offsets,
+            value.ring_offsets,
+            value.validity,
+            value.metadata,
+        )
+        .unwrap()
     }
 }

--- a/src/array/multilinestring/capacity.rs
+++ b/src/array/multilinestring/capacity.rs
@@ -1,7 +1,5 @@
 use std::ops::{Add, AddAssign};
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::linestring::LineStringCapacity;
 use crate::geo_traits::{LineStringTrait, MultiLineStringTrait};
 
@@ -89,8 +87,8 @@ impl MultiLineStringCapacity {
     }
 
     /// The number of bytes an array with this capacity would occupy.
-    pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
-        let offsets_byte_width = if O::IS_LARGE { 8 } else { 4 };
+    pub fn num_bytes(&self) -> usize {
+        let offsets_byte_width = 4;
         let num_offsets = self.geom_capacity + self.ring_capacity;
         (offsets_byte_width * num_offsets) + (self.coord_capacity * 2 * 8)
     }

--- a/src/array/multipoint/builder.rs
+++ b/src/array/multipoint/builder.rs
@@ -4,10 +4,7 @@ use crate::array::metadata::ArrayMetadata;
 use crate::array::multipoint::MultiPointCapacity;
 // use super::array::check;
 use crate::array::offset_builder::OffsetsBuilder;
-use crate::array::{
-    CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, LineStringBuilder,
-    MultiPointArray, SeparatedCoordBufferBuilder, WKBArray,
-};
+use crate::array::{CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, LineStringBuilder, MultiPointArray, SeparatedCoordBufferBuilder, WKBArray};
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
 use crate::io::wkb::reader::WKBMaybeMultiPoint;
@@ -20,18 +17,18 @@ use arrow_buffer::NullBufferBuilder;
 ///
 /// Converting an [`MultiPointBuilder`] into a [`MultiPointArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct MultiPointBuilder<O: OffsetSizeTrait, const D: usize> {
+pub struct MultiPointBuilder<const D: usize> {
     metadata: Arc<ArrayMetadata>,
 
     coords: CoordBufferBuilder<D>,
 
-    geom_offsets: OffsetsBuilder<O>,
+    geom_offsets: OffsetsBuilder<i32>,
 
     /// Validity is only defined at the geometry level
     validity: NullBufferBuilder,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> MultiPointBuilder<O, D> {
+impl<const D: usize> MultiPointBuilder<D> {
     /// Creates a new empty [`MultiPointBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -47,25 +44,12 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointBuilder<O, D> {
     }
 
     // with capacity and options enables us to write with_capacity based on this method
-    pub fn with_capacity_and_options(
-        capacity: MultiPointCapacity,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    pub fn with_capacity_and_options(capacity: MultiPointCapacity, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
         let coords = match coord_type {
-            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
-                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
-            ),
-            CoordType::Separated => CoordBufferBuilder::Separated(
-                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
-            ),
+            CoordType::Interleaved => CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity)),
+            CoordType::Separated => CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity)),
         };
-        Self {
-            coords,
-            geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity),
-            validity: NullBufferBuilder::new(capacity.geom_capacity),
-            metadata,
-        }
+        Self { coords, geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity), validity: NullBufferBuilder::new(capacity.geom_capacity), metadata }
     }
 
     /// Reserves capacity for at least `additional` more MultiPoints to be inserted
@@ -107,27 +91,17 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointBuilder<O, D> {
     ///
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
-    pub fn try_new(
-        coords: CoordBufferBuilder<D>,
-        geom_offsets: OffsetsBuilder<O>,
-        validity: NullBufferBuilder,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self> {
+    pub fn try_new(coords: CoordBufferBuilder<D>, geom_offsets: OffsetsBuilder<i32>, validity: NullBufferBuilder, metadata: Arc<ArrayMetadata>) -> Result<Self> {
         // check(
         //     &coords.clone().into(),
         //     validity.as_ref().map(|x| x.len()),
         //     &geom_offsets.clone().into(),
         // )?;
-        Ok(Self {
-            coords,
-            geom_offsets,
-            validity,
-            metadata,
-        })
+        Ok(Self { coords, geom_offsets, validity, metadata })
     }
 
     /// Extract the low-level APIs from the [`MultiPointBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder<D>, OffsetsBuilder<O>, NullBufferBuilder) {
+    pub fn into_inner(self) -> (CoordBufferBuilder<D>, OffsetsBuilder<i32>, NullBufferBuilder) {
         (self.coords, self.geom_offsets, self.validity)
     }
 
@@ -135,48 +109,30 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointBuilder<O, D> {
         Arc::new(self.into_arrow())
     }
 
-    pub fn finish(self) -> MultiPointArray<O, D> {
+    pub fn finish(self) -> MultiPointArray<D> {
         self.into()
     }
 
-    pub fn with_capacity_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-    ) -> Self {
+    pub fn with_capacity_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>) -> Self {
         Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    pub fn with_capacity_and_options_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
         let counter = MultiPointCapacity::from_multi_points(geoms);
         Self::with_capacity_and_options(counter, coord_type, metadata)
     }
 
-    pub fn reserve_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-    ) {
+    pub fn reserve_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>) {
         let counter = MultiPointCapacity::from_multi_points(geoms);
         self.reserve(counter)
     }
 
-    pub fn reserve_exact_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-    ) {
+    pub fn reserve_exact_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>) {
         let counter = MultiPointCapacity::from_multi_points(geoms);
         self.reserve_exact(counter)
     }
-    pub fn extend_from_iter<'a>(
-        &mut self,
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait<T = f64> + 'a)>>,
-    ) {
-        geoms
-            .into_iter()
-            .try_for_each(|maybe_multi_point| self.push_multi_point(maybe_multi_point))
-            .unwrap();
+    pub fn extend_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait<T = f64> + 'a)>>) {
+        geoms.into_iter().try_for_each(|maybe_multi_point| self.push_multi_point(maybe_multi_point)).unwrap();
     }
 
     /// Add a new Point to the end of this array.
@@ -202,10 +158,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointBuilder<O, D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_point(
-        &mut self,
-        value: Option<&impl MultiPointTrait<T = f64>>,
-    ) -> Result<()> {
+    pub fn push_multi_point(&mut self, value: Option<&impl MultiPointTrait<T = f64>>) -> Result<()> {
         if let Some(multi_point) = value {
             let num_points = multi_point.num_points();
             for point in multi_point.points() {
@@ -247,9 +200,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointBuilder<O, D> {
     fn calculate_added_length(&self) -> Result<usize> {
         let total_length = self.coords.len();
         let offset = self.geom_offsets.last().to_usize().unwrap();
-        total_length
-            .checked_sub(offset)
-            .ok_or(GeoArrowError::Overflow)
+        total_length.checked_sub(offset).ok_or(GeoArrowError::Overflow)
     }
 
     /// Needs to be called when a valid value was extended to this array.
@@ -275,71 +226,36 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPointBuilder<O, D> {
         self.validity.append(false);
     }
 
-    pub fn from_multi_points(
-        geoms: &[impl MultiPointTrait<T = f64>],
-        coord_type: Option<CoordType>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(Some),
-            coord_type.unwrap_or_default(),
-            metadata,
-        );
+    pub fn from_multi_points(geoms: &[impl MultiPointTrait<T = f64>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(Some), coord_type.unwrap_or_default(), metadata);
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }
 
-    pub fn from_nullable_multi_points(
-        geoms: &[Option<impl MultiPointTrait<T = f64>>],
-        coord_type: Option<CoordType>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(|x| x.as_ref()),
-            coord_type.unwrap_or_default(),
-            metadata,
-        );
+    pub fn from_nullable_multi_points(geoms: &[Option<impl MultiPointTrait<T = f64>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(|x| x.as_ref()), coord_type.unwrap_or_default(), metadata);
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
     }
 
-    pub(crate) fn from_wkb<W: OffsetSizeTrait>(
-        wkb_objects: &[Option<WKB<'_, W>>],
-        coord_type: Option<CoordType>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self> {
-        let wkb_objects2: Vec<Option<WKBMaybeMultiPoint>> = wkb_objects
-            .iter()
-            .map(|maybe_wkb| {
-                maybe_wkb
-                    .as_ref()
-                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_point())
-            })
-            .collect();
-        Ok(Self::from_nullable_multi_points(
-            &wkb_objects2,
-            coord_type,
-            metadata,
-        ))
+    pub(crate) fn from_wkb<W: OffsetSizeTrait>(wkb_objects: &[Option<WKB<'_, W>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+        let wkb_objects2: Vec<Option<WKBMaybeMultiPoint>> = wkb_objects.iter().map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object().into_maybe_multi_point())).collect();
+        Ok(Self::from_nullable_multi_points(&wkb_objects2, coord_type, metadata))
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Default for MultiPointBuilder<O, D> {
+impl<const D: usize> Default for MultiPointBuilder<D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MultiPointBuilder<O, D> {
+impl<const D: usize> GeometryArrayBuilder for MultiPointBuilder<D> {
     fn new() -> Self {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(
-        geom_capacity: usize,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
         let capacity = MultiPointCapacity::new(0, geom_capacity);
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
@@ -373,55 +289,46 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MultiPointBuil
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiPointBuilder<O, D> {
-    type ArrowArray = GenericListArray<O>;
+impl<const D: usize> IntoArrow for MultiPointBuilder<D> {
+    type ArrowArray = GenericListArray<i32>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let arr: MultiPointArray<O, D> = self.into();
+        let arr: MultiPointArray<D> = self.into();
         arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<MultiPointBuilder<O, D>> for MultiPointArray<O, D> {
-    fn from(mut other: MultiPointBuilder<O, D>) -> Self {
+impl<const D: usize> From<MultiPointBuilder<D>> for MultiPointArray<D> {
+    fn from(mut other: MultiPointBuilder<D>) -> Self {
         let validity = other.validity.finish();
 
         // TODO: impl shrink_to_fit for all mutable -> * impls
         // other.coords.shrink_to_fit();
         other.geom_offsets.shrink_to_fit();
 
-        Self::new(
-            other.coords.into(),
-            other.geom_offsets.into(),
-            validity,
-            other.metadata,
-        )
+        Self::new(other.coords.into(), other.geom_offsets.into(), validity, other.metadata)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<MultiPointBuilder<O, D>> for GenericListArray<O> {
-    fn from(arr: MultiPointBuilder<O, D>) -> Self {
+impl<const D: usize> From<MultiPointBuilder<D>> for GenericListArray<i32> {
+    fn from(arr: MultiPointBuilder<D>) -> Self {
         arr.into_arrow()
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>, const D: usize> From<&[G]>
-    for MultiPointBuilder<O, D>
-{
+impl<G: MultiPointTrait<T = f64>, const D: usize> From<&[G]> for MultiPointBuilder<D> {
     fn from(geoms: &[G]) -> Self {
         Self::from_multi_points(geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPointTrait<T = f64>, const D: usize> From<Vec<Option<G>>>
-    for MultiPointBuilder<O, D>
-{
+impl<G: MultiPointTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiPointBuilder<D> {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_multi_points(&geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointBuilder<O, D> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -433,14 +340,8 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointBuil
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<O: OffsetSizeTrait, const D: usize> From<MultiPointBuilder<O, D>> for LineStringBuilder<O, D> {
-    fn from(value: MultiPointBuilder<O, D>) -> Self {
-        Self::try_new(
-            value.coords,
-            value.geom_offsets,
-            value.validity,
-            value.metadata,
-        )
-        .unwrap()
+impl<const D: usize> From<MultiPointBuilder<D>> for LineStringBuilder<D> {
+    fn from(value: MultiPointBuilder<D>) -> Self {
+        Self::try_new(value.coords, value.geom_offsets, value.validity, value.metadata).unwrap()
     }
 }

--- a/src/array/multipoint/builder.rs
+++ b/src/array/multipoint/builder.rs
@@ -4,7 +4,10 @@ use crate::array::metadata::ArrayMetadata;
 use crate::array::multipoint::MultiPointCapacity;
 // use super::array::check;
 use crate::array::offset_builder::OffsetsBuilder;
-use crate::array::{CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, LineStringBuilder, MultiPointArray, SeparatedCoordBufferBuilder, WKBArray};
+use crate::array::{
+    CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, LineStringBuilder,
+    MultiPointArray, SeparatedCoordBufferBuilder, WKBArray,
+};
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
 use crate::io::wkb::reader::WKBMaybeMultiPoint;
@@ -44,12 +47,25 @@ impl<const D: usize> MultiPointBuilder<D> {
     }
 
     // with capacity and options enables us to write with_capacity based on this method
-    pub fn with_capacity_and_options(capacity: MultiPointCapacity, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn with_capacity_and_options(
+        capacity: MultiPointCapacity,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let coords = match coord_type {
-            CoordType::Interleaved => CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity)),
-            CoordType::Separated => CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity)),
+            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
+                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
+            ),
+            CoordType::Separated => CoordBufferBuilder::Separated(
+                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
+            ),
         };
-        Self { coords, geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity), validity: NullBufferBuilder::new(capacity.geom_capacity), metadata }
+        Self {
+            coords,
+            geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity),
+            validity: NullBufferBuilder::new(capacity.geom_capacity),
+            metadata,
+        }
     }
 
     /// Reserves capacity for at least `additional` more MultiPoints to be inserted
@@ -91,17 +107,33 @@ impl<const D: usize> MultiPointBuilder<D> {
     ///
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
-    pub fn try_new(coords: CoordBufferBuilder<D>, geom_offsets: OffsetsBuilder<i32>, validity: NullBufferBuilder, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+    pub fn try_new(
+        coords: CoordBufferBuilder<D>,
+        geom_offsets: OffsetsBuilder<i32>,
+        validity: NullBufferBuilder,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
         // check(
         //     &coords.clone().into(),
         //     validity.as_ref().map(|x| x.len()),
         //     &geom_offsets.clone().into(),
         // )?;
-        Ok(Self { coords, geom_offsets, validity, metadata })
+        Ok(Self {
+            coords,
+            geom_offsets,
+            validity,
+            metadata,
+        })
     }
 
     /// Extract the low-level APIs from the [`MultiPointBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder<D>, OffsetsBuilder<i32>, NullBufferBuilder) {
+    pub fn into_inner(
+        self,
+    ) -> (
+        CoordBufferBuilder<D>,
+        OffsetsBuilder<i32>,
+        NullBufferBuilder,
+    ) {
         (self.coords, self.geom_offsets, self.validity)
     }
 
@@ -113,26 +145,44 @@ impl<const D: usize> MultiPointBuilder<D> {
         self.into()
     }
 
-    pub fn with_capacity_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>) -> Self {
+    pub fn with_capacity_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+    ) -> Self {
         Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn with_capacity_and_options_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let counter = MultiPointCapacity::from_multi_points(geoms);
         Self::with_capacity_and_options(counter, coord_type, metadata)
     }
 
-    pub fn reserve_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>) {
+    pub fn reserve_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+    ) {
         let counter = MultiPointCapacity::from_multi_points(geoms);
         self.reserve(counter)
     }
 
-    pub fn reserve_exact_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>) {
+    pub fn reserve_exact_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+    ) {
         let counter = MultiPointCapacity::from_multi_points(geoms);
         self.reserve_exact(counter)
     }
-    pub fn extend_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait<T = f64> + 'a)>>) {
-        geoms.into_iter().try_for_each(|maybe_multi_point| self.push_multi_point(maybe_multi_point)).unwrap();
+    pub fn extend_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait<T = f64> + 'a)>>,
+    ) {
+        geoms
+            .into_iter()
+            .try_for_each(|maybe_multi_point| self.push_multi_point(maybe_multi_point))
+            .unwrap();
     }
 
     /// Add a new Point to the end of this array.
@@ -158,7 +208,10 @@ impl<const D: usize> MultiPointBuilder<D> {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_point(&mut self, value: Option<&impl MultiPointTrait<T = f64>>) -> Result<()> {
+    pub fn push_multi_point(
+        &mut self,
+        value: Option<&impl MultiPointTrait<T = f64>>,
+    ) -> Result<()> {
         if let Some(multi_point) = value {
             let num_points = multi_point.num_points();
             for point in multi_point.points() {
@@ -199,8 +252,10 @@ impl<const D: usize> MultiPointBuilder<D> {
 
     fn calculate_added_length(&self) -> Result<usize> {
         let total_length = self.coords.len();
-        let offset = self.geom_offsets.last().to_usize().unwrap();
-        total_length.checked_sub(offset).ok_or(GeoArrowError::Overflow)
+        let offset = *self.geom_offsets.last() as usize;
+        total_length
+            .checked_sub(offset)
+            .ok_or(GeoArrowError::Overflow)
     }
 
     /// Needs to be called when a valid value was extended to this array.
@@ -226,21 +281,52 @@ impl<const D: usize> MultiPointBuilder<D> {
         self.validity.append(false);
     }
 
-    pub fn from_multi_points(geoms: &[impl MultiPointTrait<T = f64>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(Some), coord_type.unwrap_or_default(), metadata);
+    pub fn from_multi_points(
+        geoms: &[impl MultiPointTrait<T = f64>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }
 
-    pub fn from_nullable_multi_points(geoms: &[Option<impl MultiPointTrait<T = f64>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(|x| x.as_ref()), coord_type.unwrap_or_default(), metadata);
+    pub fn from_nullable_multi_points(
+        geoms: &[Option<impl MultiPointTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(|x| x.as_ref()),
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
     }
 
-    pub(crate) fn from_wkb<W: OffsetSizeTrait>(wkb_objects: &[Option<WKB<'_, W>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Result<Self> {
-        let wkb_objects2: Vec<Option<WKBMaybeMultiPoint>> = wkb_objects.iter().map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object().into_maybe_multi_point())).collect();
-        Ok(Self::from_nullable_multi_points(&wkb_objects2, coord_type, metadata))
+    pub(crate) fn from_wkb<W: OffsetSizeTrait>(
+        wkb_objects: &[Option<WKB<'_, W>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
+        let wkb_objects2: Vec<Option<WKBMaybeMultiPoint>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_maybe_multi_point())
+            })
+            .collect();
+        Ok(Self::from_nullable_multi_points(
+            &wkb_objects2,
+            coord_type,
+            metadata,
+        ))
     }
 }
 
@@ -255,7 +341,11 @@ impl<const D: usize> GeometryArrayBuilder for MultiPointBuilder<D> {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let capacity = MultiPointCapacity::new(0, geom_capacity);
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
@@ -306,7 +396,12 @@ impl<const D: usize> From<MultiPointBuilder<D>> for MultiPointArray<D> {
         // other.coords.shrink_to_fit();
         other.geom_offsets.shrink_to_fit();
 
-        Self::new(other.coords.into(), other.geom_offsets.into(), validity, other.metadata)
+        Self::new(
+            other.coords.into(),
+            other.geom_offsets.into(),
+            validity,
+            other.metadata,
+        )
     }
 }
 
@@ -342,6 +437,12 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointBuil
 /// the semantic type
 impl<const D: usize> From<MultiPointBuilder<D>> for LineStringBuilder<D> {
     fn from(value: MultiPointBuilder<D>) -> Self {
-        Self::try_new(value.coords, value.geom_offsets, value.validity, value.metadata).unwrap()
+        Self::try_new(
+            value.coords,
+            value.geom_offsets,
+            value.validity,
+            value.metadata,
+        )
+        .unwrap()
     }
 }

--- a/src/array/multipoint/capacity.rs
+++ b/src/array/multipoint/capacity.rs
@@ -1,7 +1,5 @@
 use std::ops::Add;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::{GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
 
@@ -100,8 +98,8 @@ impl MultiPointCapacity {
     }
 
     /// The number of bytes an array with this capacity would occupy.
-    pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
-        let offsets_byte_width = if O::IS_LARGE { 8 } else { 4 };
+    pub fn num_bytes(&self) -> usize {
+        let offsets_byte_width = 4;
         let num_offsets = self.geom_capacity;
         (offsets_byte_width * num_offsets) + (self.coord_capacity * 2 * 8)
     }

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -3,13 +3,8 @@ use std::sync::Arc;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::multipolygon::MultiPolygonCapacity;
-use crate::array::util::{
-    offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32,
-    offsets_buffer_to_i64, OffsetBufferUtils,
-};
-use crate::array::{
-    CoordBuffer, CoordType, GeometryCollectionArray, MixedGeometryArray, PolygonArray, WKBArray,
-};
+use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32, offsets_buffer_to_i64, OffsetBufferUtils};
+use crate::array::{CoordBuffer, CoordType, GeometryCollectionArray, MixedGeometryArray, PolygonArray, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiPolygonTrait;
@@ -29,7 +24,7 @@ use super::MultiPolygonBuilder;
 /// This is semantically equivalent to `Vec<Option<MultiPolygon>>` due to the internal validity
 /// bitmap.
 #[derive(Debug, Clone)]
-pub struct MultiPolygonArray<O: OffsetSizeTrait, const D: usize> {
+pub struct MultiPolygonArray<const D: usize> {
     // Always NativeType::MultiPolygon or NativeType::LargeMultiPolygon
     data_type: NativeType,
 
@@ -38,52 +33,38 @@ pub struct MultiPolygonArray<O: OffsetSizeTrait, const D: usize> {
     pub(crate) coords: CoordBuffer<D>,
 
     /// Offsets into the polygon array where each geometry starts
-    pub(crate) geom_offsets: OffsetBuffer<O>,
+    pub(crate) geom_offsets: OffsetBuffer<i32>,
 
     /// Offsets into the ring array where each polygon starts
-    pub(crate) polygon_offsets: OffsetBuffer<O>,
+    pub(crate) polygon_offsets: OffsetBuffer<i32>,
 
     /// Offsets into the coordinate array where each ring starts
-    pub(crate) ring_offsets: OffsetBuffer<O>,
+    pub(crate) ring_offsets: OffsetBuffer<i32>,
 
     /// Validity bitmap
     pub(crate) validity: Option<NullBuffer>,
 }
 
-pub(super) fn check<O: OffsetSizeTrait, const D: usize>(
-    coords: &CoordBuffer<D>,
-    geom_offsets: &OffsetBuffer<O>,
-    polygon_offsets: &OffsetBuffer<O>,
-    ring_offsets: &OffsetBuffer<O>,
-    validity_len: Option<usize>,
-) -> Result<()> {
+pub(super) fn check<const D: usize>(coords: &CoordBuffer<D>, geom_offsets: &OffsetBuffer<i32>, polygon_offsets: &OffsetBuffer<i32>, ring_offsets: &OffsetBuffer<i32>, validity_len: Option<usize>) -> Result<()> {
     if validity_len.map_or(false, |len| len != geom_offsets.len_proxy()) {
-        return Err(GeoArrowError::General(
-            "validity mask length must match the number of values".to_string(),
-        ));
+        return Err(GeoArrowError::General("validity mask length must match the number of values".to_string()));
     }
     if ring_offsets.last().to_usize().unwrap() != coords.len() {
-        return Err(GeoArrowError::General(
-            "largest ring offset must match coords length".to_string(),
-        ));
+        return Err(GeoArrowError::General("largest ring offset must match coords length".to_string()));
     }
 
     if polygon_offsets.last().to_usize().unwrap() != ring_offsets.len_proxy() {
-        return Err(GeoArrowError::General(
-            "largest polygon offset must match ring offsets length".to_string(),
-        ));
+        return Err(GeoArrowError::General("largest polygon offset must match ring offsets length".to_string()));
     }
 
     if geom_offsets.last().to_usize().unwrap() != polygon_offsets.len_proxy() {
-        return Err(GeoArrowError::General(
-            "largest geometry offset must match polygon offsets length".to_string(),
-        ));
+        return Err(GeoArrowError::General("largest geometry offset must match polygon offsets length".to_string()));
     }
 
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
+impl<const D: usize> MultiPolygonArray<D> {
     /// Create a new MultiPolygonArray from parts
     ///
     /// # Implementation
@@ -96,23 +77,8 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest polygon offset does not match the size of ring offsets
     /// - if the largest geometry offset does not match the size of polygon offsets
-    pub fn new(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        polygon_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
-        validity: Option<NullBuffer>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
-        Self::try_new(
-            coords,
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
-            metadata,
-        )
-        .unwrap()
+    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, polygon_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, validity: Option<NullBuffer>, metadata: Arc<ArrayMetadata>) -> Self {
+        Self::try_new(coords, geom_offsets, polygon_offsets, ring_offsets, validity, metadata).unwrap()
     }
 
     /// Create a new MultiPolygonArray from parts
@@ -127,37 +93,13 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest polygon offset does not match the size of ring offsets
     /// - if the largest geometry offset does not match the size of polygon offsets
-    pub fn try_new(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        polygon_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
-        validity: Option<NullBuffer>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self> {
-        check(
-            &coords,
-            &geom_offsets,
-            &polygon_offsets,
-            &ring_offsets,
-            validity.as_ref().map(|v| v.len()),
-        )?;
+    pub fn try_new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, polygon_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, validity: Option<NullBuffer>, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+        check(&coords, &geom_offsets, &polygon_offsets, &ring_offsets, validity.as_ref().map(|v| v.len()))?;
 
         let coord_type = coords.coord_type();
-        let data_type = match O::IS_LARGE {
-            true => NativeType::LargeMultiPolygon(coord_type, D.try_into()?),
-            false => NativeType::MultiPolygon(coord_type, D.try_into()?),
-        };
+        let data_type = NativeType::MultiPolygon(coord_type, D.try_into()?);
 
-        Ok(Self {
-            data_type,
-            coords,
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
-            metadata,
-        })
+        Ok(Self { data_type, coords, geom_offsets, polygon_offsets, ring_offsets, validity, metadata })
     }
 
     fn vertices_field(&self) -> Arc<Field> {
@@ -166,66 +108,43 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
 
     fn rings_field(&self) -> Arc<Field> {
         let name = "rings";
-        match O::IS_LARGE {
-            true => Field::new_large_list(name, self.vertices_field(), false).into(),
-            false => Field::new_list(name, self.vertices_field(), false).into(),
-        }
+        Field::new_list(name, self.vertices_field(), false).into()
     }
 
     fn polygons_field(&self) -> Arc<Field> {
         let name = "polygons";
-        match O::IS_LARGE {
-            true => Field::new_large_list(name, self.rings_field(), false).into(),
-            false => Field::new_list(name, self.rings_field(), false).into(),
-        }
+        Field::new_list(name, self.rings_field(), false).into()
     }
 
     pub fn coords(&self) -> &CoordBuffer<D> {
         &self.coords
     }
 
-    pub fn into_inner(
-        self,
-    ) -> (
-        CoordBuffer<D>,
-        OffsetBuffer<O>,
-        OffsetBuffer<O>,
-        OffsetBuffer<O>,
-    ) {
-        (
-            self.coords,
-            self.geom_offsets,
-            self.polygon_offsets,
-            self.ring_offsets,
-        )
+    pub fn into_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, OffsetBuffer<i32>, OffsetBuffer<i32>) {
+        (self.coords, self.geom_offsets, self.polygon_offsets, self.ring_offsets)
     }
 
-    pub fn geom_offsets(&self) -> &OffsetBuffer<O> {
+    pub fn geom_offsets(&self) -> &OffsetBuffer<i32> {
         &self.geom_offsets
     }
 
-    pub fn polygon_offsets(&self) -> &OffsetBuffer<O> {
+    pub fn polygon_offsets(&self) -> &OffsetBuffer<i32> {
         &self.polygon_offsets
     }
 
-    pub fn ring_offsets(&self) -> &OffsetBuffer<O> {
+    pub fn ring_offsets(&self) -> &OffsetBuffer<i32> {
         &self.ring_offsets
     }
 
     /// The lengths of each buffer contained in this array.
     pub fn buffer_lengths(&self) -> MultiPolygonCapacity {
-        MultiPolygonCapacity::new(
-            self.ring_offsets.last().to_usize().unwrap(),
-            self.polygon_offsets.last().to_usize().unwrap(),
-            self.geom_offsets.last().to_usize().unwrap(),
-            self.len(),
-        )
+        MultiPolygonCapacity::new(self.ring_offsets.last().to_usize().unwrap(), self.polygon_offsets.last().to_usize().unwrap(), self.geom_offsets.last().to_usize().unwrap(), self.len())
     }
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
         let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
-        validity_len + self.buffer_lengths().num_bytes::<O>()
+        validity_len + self.buffer_lengths().num_bytes()
     }
 
     /// Slices this [`MultiPolygonArray`] in place.
@@ -233,10 +152,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        assert!(
-            offset + length <= self.len(),
-            "offset + length may not exceed length of array"
-        );
+        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
         // Note: we **only** slice the geom_offsets and not any actual data. Otherwise the offsets
         // would be in the wrong location.
         Self {
@@ -251,10 +167,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
     }
 
     pub fn owned_slice(&self, offset: usize, length: usize) -> Self {
-        assert!(
-            offset + length <= self.len(),
-            "offset + length may not exceed length of array"
-        );
+        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
         assert!(length >= 1, "length must be at least 1");
 
         // Find the start and end of the polygon offsets
@@ -271,30 +184,13 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
 
         // Slice the geom_offsets
         let geom_offsets = owned_slice_offsets(&self.geom_offsets, offset, length);
-        let polygon_offsets = owned_slice_offsets(
-            &self.polygon_offsets,
-            start_polygon_idx,
-            end_polygon_idx - start_polygon_idx,
-        );
-        let ring_offsets = owned_slice_offsets(
-            &self.ring_offsets,
-            start_ring_idx,
-            end_ring_idx - start_ring_idx,
-        );
-        let coords = self
-            .coords
-            .owned_slice(start_coord_idx, end_coord_idx - start_coord_idx);
+        let polygon_offsets = owned_slice_offsets(&self.polygon_offsets, start_polygon_idx, end_polygon_idx - start_polygon_idx);
+        let ring_offsets = owned_slice_offsets(&self.ring_offsets, start_ring_idx, end_ring_idx - start_ring_idx);
+        let coords = self.coords.owned_slice(start_coord_idx, end_coord_idx - start_coord_idx);
 
         let validity = owned_slice_validity(self.nulls(), offset, length);
 
-        Self::new(
-            coords,
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
-            self.metadata(),
-        )
+        Self::new(coords, geom_offsets, polygon_offsets, ring_offsets, validity, self.metadata())
     }
 
     pub fn to_coord_type(&self, coord_type: CoordType) -> Self {
@@ -302,40 +198,11 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonArray<O, D> {
     }
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
-        Self::new(
-            self.coords.into_coord_type(coord_type),
-            self.geom_offsets,
-            self.polygon_offsets,
-            self.ring_offsets,
-            self.validity,
-            self.metadata,
-        )
-    }
-
-    pub fn to_small_offsets(&self) -> Result<MultiPolygonArray<i32, D>> {
-        Ok(MultiPolygonArray::new(
-            self.coords.clone(),
-            offsets_buffer_to_i32(&self.geom_offsets)?,
-            offsets_buffer_to_i32(&self.polygon_offsets)?,
-            offsets_buffer_to_i32(&self.ring_offsets)?,
-            self.validity.clone(),
-            self.metadata.clone(),
-        ))
-    }
-
-    pub fn to_large_offsets(&self) -> MultiPolygonArray<i64, D> {
-        MultiPolygonArray::new(
-            self.coords.clone(),
-            offsets_buffer_to_i64(&self.geom_offsets),
-            offsets_buffer_to_i64(&self.polygon_offsets),
-            offsets_buffer_to_i64(&self.ring_offsets),
-            self.validity.clone(),
-            self.metadata.clone(),
-        )
+        Self::new(self.coords.into_coord_type(coord_type), self.geom_offsets, self.polygon_offsets, self.ring_offsets, self.validity, self.metadata)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> ArrayBase for MultiPolygonArray<O, D> {
+impl<const D: usize> ArrayBase for MultiPolygonArray<D> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -345,9 +212,7 @@ impl<O: OffsetSizeTrait, const D: usize> ArrayBase for MultiPolygonArray<O, D> {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        self.data_type
-            .to_field_with_metadata("geometry", true, &self.metadata)
-            .into()
+        self.data_type.to_field_with_metadata("geometry", true, &self.metadata).into()
     }
 
     fn extension_name(&self) -> &str {
@@ -379,7 +244,7 @@ impl<O: OffsetSizeTrait, const D: usize> ArrayBase for MultiPolygonArray<O, D> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> NativeArray for MultiPolygonArray<O, D> {
+impl<const D: usize> NativeArray for MultiPolygonArray<D> {
     fn data_type(&self) -> NativeType {
         self.data_type
     }
@@ -411,49 +276,29 @@ impl<O: OffsetSizeTrait, const D: usize> NativeArray for MultiPolygonArray<O, D>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryArraySelfMethods<D> for MultiPolygonArray<O, D> {
+impl<const D: usize> GeometryArraySelfMethods<D> for MultiPolygonArray<D> {
     fn with_coords(self, coords: CoordBuffer<D>) -> Self {
         assert_eq!(coords.len(), self.coords.len());
-        Self::new(
-            coords,
-            self.geom_offsets,
-            self.polygon_offsets,
-            self.ring_offsets,
-            self.validity,
-            self.metadata,
-        )
+        Self::new(coords, self.geom_offsets, self.polygon_offsets, self.ring_offsets, self.validity, self.metadata)
     }
 
     fn into_coord_type(self, coord_type: CoordType) -> Self {
-        Self::new(
-            self.coords.into_coord_type(coord_type),
-            self.geom_offsets,
-            self.polygon_offsets,
-            self.ring_offsets,
-            self.validity,
-            self.metadata,
-        )
+        Self::new(self.coords.into_coord_type(coord_type), self.geom_offsets, self.polygon_offsets, self.ring_offsets, self.validity, self.metadata)
     }
 }
 
 // Implement geometry accessors
-impl<'a, O: OffsetSizeTrait, const D: usize> ArrayAccessor<'a> for MultiPolygonArray<O, D> {
-    type Item = MultiPolygon<'a, O, D>;
+impl<'a, const D: usize> ArrayAccessor<'a> for MultiPolygonArray<D> {
+    type Item = MultiPolygon<'a, D>;
     type ItemGeo = geo::MultiPolygon;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        MultiPolygon::new(
-            &self.coords,
-            &self.geom_offsets,
-            &self.polygon_offsets,
-            &self.ring_offsets,
-            index,
-        )
+        MultiPolygon::new(&self.coords, &self.geom_offsets, &self.polygon_offsets, &self.ring_offsets, index)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiPolygonArray<O, D> {
-    type ArrowArray = GenericListArray<O>;
+impl<const D: usize> IntoArrow for MultiPolygonArray<D> {
+    type ArrowArray = GenericListArray<i32>;
 
     fn into_arrow(self) -> Self::ArrowArray {
         let vertices_field = self.vertices_field();
@@ -462,23 +307,13 @@ impl<O: OffsetSizeTrait, const D: usize> IntoArrow for MultiPolygonArray<O, D> {
 
         let validity = self.validity;
         let coord_array = self.coords.into_arrow();
-        let ring_array = Arc::new(GenericListArray::new(
-            vertices_field,
-            self.ring_offsets,
-            coord_array,
-            None,
-        ));
-        let polygons_array = Arc::new(GenericListArray::new(
-            rings_field,
-            self.polygon_offsets,
-            ring_array,
-            None,
-        ));
+        let ring_array = Arc::new(GenericListArray::new(vertices_field, self.ring_offsets, coord_array, None));
+        let polygons_array = Arc::new(GenericListArray::new(rings_field, self.polygon_offsets, ring_array, None));
         GenericListArray::new(polygons_field, self.geom_offsets, polygons_array, validity)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>> for MultiPolygonArray<O, D> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>> for MultiPolygonArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(geom_array: &GenericListArray<O>) -> Result<Self> {
@@ -486,33 +321,20 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<&GenericListArray<O>> for Multi
         let validity = geom_array.nulls();
 
         let polygons_dyn_array = geom_array.values();
-        let polygons_array = polygons_dyn_array
-            .as_any()
-            .downcast_ref::<GenericListArray<O>>()
-            .unwrap();
+        let polygons_array = polygons_dyn_array.as_any().downcast_ref::<GenericListArray<O>>().unwrap();
 
         let polygon_offsets = polygons_array.offsets();
         let rings_dyn_array = polygons_array.values();
-        let rings_array = rings_dyn_array
-            .as_any()
-            .downcast_ref::<GenericListArray<O>>()
-            .unwrap();
+        let rings_array = rings_dyn_array.as_any().downcast_ref::<GenericListArray<O>>().unwrap();
 
         let ring_offsets = rings_array.offsets();
         let coords: CoordBuffer<D> = rings_array.values().as_ref().try_into()?;
 
-        Ok(Self::new(
-            coords,
-            geom_offsets.clone(),
-            polygon_offsets.clone(),
-            ring_offsets.clone(),
-            validity.cloned(),
-            Default::default(),
-        ))
+        Ok(Self::new(coords, geom_offsets.clone(), polygon_offsets.clone(), ring_offsets.clone(), validity.cloned(), Default::default()))
     }
 }
 
-impl<const D: usize> TryFrom<&dyn Array> for MultiPolygonArray<i32, D> {
+impl<const D: usize> TryFrom<&dyn Array> for MultiPolygonArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
@@ -526,37 +348,12 @@ impl<const D: usize> TryFrom<&dyn Array> for MultiPolygonArray<i32, D> {
                 let geom_array: MultiPolygonArray<i64, D> = downcasted.try_into()?;
                 geom_array.try_into()
             }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
-            ))),
+            _ => Err(GeoArrowError::General(format!("Unexpected type: {:?}", value.data_type()))),
         }
     }
 }
 
-impl<const D: usize> TryFrom<&dyn Array> for MultiPolygonArray<i64, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: &dyn Array) -> Result<Self> {
-        match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_any().downcast_ref::<ListArray>().unwrap();
-                let geom_array: MultiPolygonArray<i32, D> = downcasted.try_into()?;
-                Ok(geom_array.into())
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_any().downcast_ref::<LargeListArray>().unwrap();
-                downcasted.try_into()
-            }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
-            ))),
-        }
-    }
-}
-
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiPolygonArray<i32, D> {
+impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiPolygonArray<D> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -566,97 +363,48 @@ impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiPolygonArray<i32, D>
     }
 }
 
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiPolygonArray<i64, D> {
-    type Error = GeoArrowError;
-
-    fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let mut arr: Self = arr.try_into()?;
-        arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
-        Ok(arr)
-    }
-}
-
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>, const D: usize> From<Vec<Option<G>>>
-    for MultiPolygonArray<O, D>
-{
+impl<G: MultiPolygonTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiPolygonArray<D> {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: MultiPolygonBuilder<O, D> = other.into();
+        let mut_arr: MultiPolygonBuilder<D> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>, const D: usize> From<&[G]>
-    for MultiPolygonArray<O, D>
-{
+impl<G: MultiPolygonTrait<T = f64>, const D: usize> From<&[G]> for MultiPolygonArray<D> {
     fn from(other: &[G]) -> Self {
-        let mut_arr: MultiPolygonBuilder<O, D> = other.into();
+        let mut_arr: MultiPolygonBuilder<D> = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPolygonArray<O, D> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPolygonArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
-        let mut_arr: MultiPolygonBuilder<O, D> = value.try_into()?;
+        let mut_arr: MultiPolygonBuilder<D> = value.try_into()?;
         Ok(mut_arr.into())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<PolygonArray<O, D>> for MultiPolygonArray<O, D> {
-    fn from(value: PolygonArray<O, D>) -> Self {
+impl<const D: usize> From<PolygonArray<D>> for MultiPolygonArray<D> {
+    fn from(value: PolygonArray<D>) -> Self {
         let coords = value.coords;
         let geom_offsets = OffsetBuffer::from_lengths(vec![1; coords.len()]);
         let ring_offsets = value.ring_offsets;
         let polygon_offsets = value.geom_offsets;
         let validity = value.validity;
-        Self::new(
-            coords,
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
-            value.metadata,
-        )
-    }
-}
-
-impl<const D: usize> From<MultiPolygonArray<i32, D>> for MultiPolygonArray<i64, D> {
-    fn from(value: MultiPolygonArray<i32, D>) -> Self {
-        Self::new(
-            value.coords,
-            offsets_buffer_i32_to_i64(&value.geom_offsets),
-            offsets_buffer_i32_to_i64(&value.polygon_offsets),
-            offsets_buffer_i32_to_i64(&value.ring_offsets),
-            value.validity,
-            value.metadata,
-        )
-    }
-}
-
-impl<const D: usize> TryFrom<MultiPolygonArray<i64, D>> for MultiPolygonArray<i32, D> {
-    type Error = GeoArrowError;
-
-    fn try_from(value: MultiPolygonArray<i64, D>) -> Result<Self> {
-        Ok(Self::new(
-            value.coords,
-            offsets_buffer_i64_to_i32(&value.geom_offsets)?,
-            offsets_buffer_i64_to_i32(&value.polygon_offsets)?,
-            offsets_buffer_i64_to_i32(&value.ring_offsets)?,
-            value.validity,
-            value.metadata,
-        ))
+        Self::new(coords, geom_offsets, polygon_offsets, ring_offsets, validity, value.metadata)
     }
 }
 
 /// Default to an empty array
-impl<O: OffsetSizeTrait, const D: usize> Default for MultiPolygonArray<O, D> {
+impl<const D: usize> Default for MultiPolygonArray<D> {
     fn default() -> Self {
         MultiPolygonBuilder::default().into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> PartialEq for MultiPolygonArray<O, D> {
+impl<const D: usize> PartialEq for MultiPolygonArray<D> {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;
@@ -682,17 +430,11 @@ impl<O: OffsetSizeTrait, const D: usize> PartialEq for MultiPolygonArray<O, D> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
-    for MultiPolygonArray<O, D>
-{
+impl<const D: usize> TryFrom<MixedGeometryArray<D>> for MultiPolygonArray<D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: MixedGeometryArray<O, D>) -> Result<Self> {
-        if value.has_points()
-            || value.has_line_strings()
-            || value.has_multi_points()
-            || value.has_multi_line_strings()
-        {
+    fn try_from(value: MixedGeometryArray<D>) -> Result<Self> {
+        if value.has_points() || value.has_line_strings() || value.has_multi_points() || value.has_multi_line_strings() {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
@@ -707,24 +449,16 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>>
         let mut capacity = value.multi_polygons.buffer_lengths();
         capacity += value.polygons.buffer_lengths();
 
-        let mut builder = MultiPolygonBuilder::<O, D>::with_capacity_and_options(
-            capacity,
-            value.coord_type(),
-            value.metadata(),
-        );
-        value
-            .iter()
-            .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
+        let mut builder = MultiPolygonBuilder::<D>::with_capacity_and_options(capacity, value.coord_type(), value.metadata());
+        value.iter().try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>>
-    for MultiPolygonArray<O, D>
-{
+impl<const D: usize> TryFrom<GeometryCollectionArray<D>> for MultiPolygonArray<D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self> {
+    fn try_from(value: GeometryCollectionArray<D>) -> Result<Self> {
         MixedGeometryArray::try_from(value)?.try_into()
     }
 }
@@ -732,21 +466,19 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>>
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test::geoarrow_data::{
-        example_multipolygon_interleaved, example_multipolygon_separated, example_multipolygon_wkb,
-    };
+    use crate::test::geoarrow_data::{example_multipolygon_interleaved, example_multipolygon_separated, example_multipolygon_wkb};
     use crate::test::multipolygon::{mp0, mp1};
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: MultiPolygonArray<i64, 2> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPolygonArray<2> = vec![mp0(), mp1()].as_slice().into();
         assert_eq!(arr.value_as_geo(0), mp0());
         assert_eq!(arr.value_as_geo(1), mp1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: MultiPolygonArray<i64, 2> = vec![Some(mp0()), Some(mp1()), None].into();
+        let arr: MultiPolygonArray<2> = vec![Some(mp0()), Some(mp1()), None].into();
         assert_eq!(arr.get_as_geo(0), Some(mp0()));
         assert_eq!(arr.get_as_geo(1), Some(mp1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -754,7 +486,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiPolygonArray<i64, 2> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPolygonArray<2> = vec![mp0(), mp1()].as_slice().into();
         let sliced = arr.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(mp1()));
@@ -762,7 +494,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: MultiPolygonArray<i64, 2> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPolygonArray<2> = vec![mp0(), mp1()].as_slice().into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -783,7 +515,7 @@ mod test {
         let geom_arr = example_multipolygon_interleaved();
 
         let wkb_arr = example_multipolygon_wkb();
-        let parsed_geom_arr: MultiPolygonArray<i64, 2> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiPolygonArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }
@@ -794,7 +526,7 @@ mod test {
         let geom_arr = example_multipolygon_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_multipolygon_wkb();
-        let parsed_geom_arr: MultiPolygonArray<i64, 2> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiPolygonArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::multipolygon::MultiPolygonCapacity;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32, offsets_buffer_to_i64, OffsetBufferUtils};
+use crate::array::util::OffsetBufferUtils;
 use crate::array::{CoordBuffer, CoordType, GeometryCollectionArray, MixedGeometryArray, PolygonArray, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};

--- a/src/array/multipolygon/capacity.rs
+++ b/src/array/multipolygon/capacity.rs
@@ -1,7 +1,5 @@
 use std::ops::{Add, AddAssign};
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::polygon::PolygonCapacity;
 use crate::geo_traits::{LineStringTrait, MultiPolygonTrait, PolygonTrait};
 
@@ -132,8 +130,8 @@ impl MultiPolygonCapacity {
     }
 
     /// The number of bytes an array with this capacity would occupy.
-    pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
-        let offsets_byte_width = if O::IS_LARGE { 8 } else { 4 };
+    pub fn num_bytes(&self) -> usize {
+        let offsets_byte_width = 4;
         let num_offsets = self.geom_capacity + self.polygon_capacity + self.ring_capacity;
         (offsets_byte_width * num_offsets) + (self.coord_capacity * 2 * 8)
     }

--- a/src/array/offset_builder.rs
+++ b/src/array/offset_builder.rs
@@ -275,7 +275,7 @@ impl<O: OffsetSizeTrait> OffsetsBuilder<O> {
         self.0
     }
 
-    pub fn finish(self) -> OffsetBuffer<O> {
+    pub fn finish(self) -> OffsetBuffer<i32> {
         self.into()
     }
 }
@@ -340,7 +340,7 @@ impl TryFrom<OffsetsBuilder<i64>> for OffsetsBuilder<i32> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<OffsetsBuilder<O>> for OffsetBuffer<O> {
+impl<O: OffsetSizeTrait> From<OffsetsBuilder<O>> for OffsetBuffer<i32> {
     fn from(value: OffsetsBuilder<O>) -> Self {
         OffsetBuffer::new(value.0.into())
     }

--- a/src/array/offset_builder.rs
+++ b/src/array/offset_builder.rs
@@ -275,7 +275,7 @@ impl<O: OffsetSizeTrait> OffsetsBuilder<O> {
         self.0
     }
 
-    pub fn finish(self) -> OffsetBuffer<i32> {
+    pub fn finish(self) -> OffsetBuffer<O> {
         self.into()
     }
 }
@@ -340,7 +340,7 @@ impl TryFrom<OffsetsBuilder<i64>> for OffsetsBuilder<i32> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<OffsetsBuilder<O>> for OffsetBuffer<i32> {
+impl<O: OffsetSizeTrait> From<OffsetsBuilder<O>> for OffsetBuffer<O> {
     fn from(value: OffsetsBuilder<O>) -> Self {
         OffsetBuffer::new(value.0.into())
     }

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -3,10 +3,7 @@ use std::sync::Arc;
 use crate::algorithm::native::downcast::can_downcast_multi;
 use crate::algorithm::native::eq::coord_eq_allow_nan;
 use crate::array::metadata::ArrayMetadata;
-use crate::array::{
-    CoordBuffer, CoordType, GeometryCollectionArray, InterleavedCoordBuffer, MixedGeometryArray,
-    MultiPointArray, PointBuilder, SeparatedCoordBuffer, WKBArray,
-};
+use crate::array::{CoordBuffer, CoordType, GeometryCollectionArray, InterleavedCoordBuffer, MixedGeometryArray, MultiPointArray, PointBuilder, SeparatedCoordBuffer, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::GeoArrowError;
 use crate::geo_traits::PointTrait;
@@ -31,14 +28,9 @@ pub struct PointArray<const D: usize> {
     pub(crate) validity: Option<NullBuffer>,
 }
 
-pub(super) fn check<const D: usize>(
-    coords: &CoordBuffer<D>,
-    validity_len: Option<usize>,
-) -> Result<(), GeoArrowError> {
+pub(super) fn check<const D: usize>(coords: &CoordBuffer<D>, validity_len: Option<usize>) -> Result<(), GeoArrowError> {
     if validity_len.map_or(false, |len| len != coords.len()) {
-        return Err(GeoArrowError::General(
-            "validity mask length must match the number of values".to_string(),
-        ));
+        return Err(GeoArrowError::General("validity mask length must match the number of values".to_string()));
     }
 
     Ok(())
@@ -54,11 +46,7 @@ impl<const D: usize> PointArray<D> {
     /// # Panics
     ///
     /// - if the validity is not `None` and its length is different from the number of geometries
-    pub fn new(
-        coords: CoordBuffer<D>,
-        validity: Option<NullBuffer>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Self {
+    pub fn new(coords: CoordBuffer<D>, validity: Option<NullBuffer>, metadata: Arc<ArrayMetadata>) -> Self {
         Self::try_new(coords, validity, metadata).unwrap()
     }
 
@@ -71,19 +59,10 @@ impl<const D: usize> PointArray<D> {
     /// # Errors
     ///
     /// - if the validity is not `None` and its length is different from the number of geometries
-    pub fn try_new(
-        coords: CoordBuffer<D>,
-        validity: Option<NullBuffer>,
-        metadata: Arc<ArrayMetadata>,
-    ) -> Result<Self, GeoArrowError> {
+    pub fn try_new(coords: CoordBuffer<D>, validity: Option<NullBuffer>, metadata: Arc<ArrayMetadata>) -> Result<Self, GeoArrowError> {
         check(&coords, validity.as_ref().map(|v| v.len()))?;
         let data_type = NativeType::Point(coords.coord_type(), D.try_into()?);
-        Ok(Self {
-            data_type,
-            coords,
-            validity,
-            metadata,
-        })
+        Ok(Self { data_type, coords, validity, metadata })
     }
 
     pub fn coords(&self) -> &CoordBuffer<D> {
@@ -110,23 +89,12 @@ impl<const D: usize> PointArray<D> {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        assert!(
-            offset + length <= self.len(),
-            "offset + length may not exceed length of array"
-        );
-        Self {
-            data_type: self.data_type,
-            coords: self.coords.slice(offset, length),
-            validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
-            metadata: self.metadata(),
-        }
+        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
+        Self { data_type: self.data_type, coords: self.coords.slice(offset, length), validity: self.validity.as_ref().map(|v| v.slice(offset, length)), metadata: self.metadata() }
     }
 
     pub fn owned_slice(&self, offset: usize, length: usize) -> Self {
-        assert!(
-            offset + length <= self.len(),
-            "offset + length may not exceed length of array"
-        );
+        assert!(offset + length <= self.len(), "offset + length may not exceed length of array");
         assert!(length >= 1, "length must be at least 1");
 
         let coords = self.coords.owned_slice(offset, length);
@@ -141,11 +109,7 @@ impl<const D: usize> PointArray<D> {
     }
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
-        Self::new(
-            self.coords.into_coord_type(coord_type),
-            self.validity,
-            self.metadata,
-        )
+        Self::new(self.coords.into_coord_type(coord_type), self.validity, self.metadata)
     }
 }
 
@@ -159,9 +123,7 @@ impl<const D: usize> ArrayBase for PointArray<D> {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        self.data_type
-            .to_field_with_metadata("geometry", true, &self.metadata)
-            .into()
+        self.data_type.to_field_with_metadata("geometry", true, &self.metadata).into()
     }
 
     fn extension_name(&self) -> &str {
@@ -252,12 +214,7 @@ impl<const D: usize> IntoArrow for PointArray<D> {
     fn into_arrow(self) -> Self::ArrowArray {
         let validity = self.validity;
         match self.coords {
-            CoordBuffer::Interleaved(c) => Arc::new(FixedSizeListArray::new(
-                c.values_field().into(),
-                D as i32,
-                Arc::new(c.values_array()),
-                validity,
-            )),
+            CoordBuffer::Interleaved(c) => Arc::new(FixedSizeListArray::new(c.values_field().into(), D as i32, Arc::new(c.values_array()), validity)),
             CoordBuffer::Separated(c) => {
                 let fields = c.values_field();
                 Arc::new(StructArray::new(fields.into(), c.values_array(), validity))
@@ -272,11 +229,7 @@ impl<const D: usize> TryFrom<&FixedSizeListArray> for PointArray<D> {
     fn try_from(value: &FixedSizeListArray) -> Result<Self, Self::Error> {
         let interleaved_coords: InterleavedCoordBuffer<D> = value.try_into()?;
 
-        Ok(Self::new(
-            CoordBuffer::Interleaved(interleaved_coords),
-            value.nulls().cloned(),
-            Default::default(),
-        ))
+        Ok(Self::new(CoordBuffer::Interleaved(interleaved_coords), value.nulls().cloned(), Default::default()))
     }
 }
 
@@ -286,11 +239,7 @@ impl<const D: usize> TryFrom<&StructArray> for PointArray<D> {
     fn try_from(value: &StructArray) -> Result<Self, Self::Error> {
         let validity = value.nulls();
         let separated_coords: SeparatedCoordBuffer<D> = value.try_into()?;
-        Ok(Self::new(
-            CoordBuffer::Separated(separated_coords),
-            validity.cloned(),
-            Default::default(),
-        ))
+        Ok(Self::new(CoordBuffer::Separated(separated_coords), validity.cloned(), Default::default()))
     }
 }
 
@@ -307,9 +256,7 @@ impl<const D: usize> TryFrom<&dyn Array> for PointArray<D> {
                 let arr = value.as_any().downcast_ref::<StructArray>().unwrap();
                 arr.try_into()
             }
-            _ => Err(GeoArrowError::General(
-                "Invalid data type for PointArray".to_string(),
-            )),
+            _ => Err(GeoArrowError::General("Invalid data type for PointArray".to_string())),
         }
     }
 }
@@ -384,31 +331,23 @@ impl<const D: usize> PartialEq for PointArray<D> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<MultiPointArray<O, D>> for PointArray<D> {
+impl<const D: usize> TryFrom<MultiPointArray<D>> for PointArray<D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: MultiPointArray<O, D>) -> Result<Self, Self::Error> {
+    fn try_from(value: MultiPointArray<D>) -> Result<Self, Self::Error> {
         if !can_downcast_multi(&value.geom_offsets) {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
-        Ok(PointArray::new(
-            value.coords,
-            value.validity,
-            value.metadata,
-        ))
+        Ok(PointArray::new(value.coords, value.validity, value.metadata))
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>> for PointArray<D> {
+impl<const D: usize> TryFrom<MixedGeometryArray<D>> for PointArray<D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: MixedGeometryArray<O, D>) -> Result<Self, Self::Error> {
-        if value.has_line_strings()
-            || value.has_polygons()
-            || value.has_multi_line_strings()
-            || value.has_multi_polygons()
-        {
+    fn try_from(value: MixedGeometryArray<D>) -> Result<Self, Self::Error> {
+        if value.has_line_strings() || value.has_polygons() || value.has_multi_line_strings() || value.has_multi_polygons() {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
@@ -420,31 +359,23 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<MixedGeometryArray<O, D>> for P
             return value.multi_points.try_into();
         }
 
-        let mut builder = PointBuilder::<D>::with_capacity_and_options(
-            value.len(),
-            value.coord_type(),
-            value.metadata(),
-        );
-        value
-            .iter()
-            .try_for_each(|x| builder.push_geometry(x.as_ref()))?;
+        let mut builder = PointBuilder::<D>::with_capacity_and_options(value.len(), value.coord_type(), value.metadata());
+        value.iter().try_for_each(|x| builder.push_geometry(x.as_ref()))?;
         Ok(builder.finish())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<GeometryCollectionArray<O, D>> for PointArray<D> {
+impl<const D: usize> TryFrom<GeometryCollectionArray<D>> for PointArray<D> {
     type Error = GeoArrowError;
 
-    fn try_from(value: GeometryCollectionArray<O, D>) -> Result<Self, Self::Error> {
+    fn try_from(value: GeometryCollectionArray<D>) -> Result<Self, Self::Error> {
         MixedGeometryArray::try_from(value)?.try_into()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::test::geoarrow_data::{
-        example_point_interleaved, example_point_separated, example_point_wkb,
-    };
+    use crate::test::geoarrow_data::{example_point_interleaved, example_point_separated, example_point_wkb};
     use crate::test::point::{p0, p1, p2};
 
     use super::*;

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -4,7 +4,7 @@ use crate::algorithm::native::downcast::can_downcast_multi;
 use crate::algorithm::native::eq::offset_buffer_eq;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::polygon::PolygonCapacity;
-use crate::array::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32, offsets_buffer_to_i32, offsets_buffer_to_i64, OffsetBufferUtils};
+use crate::array::util::OffsetBufferUtils;
 use crate::array::{CoordBuffer, CoordType, GeometryCollectionArray, MixedGeometryArray, MultiLineStringArray, MultiPolygonArray, RectArray, WKBArray};
 use crate::datatypes::NativeType;
 use crate::error::{GeoArrowError, Result};
@@ -174,14 +174,6 @@ impl<const D: usize> PolygonArray<D> {
 
     pub fn into_coord_type(self, coord_type: CoordType) -> Self {
         Self::new(self.coords.into_coord_type(coord_type), self.geom_offsets, self.ring_offsets, self.validity, self.metadata)
-    }
-
-    pub fn to_small_offsets(&self) -> Result<PolygonArray<i32, D>> {
-        Ok(PolygonArray::new(self.coords.clone(), offsets_buffer_to_i32(&self.geom_offsets)?, offsets_buffer_to_i32(&self.ring_offsets)?, self.validity.clone(), self.metadata.clone()))
-    }
-
-    pub fn to_large_offsets(&self) -> PolygonArray<i64, D> {
-        PolygonArray::new(self.coords.clone(), offsets_buffer_to_i64(&self.geom_offsets), offsets_buffer_to_i64(&self.ring_offsets), self.validity.clone(), self.metadata.clone())
     }
 }
 

--- a/src/array/polygon/builder.rs
+++ b/src/array/polygon/builder.rs
@@ -4,16 +4,27 @@ use crate::array::metadata::ArrayMetadata;
 // use super::array::check;
 use crate::array::offset_builder::OffsetsBuilder;
 use crate::array::polygon::PolygonCapacity;
-use crate::array::{CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, MultiLineStringBuilder, PolygonArray, SeparatedCoordBufferBuilder, WKBArray};
+use crate::array::{
+    CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, MultiLineStringBuilder,
+    PolygonArray, SeparatedCoordBufferBuilder, WKBArray,
+};
 use crate::error::{GeoArrowError, Result};
-use crate::geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait, RectTrait};
+use crate::geo_traits::{
+    CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait,
+    RectTrait,
+};
 use crate::io::wkb::reader::WKBPolygon;
 use crate::scalar::WKB;
 use crate::trait_::{ArrayAccessor, GeometryArrayBuilder, IntoArrow};
 use arrow_array::{Array, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 
-pub type MutablePolygonParts<const D: usize> = (CoordBufferBuilder<D>, OffsetsBuilder<i32>, OffsetsBuilder<i32>, NullBufferBuilder);
+pub type MutablePolygonParts<const D: usize> = (
+    CoordBufferBuilder<D>,
+    OffsetsBuilder<i32>,
+    OffsetsBuilder<i32>,
+    NullBufferBuilder,
+);
 
 /// The GeoArrow equivalent to `Vec<Option<Polygon>>`: a mutable collection of Polygons.
 ///
@@ -49,10 +60,18 @@ impl<const D: usize> PolygonBuilder<D> {
         Self::with_capacity_and_options(capacity, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options(capacity: PolygonCapacity, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn with_capacity_and_options(
+        capacity: PolygonCapacity,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let coords = match coord_type {
-            CoordType::Interleaved => CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity)),
-            CoordType::Separated => CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity)),
+            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
+                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
+            ),
+            CoordType::Separated => CoordBufferBuilder::Separated(
+                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity),
+            ),
         };
         Self {
             coords,
@@ -92,12 +111,18 @@ impl<const D: usize> PolygonBuilder<D> {
         self.geom_offsets.reserve_exact(capacity.geom_capacity);
     }
 
-    pub fn reserve_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>) {
+    pub fn reserve_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
+    ) {
         let counter = PolygonCapacity::from_polygons(geoms);
         self.reserve(counter)
     }
 
-    pub fn reserve_exact_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>) {
+    pub fn reserve_exact_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
+    ) {
         let counter = PolygonCapacity::from_polygons(geoms);
         self.reserve_exact(counter)
     }
@@ -113,19 +138,36 @@ impl<const D: usize> PolygonBuilder<D> {
     /// - if the validity is not `None` and its length is different from the number of geometries
     /// - if the largest ring offset does not match the number of coordinates
     /// - if the largest geometry offset does not match the size of ring offsets
-    pub fn try_new(coords: CoordBufferBuilder<D>, geom_offsets: OffsetsBuilder<i32>, ring_offsets: OffsetsBuilder<i32>, validity: NullBufferBuilder, metadata: Arc<ArrayMetadata>) -> Result<Self> {
+    pub fn try_new(
+        coords: CoordBufferBuilder<D>,
+        geom_offsets: OffsetsBuilder<i32>,
+        ring_offsets: OffsetsBuilder<i32>,
+        validity: NullBufferBuilder,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
         // check(
         //     &coords.clone().into(),
         //     &geom_offsets.clone().into(),
         //     &ring_offsets.clone().into(),
         //     validity.as_ref().map(|x| x.len()),
         // )?;
-        Ok(Self { coords, geom_offsets, ring_offsets, validity, metadata })
+        Ok(Self {
+            coords,
+            geom_offsets,
+            ring_offsets,
+            validity,
+            metadata,
+        })
     }
 
     /// Extract the low-level APIs from the [`PolygonBuilder`].
     pub fn into_inner(self) -> MutablePolygonParts<D> {
-        (self.coords, self.geom_offsets, self.ring_offsets, self.validity)
+        (
+            self.coords,
+            self.geom_offsets,
+            self.ring_offsets,
+            self.validity,
+        )
     }
 
     pub fn into_array_ref(self) -> Arc<dyn Array> {
@@ -161,11 +203,17 @@ impl<const D: usize> PolygonBuilder<D> {
         self.into()
     }
 
-    pub fn with_capacity_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>) -> Self {
+    pub fn with_capacity_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
+    ) -> Self {
         Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
     }
 
-    pub fn with_capacity_and_options_from_iter<'a>(geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    pub fn with_capacity_and_options_from_iter<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let counter = PolygonCapacity::from_polygons(geoms);
         Self::with_capacity_and_options(counter, coord_type, metadata)
     }
@@ -229,11 +277,26 @@ impl<const D: usize> PolygonBuilder<D> {
             // Ref below because I always forget the ordering
             // https://github.com/georust/geo/blob/76ad2a358bd079e9d47b1229af89608744d2635b/geo-types/src/geometry/rect.rs#L217-L225
 
-            self.coords.push_coord(&geo::Coord { x: lower.x(), y: lower.y() });
-            self.coords.push_coord(&geo::Coord { x: lower.x(), y: upper.y() });
-            self.coords.push_coord(&geo::Coord { x: upper.x(), y: upper.y() });
-            self.coords.push_coord(&geo::Coord { x: upper.x(), y: lower.y() });
-            self.coords.push_coord(&geo::Coord { x: lower.x(), y: lower.y() });
+            self.coords.push_coord(&geo::Coord {
+                x: lower.x(),
+                y: lower.y(),
+            });
+            self.coords.push_coord(&geo::Coord {
+                x: lower.x(),
+                y: upper.y(),
+            });
+            self.coords.push_coord(&geo::Coord {
+                x: upper.x(),
+                y: upper.y(),
+            });
+            self.coords.push_coord(&geo::Coord {
+                x: upper.x(),
+                y: lower.y(),
+            });
+            self.coords.push_coord(&geo::Coord {
+                x: lower.x(),
+                y: lower.y(),
+            });
         } else {
             self.push_null();
         }
@@ -261,8 +324,14 @@ impl<const D: usize> PolygonBuilder<D> {
         Ok(())
     }
 
-    pub fn extend_from_iter<'a>(&mut self, geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait<T = f64> + 'a)>>) {
-        geoms.into_iter().try_for_each(|maybe_polygon| self.push_polygon(maybe_polygon)).unwrap();
+    pub fn extend_from_iter<'a>(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait<T = f64> + 'a)>>,
+    ) {
+        geoms
+            .into_iter()
+            .try_for_each(|maybe_polygon| self.push_polygon(maybe_polygon))
+            .unwrap();
     }
 
     /// Push a raw coordinate to the underlying coordinate array.
@@ -291,21 +360,52 @@ impl<const D: usize> PolygonBuilder<D> {
         self.validity.append(false);
     }
 
-    pub fn from_polygons(geoms: &[impl PolygonTrait<T = f64>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(Some), coord_type.unwrap_or_default(), metadata);
+    pub fn from_polygons(
+        geoms: &[impl PolygonTrait<T = f64>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }
 
-    pub fn from_nullable_polygons(geoms: &[Option<impl PolygonTrait<T = f64>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(geoms.iter().map(|x| x.as_ref()), coord_type.unwrap_or_default(), metadata);
+    pub fn from_nullable_polygons(
+        geoms: &[Option<impl PolygonTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(|x| x.as_ref()),
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
     }
 
-    pub(crate) fn from_wkb<W: OffsetSizeTrait>(wkb_objects: &[Option<WKB<'_, W>>], coord_type: Option<CoordType>, metadata: Arc<ArrayMetadata>) -> Result<Self> {
-        let wkb_objects2: Vec<Option<WKBPolygon>> = wkb_objects.iter().map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.to_wkb_object().into_polygon())).collect();
-        Ok(Self::from_nullable_polygons(&wkb_objects2, coord_type, metadata))
+    pub(crate) fn from_wkb<W: OffsetSizeTrait>(
+        wkb_objects: &[Option<WKB<'_, W>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Result<Self> {
+        let wkb_objects2: Vec<Option<WKBPolygon>> = wkb_objects
+            .iter()
+            .map(|maybe_wkb| {
+                maybe_wkb
+                    .as_ref()
+                    .map(|wkb| wkb.to_wkb_object().into_polygon())
+            })
+            .collect();
+        Ok(Self::from_nullable_polygons(
+            &wkb_objects2,
+            coord_type,
+            metadata,
+        ))
     }
 }
 
@@ -320,7 +420,11 @@ impl<const D: usize> GeometryArrayBuilder for PolygonBuilder<D> {
         Self::new()
     }
 
-    fn with_geom_capacity_and_options(geom_capacity: usize, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    fn with_geom_capacity_and_options(
+        geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         let capacity = PolygonCapacity::new(0, 0, geom_capacity);
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
@@ -370,7 +474,13 @@ impl<const D: usize> From<PolygonBuilder<D>> for PolygonArray<D> {
         let geom_offsets: OffsetBuffer<i32> = other.geom_offsets.into();
         let ring_offsets: OffsetBuffer<i32> = other.ring_offsets.into();
 
-        Self::new(other.coords.into(), geom_offsets, ring_offsets, validity, other.metadata)
+        Self::new(
+            other.coords.into(),
+            geom_offsets,
+            ring_offsets,
+            validity,
+            other.metadata,
+        )
     }
 }
 
@@ -400,6 +510,13 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for PolygonBuilder
 /// change the semantic type
 impl<const D: usize> From<PolygonBuilder<D>> for MultiLineStringBuilder<D> {
     fn from(value: PolygonBuilder<D>) -> Self {
-        Self::try_new(value.coords, value.geom_offsets, value.ring_offsets, value.validity, value.metadata).unwrap()
+        Self::try_new(
+            value.coords,
+            value.geom_offsets,
+            value.ring_offsets,
+            value.validity,
+            value.metadata,
+        )
+        .unwrap()
     }
 }

--- a/src/array/polygon/capacity.rs
+++ b/src/array/polygon/capacity.rs
@@ -1,7 +1,5 @@
 use std::ops::Add;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::geo_traits::{LineStringTrait, PolygonTrait, RectTrait};
 
 /// A counter for the buffer sizes of a [`PolygonArray`][crate::array::PolygonArray].
@@ -95,8 +93,8 @@ impl PolygonCapacity {
     }
 
     /// The number of bytes an array with this capacity would occupy.
-    pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
-        let offsets_byte_width = if O::IS_LARGE { 8 } else { 4 };
+    pub fn num_bytes(&self) -> usize {
+        let offsets_byte_width = 4;
         let num_offsets = self.geom_capacity + self.ring_capacity;
         (offsets_byte_width * num_offsets) + (self.coord_capacity * 2 * 8)
     }

--- a/src/array/util.rs
+++ b/src/array/util.rs
@@ -20,7 +20,7 @@ pub(crate) fn offsets_buffer_i64_to_i32(offsets: &OffsetBuffer<i64>) -> Result<O
 }
 
 pub(crate) fn offsets_buffer_to_i64<O: OffsetSizeTrait>(
-    offsets: &OffsetBuffer<O>,
+    offsets: &OffsetBuffer<i32>,
 ) -> OffsetBuffer<i64> {
     let i64_offsets = offsets
         .iter()
@@ -30,7 +30,7 @@ pub(crate) fn offsets_buffer_to_i64<O: OffsetSizeTrait>(
 }
 
 pub(crate) fn offsets_buffer_to_i32<O: OffsetSizeTrait>(
-    offsets: &OffsetBuffer<O>,
+    offsets: &OffsetBuffer<i32>,
 ) -> Result<OffsetBuffer<i32>> {
     // TODO: raise nicer error. Ref:
     // https://github.com/jorgecarleitao/arrow2/blob/6a4b53169a48cbd234cecde6ab6a98f84146fca2/src/offset.rs#L492
@@ -46,7 +46,7 @@ pub(crate) fn offsets_buffer_to_i32<O: OffsetSizeTrait>(
 /// Returns an iterator with the lengths of the offsets
 #[inline]
 pub(crate) fn offset_lengths<O: OffsetSizeTrait>(
-    offsets: &OffsetBuffer<O>,
+    offsets: &OffsetBuffer<i32>,
 ) -> impl Iterator<Item = usize> + '_ {
     offsets
         .windows(2)
@@ -67,7 +67,7 @@ pub(crate) trait OffsetBufferUtils<O: OffsetSizeTrait> {
     fn last(&self) -> &O;
 }
 
-impl<O: OffsetSizeTrait> OffsetBufferUtils<O> for OffsetBuffer<O> {
+impl<O: OffsetSizeTrait> OffsetBufferUtils<O> for OffsetBuffer<i32> {
     /// Returns the length an array with these offsets would be.
     #[inline]
     fn len_proxy(&self) -> usize {

--- a/src/chunked_array/dynamic.rs
+++ b/src/chunked_array/dynamic.rs
@@ -38,19 +38,12 @@ impl ChunkedNativeArrayDyn {
     /// ```
     pub fn from_arrow_chunks(chunks: &[&dyn Array], field: &Field) -> Result<Self> {
         if chunks.is_empty() {
-            return Err(GeoArrowError::General(
-                "Cannot create zero-length chunked array".to_string(),
-            ));
+            return Err(GeoArrowError::General("Cannot create zero-length chunked array".to_string()));
         }
 
         macro_rules! impl_downcast {
             ($array:ty) => {
-                Arc::new(ChunkedGeometryArray::new(
-                    chunks
-                        .iter()
-                        .map(|array| <$array>::try_from((*array, field)))
-                        .collect::<Result<Vec<_>>>()?,
-                ))
+                Arc::new(ChunkedGeometryArray::new(chunks.iter().map(|array| <$array>::try_from((*array, field))).collect::<Result<Vec<_>>>()?))
             };
         }
         use NativeType::*;
@@ -59,47 +52,25 @@ impl ChunkedNativeArrayDyn {
         let ca: Arc<dyn ChunkedNativeArray> = match typ {
             Point(_, Dimension::XY) => impl_downcast!(PointArray<2>),
             LineString(_, Dimension::XY) => impl_downcast!(LineStringArray<i32, 2>),
-            LargeLineString(_, Dimension::XY) => impl_downcast!(LineStringArray<i64, 2>),
             Polygon(_, Dimension::XY) => impl_downcast!(PolygonArray<i32, 2>),
-            LargePolygon(_, Dimension::XY) => impl_downcast!(PolygonArray<i64, 2>),
             MultiPoint(_, Dimension::XY) => impl_downcast!(MultiPointArray<i32, 2>),
-            LargeMultiPoint(_, Dimension::XY) => impl_downcast!(MultiPointArray<i64, 2>),
             MultiLineString(_, Dimension::XY) => impl_downcast!(MultiLineStringArray<i32, 2>),
-            LargeMultiLineString(_, Dimension::XY) => {
-                impl_downcast!(MultiLineStringArray<i64, 2>)
-            }
             MultiPolygon(_, Dimension::XY) => impl_downcast!(MultiPolygonArray<i32, 2>),
-            LargeMultiPolygon(_, Dimension::XY) => impl_downcast!(MultiPolygonArray<i64, 2>),
             Mixed(_, Dimension::XY) => impl_downcast!(MixedGeometryArray<i32, 2>),
-            LargeMixed(_, Dimension::XY) => impl_downcast!(MixedGeometryArray<i64, 2>),
             GeometryCollection(_, Dimension::XY) => {
                 impl_downcast!(GeometryCollectionArray<i32, 2>)
-            }
-            LargeGeometryCollection(_, Dimension::XY) => {
-                impl_downcast!(GeometryCollectionArray<i64, 2>)
             }
             Rect(Dimension::XY) => impl_downcast!(RectArray<2>),
 
             Point(_, Dimension::XYZ) => impl_downcast!(PointArray<3>),
             LineString(_, Dimension::XYZ) => impl_downcast!(LineStringArray<i32, 3>),
-            LargeLineString(_, Dimension::XYZ) => impl_downcast!(LineStringArray<i64, 3>),
             Polygon(_, Dimension::XYZ) => impl_downcast!(PolygonArray<i32, 3>),
-            LargePolygon(_, Dimension::XYZ) => impl_downcast!(PolygonArray<i64, 3>),
             MultiPoint(_, Dimension::XYZ) => impl_downcast!(MultiPointArray<i32, 3>),
-            LargeMultiPoint(_, Dimension::XYZ) => impl_downcast!(MultiPointArray<i64, 3>),
             MultiLineString(_, Dimension::XYZ) => impl_downcast!(MultiLineStringArray<i32, 3>),
-            LargeMultiLineString(_, Dimension::XYZ) => {
-                impl_downcast!(MultiLineStringArray<i64, 3>)
-            }
             MultiPolygon(_, Dimension::XYZ) => impl_downcast!(MultiPolygonArray<i32, 3>),
-            LargeMultiPolygon(_, Dimension::XYZ) => impl_downcast!(MultiPolygonArray<i64, 3>),
             Mixed(_, Dimension::XYZ) => impl_downcast!(MixedGeometryArray<i32, 3>),
-            LargeMixed(_, Dimension::XYZ) => impl_downcast!(MixedGeometryArray<i64, 3>),
             GeometryCollection(_, Dimension::XYZ) => {
                 impl_downcast!(GeometryCollectionArray<i32, 3>)
-            }
-            LargeGeometryCollection(_, Dimension::XYZ) => {
-                impl_downcast!(GeometryCollectionArray<i64, 3>)
             }
             Rect(Dimension::XYZ) => impl_downcast!(RectArray<3>),
         };
@@ -121,9 +92,7 @@ impl ChunkedNativeArrayDyn {
     /// ```
     pub fn from_geoarrow_chunks(chunks: &[&dyn NativeArray]) -> Result<Self> {
         if chunks.is_empty() {
-            return Err(GeoArrowError::General(
-                "Cannot create zero-length chunked array".to_string(),
-            ));
+            return Err(GeoArrowError::General("Cannot create zero-length chunked array".to_string()));
         }
 
         let mut data_types = HashSet::new();
@@ -134,12 +103,7 @@ impl ChunkedNativeArrayDyn {
         if data_types.len() == 1 {
             macro_rules! impl_downcast {
                 ($cast_func:ident, $dim:expr) => {
-                    Arc::new(ChunkedGeometryArray::new(
-                        chunks
-                            .iter()
-                            .map(|chunk| chunk.as_ref().$cast_func::<$dim>().clone())
-                            .collect(),
-                    ))
+                    Arc::new(ChunkedGeometryArray::new(chunks.iter().map(|chunk| chunk.as_ref().$cast_func::<$dim>().clone()).collect()))
                 };
             }
 
@@ -147,50 +111,26 @@ impl ChunkedNativeArrayDyn {
             let result: Arc<dyn ChunkedNativeArray> = match data_types.drain().next().unwrap() {
                 Point(_, Dimension::XY) => impl_downcast!(as_point, 2),
                 LineString(_, Dimension::XY) => impl_downcast!(as_line_string, 2),
-                LargeLineString(_, Dimension::XY) => impl_downcast!(as_large_line_string, 2),
                 Polygon(_, Dimension::XY) => impl_downcast!(as_polygon, 2),
-                LargePolygon(_, Dimension::XY) => impl_downcast!(as_large_polygon, 2),
                 MultiPoint(_, Dimension::XY) => impl_downcast!(as_multi_point, 2),
-                LargeMultiPoint(_, Dimension::XY) => impl_downcast!(as_large_multi_point, 2),
                 MultiLineString(_, Dimension::XY) => impl_downcast!(as_multi_line_string, 2),
-                LargeMultiLineString(_, Dimension::XY) => {
-                    impl_downcast!(as_large_multi_line_string, 2)
-                }
                 MultiPolygon(_, Dimension::XY) => impl_downcast!(as_multi_polygon, 2),
-                LargeMultiPolygon(_, Dimension::XY) => impl_downcast!(as_large_multi_polygon, 2),
                 Mixed(_, Dimension::XY) => impl_downcast!(as_mixed, 2),
-                LargeMixed(_, Dimension::XY) => impl_downcast!(as_large_mixed, 2),
                 GeometryCollection(_, Dimension::XY) => impl_downcast!(as_geometry_collection, 2),
-                LargeGeometryCollection(_, Dimension::XY) => {
-                    impl_downcast!(as_large_geometry_collection, 2)
-                }
                 Point(_, Dimension::XYZ) => impl_downcast!(as_point, 3),
                 LineString(_, Dimension::XYZ) => impl_downcast!(as_line_string, 3),
-                LargeLineString(_, Dimension::XYZ) => impl_downcast!(as_large_line_string, 3),
                 Polygon(_, Dimension::XYZ) => impl_downcast!(as_polygon, 3),
-                LargePolygon(_, Dimension::XYZ) => impl_downcast!(as_large_polygon, 3),
                 MultiPoint(_, Dimension::XYZ) => impl_downcast!(as_multi_point, 3),
-                LargeMultiPoint(_, Dimension::XYZ) => impl_downcast!(as_large_multi_point, 3),
                 MultiLineString(_, Dimension::XYZ) => impl_downcast!(as_multi_line_string, 3),
-                LargeMultiLineString(_, Dimension::XYZ) => {
-                    impl_downcast!(as_large_multi_line_string, 3)
-                }
                 MultiPolygon(_, Dimension::XYZ) => impl_downcast!(as_multi_polygon, 3),
-                LargeMultiPolygon(_, Dimension::XYZ) => impl_downcast!(as_large_multi_polygon, 3),
                 Mixed(_, Dimension::XYZ) => impl_downcast!(as_mixed, 3),
-                LargeMixed(_, Dimension::XYZ) => impl_downcast!(as_large_mixed, 3),
                 GeometryCollection(_, Dimension::XYZ) => impl_downcast!(as_geometry_collection, 3),
-                LargeGeometryCollection(_, Dimension::XYZ) => {
-                    impl_downcast!(as_large_geometry_collection, 3)
-                }
                 Rect(Dimension::XY) => impl_downcast!(as_rect, 2),
                 Rect(Dimension::XYZ) => impl_downcast!(as_rect, 3),
             };
             Ok(Self(result))
         } else {
-            Err(GeoArrowError::General(format!(
-            "Handling multiple geometry types in `from_geoarrow_chunks` not yet implemented. Received {:?}", data_types
-        )))
+            Err(GeoArrowError::General(format!("Handling multiple geometry types in `from_geoarrow_chunks` not yet implemented. Received {:?}", data_types)))
         }
     }
 

--- a/src/chunked_array/dynamic.rs
+++ b/src/chunked_array/dynamic.rs
@@ -38,12 +38,19 @@ impl ChunkedNativeArrayDyn {
     /// ```
     pub fn from_arrow_chunks(chunks: &[&dyn Array], field: &Field) -> Result<Self> {
         if chunks.is_empty() {
-            return Err(GeoArrowError::General("Cannot create zero-length chunked array".to_string()));
+            return Err(GeoArrowError::General(
+                "Cannot create zero-length chunked array".to_string(),
+            ));
         }
 
         macro_rules! impl_downcast {
             ($array:ty) => {
-                Arc::new(ChunkedGeometryArray::new(chunks.iter().map(|array| <$array>::try_from((*array, field))).collect::<Result<Vec<_>>>()?))
+                Arc::new(ChunkedGeometryArray::new(
+                    chunks
+                        .iter()
+                        .map(|array| <$array>::try_from((*array, field)))
+                        .collect::<Result<Vec<_>>>()?,
+                ))
             };
         }
         use NativeType::*;
@@ -92,7 +99,9 @@ impl ChunkedNativeArrayDyn {
     /// ```
     pub fn from_geoarrow_chunks(chunks: &[&dyn NativeArray]) -> Result<Self> {
         if chunks.is_empty() {
-            return Err(GeoArrowError::General("Cannot create zero-length chunked array".to_string()));
+            return Err(GeoArrowError::General(
+                "Cannot create zero-length chunked array".to_string(),
+            ));
         }
 
         let mut data_types = HashSet::new();
@@ -103,7 +112,12 @@ impl ChunkedNativeArrayDyn {
         if data_types.len() == 1 {
             macro_rules! impl_downcast {
                 ($cast_func:ident, $dim:expr) => {
-                    Arc::new(ChunkedGeometryArray::new(chunks.iter().map(|chunk| chunk.as_ref().$cast_func::<$dim>().clone()).collect()))
+                    Arc::new(ChunkedGeometryArray::new(
+                        chunks
+                            .iter()
+                            .map(|chunk| chunk.as_ref().$cast_func::<$dim>().clone())
+                            .collect(),
+                    ))
                 };
             }
 

--- a/src/chunked_array/dynamic.rs
+++ b/src/chunked_array/dynamic.rs
@@ -51,26 +51,26 @@ impl ChunkedNativeArrayDyn {
         let typ = NativeType::try_from(field)?;
         let ca: Arc<dyn ChunkedNativeArray> = match typ {
             Point(_, Dimension::XY) => impl_downcast!(PointArray<2>),
-            LineString(_, Dimension::XY) => impl_downcast!(LineStringArray<i32, 2>),
-            Polygon(_, Dimension::XY) => impl_downcast!(PolygonArray<i32, 2>),
-            MultiPoint(_, Dimension::XY) => impl_downcast!(MultiPointArray<i32, 2>),
-            MultiLineString(_, Dimension::XY) => impl_downcast!(MultiLineStringArray<i32, 2>),
-            MultiPolygon(_, Dimension::XY) => impl_downcast!(MultiPolygonArray<i32, 2>),
-            Mixed(_, Dimension::XY) => impl_downcast!(MixedGeometryArray<i32, 2>),
+            LineString(_, Dimension::XY) => impl_downcast!(LineStringArray<2>),
+            Polygon(_, Dimension::XY) => impl_downcast!(PolygonArray<2>),
+            MultiPoint(_, Dimension::XY) => impl_downcast!(MultiPointArray<2>),
+            MultiLineString(_, Dimension::XY) => impl_downcast!(MultiLineStringArray<2>),
+            MultiPolygon(_, Dimension::XY) => impl_downcast!(MultiPolygonArray<2>),
+            Mixed(_, Dimension::XY) => impl_downcast!(MixedGeometryArray<2>),
             GeometryCollection(_, Dimension::XY) => {
-                impl_downcast!(GeometryCollectionArray<i32, 2>)
+                impl_downcast!(GeometryCollectionArray<2>)
             }
             Rect(Dimension::XY) => impl_downcast!(RectArray<2>),
 
             Point(_, Dimension::XYZ) => impl_downcast!(PointArray<3>),
-            LineString(_, Dimension::XYZ) => impl_downcast!(LineStringArray<i32, 3>),
-            Polygon(_, Dimension::XYZ) => impl_downcast!(PolygonArray<i32, 3>),
-            MultiPoint(_, Dimension::XYZ) => impl_downcast!(MultiPointArray<i32, 3>),
-            MultiLineString(_, Dimension::XYZ) => impl_downcast!(MultiLineStringArray<i32, 3>),
-            MultiPolygon(_, Dimension::XYZ) => impl_downcast!(MultiPolygonArray<i32, 3>),
-            Mixed(_, Dimension::XYZ) => impl_downcast!(MixedGeometryArray<i32, 3>),
+            LineString(_, Dimension::XYZ) => impl_downcast!(LineStringArray<3>),
+            Polygon(_, Dimension::XYZ) => impl_downcast!(PolygonArray<3>),
+            MultiPoint(_, Dimension::XYZ) => impl_downcast!(MultiPointArray<3>),
+            MultiLineString(_, Dimension::XYZ) => impl_downcast!(MultiLineStringArray<3>),
+            MultiPolygon(_, Dimension::XYZ) => impl_downcast!(MultiPolygonArray<3>),
+            Mixed(_, Dimension::XYZ) => impl_downcast!(MixedGeometryArray<3>),
             GeometryCollection(_, Dimension::XYZ) => {
-                impl_downcast!(GeometryCollectionArray<i32, 3>)
+                impl_downcast!(GeometryCollectionArray<3>)
             }
             Rect(Dimension::XYZ) => impl_downcast!(RectArray<3>),
         };

--- a/src/chunked_array/mod.rs
+++ b/src/chunked_array/mod.rs
@@ -53,7 +53,10 @@ impl<A: Array> ChunkedArray<A> {
     pub fn new(chunks: Vec<A>) -> Self {
         let mut length = 0;
         chunks.iter().for_each(|x| length += x.len());
-        if !chunks.windows(2).all(|w| w[0].data_type() == w[1].data_type()) {
+        if !chunks
+            .windows(2)
+            .all(|w| w[0].data_type() == w[1].data_type())
+        {
             // TODO: switch to try_new with Err
             panic!("All data types should be the same.")
         }
@@ -147,7 +150,9 @@ impl<A: Array> ChunkedArray<A> {
     /// assert_eq!(chunked_array.null_count(), 0);
     /// ```
     pub fn null_count(&self) -> usize {
-        self.chunks().iter().fold(0, |acc, chunk| acc + chunk.null_count())
+        self.chunks()
+            .iter()
+            .fold(0, |acc, chunk| acc + chunk.null_count())
     }
 
     /// Returns an immutable reference to this chunked array's chunks.
@@ -169,7 +174,10 @@ impl<A: Array> ChunkedArray<A> {
 
     /// Returns a Vec of dynamically-typed [ArrayRef].
     pub fn chunk_refs(&self) -> Vec<ArrayRef> {
-        self.chunks.iter().map(|arr| make_array(arr.to_data())).collect()
+        self.chunks
+            .iter()
+            .map(|arr| make_array(arr.to_data()))
+            .collect()
     }
 
     /// Applies an operation over each chunk of this chunked array.
@@ -193,7 +201,10 @@ impl<A: Array> ChunkedArray<A> {
         #[cfg(feature = "rayon")]
         {
             let mut output_vec = Vec::with_capacity(self.chunks.len());
-            self.chunks.par_iter().map(map_op).collect_into_vec(&mut output_vec);
+            self.chunks
+                .par_iter()
+                .map(map_op)
+                .collect_into_vec(&mut output_vec);
             output_vec
         }
 
@@ -218,7 +229,10 @@ impl<A: Array> ChunkedArray<A> {
     /// let lengths = chunked_array.try_map(|chunk| Ok(chunk.len())).unwrap();
     /// assert_eq!(lengths, vec![1, 2]);
     /// ```
-    pub fn try_map<F: Fn(&A) -> Result<R> + Sync + Send, R: Send>(&self, map_op: F) -> Result<Vec<R>> {
+    pub fn try_map<F: Fn(&A) -> Result<R> + Sync + Send, R: Send>(
+        &self,
+        map_op: F,
+    ) -> Result<Vec<R>> {
         #[cfg(feature = "rayon")]
         {
             self.chunks.par_iter().map(map_op).collect()
@@ -385,7 +399,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
         #[cfg(feature = "rayon")]
         {
             let mut output_vec = Vec::with_capacity(self.chunks.len());
-            self.chunks.into_par_iter().map(map_op).collect_into_vec(&mut output_vec);
+            self.chunks
+                .into_par_iter()
+                .map(map_op)
+                .collect_into_vec(&mut output_vec);
             output_vec
         }
 
@@ -417,7 +434,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
         #[cfg(feature = "rayon")]
         {
             let mut output_vec = Vec::with_capacity(self.chunks.len());
-            self.chunks.par_iter().map(map_op).collect_into_vec(&mut output_vec);
+            self.chunks
+                .par_iter()
+                .map(map_op)
+                .collect_into_vec(&mut output_vec);
             output_vec
         }
 
@@ -445,7 +465,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     /// let lengths = chunked_array.try_map(|chunk| Ok(chunk.len())).unwrap();
     /// assert_eq!(lengths, vec![1, 1]);
     /// ```
-    pub fn try_map<F: Fn(&G) -> Result<R> + Sync + Send, R: Send>(&self, map_op: F) -> Result<Vec<R>> {
+    pub fn try_map<F: Fn(&G) -> Result<R> + Sync + Send, R: Send>(
+        &self,
+        map_op: F,
+    ) -> Result<Vec<R>> {
         #[cfg(feature = "rayon")]
         {
             self.chunks.par_iter().map(map_op).collect()
@@ -553,13 +576,15 @@ pub type ChunkedPolygonArray<const D: usize> = ChunkedGeometryArray<PolygonArray
 /// A chunked multi-point array.
 pub type ChunkedMultiPointArray<const D: usize> = ChunkedGeometryArray<MultiPointArray<D>>;
 /// A chunked mutli-line string array.
-pub type ChunkedMultiLineStringArray<const D: usize> = ChunkedGeometryArray<MultiLineStringArray<D>>;
+pub type ChunkedMultiLineStringArray<const D: usize> =
+    ChunkedGeometryArray<MultiLineStringArray<D>>;
 /// A chunked multi-polygon array.
 pub type ChunkedMultiPolygonArray<const D: usize> = ChunkedGeometryArray<MultiPolygonArray<D>>;
 /// A chunked mixed geometry array.
 pub type ChunkedMixedGeometryArray<const D: usize> = ChunkedGeometryArray<MixedGeometryArray<D>>;
 /// A chunked geometry collection array.
-pub type ChunkedGeometryCollectionArray<const D: usize> = ChunkedGeometryArray<GeometryCollectionArray<D>>;
+pub type ChunkedGeometryCollectionArray<const D: usize> =
+    ChunkedGeometryArray<GeometryCollectionArray<D>>;
 /// A chunked rect array.
 pub type ChunkedRectArray<const D: usize> = ChunkedGeometryArray<RectArray<D>>;
 /// A chunked unknown geometry array.
@@ -791,7 +816,10 @@ impl<const D: usize> ChunkedArrayBase for ChunkedPointArray<D> {
     }
 
     fn array_refs(&self) -> Vec<Arc<dyn Array>> {
-        self.chunks.iter().map(|chunk| chunk.to_array_ref()).collect()
+        self.chunks
+            .iter()
+            .map(|chunk| chunk.to_array_ref())
+            .collect()
     }
 }
 
@@ -801,7 +829,10 @@ impl<const D: usize> ChunkedNativeArray for ChunkedPointArray<D> {
     }
 
     fn geometry_chunks(&self) -> Vec<Arc<dyn NativeArray>> {
-        self.chunks.iter().map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef).collect()
+        self.chunks
+            .iter()
+            .map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef)
+            .collect()
     }
 
     fn as_ref(&self) -> &dyn ChunkedNativeArray {
@@ -844,7 +875,10 @@ impl<O: OffsetSizeTrait> ChunkedArrayBase for ChunkedWKBArray<O> {
     // }
 
     fn array_refs(&self) -> Vec<Arc<dyn Array>> {
-        self.chunks.iter().map(|chunk| chunk.to_array_ref()).collect()
+        self.chunks
+            .iter()
+            .map(|chunk| chunk.to_array_ref())
+            .collect()
     }
 }
 
@@ -870,7 +904,10 @@ macro_rules! impl_trait {
             }
 
             fn array_refs(&self) -> Vec<Arc<dyn Array>> {
-                self.chunks.iter().map(|chunk| chunk.to_array_ref()).collect()
+                self.chunks
+                    .iter()
+                    .map(|chunk| chunk.to_array_ref())
+                    .collect()
             }
         }
 
@@ -880,7 +917,10 @@ macro_rules! impl_trait {
             }
 
             fn geometry_chunks(&self) -> Vec<Arc<dyn NativeArray>> {
-                self.chunks.iter().map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef).collect()
+                self.chunks
+                    .iter()
+                    .map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef)
+                    .collect()
             }
 
             fn as_ref(&self) -> &dyn ChunkedNativeArray {
@@ -918,7 +958,10 @@ impl<const D: usize> ChunkedArrayBase for ChunkedRectArray<D> {
     }
 
     fn array_refs(&self) -> Vec<Arc<dyn Array>> {
-        self.chunks.iter().map(|chunk| chunk.to_array_ref()).collect()
+        self.chunks
+            .iter()
+            .map(|chunk| chunk.to_array_ref())
+            .collect()
     }
 }
 
@@ -928,7 +971,10 @@ impl<const D: usize> ChunkedNativeArray for ChunkedRectArray<D> {
     }
 
     fn geometry_chunks(&self) -> Vec<Arc<dyn NativeArray>> {
-        self.chunks.iter().map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef).collect()
+        self.chunks
+            .iter()
+            .map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef)
+            .collect()
     }
 
     fn as_ref(&self) -> &dyn ChunkedNativeArray {

--- a/src/chunked_array/mod.rs
+++ b/src/chunked_array/mod.rs
@@ -53,10 +53,7 @@ impl<A: Array> ChunkedArray<A> {
     pub fn new(chunks: Vec<A>) -> Self {
         let mut length = 0;
         chunks.iter().for_each(|x| length += x.len());
-        if !chunks
-            .windows(2)
-            .all(|w| w[0].data_type() == w[1].data_type())
-        {
+        if !chunks.windows(2).all(|w| w[0].data_type() == w[1].data_type()) {
             // TODO: switch to try_new with Err
             panic!("All data types should be the same.")
         }
@@ -150,9 +147,7 @@ impl<A: Array> ChunkedArray<A> {
     /// assert_eq!(chunked_array.null_count(), 0);
     /// ```
     pub fn null_count(&self) -> usize {
-        self.chunks()
-            .iter()
-            .fold(0, |acc, chunk| acc + chunk.null_count())
+        self.chunks().iter().fold(0, |acc, chunk| acc + chunk.null_count())
     }
 
     /// Returns an immutable reference to this chunked array's chunks.
@@ -174,10 +169,7 @@ impl<A: Array> ChunkedArray<A> {
 
     /// Returns a Vec of dynamically-typed [ArrayRef].
     pub fn chunk_refs(&self) -> Vec<ArrayRef> {
-        self.chunks
-            .iter()
-            .map(|arr| make_array(arr.to_data()))
-            .collect()
+        self.chunks.iter().map(|arr| make_array(arr.to_data())).collect()
     }
 
     /// Applies an operation over each chunk of this chunked array.
@@ -201,10 +193,7 @@ impl<A: Array> ChunkedArray<A> {
         #[cfg(feature = "rayon")]
         {
             let mut output_vec = Vec::with_capacity(self.chunks.len());
-            self.chunks
-                .par_iter()
-                .map(map_op)
-                .collect_into_vec(&mut output_vec);
+            self.chunks.par_iter().map(map_op).collect_into_vec(&mut output_vec);
             output_vec
         }
 
@@ -229,10 +218,7 @@ impl<A: Array> ChunkedArray<A> {
     /// let lengths = chunked_array.try_map(|chunk| Ok(chunk.len())).unwrap();
     /// assert_eq!(lengths, vec![1, 2]);
     /// ```
-    pub fn try_map<F: Fn(&A) -> Result<R> + Sync + Send, R: Send>(
-        &self,
-        map_op: F,
-    ) -> Result<Vec<R>> {
+    pub fn try_map<F: Fn(&A) -> Result<R> + Sync + Send, R: Send>(&self, map_op: F) -> Result<Vec<R>> {
         #[cfg(feature = "rayon")]
         {
             self.chunks.par_iter().map(map_op).collect()
@@ -399,10 +385,7 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
         #[cfg(feature = "rayon")]
         {
             let mut output_vec = Vec::with_capacity(self.chunks.len());
-            self.chunks
-                .into_par_iter()
-                .map(map_op)
-                .collect_into_vec(&mut output_vec);
+            self.chunks.into_par_iter().map(map_op).collect_into_vec(&mut output_vec);
             output_vec
         }
 
@@ -434,10 +417,7 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
         #[cfg(feature = "rayon")]
         {
             let mut output_vec = Vec::with_capacity(self.chunks.len());
-            self.chunks
-                .par_iter()
-                .map(map_op)
-                .collect_into_vec(&mut output_vec);
+            self.chunks.par_iter().map(map_op).collect_into_vec(&mut output_vec);
             output_vec
         }
 
@@ -465,10 +445,7 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     /// let lengths = chunked_array.try_map(|chunk| Ok(chunk.len())).unwrap();
     /// assert_eq!(lengths, vec![1, 1]);
     /// ```
-    pub fn try_map<F: Fn(&G) -> Result<R> + Sync + Send, R: Send>(
-        &self,
-        map_op: F,
-    ) -> Result<Vec<R>> {
+    pub fn try_map<F: Fn(&G) -> Result<R> + Sync + Send, R: Send>(&self, map_op: F) -> Result<Vec<R>> {
         #[cfg(feature = "rayon")]
         {
             self.chunks.par_iter().map(map_op).collect()
@@ -570,23 +547,19 @@ impl<G: ArrayBase> TryFrom<Vec<G>> for ChunkedGeometryArray<G> {
 /// A chunked point array.
 pub type ChunkedPointArray<const D: usize> = ChunkedGeometryArray<PointArray<D>>;
 /// A chunked line string array.
-pub type ChunkedLineStringArray<O, const D: usize> = ChunkedGeometryArray<LineStringArray<O, D>>;
+pub type ChunkedLineStringArray<const D: usize> = ChunkedGeometryArray<LineStringArray<D>>;
 /// A chunked polygon array.
-pub type ChunkedPolygonArray<O, const D: usize> = ChunkedGeometryArray<PolygonArray<O, D>>;
+pub type ChunkedPolygonArray<const D: usize> = ChunkedGeometryArray<PolygonArray<D>>;
 /// A chunked multi-point array.
-pub type ChunkedMultiPointArray<O, const D: usize> = ChunkedGeometryArray<MultiPointArray<O, D>>;
+pub type ChunkedMultiPointArray<const D: usize> = ChunkedGeometryArray<MultiPointArray<D>>;
 /// A chunked mutli-line string array.
-pub type ChunkedMultiLineStringArray<O, const D: usize> =
-    ChunkedGeometryArray<MultiLineStringArray<O, D>>;
+pub type ChunkedMultiLineStringArray<const D: usize> = ChunkedGeometryArray<MultiLineStringArray<D>>;
 /// A chunked multi-polygon array.
-pub type ChunkedMultiPolygonArray<O, const D: usize> =
-    ChunkedGeometryArray<MultiPolygonArray<O, D>>;
+pub type ChunkedMultiPolygonArray<const D: usize> = ChunkedGeometryArray<MultiPolygonArray<D>>;
 /// A chunked mixed geometry array.
-pub type ChunkedMixedGeometryArray<O, const D: usize> =
-    ChunkedGeometryArray<MixedGeometryArray<O, D>>;
+pub type ChunkedMixedGeometryArray<const D: usize> = ChunkedGeometryArray<MixedGeometryArray<D>>;
 /// A chunked geometry collection array.
-pub type ChunkedGeometryCollectionArray<O, const D: usize> =
-    ChunkedGeometryArray<GeometryCollectionArray<O, D>>;
+pub type ChunkedGeometryCollectionArray<const D: usize> = ChunkedGeometryArray<GeometryCollectionArray<D>>;
 /// A chunked rect array.
 pub type ChunkedRectArray<const D: usize> = ChunkedGeometryArray<RectArray<D>>;
 /// A chunked unknown geometry array.
@@ -818,10 +791,7 @@ impl<const D: usize> ChunkedArrayBase for ChunkedPointArray<D> {
     }
 
     fn array_refs(&self) -> Vec<Arc<dyn Array>> {
-        self.chunks
-            .iter()
-            .map(|chunk| chunk.to_array_ref())
-            .collect()
+        self.chunks.iter().map(|chunk| chunk.to_array_ref()).collect()
     }
 }
 
@@ -831,10 +801,7 @@ impl<const D: usize> ChunkedNativeArray for ChunkedPointArray<D> {
     }
 
     fn geometry_chunks(&self) -> Vec<Arc<dyn NativeArray>> {
-        self.chunks
-            .iter()
-            .map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef)
-            .collect()
+        self.chunks.iter().map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef).collect()
     }
 
     fn as_ref(&self) -> &dyn ChunkedNativeArray {
@@ -877,16 +844,13 @@ impl<O: OffsetSizeTrait> ChunkedArrayBase for ChunkedWKBArray<O> {
     // }
 
     fn array_refs(&self) -> Vec<Arc<dyn Array>> {
-        self.chunks
-            .iter()
-            .map(|chunk| chunk.to_array_ref())
-            .collect()
+        self.chunks.iter().map(|chunk| chunk.to_array_ref()).collect()
     }
 }
 
 macro_rules! impl_trait {
     ($chunked_array:ty) => {
-        impl<O: OffsetSizeTrait, const D: usize> ChunkedArrayBase for $chunked_array {
+        impl<const D: usize> ChunkedArrayBase for $chunked_array {
             fn as_any(&self) -> &dyn Any {
                 self
             }
@@ -906,23 +870,17 @@ macro_rules! impl_trait {
             }
 
             fn array_refs(&self) -> Vec<Arc<dyn Array>> {
-                self.chunks
-                    .iter()
-                    .map(|chunk| chunk.to_array_ref())
-                    .collect()
+                self.chunks.iter().map(|chunk| chunk.to_array_ref()).collect()
             }
         }
 
-        impl<O: OffsetSizeTrait, const D: usize> ChunkedNativeArray for $chunked_array {
+        impl<const D: usize> ChunkedNativeArray for $chunked_array {
             fn data_type(&self) -> NativeType {
                 self.chunks.first().unwrap().data_type()
             }
 
             fn geometry_chunks(&self) -> Vec<Arc<dyn NativeArray>> {
-                self.chunks
-                    .iter()
-                    .map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef)
-                    .collect()
+                self.chunks.iter().map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef).collect()
             }
 
             fn as_ref(&self) -> &dyn ChunkedNativeArray {
@@ -932,13 +890,13 @@ macro_rules! impl_trait {
     };
 }
 
-impl_trait!(ChunkedLineStringArray<O, D>);
-impl_trait!(ChunkedPolygonArray<O, D>);
-impl_trait!(ChunkedMultiPointArray<O, D>);
-impl_trait!(ChunkedMultiLineStringArray<O, D>);
-impl_trait!(ChunkedMultiPolygonArray<O, D>);
-impl_trait!(ChunkedMixedGeometryArray<O, D>);
-impl_trait!(ChunkedGeometryCollectionArray<O, D>);
+impl_trait!(ChunkedLineStringArray<D>);
+impl_trait!(ChunkedPolygonArray<D>);
+impl_trait!(ChunkedMultiPointArray<D>);
+impl_trait!(ChunkedMultiLineStringArray<D>);
+impl_trait!(ChunkedMultiPolygonArray<D>);
+impl_trait!(ChunkedMixedGeometryArray<D>);
+impl_trait!(ChunkedGeometryCollectionArray<D>);
 
 impl<const D: usize> ChunkedArrayBase for ChunkedRectArray<D> {
     fn as_any(&self) -> &dyn Any {
@@ -960,10 +918,7 @@ impl<const D: usize> ChunkedArrayBase for ChunkedRectArray<D> {
     }
 
     fn array_refs(&self) -> Vec<Arc<dyn Array>> {
-        self.chunks
-            .iter()
-            .map(|chunk| chunk.to_array_ref())
-            .collect()
+        self.chunks.iter().map(|chunk| chunk.to_array_ref()).collect()
     }
 }
 
@@ -973,10 +928,7 @@ impl<const D: usize> ChunkedNativeArray for ChunkedRectArray<D> {
     }
 
     fn geometry_chunks(&self) -> Vec<Arc<dyn NativeArray>> {
-        self.chunks
-            .iter()
-            .map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef)
-            .collect()
+        self.chunks.iter().map(|chunk| Arc::new(chunk.clone()) as NativeArrayRef).collect()
     }
 
     fn as_ref(&self) -> &dyn ChunkedNativeArray {

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -64,8 +64,7 @@ impl TryFrom<i32> for Dimension {
     type Error = GeoArrowError;
 
     fn try_from(value: i32) -> std::result::Result<Self, Self::Error> {
-        let usize_num =
-            usize::try_from(value).map_err(|err| GeoArrowError::General(err.to_string()))?;
+        let usize_num = usize::try_from(value).map_err(|err| GeoArrowError::General(err.to_string()))?;
         Dimension::try_from(usize_num)
     }
 }
@@ -87,65 +86,33 @@ pub enum NativeType {
     /// [ChunkedLineStringArray][crate::chunked_array::ChunkedLineStringArray] with `i32` offsets.
     LineString(CoordType, Dimension),
 
-    /// Represents a [LineStringArray][crate::array::LineStringArray] or
-    /// [ChunkedLineStringArray][crate::chunked_array::ChunkedLineStringArray] with `i64` offsets.
-    LargeLineString(CoordType, Dimension),
-
     /// Represents a [PolygonArray][crate::array::PolygonArray] or
     /// [ChunkedPolygonArray][crate::chunked_array::ChunkedPolygonArray] with `i32` offsets.
     Polygon(CoordType, Dimension),
 
-    /// Represents a [PolygonArray][crate::array::PolygonArray] or
-    /// [ChunkedPolygonArray][crate::chunked_array::ChunkedPolygonArray] with `i64` offsets.
-    LargePolygon(CoordType, Dimension),
-
     /// Represents a [MultiPointArray][crate::array::MultiPointArray] or
     /// [ChunkedMultiPointArray][crate::chunked_array::ChunkedMultiPointArray] with `i32` offsets.
     MultiPoint(CoordType, Dimension),
-
-    /// Represents a [MultiPointArray][crate::array::MultiPointArray] or
-    /// [ChunkedMultiPointArray][crate::chunked_array::ChunkedMultiPointArray] with `i64` offsets.
-    LargeMultiPoint(CoordType, Dimension),
 
     /// Represents a [MultiLineStringArray][crate::array::MultiLineStringArray] or
     /// [ChunkedMultiLineStringArray][crate::chunked_array::ChunkedMultiLineStringArray] with `i32`
     /// offsets.
     MultiLineString(CoordType, Dimension),
 
-    /// Represents a [MultiLineStringArray][crate::array::MultiLineStringArray] or
-    /// [ChunkedMultiLineStringArray][crate::chunked_array::ChunkedMultiLineStringArray] with `i64`
-    /// offsets.
-    LargeMultiLineString(CoordType, Dimension),
-
     /// Represents a [MultiPolygonArray][crate::array::MultiPolygonArray] or
     /// [ChunkedMultiPolygonArray][crate::chunked_array::ChunkedMultiPolygonArray] with `i32`
     /// offsets.
     MultiPolygon(CoordType, Dimension),
-
-    /// Represents a [MultiPolygonArray][crate::array::MultiPolygonArray] or
-    /// [ChunkedMultiPolygonArray][crate::chunked_array::ChunkedMultiPolygonArray] with `i64`
-    /// offsets.
-    LargeMultiPolygon(CoordType, Dimension),
 
     /// Represents a [MixedGeometryArray][crate::array::MixedGeometryArray] or
     /// [ChunkedMixedGeometryArray][crate::chunked_array::ChunkedMixedGeometryArray] with `i32`
     /// offsets.
     Mixed(CoordType, Dimension),
 
-    /// Represents a [MixedGeometryArray][crate::array::MixedGeometryArray] or
-    /// [ChunkedMixedGeometryArray][crate::chunked_array::ChunkedMixedGeometryArray] with `i64`
-    /// offsets.
-    LargeMixed(CoordType, Dimension),
-
     /// Represents a [GeometryCollectionArray][crate::array::GeometryCollectionArray] or
     /// [ChunkedGeometryCollectionArray][crate::chunked_array::ChunkedGeometryCollectionArray] with
     /// `i32` offsets.
     GeometryCollection(CoordType, Dimension),
-
-    /// Represents a [GeometryCollectionArray][crate::array::GeometryCollectionArray] or
-    /// [ChunkedGeometryCollectionArray][crate::chunked_array::ChunkedGeometryCollectionArray] with
-    /// `i64` offsets.
-    LargeGeometryCollection(CoordType, Dimension),
 
     /// Represents a [RectArray][crate::array::RectArray] or
     /// [ChunkedRectArray][crate::chunked_array::ChunkedRectArray].
@@ -194,18 +161,11 @@ pub(crate) fn coord_type_to_data_type(coord_type: CoordType, dim: Dimension) -> 
             DataType::FixedSizeList(Arc::new(values_field), 3)
         }
         (CoordType::Separated, Dimension::XY) => {
-            let values_fields = vec![
-                Field::new("x", DataType::Float64, false),
-                Field::new("y", DataType::Float64, false),
-            ];
+            let values_fields = vec![Field::new("x", DataType::Float64, false), Field::new("y", DataType::Float64, false)];
             DataType::Struct(values_fields.into())
         }
         (CoordType::Separated, Dimension::XYZ) => {
-            let values_fields = vec![
-                Field::new("x", DataType::Float64, false),
-                Field::new("y", DataType::Float64, false),
-                Field::new("z", DataType::Float64, false),
-            ];
+            let values_fields = vec![Field::new("x", DataType::Float64, false), Field::new("y", DataType::Float64, false), Field::new("z", DataType::Float64, false)];
             DataType::Struct(values_fields.into())
         }
     }
@@ -215,71 +175,41 @@ fn point_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
     coord_type_to_data_type(coord_type, dim)
 }
 
-fn line_string_data_type<O: OffsetSizeTrait>(coord_type: CoordType, dim: Dimension) -> DataType {
+fn line_string_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
     let coords_type = coord_type_to_data_type(coord_type, dim);
     let vertices_field = Field::new("vertices", coords_type, false).into();
-    match O::IS_LARGE {
-        true => DataType::LargeList(vertices_field),
-        false => DataType::List(vertices_field),
-    }
+    DataType::List(vertices_field)
 }
 
-fn polygon_data_type<O: OffsetSizeTrait>(coord_type: CoordType, dim: Dimension) -> DataType {
+fn polygon_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
     let coords_type = coord_type_to_data_type(coord_type, dim);
     let vertices_field = Field::new("vertices", coords_type, false);
-    let rings_field = match O::IS_LARGE {
-        true => Field::new_large_list("rings", vertices_field, false).into(),
-        false => Field::new_list("rings", vertices_field, false).into(),
-    };
-    match O::IS_LARGE {
-        true => DataType::LargeList(rings_field),
-        false => DataType::List(rings_field),
-    }
+    let rings_field = Field::new_list("rings", vertices_field, false).into();
+    DataType::List(rings_field)
 }
 
-fn multi_point_data_type<O: OffsetSizeTrait>(coord_type: CoordType, dim: Dimension) -> DataType {
+fn multi_point_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
     let coords_type = coord_type_to_data_type(coord_type, dim);
     let vertices_field = Field::new("points", coords_type, false).into();
-    match O::IS_LARGE {
-        true => DataType::LargeList(vertices_field),
-        false => DataType::List(vertices_field),
-    }
+    DataType::List(vertices_field)
 }
 
-fn multi_line_string_data_type<O: OffsetSizeTrait>(
-    coord_type: CoordType,
-    dim: Dimension,
-) -> DataType {
+fn multi_line_string_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
     let coords_type = coord_type_to_data_type(coord_type, dim);
     let vertices_field = Field::new("vertices", coords_type, false);
-    let linestrings_field = match O::IS_LARGE {
-        true => Field::new_large_list("linestrings", vertices_field, false).into(),
-        false => Field::new_list("linestrings", vertices_field, false).into(),
-    };
-    match O::IS_LARGE {
-        true => DataType::LargeList(linestrings_field),
-        false => DataType::List(linestrings_field),
-    }
+    let linestrings_field = Field::new_list("linestrings", vertices_field, false).into();
+    DataType::List(linestrings_field)
 }
 
-fn multi_polygon_data_type<O: OffsetSizeTrait>(coord_type: CoordType, dim: Dimension) -> DataType {
+fn multi_polygon_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
     let coords_type = coord_type_to_data_type(coord_type, dim);
     let vertices_field = Field::new("vertices", coords_type, false);
-    let rings_field = match O::IS_LARGE {
-        true => Field::new_large_list("rings", vertices_field, false),
-        false => Field::new_list("rings", vertices_field, false),
-    };
-    let polygons_field = match O::IS_LARGE {
-        true => Field::new_large_list("polygons", rings_field, false).into(),
-        false => Field::new_list("polygons", rings_field, false).into(),
-    };
-    match O::IS_LARGE {
-        true => DataType::LargeList(polygons_field),
-        false => DataType::List(polygons_field),
-    }
+    let rings_field = Field::new_list("rings", vertices_field, false);
+    let polygons_field = Field::new_list("polygons", rings_field, false).into();
+    DataType::List(polygons_field)
 }
 
-fn mixed_data_type<O: OffsetSizeTrait>(coord_type: CoordType, dim: Dimension) -> DataType {
+fn mixed_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
     let mut fields = vec![];
     let mut type_ids = vec![];
 
@@ -290,56 +220,30 @@ fn mixed_data_type<O: OffsetSizeTrait>(coord_type: CoordType, dim: Dimension) ->
 
     // Note: we manually construct the fields because these fields shouldn't have their own
     // GeoArrow extension metadata
-    fields.push(Field::new(
-        "",
-        NativeType::Point(coord_type, dim).to_data_type(),
-        true,
-    ));
+    fields.push(Field::new("", NativeType::Point(coord_type, dim).to_data_type(), true));
 
-    let linestring = match O::IS_LARGE {
-        true => NativeType::LargeLineString(coord_type, dim),
-        false => NativeType::LineString(coord_type, dim),
-    };
+    let linestring = NativeType::LineString(coord_type, dim);
     fields.push(Field::new("", linestring.to_data_type(), true));
 
-    let polygon = match O::IS_LARGE {
-        true => NativeType::LargePolygon(coord_type, dim),
-        false => NativeType::Polygon(coord_type, dim),
-    };
+    let polygon = NativeType::Polygon(coord_type, dim);
     fields.push(Field::new("", polygon.to_data_type(), true));
 
-    let multi_point = match O::IS_LARGE {
-        true => NativeType::LargeMultiPoint(coord_type, dim),
-        false => NativeType::MultiPoint(coord_type, dim),
-    };
+    let multi_point = NativeType::MultiPoint(coord_type, dim);
     fields.push(Field::new("", multi_point.to_data_type(), true));
 
-    let multi_line_string = match O::IS_LARGE {
-        true => NativeType::LargeMultiLineString(coord_type, dim),
-        false => NativeType::MultiLineString(coord_type, dim),
-    };
+    let multi_line_string = NativeType::MultiLineString(coord_type, dim);
     fields.push(Field::new("", multi_line_string.to_data_type(), true));
 
-    let multi_polygon = match O::IS_LARGE {
-        true => NativeType::LargeMultiPolygon(coord_type, dim),
-        false => NativeType::MultiPolygon(coord_type, dim),
-    };
+    let multi_polygon = NativeType::MultiPolygon(coord_type, dim);
     fields.push(Field::new("", multi_polygon.to_data_type(), true));
 
     let union_fields = UnionFields::new(type_ids, fields);
     DataType::Union(union_fields, UnionMode::Dense)
 }
 
-fn geometry_collection_data_type<O: OffsetSizeTrait>(
-    coord_type: CoordType,
-    dim: Dimension,
-) -> DataType {
-    let geometries_field =
-        Field::new("geometries", mixed_data_type::<O>(coord_type, dim), false).into();
-    match O::IS_LARGE {
-        true => DataType::LargeList(geometries_field),
-        false => DataType::List(geometries_field),
-    }
+fn geometry_collection_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
+    let geometries_field = Field::new("geometries", mixed_data_type(coord_type, dim), false).into();
+    DataType::List(geometries_field)
 }
 
 fn wkb_data_type<O: OffsetSizeTrait>() -> DataType {
@@ -359,22 +263,10 @@ fn wkt_data_type<O: OffsetSizeTrait>() -> DataType {
 pub(crate) fn rect_fields(dim: Dimension) -> Fields {
     let values_fields = match dim {
         Dimension::XY => {
-            vec![
-                Field::new("xmin", DataType::Float64, false),
-                Field::new("ymin", DataType::Float64, false),
-                Field::new("xmax", DataType::Float64, false),
-                Field::new("ymax", DataType::Float64, false),
-            ]
+            vec![Field::new("xmin", DataType::Float64, false), Field::new("ymin", DataType::Float64, false), Field::new("xmax", DataType::Float64, false), Field::new("ymax", DataType::Float64, false)]
         }
         Dimension::XYZ => {
-            vec![
-                Field::new("xmin", DataType::Float64, false),
-                Field::new("ymin", DataType::Float64, false),
-                Field::new("zmin", DataType::Float64, false),
-                Field::new("xmax", DataType::Float64, false),
-                Field::new("ymax", DataType::Float64, false),
-                Field::new("zmax", DataType::Float64, false),
-            ]
+            vec![Field::new("xmin", DataType::Float64, false), Field::new("ymin", DataType::Float64, false), Field::new("zmin", DataType::Float64, false), Field::new("xmax", DataType::Float64, false), Field::new("ymax", DataType::Float64, false), Field::new("zmax", DataType::Float64, false)]
         }
     };
 
@@ -387,51 +279,33 @@ fn rect_data_type(dim: Dimension) -> DataType {
 
 impl NativeType {
     /// Get the [`CoordType`] of this data type.
-    ///
-    /// Returns None for WKB and LargeWKB
     pub fn coord_type(&self) -> CoordType {
         use NativeType::*;
         match self {
             Point(ct, _) => *ct,
             LineString(ct, _) => *ct,
-            LargeLineString(ct, _) => *ct,
             Polygon(ct, _) => *ct,
-            LargePolygon(ct, _) => *ct,
             MultiPoint(ct, _) => *ct,
-            LargeMultiPoint(ct, _) => *ct,
             MultiLineString(ct, _) => *ct,
-            LargeMultiLineString(ct, _) => *ct,
             MultiPolygon(ct, _) => *ct,
-            LargeMultiPolygon(ct, _) => *ct,
             Mixed(ct, _) => *ct,
-            LargeMixed(ct, _) => *ct,
             GeometryCollection(ct, _) => *ct,
-            LargeGeometryCollection(ct, _) => *ct,
             Rect(_) => CoordType::Separated,
         }
     }
 
     /// Get the [`Dimension`] of this data type.
-    ///
-    /// Returns None for WKB and LargeWKB
     pub fn dimension(&self) -> Dimension {
         use NativeType::*;
         match self {
             Point(_, dim) => *dim,
             LineString(_, dim) => *dim,
-            LargeLineString(_, dim) => *dim,
             Polygon(_, dim) => *dim,
-            LargePolygon(_, dim) => *dim,
             MultiPoint(_, dim) => *dim,
-            LargeMultiPoint(_, dim) => *dim,
             MultiLineString(_, dim) => *dim,
-            LargeMultiLineString(_, dim) => *dim,
             MultiPolygon(_, dim) => *dim,
-            LargeMultiPolygon(_, dim) => *dim,
             Mixed(_, dim) => *dim,
-            LargeMixed(_, dim) => *dim,
             GeometryCollection(_, dim) => *dim,
-            LargeGeometryCollection(_, dim) => *dim,
             Rect(dim) => *dim,
         }
     }
@@ -455,27 +329,12 @@ impl NativeType {
         match self {
             Point(coord_type, dim) => point_data_type(*coord_type, *dim),
             LineString(coord_type, dim) => line_string_data_type::<i32>(*coord_type, *dim),
-            LargeLineString(coord_type, dim) => line_string_data_type::<i64>(*coord_type, *dim),
             Polygon(coord_type, dim) => polygon_data_type::<i32>(*coord_type, *dim),
-            LargePolygon(coord_type, dim) => polygon_data_type::<i64>(*coord_type, *dim),
             MultiPoint(coord_type, dim) => multi_point_data_type::<i32>(*coord_type, *dim),
-            LargeMultiPoint(coord_type, dim) => multi_point_data_type::<i64>(*coord_type, *dim),
-            MultiLineString(coord_type, dim) => {
-                multi_line_string_data_type::<i32>(*coord_type, *dim)
-            }
-            LargeMultiLineString(coord_type, dim) => {
-                multi_line_string_data_type::<i64>(*coord_type, *dim)
-            }
+            MultiLineString(coord_type, dim) => multi_line_string_data_type::<i32>(*coord_type, *dim),
             MultiPolygon(coord_type, dim) => multi_polygon_data_type::<i32>(*coord_type, *dim),
-            LargeMultiPolygon(coord_type, dim) => multi_polygon_data_type::<i64>(*coord_type, *dim),
             Mixed(coord_type, dim) => mixed_data_type::<i32>(*coord_type, *dim),
-            LargeMixed(coord_type, dim) => mixed_data_type::<i64>(*coord_type, *dim),
-            GeometryCollection(coord_type, dim) => {
-                geometry_collection_data_type::<i32>(*coord_type, *dim)
-            }
-            LargeGeometryCollection(coord_type, dim) => {
-                geometry_collection_data_type::<i64>(*coord_type, *dim)
-            }
+            GeometryCollection(coord_type, dim) => geometry_collection_data_type::<i32>(*coord_type, *dim),
             Rect(dim) => rect_data_type(*dim),
         }
     }
@@ -494,15 +353,13 @@ impl NativeType {
         use NativeType::*;
         match self {
             Point(_, _) => "geoarrow.point",
-            LineString(_, _) | LargeLineString(_, _) => "geoarrow.linestring",
-            Polygon(_, _) | LargePolygon(_, _) => "geoarrow.polygon",
-            MultiPoint(_, _) | LargeMultiPoint(_, _) => "geoarrow.multipoint",
-            MultiLineString(_, _) | LargeMultiLineString(_, _) => "geoarrow.multilinestring",
-            MultiPolygon(_, _) | LargeMultiPolygon(_, _) => "geoarrow.multipolygon",
-            Mixed(_, _) | LargeMixed(_, _) => "geoarrow.geometry",
-            GeometryCollection(_, _) | LargeGeometryCollection(_, _) => {
-                "geoarrow.geometrycollection"
-            }
+            LineString(_, _) => "geoarrow.linestring",
+            Polygon(_, _) => "geoarrow.polygon",
+            MultiPoint(_, _) => "geoarrow.multipoint",
+            MultiLineString(_, _) => "geoarrow.multilinestring",
+            MultiPolygon(_, _) => "geoarrow.multipolygon",
+            Mixed(_, _) => "geoarrow.geometry",
+            GeometryCollection(_, _) => "geoarrow.geometrycollection",
             Rect(_) => "geoarrow.box",
         }
     }
@@ -524,10 +381,7 @@ impl NativeType {
     pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool) -> Field {
         let extension_name = self.extension_name();
         let mut metadata = HashMap::with_capacity(1);
-        metadata.insert(
-            "ARROW:extension:name".to_string(),
-            extension_name.to_string(),
-        );
+        metadata.insert("ARROW:extension:name".to_string(), extension_name.to_string());
         Field::new(name, self.to_data_type(), nullable).with_metadata(metadata)
     }
 
@@ -545,23 +399,12 @@ impl NativeType {
     /// };
     /// let field = geo_data_type.to_field_with_metadata("geometry", false, &metadata);
     /// ```
-    pub fn to_field_with_metadata<N: Into<String>>(
-        &self,
-        name: N,
-        nullable: bool,
-        array_metadata: &ArrayMetadata,
-    ) -> Field {
+    pub fn to_field_with_metadata<N: Into<String>>(&self, name: N, nullable: bool, array_metadata: &ArrayMetadata) -> Field {
         let extension_name = self.extension_name();
         let mut metadata = HashMap::with_capacity(2);
-        metadata.insert(
-            "ARROW:extension:name".to_string(),
-            extension_name.to_string(),
-        );
+        metadata.insert("ARROW:extension:name".to_string(), extension_name.to_string());
         if array_metadata.should_serialize() {
-            metadata.insert(
-                "ARROW:extension:metadata".to_string(),
-                serde_json::to_string(array_metadata).unwrap(),
-            );
+            metadata.insert("ARROW:extension:metadata".to_string(), serde_json::to_string(array_metadata).unwrap());
         }
         Field::new(name, self.to_data_type(), nullable).with_metadata(metadata)
     }
@@ -581,19 +424,12 @@ impl NativeType {
         match self {
             Point(_, dim) => Point(coord_type, dim),
             LineString(_, dim) => LineString(coord_type, dim),
-            LargeLineString(_, dim) => LargeLineString(coord_type, dim),
             Polygon(_, dim) => Polygon(coord_type, dim),
-            LargePolygon(_, dim) => LargePolygon(coord_type, dim),
             MultiPoint(_, dim) => MultiPoint(coord_type, dim),
-            LargeMultiPoint(_, dim) => LargeMultiPoint(coord_type, dim),
             MultiLineString(_, dim) => MultiLineString(coord_type, dim),
-            LargeMultiLineString(_, dim) => LargeMultiLineString(coord_type, dim),
             MultiPolygon(_, dim) => MultiPolygon(coord_type, dim),
-            LargeMultiPolygon(_, dim) => LargeMultiPolygon(coord_type, dim),
             Mixed(_, dim) => Mixed(coord_type, dim),
-            LargeMixed(_, dim) => LargeMixed(coord_type, dim),
             GeometryCollection(_, dim) => GeometryCollection(coord_type, dim),
-            LargeGeometryCollection(_, dim) => LargeGeometryCollection(coord_type, dim),
             Rect(dim) => Rect(dim),
         }
     }
@@ -613,19 +449,12 @@ impl NativeType {
         match self {
             Point(coord_type, _) => Point(coord_type, dim),
             LineString(coord_type, _) => LineString(coord_type, dim),
-            LargeLineString(coord_type, _) => LargeLineString(coord_type, dim),
             Polygon(coord_type, _) => Polygon(coord_type, dim),
-            LargePolygon(coord_type, _) => LargePolygon(coord_type, dim),
             MultiPoint(coord_type, _) => MultiPoint(coord_type, dim),
-            LargeMultiPoint(coord_type, _) => LargeMultiPoint(coord_type, dim),
             MultiLineString(coord_type, _) => MultiLineString(coord_type, dim),
-            LargeMultiLineString(coord_type, _) => LargeMultiLineString(coord_type, dim),
             MultiPolygon(coord_type, _) => MultiPolygon(coord_type, dim),
-            LargeMultiPolygon(coord_type, _) => LargeMultiPolygon(coord_type, dim),
             Mixed(coord_type, _) => Mixed(coord_type, dim),
-            LargeMixed(coord_type, _) => LargeMixed(coord_type, dim),
             GeometryCollection(coord_type, _) => GeometryCollection(coord_type, dim),
-            LargeGeometryCollection(coord_type, _) => LargeGeometryCollection(coord_type, dim),
             Rect(_) => Rect(dim),
         }
     }
@@ -660,31 +489,17 @@ impl SerializedType {
     pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool) -> Field {
         let extension_name = self.extension_name();
         let mut metadata = HashMap::with_capacity(1);
-        metadata.insert(
-            "ARROW:extension:name".to_string(),
-            extension_name.to_string(),
-        );
+        metadata.insert("ARROW:extension:name".to_string(), extension_name.to_string());
         Field::new(name, self.to_data_type(), nullable).with_metadata(metadata)
     }
 
     /// Converts this geo-data type to a field with the additional [ArrayMetadata].
-    pub fn to_field_with_metadata<N: Into<String>>(
-        &self,
-        name: N,
-        nullable: bool,
-        array_metadata: &ArrayMetadata,
-    ) -> Field {
+    pub fn to_field_with_metadata<N: Into<String>>(&self, name: N, nullable: bool, array_metadata: &ArrayMetadata) -> Field {
         let extension_name = self.extension_name();
         let mut metadata = HashMap::with_capacity(2);
-        metadata.insert(
-            "ARROW:extension:name".to_string(),
-            extension_name.to_string(),
-        );
+        metadata.insert("ARROW:extension:name".to_string(), extension_name.to_string());
         if array_metadata.should_serialize() {
-            metadata.insert(
-                "ARROW:extension:metadata".to_string(),
-                serde_json::to_string(array_metadata).unwrap(),
-            );
+            metadata.insert("ARROW:extension:metadata".to_string(), serde_json::to_string(array_metadata).unwrap());
         }
         Field::new(name, self.to_data_type(), nullable).with_metadata(metadata)
     }
@@ -720,12 +535,7 @@ impl AnyType {
     }
 
     /// Converts this geo-data type to a field with the additional [ArrayMetadata].
-    pub fn to_field_with_metadata<N: Into<String>>(
-        &self,
-        name: N,
-        nullable: bool,
-        array_metadata: &ArrayMetadata,
-    ) -> Field {
+    pub fn to_field_with_metadata<N: Into<String>>(&self, name: N, nullable: bool, array_metadata: &ArrayMetadata) -> Field {
         match self {
             Self::Native(x) => x.to_field_with_metadata(name, nullable, array_metadata),
             Self::Serialized(x) => x.to_field_with_metadata(name, nullable, array_metadata),
@@ -735,12 +545,8 @@ impl AnyType {
 
 fn parse_data_type(data_type: &DataType) -> Result<(CoordType, Dimension)> {
     match data_type {
-        DataType::FixedSizeList(_, list_size) => {
-            Ok((CoordType::Interleaved, (*list_size).try_into()?))
-        }
-        DataType::Struct(struct_fields) => {
-            Ok((CoordType::Separated, struct_fields.len().try_into()?))
-        }
+        DataType::FixedSizeList(_, list_size) => Ok((CoordType::Interleaved, (*list_size).try_into()?)),
+        DataType::Struct(struct_fields) => Ok((CoordType::Separated, struct_fields.len().try_into()?)),
         dt => Err(GeoArrowError::General(format!("Unexpected data type {dt}"))),
     }
 }
@@ -772,7 +578,7 @@ fn parse_polygon(field: &Field) -> Result<NativeType> {
         DataType::LargeList(inner1) => match inner1.data_type() {
             DataType::LargeList(inner2) => {
                 let (ct, dim) = parse_data_type(inner2.data_type())?;
-                Ok(NativeType::LargePolygon(ct, dim))
+                Ok(NativeType::Polygon(ct, dim))
             }
             _ => panic!(),
         },
@@ -788,7 +594,7 @@ fn parse_multi_point(field: &Field) -> Result<NativeType> {
         }
         DataType::LargeList(inner_field) => {
             let (ct, dim) = parse_data_type(inner_field.data_type())?;
-            Ok(NativeType::LargeMultiPoint(ct, dim))
+            Ok(NativeType::MultiPoint(ct, dim))
         }
         _ => panic!(),
     }
@@ -806,7 +612,7 @@ fn parse_multi_linestring(field: &Field) -> Result<NativeType> {
         DataType::LargeList(inner1) => match inner1.data_type() {
             DataType::LargeList(inner2) => {
                 let (ct, dim) = parse_data_type(inner2.data_type())?;
-                Ok(NativeType::LargeMultiLineString(ct, dim))
+                Ok(NativeType::MultiLineString(ct, dim))
             }
             _ => panic!(),
         },
@@ -830,7 +636,7 @@ fn parse_multi_polygon(field: &Field) -> Result<NativeType> {
             DataType::LargeList(inner2) => match inner2.data_type() {
                 DataType::LargeList(inner3) => {
                     let (ct, dim) = parse_data_type(inner3.data_type())?;
-                    Ok(NativeType::LargeMultiPolygon(ct, dim))
+                    Ok(NativeType::MultiPolygon(ct, dim))
                 }
                 _ => panic!(),
             },
@@ -859,18 +665,10 @@ fn parse_geometry(field: &Field) -> Result<NativeType> {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XY);
                         }
-                        NativeType::LargeLineString(ct, Dimension::XY) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XY);
-                        }
                         _ => unreachable!(),
                     },
                     3 => match parse_polygon(field)? {
                         NativeType::Polygon(ct, Dimension::XY) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XY);
-                        }
-                        NativeType::LargePolygon(ct, Dimension::XY) => {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XY);
                         }
@@ -881,18 +679,10 @@ fn parse_geometry(field: &Field) -> Result<NativeType> {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XY);
                         }
-                        NativeType::LargeMultiPoint(ct, Dimension::XY) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XY);
-                        }
                         _ => unreachable!(),
                     },
                     5 => match parse_multi_linestring(field)? {
                         NativeType::MultiLineString(ct, Dimension::XY) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XY);
-                        }
-                        NativeType::LargeMultiLineString(ct, Dimension::XY) => {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XY);
                         }
@@ -903,18 +693,10 @@ fn parse_geometry(field: &Field) -> Result<NativeType> {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XY);
                         }
-                        NativeType::LargeMultiPolygon(ct, Dimension::XY) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XY);
-                        }
                         _ => unreachable!(),
                     },
                     7 => match parse_geometry_collection(field)? {
                         NativeType::GeometryCollection(ct, Dimension::XY) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XY);
-                        }
-                        NativeType::LargeGeometryCollection(ct, Dimension::XY) => {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XY);
                         }
@@ -932,18 +714,10 @@ fn parse_geometry(field: &Field) -> Result<NativeType> {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XYZ);
                         }
-                        NativeType::LargeLineString(ct, Dimension::XYZ) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XYZ);
-                        }
                         _ => unreachable!(),
                     },
                     13 => match parse_polygon(field)? {
                         NativeType::Polygon(ct, Dimension::XYZ) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XYZ);
-                        }
-                        NativeType::LargePolygon(ct, Dimension::XYZ) => {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XYZ);
                         }
@@ -954,18 +728,10 @@ fn parse_geometry(field: &Field) -> Result<NativeType> {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XYZ);
                         }
-                        NativeType::LargeMultiPoint(ct, Dimension::XYZ) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XYZ);
-                        }
                         _ => unreachable!(),
                     },
                     15 => match parse_multi_linestring(field)? {
                         NativeType::MultiLineString(ct, Dimension::XYZ) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XYZ);
-                        }
-                        NativeType::LargeMultiLineString(ct, Dimension::XYZ) => {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XYZ);
                         }
@@ -976,18 +742,10 @@ fn parse_geometry(field: &Field) -> Result<NativeType> {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XYZ);
                         }
-                        NativeType::LargeMultiPolygon(ct, Dimension::XYZ) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XYZ);
-                        }
                         _ => unreachable!(),
                     },
                     17 => match parse_geometry_collection(field)? {
                         NativeType::GeometryCollection(ct, Dimension::XYZ) => {
-                            coord_types.insert(ct);
-                            dimensions.insert(Dimension::XYZ);
-                        }
-                        NativeType::LargeGeometryCollection(ct, Dimension::XYZ) => {
                             coord_types.insert(ct);
                             dimensions.insert(Dimension::XYZ);
                         }
@@ -999,14 +757,10 @@ fn parse_geometry(field: &Field) -> Result<NativeType> {
             })?;
 
             if coord_types.len() > 1 {
-                return Err(GeoArrowError::General(
-                    "Multi coord types in union".to_string(),
-                ));
+                return Err(GeoArrowError::General("Multi coord types in union".to_string()));
             }
             if dimensions.len() > 1 {
-                return Err(GeoArrowError::General(
-                    "Multi dimensions types in union".to_string(),
-                ));
+                return Err(GeoArrowError::General("Multi dimensions types in union".to_string()));
             }
 
             let coord_type = coord_types.drain().next().unwrap();
@@ -1022,15 +776,11 @@ fn parse_geometry_collection(field: &Field) -> Result<NativeType> {
     // what coordinate type it's using.
     match field.data_type() {
         DataType::List(inner_field) => match parse_geometry(inner_field)? {
-            NativeType::Mixed(coord_type, dim) => {
-                Ok(NativeType::GeometryCollection(coord_type, dim))
-            }
+            NativeType::Mixed(coord_type, dim) => Ok(NativeType::GeometryCollection(coord_type, dim)),
             _ => panic!(),
         },
         DataType::LargeList(inner_field) => match parse_geometry(inner_field)? {
-            NativeType::LargeMixed(coord_type, dim) => {
-                Ok(NativeType::LargeGeometryCollection(coord_type, dim))
-            }
+            NativeType::Mixed(coord_type, dim) => Ok(NativeType::GeometryCollection(coord_type, dim)),
             _ => panic!(),
         },
         _ => panic!(),
@@ -1079,12 +829,7 @@ impl TryFrom<&Field> for NativeType {
                 "geoarrow.geometry" => parse_geometry(field)?,
                 "geoarrow.geometrycollection" => parse_geometry_collection(field)?,
                 "geoarrow.box" => parse_rect(field),
-                name => {
-                    return Err(GeoArrowError::General(format!(
-                        "Expected GeoArrow native type, got '{}'.\nIf you're passing a serialized GeoArrow type like 'geoarrow.wkb' or 'geoarrow.wkt', you need to parse to a native representation.",
-                        name
-                    )))
-                }
+                name => return Err(GeoArrowError::General(format!("Expected GeoArrow native type, got '{}'.\nIf you're passing a serialized GeoArrow type like 'geoarrow.wkb' or 'geoarrow.wkt', you need to parse to a native representation.", name))),
             };
             Ok(data_type)
         } else {
@@ -1092,18 +837,14 @@ impl TryFrom<&Field> for NativeType {
             // metadata should use TryFrom for a specific geometry type directly, instead of using
             // GeometryArray
             let data_type = match field.data_type() {
-            DataType::Struct(struct_fields) => {
-                match struct_fields.len() {
+                DataType::Struct(struct_fields) => match struct_fields.len() {
                     2 => NativeType::Point(CoordType::Separated, Dimension::XY),
                     3 => NativeType::Point(CoordType::Separated, Dimension::XYZ),
-                    l => return Err(GeoArrowError::General(format!("incorrect number of struct fields {l}") ))
-                }
-            }
-            DataType::FixedSizeList(_, list_size) => {
-                NativeType::Point(CoordType::Interleaved, (*list_size as usize).try_into()?)
-            }
-            _ => return Err(GeoArrowError::General("Only FixedSizeList and Struct arrays are unambigously typed for a GeoArrow native type and can be used without extension metadata.".to_string()))
-        };
+                    l => return Err(GeoArrowError::General(format!("incorrect number of struct fields {l}"))),
+                },
+                DataType::FixedSizeList(_, list_size) => NativeType::Point(CoordType::Interleaved, (*list_size as usize).try_into()?),
+                _ => return Err(GeoArrowError::General("Only FixedSizeList and Struct arrays are unambigously typed for a GeoArrow native type and can be used without extension metadata.".to_string())),
+            };
             Ok(data_type)
         }
     }
@@ -1117,12 +858,7 @@ impl TryFrom<&Field> for SerializedType {
             let data_type = match extension_name.as_str() {
                 "geoarrow.wkb" | "ogc.wkb" => parse_wkb(field),
                 "geoarrow.wkt" => parse_wkt(field),
-                name => {
-                    return Err(GeoArrowError::General(format!(
-                        "Expected GeoArrow serialized type, got '{}'",
-                        name
-                    )))
-                }
+                name => return Err(GeoArrowError::General(format!("Expected GeoArrow serialized type, got '{}'", name))),
             };
             Ok(data_type)
         } else {
@@ -1130,20 +866,12 @@ impl TryFrom<&Field> for SerializedType {
             // metadata should use TryFrom for a specific geometry type directly, instead of using
             // GeometryArray
             let data_type = match field.data_type() {
-            DataType::Binary => {
-                SerializedType::WKB
-            }
-            DataType::LargeBinary => {
-                SerializedType::LargeWKB
-            }
-            DataType::Utf8 => {
-                SerializedType::WKT
-            }
-            DataType::LargeUtf8 => {
-                SerializedType::LargeWKT
-            }
-            _ => return Err(GeoArrowError::General("Only Binary, LargeBinary, String, and LargeString arrays are unambigously typed for a GeoArrow serialized type and can be used without extension metadata.".to_string()))
-        };
+                DataType::Binary => SerializedType::WKB,
+                DataType::LargeBinary => SerializedType::LargeWKB,
+                DataType::Utf8 => SerializedType::WKT,
+                DataType::LargeUtf8 => SerializedType::LargeWKT,
+                _ => return Err(GeoArrowError::General("Only Binary, LargeBinary, String, and LargeString arrays are unambigously typed for a GeoArrow serialized type and can be used without extension metadata.".to_string())),
+            };
             Ok(data_type)
         }
     }
@@ -1179,16 +907,12 @@ mod test {
         let data_type: NativeType = field.as_ref().try_into().unwrap();
         assert_eq!(ml_array.data_type(), data_type);
 
-        let mut builder = MixedGeometryBuilder::<i32, 2>::new();
+        let mut builder = MixedGeometryBuilder::<2>::new();
         builder.push_point(Some(&crate::test::point::p0()));
         builder.push_point(Some(&crate::test::point::p1()));
         builder.push_point(Some(&crate::test::point::p2()));
-        builder
-            .push_multi_line_string(Some(&crate::test::multilinestring::ml0()))
-            .unwrap();
-        builder
-            .push_multi_line_string(Some(&crate::test::multilinestring::ml1()))
-            .unwrap();
+        builder.push_multi_line_string(Some(&crate::test::multilinestring::ml0())).unwrap();
+        builder.push_multi_line_string(Some(&crate::test::multilinestring::ml1())).unwrap();
         let mixed_array = builder.finish();
         let field = mixed_array.extension_field();
         let data_type: NativeType = field.as_ref().try_into().unwrap();

--- a/src/indexed/array.rs
+++ b/src/indexed/array.rs
@@ -47,8 +47,12 @@ impl<G: NativeArray> IndexedGeometryArray<G> {
         self.index.search(min_x, min_y, max_x, max_y)
     }
 
-    pub fn intersection_candidates_with_other<'a, G2: NativeArray>(&'a self, other: &'a IndexedGeometryArray<G2>) -> impl Iterator<Item = (usize, usize)> + 'a {
-        self.index.intersection_candidates_with_other_tree(&other.index)
+    pub fn intersection_candidates_with_other<'a, G2: NativeArray>(
+        &'a self,
+        other: &'a IndexedGeometryArray<G2>,
+    ) -> impl Iterator<Item = (usize, usize)> + 'a {
+        self.index
+            .intersection_candidates_with_other_tree(&other.index)
     }
 }
 
@@ -65,7 +69,12 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
         buffer.append_n(len, false);
 
         // TODO: ensure this is only on valid indexes
-        for candidate_idx in self.search(rhs_rect.lower().x(), rhs_rect.lower().y(), rhs_rect.upper().x(), rhs_rect.upper().y()) {
+        for candidate_idx in self.search(
+            rhs_rect.lower().x(),
+            rhs_rect.lower().y(),
+            rhs_rect.upper().x(),
+            rhs_rect.upper().y(),
+        ) {
             buffer.set_bit(candidate_idx, op(self.array.value(candidate_idx)));
         }
 
@@ -76,13 +85,19 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
     /// boxes intersect.
     ///
     /// Note that this only compares pairs at the same row index.
-    pub fn try_binary_boolean<F, G2>(&'a self, other: &'a IndexedGeometryArray<G2>, op: F) -> Result<BooleanArray>
+    pub fn try_binary_boolean<F, G2>(
+        &'a self,
+        other: &'a IndexedGeometryArray<G2>,
+        op: F,
+    ) -> Result<BooleanArray>
     where
         G2: NativeArray + ArrayAccessor<'a>,
         F: Fn(G::Item, G2::Item) -> Result<bool>,
     {
         if self.len() != other.len() {
-            return Err(GeoArrowError::General("Cannot perform binary operation on arrays of different length".to_string()));
+            return Err(GeoArrowError::General(
+                "Cannot perform binary operation on arrays of different length".to_string(),
+            ));
         }
 
         if self.is_empty() {
@@ -93,7 +108,9 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
         let mut builder_buffer = BooleanBufferBuilder::new(self.len());
         builder_buffer.append_n(self.len(), false);
 
-        for (left_candidate_idx, right_candidate_idx) in self.intersection_candidates_with_other(other) {
+        for (left_candidate_idx, right_candidate_idx) in
+            self.intersection_candidates_with_other(other)
+        {
             if left_candidate_idx != right_candidate_idx {
                 continue;
             }
@@ -112,10 +129,12 @@ pub type IndexedPointArray<const D: usize> = IndexedGeometryArray<PointArray<D>>
 pub type IndexedLineStringArray<const D: usize> = IndexedGeometryArray<LineStringArray<D>>;
 pub type IndexedPolygonArray<const D: usize> = IndexedGeometryArray<PolygonArray<D>>;
 pub type IndexedMultiPointArray<const D: usize> = IndexedGeometryArray<MultiPointArray<D>>;
-pub type IndexedMultiLineStringArray<const D: usize> = IndexedGeometryArray<MultiLineStringArray<D>>;
+pub type IndexedMultiLineStringArray<const D: usize> =
+    IndexedGeometryArray<MultiLineStringArray<D>>;
 pub type IndexedMultiPolygonArray<const D: usize> = IndexedGeometryArray<MultiPolygonArray<D>>;
 pub type IndexedMixedGeometryArray<const D: usize> = IndexedGeometryArray<MixedGeometryArray<D>>;
-pub type IndexedGeometryCollectionArray<const D: usize> = IndexedGeometryArray<GeometryCollectionArray<D>>;
+pub type IndexedGeometryCollectionArray<const D: usize> =
+    IndexedGeometryArray<GeometryCollectionArray<D>>;
 #[allow(dead_code)]
 pub type IndexedWKBArray<O> = IndexedGeometryArray<WKBArray<O>>;
 #[allow(dead_code)]

--- a/src/indexed/array.rs
+++ b/src/indexed/array.rs
@@ -47,12 +47,8 @@ impl<G: NativeArray> IndexedGeometryArray<G> {
         self.index.search(min_x, min_y, max_x, max_y)
     }
 
-    pub fn intersection_candidates_with_other<'a, G2: NativeArray>(
-        &'a self,
-        other: &'a IndexedGeometryArray<G2>,
-    ) -> impl Iterator<Item = (usize, usize)> + 'a {
-        self.index
-            .intersection_candidates_with_other_tree(&other.index)
+    pub fn intersection_candidates_with_other<'a, G2: NativeArray>(&'a self, other: &'a IndexedGeometryArray<G2>) -> impl Iterator<Item = (usize, usize)> + 'a {
+        self.index.intersection_candidates_with_other_tree(&other.index)
     }
 }
 
@@ -69,12 +65,7 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
         buffer.append_n(len, false);
 
         // TODO: ensure this is only on valid indexes
-        for candidate_idx in self.search(
-            rhs_rect.lower().x(),
-            rhs_rect.lower().y(),
-            rhs_rect.upper().x(),
-            rhs_rect.upper().y(),
-        ) {
+        for candidate_idx in self.search(rhs_rect.lower().x(), rhs_rect.lower().y(), rhs_rect.upper().x(), rhs_rect.upper().y()) {
             buffer.set_bit(candidate_idx, op(self.array.value(candidate_idx)));
         }
 
@@ -85,19 +76,13 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
     /// boxes intersect.
     ///
     /// Note that this only compares pairs at the same row index.
-    pub fn try_binary_boolean<F, G2>(
-        &'a self,
-        other: &'a IndexedGeometryArray<G2>,
-        op: F,
-    ) -> Result<BooleanArray>
+    pub fn try_binary_boolean<F, G2>(&'a self, other: &'a IndexedGeometryArray<G2>, op: F) -> Result<BooleanArray>
     where
         G2: NativeArray + ArrayAccessor<'a>,
         F: Fn(G::Item, G2::Item) -> Result<bool>,
     {
         if self.len() != other.len() {
-            return Err(GeoArrowError::General(
-                "Cannot perform binary operation on arrays of different length".to_string(),
-            ));
+            return Err(GeoArrowError::General("Cannot perform binary operation on arrays of different length".to_string()));
         }
 
         if self.is_empty() {
@@ -108,9 +93,7 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
         let mut builder_buffer = BooleanBufferBuilder::new(self.len());
         builder_buffer.append_n(self.len(), false);
 
-        for (left_candidate_idx, right_candidate_idx) in
-            self.intersection_candidates_with_other(other)
-        {
+        for (left_candidate_idx, right_candidate_idx) in self.intersection_candidates_with_other(other) {
             if left_candidate_idx != right_candidate_idx {
                 continue;
             }
@@ -126,17 +109,13 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
 }
 
 pub type IndexedPointArray<const D: usize> = IndexedGeometryArray<PointArray<D>>;
-pub type IndexedLineStringArray<O, const D: usize> = IndexedGeometryArray<LineStringArray<O, D>>;
-pub type IndexedPolygonArray<O, const D: usize> = IndexedGeometryArray<PolygonArray<O, D>>;
-pub type IndexedMultiPointArray<O, const D: usize> = IndexedGeometryArray<MultiPointArray<O, D>>;
-pub type IndexedMultiLineStringArray<O, const D: usize> =
-    IndexedGeometryArray<MultiLineStringArray<O, D>>;
-pub type IndexedMultiPolygonArray<O, const D: usize> =
-    IndexedGeometryArray<MultiPolygonArray<O, D>>;
-pub type IndexedMixedGeometryArray<O, const D: usize> =
-    IndexedGeometryArray<MixedGeometryArray<O, D>>;
-pub type IndexedGeometryCollectionArray<O, const D: usize> =
-    IndexedGeometryArray<GeometryCollectionArray<O, D>>;
+pub type IndexedLineStringArray<const D: usize> = IndexedGeometryArray<LineStringArray<D>>;
+pub type IndexedPolygonArray<const D: usize> = IndexedGeometryArray<PolygonArray<D>>;
+pub type IndexedMultiPointArray<const D: usize> = IndexedGeometryArray<MultiPointArray<D>>;
+pub type IndexedMultiLineStringArray<const D: usize> = IndexedGeometryArray<MultiLineStringArray<D>>;
+pub type IndexedMultiPolygonArray<const D: usize> = IndexedGeometryArray<MultiPolygonArray<D>>;
+pub type IndexedMixedGeometryArray<const D: usize> = IndexedGeometryArray<MixedGeometryArray<D>>;
+pub type IndexedGeometryCollectionArray<const D: usize> = IndexedGeometryArray<GeometryCollectionArray<D>>;
 #[allow(dead_code)]
 pub type IndexedWKBArray<O> = IndexedGeometryArray<WKBArray<O>>;
 #[allow(dead_code)]

--- a/src/indexed/chunked.rs
+++ b/src/indexed/chunked.rs
@@ -16,15 +16,22 @@ impl<G: NativeArray> IndexedChunkedGeometryArray<G> {
     #[allow(dead_code)]
     pub fn new(chunks: Vec<G>) -> Self {
         assert!(chunks.iter().all(|chunk| chunk.null_count() == 0));
-        let chunks = ChunkedGeometryArray::new(chunks).into_map(|chunk| IndexedGeometryArray::new(chunk));
+        let chunks =
+            ChunkedGeometryArray::new(chunks).into_map(|chunk| IndexedGeometryArray::new(chunk));
         Self { chunks }
     }
 
-    pub fn map<F: Fn(&IndexedGeometryArray<G>) -> R + Sync + Send, R: Send>(&self, map_op: F) -> Vec<R> {
+    pub fn map<F: Fn(&IndexedGeometryArray<G>) -> R + Sync + Send, R: Send>(
+        &self,
+        map_op: F,
+    ) -> Vec<R> {
         #[cfg(feature = "rayon")]
         {
             let mut output_vec = Vec::with_capacity(self.chunks.len());
-            self.chunks.par_iter().map(map_op).collect_into_vec(&mut output_vec);
+            self.chunks
+                .par_iter()
+                .map(map_op)
+                .collect_into_vec(&mut output_vec);
             output_vec
         }
 
@@ -36,16 +43,23 @@ impl<G: NativeArray> IndexedChunkedGeometryArray<G> {
 }
 
 pub type IndexedChunkedPointArray<const D: usize> = IndexedChunkedGeometryArray<PointArray<D>>;
-pub type IndexedChunkedLineStringArray<const D: usize> = IndexedChunkedGeometryArray<LineStringArray<D>>;
+pub type IndexedChunkedLineStringArray<const D: usize> =
+    IndexedChunkedGeometryArray<LineStringArray<D>>;
 pub type IndexedChunkedPolygonArray<const D: usize> = IndexedChunkedGeometryArray<PolygonArray<D>>;
-pub type IndexedChunkedMultiPointArray<const D: usize> = IndexedChunkedGeometryArray<MultiPointArray<D>>;
-pub type IndexedChunkedMultiLineStringArray<const D: usize> = IndexedChunkedGeometryArray<MultiLineStringArray<D>>;
-pub type IndexedChunkedMultiPolygonArray<const D: usize> = IndexedChunkedGeometryArray<MultiPolygonArray<D>>;
-pub type IndexedChunkedMixedGeometryArray<const D: usize> = IndexedChunkedGeometryArray<MixedGeometryArray<D>>;
-pub type IndexedChunkedGeometryCollectionArray<const D: usize> = IndexedChunkedGeometryArray<GeometryCollectionArray<D>>;
+pub type IndexedChunkedMultiPointArray<const D: usize> =
+    IndexedChunkedGeometryArray<MultiPointArray<D>>;
+pub type IndexedChunkedMultiLineStringArray<const D: usize> =
+    IndexedChunkedGeometryArray<MultiLineStringArray<D>>;
+pub type IndexedChunkedMultiPolygonArray<const D: usize> =
+    IndexedChunkedGeometryArray<MultiPolygonArray<D>>;
+pub type IndexedChunkedMixedGeometryArray<const D: usize> =
+    IndexedChunkedGeometryArray<MixedGeometryArray<D>>;
+pub type IndexedChunkedGeometryCollectionArray<const D: usize> =
+    IndexedChunkedGeometryArray<GeometryCollectionArray<D>>;
 #[allow(dead_code)]
 pub type IndexedChunkedWKBArray<O> = IndexedChunkedGeometryArray<WKBArray<O>>;
 #[allow(dead_code)]
 pub type IndexedChunkedRectArray<const D: usize> = IndexedChunkedGeometryArray<RectArray<D>>;
 #[allow(dead_code)]
-pub type IndexedChunkedUnknownGeometryArray = IndexedChunkedGeometryArray<Arc<dyn ChunkedNativeArray>>;
+pub type IndexedChunkedUnknownGeometryArray =
+    IndexedChunkedGeometryArray<Arc<dyn ChunkedNativeArray>>;

--- a/src/indexed/chunked.rs
+++ b/src/indexed/chunked.rs
@@ -16,22 +16,15 @@ impl<G: NativeArray> IndexedChunkedGeometryArray<G> {
     #[allow(dead_code)]
     pub fn new(chunks: Vec<G>) -> Self {
         assert!(chunks.iter().all(|chunk| chunk.null_count() == 0));
-        let chunks =
-            ChunkedGeometryArray::new(chunks).into_map(|chunk| IndexedGeometryArray::new(chunk));
+        let chunks = ChunkedGeometryArray::new(chunks).into_map(|chunk| IndexedGeometryArray::new(chunk));
         Self { chunks }
     }
 
-    pub fn map<F: Fn(&IndexedGeometryArray<G>) -> R + Sync + Send, R: Send>(
-        &self,
-        map_op: F,
-    ) -> Vec<R> {
+    pub fn map<F: Fn(&IndexedGeometryArray<G>) -> R + Sync + Send, R: Send>(&self, map_op: F) -> Vec<R> {
         #[cfg(feature = "rayon")]
         {
             let mut output_vec = Vec::with_capacity(self.chunks.len());
-            self.chunks
-                .par_iter()
-                .map(map_op)
-                .collect_into_vec(&mut output_vec);
+            self.chunks.par_iter().map(map_op).collect_into_vec(&mut output_vec);
             output_vec
         }
 
@@ -43,24 +36,16 @@ impl<G: NativeArray> IndexedChunkedGeometryArray<G> {
 }
 
 pub type IndexedChunkedPointArray<const D: usize> = IndexedChunkedGeometryArray<PointArray<D>>;
-pub type IndexedChunkedLineStringArray<O, const D: usize> =
-    IndexedChunkedGeometryArray<LineStringArray<O, D>>;
-pub type IndexedChunkedPolygonArray<O, const D: usize> =
-    IndexedChunkedGeometryArray<PolygonArray<O, D>>;
-pub type IndexedChunkedMultiPointArray<O, const D: usize> =
-    IndexedChunkedGeometryArray<MultiPointArray<O, D>>;
-pub type IndexedChunkedMultiLineStringArray<O, const D: usize> =
-    IndexedChunkedGeometryArray<MultiLineStringArray<O, D>>;
-pub type IndexedChunkedMultiPolygonArray<O, const D: usize> =
-    IndexedChunkedGeometryArray<MultiPolygonArray<O, D>>;
-pub type IndexedChunkedMixedGeometryArray<O, const D: usize> =
-    IndexedChunkedGeometryArray<MixedGeometryArray<O, D>>;
-pub type IndexedChunkedGeometryCollectionArray<O, const D: usize> =
-    IndexedChunkedGeometryArray<GeometryCollectionArray<O, D>>;
+pub type IndexedChunkedLineStringArray<const D: usize> = IndexedChunkedGeometryArray<LineStringArray<D>>;
+pub type IndexedChunkedPolygonArray<const D: usize> = IndexedChunkedGeometryArray<PolygonArray<D>>;
+pub type IndexedChunkedMultiPointArray<const D: usize> = IndexedChunkedGeometryArray<MultiPointArray<D>>;
+pub type IndexedChunkedMultiLineStringArray<const D: usize> = IndexedChunkedGeometryArray<MultiLineStringArray<D>>;
+pub type IndexedChunkedMultiPolygonArray<const D: usize> = IndexedChunkedGeometryArray<MultiPolygonArray<D>>;
+pub type IndexedChunkedMixedGeometryArray<const D: usize> = IndexedChunkedGeometryArray<MixedGeometryArray<D>>;
+pub type IndexedChunkedGeometryCollectionArray<const D: usize> = IndexedChunkedGeometryArray<GeometryCollectionArray<D>>;
 #[allow(dead_code)]
 pub type IndexedChunkedWKBArray<O> = IndexedChunkedGeometryArray<WKBArray<O>>;
 #[allow(dead_code)]
 pub type IndexedChunkedRectArray<const D: usize> = IndexedChunkedGeometryArray<RectArray<D>>;
 #[allow(dead_code)]
-pub type IndexedChunkedUnknownGeometryArray =
-    IndexedChunkedGeometryArray<Arc<dyn ChunkedNativeArray>>;
+pub type IndexedChunkedUnknownGeometryArray = IndexedChunkedGeometryArray<Arc<dyn ChunkedNativeArray>>;

--- a/src/io/csv/reader.rs
+++ b/src/io/csv/reader.rs
@@ -19,7 +19,10 @@ pub struct CSVReaderOptions {
 
 impl CSVReaderOptions {
     pub fn new(coord_type: CoordType, batch_size: usize) -> Self {
-        Self { coord_type, batch_size }
+        Self {
+            coord_type,
+            batch_size,
+        }
     }
 }
 
@@ -30,10 +33,22 @@ impl Default for CSVReaderOptions {
 }
 
 /// Read a CSV file to a Table
-pub fn read_csv<R: Read>(reader: R, geometry_column_name: &str, options: CSVReaderOptions) -> Result<Table> {
+pub fn read_csv<R: Read>(
+    reader: R,
+    geometry_column_name: &str,
+    options: CSVReaderOptions,
+) -> Result<Table> {
     let mut csv = CsvReader::new(geometry_column_name, reader);
-    let table_builder_options = GeoTableBuilderOptions::new(options.coord_type, true, Some(options.batch_size), None, None, Default::default());
-    let mut geo_table = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(table_builder_options);
+    let table_builder_options = GeoTableBuilderOptions::new(
+        options.coord_type,
+        true,
+        Some(options.batch_size),
+        None,
+        None,
+        Default::default(),
+    );
+    let mut geo_table =
+        GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(table_builder_options);
     csv.process(&mut geo_table)?;
     geo_table.finish()
 }

--- a/src/io/csv/reader.rs
+++ b/src/io/csv/reader.rs
@@ -19,10 +19,7 @@ pub struct CSVReaderOptions {
 
 impl CSVReaderOptions {
     pub fn new(coord_type: CoordType, batch_size: usize) -> Self {
-        Self {
-            coord_type,
-            batch_size,
-        }
+        Self { coord_type, batch_size }
     }
 }
 
@@ -33,23 +30,10 @@ impl Default for CSVReaderOptions {
 }
 
 /// Read a CSV file to a Table
-pub fn read_csv<R: Read>(
-    reader: R,
-    geometry_column_name: &str,
-    options: CSVReaderOptions,
-) -> Result<Table> {
+pub fn read_csv<R: Read>(reader: R, geometry_column_name: &str, options: CSVReaderOptions) -> Result<Table> {
     let mut csv = CsvReader::new(geometry_column_name, reader);
-    let table_builder_options = GeoTableBuilderOptions::new(
-        options.coord_type,
-        true,
-        Some(options.batch_size),
-        None,
-        None,
-        Default::default(),
-    );
-    let mut geo_table = GeoTableBuilder::<MixedGeometryStreamBuilder<i32, 2>>::new_with_options(
-        table_builder_options,
-    );
+    let table_builder_options = GeoTableBuilderOptions::new(options.coord_type, true, Some(options.batch_size), None, None, Default::default());
+    let mut geo_table = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(table_builder_options);
     csv.process(&mut geo_table)?;
     geo_table.finish()
 }

--- a/src/io/display/array.rs
+++ b/src/io/display/array.rs
@@ -182,7 +182,7 @@ mod test {
     fn test_display_ls_array() {
         let array = linestring::large_ls_array();
         let result = array.to_string();
-        let expected = "LargeLineStringArray([
+        let expected = "LineStringArray([
     <LINESTRING(0 1,1 2)>,
     <LINESTRING(3 4,5 6)>,
 ])";

--- a/src/io/display/array.rs
+++ b/src/io/display/array.rs
@@ -8,7 +8,11 @@ pub(crate) fn indent(f: &mut fmt::Formatter<'_>, indented_spaces: usize) -> fmt:
     (0..indented_spaces).try_for_each(|_| f.write_char(' '))
 }
 
-pub(crate) fn write_indented_geom(f: &mut fmt::Formatter<'_>, geom: Option<geo::Geometry>, indented_spaces: usize) -> fmt::Result {
+pub(crate) fn write_indented_geom(
+    f: &mut fmt::Formatter<'_>,
+    geom: Option<geo::Geometry>,
+    indented_spaces: usize,
+) -> fmt::Result {
     indent(f, indented_spaces)?;
     if let Some(geom) = geom {
         write_geometry(f, geom, 80 - indented_spaces - 1)?;
@@ -20,7 +24,10 @@ pub(crate) fn write_indented_geom(f: &mut fmt::Formatter<'_>, geom: Option<geo::
     Ok(())
 }
 
-pub(crate) fn write_indented_ellipsis(f: &mut fmt::Formatter<'_>, indented_spaces: usize) -> fmt::Result {
+pub(crate) fn write_indented_ellipsis(
+    f: &mut fmt::Formatter<'_>,
+    indented_spaces: usize,
+) -> fmt::Result {
     indent(f, indented_spaces)?;
     writeln!(f, "...,")
 }
@@ -40,15 +47,27 @@ macro_rules! impl_fmt_non_generic {
 
                 if self.len() > 6 {
                     for maybe_geom in self.iter().take(3) {
-                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
+                        write_indented_geom(
+                            f,
+                            maybe_geom.map(|g| g.to_geo_geometry()),
+                            indented_spaces + 4,
+                        )?;
                     }
                     write_indented_ellipsis(f, indented_spaces + 4)?;
                     for maybe_geom in self.slice(self.len() - 3, 3).iter() {
-                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
+                        write_indented_geom(
+                            f,
+                            maybe_geom.map(|g| g.to_geo_geometry()),
+                            indented_spaces + 4,
+                        )?;
                     }
                 } else {
                     for maybe_geom in self.iter() {
-                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
+                        write_indented_geom(
+                            f,
+                            maybe_geom.map(|g| g.to_geo_geometry()),
+                            indented_spaces + 4,
+                        )?;
                     }
                 }
                 indent(f, indented_spaces)?;
@@ -72,15 +91,27 @@ macro_rules! impl_fmt_generic {
 
                 if self.len() > 6 {
                     for maybe_geom in self.iter().take(3) {
-                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
+                        write_indented_geom(
+                            f,
+                            maybe_geom.map(|g| g.to_geo_geometry()),
+                            indented_spaces + 4,
+                        )?;
                     }
                     write_indented_ellipsis(f, indented_spaces + 4)?;
                     for maybe_geom in self.slice(self.len() - 3, 3).iter() {
-                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
+                        write_indented_geom(
+                            f,
+                            maybe_geom.map(|g| g.to_geo_geometry()),
+                            indented_spaces + 4,
+                        )?;
                     }
                 } else {
                     for maybe_geom in self.iter() {
-                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
+                        write_indented_geom(
+                            f,
+                            maybe_geom.map(|g| g.to_geo_geometry()),
+                            indented_spaces + 4,
+                        )?;
                     }
                 }
                 indent(f, indented_spaces)?;
@@ -133,9 +164,7 @@ impl_fmt!(GeometryCollectionArray<2>, "GeometryCollectionArray");
 
 #[cfg(test)]
 mod test {
-    use crate::io::wkb::ToWKB;
     use crate::test::{linestring, point};
-    use crate::NativeArray;
 
     #[test]
     fn test_display_point_array() {
@@ -160,16 +189,16 @@ mod test {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_display_wkb_array() {
-        let array = point::point_array();
-        let wkb_array = array.as_ref().to_wkb::<i32>();
-        let result = wkb_array.to_string();
-        let expected = "WKBArray([
-    <POINT(0 1)>,
-    <POINT(1 2)>,
-    <POINT(2 3)>,
-])";
-        assert_eq!(result, expected);
-    }
+    //     #[test]
+    //     fn test_display_wkb_array() {
+    //         let array = point::point_array();
+    //         let wkb_array = array.as_ref().to_wkb::<i32>();
+    //         let result = wkb_array.to_string();
+    //         let expected = "WKBArray([
+    //     <POINT(0 1)>,
+    //     <POINT(1 2)>,
+    //     <POINT(2 3)>,
+    // ])";
+    //         assert_eq!(result, expected);
+    //     }
 }

--- a/src/io/display/array.rs
+++ b/src/io/display/array.rs
@@ -1,7 +1,5 @@
 use std::fmt::{self, Write};
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::*;
 use crate::io::display::scalar::write_geometry;
 use crate::trait_::{ArrayAccessor, NativeScalar};

--- a/src/io/display/array.rs
+++ b/src/io/display/array.rs
@@ -10,11 +10,7 @@ pub(crate) fn indent(f: &mut fmt::Formatter<'_>, indented_spaces: usize) -> fmt:
     (0..indented_spaces).try_for_each(|_| f.write_char(' '))
 }
 
-pub(crate) fn write_indented_geom(
-    f: &mut fmt::Formatter<'_>,
-    geom: Option<geo::Geometry>,
-    indented_spaces: usize,
-) -> fmt::Result {
+pub(crate) fn write_indented_geom(f: &mut fmt::Formatter<'_>, geom: Option<geo::Geometry>, indented_spaces: usize) -> fmt::Result {
     indent(f, indented_spaces)?;
     if let Some(geom) = geom {
         write_geometry(f, geom, 80 - indented_spaces - 1)?;
@@ -26,10 +22,7 @@ pub(crate) fn write_indented_geom(
     Ok(())
 }
 
-pub(crate) fn write_indented_ellipsis(
-    f: &mut fmt::Formatter<'_>,
-    indented_spaces: usize,
-) -> fmt::Result {
+pub(crate) fn write_indented_ellipsis(f: &mut fmt::Formatter<'_>, indented_spaces: usize) -> fmt::Result {
     indent(f, indented_spaces)?;
     writeln!(f, "...,")
 }
@@ -49,27 +42,15 @@ macro_rules! impl_fmt_non_generic {
 
                 if self.len() > 6 {
                     for maybe_geom in self.iter().take(3) {
-                        write_indented_geom(
-                            f,
-                            maybe_geom.map(|g| g.to_geo_geometry()),
-                            indented_spaces + 4,
-                        )?;
+                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
                     }
                     write_indented_ellipsis(f, indented_spaces + 4)?;
                     for maybe_geom in self.slice(self.len() - 3, 3).iter() {
-                        write_indented_geom(
-                            f,
-                            maybe_geom.map(|g| g.to_geo_geometry()),
-                            indented_spaces + 4,
-                        )?;
+                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
                     }
                 } else {
                     for maybe_geom in self.iter() {
-                        write_indented_geom(
-                            f,
-                            maybe_geom.map(|g| g.to_geo_geometry()),
-                            indented_spaces + 4,
-                        )?;
+                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
                     }
                 }
                 indent(f, indented_spaces)?;
@@ -85,36 +66,23 @@ impl_fmt_non_generic!(RectArray<2>, "RectArray");
 
 macro_rules! impl_fmt_generic {
     ($struct_name:ty, $str_literal:tt) => {
-        impl<O: OffsetSizeTrait> WriteArray for $struct_name {
+        impl WriteArray for $struct_name {
             fn write(&self, f: &mut fmt::Formatter<'_>, indented_spaces: usize) -> fmt::Result {
                 indent(f, indented_spaces)?;
-                f.write_str(O::PREFIX)?;
                 f.write_str($str_literal)?;
                 writeln!(f, "([")?;
 
                 if self.len() > 6 {
                     for maybe_geom in self.iter().take(3) {
-                        write_indented_geom(
-                            f,
-                            maybe_geom.map(|g| g.to_geo_geometry()),
-                            indented_spaces + 4,
-                        )?;
+                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
                     }
                     write_indented_ellipsis(f, indented_spaces + 4)?;
                     for maybe_geom in self.slice(self.len() - 3, 3).iter() {
-                        write_indented_geom(
-                            f,
-                            maybe_geom.map(|g| g.to_geo_geometry()),
-                            indented_spaces + 4,
-                        )?;
+                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
                     }
                 } else {
                     for maybe_geom in self.iter() {
-                        write_indented_geom(
-                            f,
-                            maybe_geom.map(|g| g.to_geo_geometry()),
-                            indented_spaces + 4,
-                        )?;
+                        write_indented_geom(f, maybe_geom.map(|g| g.to_geo_geometry()), indented_spaces + 4)?;
                     }
                 }
                 indent(f, indented_spaces)?;
@@ -125,14 +93,14 @@ macro_rules! impl_fmt_generic {
     };
 }
 
-impl_fmt_generic!(LineStringArray<O, 2>, "LineStringArray");
-impl_fmt_generic!(PolygonArray<O, 2>, "PolygonArray");
-impl_fmt_generic!(MultiPointArray<O, 2>, "MultiPointArray");
-impl_fmt_generic!(MultiLineStringArray<O, 2>, "MultiLineStringArray");
-impl_fmt_generic!(MultiPolygonArray<O, 2>, "MultiPolygonArray");
-impl_fmt_generic!(MixedGeometryArray<O, 2>, "MixedGeometryArray");
-impl_fmt_generic!(GeometryCollectionArray<O, 2>, "GeometryCollectionArray");
-impl_fmt_generic!(WKBArray<O>, "WKBArray");
+impl_fmt_generic!(LineStringArray<2>, "LineStringArray");
+impl_fmt_generic!(PolygonArray<2>, "PolygonArray");
+impl_fmt_generic!(MultiPointArray<2>, "MultiPointArray");
+impl_fmt_generic!(MultiLineStringArray<2>, "MultiLineStringArray");
+impl_fmt_generic!(MultiPolygonArray<2>, "MultiPolygonArray");
+impl_fmt_generic!(MixedGeometryArray<2>, "MixedGeometryArray");
+impl_fmt_generic!(GeometryCollectionArray<2>, "GeometryCollectionArray");
+// impl_fmt_generic!(WKBArray<O>, "WKBArray");
 
 impl fmt::Display for PointArray<2> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -148,7 +116,7 @@ impl fmt::Display for RectArray<2> {
 
 macro_rules! impl_fmt {
     ($struct_name:ty, $str_literal:tt) => {
-        impl<O: OffsetSizeTrait> fmt::Display for $struct_name {
+        impl fmt::Display for $struct_name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 self.write(f, 0)
             }
@@ -156,14 +124,14 @@ macro_rules! impl_fmt {
     };
 }
 
-impl_fmt!(LineStringArray<O, 2>, "LineStringArray");
-impl_fmt!(PolygonArray<O, 2>, "PolygonArray");
-impl_fmt!(MultiPointArray<O, 2>, "MultiPointArray");
-impl_fmt!(MultiLineStringArray<O, 2>, "MultiLineStringArray");
-impl_fmt!(MultiPolygonArray<O, 2>, "MultiPolygonArray");
-impl_fmt!(MixedGeometryArray<O, 2>, "MixedGeometryArray");
-impl_fmt!(GeometryCollectionArray<O, 2>, "GeometryCollectionArray");
-impl_fmt!(WKBArray<O>, "WKBArray");
+impl_fmt!(LineStringArray<2>, "LineStringArray");
+impl_fmt!(PolygonArray<2>, "PolygonArray");
+impl_fmt!(MultiPointArray<2>, "MultiPointArray");
+impl_fmt!(MultiLineStringArray<2>, "MultiLineStringArray");
+impl_fmt!(MultiPolygonArray<2>, "MultiPolygonArray");
+impl_fmt!(MixedGeometryArray<2>, "MixedGeometryArray");
+impl_fmt!(GeometryCollectionArray<2>, "GeometryCollectionArray");
+// impl_fmt!(WKBArray<O>, "WKBArray");
 
 #[cfg(test)]
 mod test {

--- a/src/io/display/chunked_array.rs
+++ b/src/io/display/chunked_array.rs
@@ -88,10 +88,16 @@ macro_rules! impl_fmt_generic {
 impl_fmt_generic!(ChunkedLineStringArray<2>, "ChunkedLineStringArray");
 impl_fmt_generic!(ChunkedPolygonArray<2>, "ChunkedPolygonArray");
 impl_fmt_generic!(ChunkedMultiPointArray<2>, "ChunkedMultiPointArray");
-impl_fmt_generic!(ChunkedMultiLineStringArray<2>, "ChunkedMultiLineStringArray");
+impl_fmt_generic!(
+    ChunkedMultiLineStringArray<2>,
+    "ChunkedMultiLineStringArray"
+);
 impl_fmt_generic!(ChunkedMultiPolygonArray<2>, "ChunkedMultiPolygonArray");
 impl_fmt_generic!(ChunkedMixedGeometryArray<2>, "ChunkedMixedGeometryArray");
-impl_fmt_generic!(ChunkedGeometryCollectionArray<2>, "ChunkedGeometryCollectionArray");
+impl_fmt_generic!(
+    ChunkedGeometryCollectionArray<2>,
+    "ChunkedGeometryCollectionArray"
+);
 // impl_fmt_generic!(ChunkedWKBArray<O>, "ChunkedWKBArray");
 
 #[cfg(test)]

--- a/src/io/display/chunked_array.rs
+++ b/src/io/display/chunked_array.rs
@@ -59,9 +59,8 @@ impl fmt::Display for ChunkedRectArray<2> {
 
 macro_rules! impl_fmt_generic {
     ($struct_name:ty, $str_literal:tt) => {
-        impl<O: OffsetSizeTrait> fmt::Display for $struct_name {
+        impl fmt::Display for $struct_name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.write_str(O::PREFIX)?;
                 f.write_str($str_literal)?;
                 writeln!(f, "([")?;
 
@@ -88,19 +87,13 @@ macro_rules! impl_fmt_generic {
     };
 }
 
-impl_fmt_generic!(ChunkedLineStringArray<O, 2>, "ChunkedLineStringArray");
-impl_fmt_generic!(ChunkedPolygonArray<O, 2>, "ChunkedPolygonArray");
-impl_fmt_generic!(ChunkedMultiPointArray<O, 2>, "ChunkedMultiPointArray");
-impl_fmt_generic!(
-    ChunkedMultiLineStringArray<O, 2>,
-    "ChunkedMultiLineStringArray"
-);
-impl_fmt_generic!(ChunkedMultiPolygonArray<O, 2>, "ChunkedMultiPolygonArray");
-impl_fmt_generic!(ChunkedMixedGeometryArray<O, 2>, "ChunkedMixedGeometryArray");
-impl_fmt_generic!(
-    ChunkedGeometryCollectionArray<O, 2>,
-    "ChunkedGeometryCollectionArray"
-);
+impl_fmt_generic!(ChunkedLineStringArray<2>, "ChunkedLineStringArray");
+impl_fmt_generic!(ChunkedPolygonArray<2>, "ChunkedPolygonArray");
+impl_fmt_generic!(ChunkedMultiPointArray<2>, "ChunkedMultiPointArray");
+impl_fmt_generic!(ChunkedMultiLineStringArray<2>, "ChunkedMultiLineStringArray");
+impl_fmt_generic!(ChunkedMultiPolygonArray<2>, "ChunkedMultiPolygonArray");
+impl_fmt_generic!(ChunkedMixedGeometryArray<2>, "ChunkedMixedGeometryArray");
+impl_fmt_generic!(ChunkedGeometryCollectionArray<2>, "ChunkedGeometryCollectionArray");
 // impl_fmt_generic!(ChunkedWKBArray<O>, "ChunkedWKBArray");
 
 #[cfg(test)]

--- a/src/io/display/chunked_array.rs
+++ b/src/io/display/chunked_array.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use arrow_array::OffsetSizeTrait;
-
 use crate::chunked_array::*;
 use crate::io::display::array::{write_indented_ellipsis, WriteArray};
 

--- a/src/io/display/scalar.rs
+++ b/src/io/display/scalar.rs
@@ -10,15 +10,8 @@ use crate::trait_::NativeScalar;
 /// Write geometry to display formatter
 /// This takes inspiration from Shapely, which prints a max of 80 characters for the geometry:
 /// https://github.com/shapely/shapely/blob/c3ddf310f108a7f589d763d613d755ac12ab5d4f/shapely/geometry/base.py#L163-L177
-pub(crate) fn write_geometry(
-    f: &mut fmt::Formatter<'_>,
-    mut geom: geo::Geometry,
-    max_chars: usize,
-) -> fmt::Result {
-    geom.map_coords_in_place(|geo::Coord { x, y }| geo::Coord {
-        x: (x * 1000.0).trunc() / 1000.0,
-        y: (y * 1000.0).trunc() / 1000.0,
-    });
+pub(crate) fn write_geometry(f: &mut fmt::Formatter<'_>, mut geom: geo::Geometry, max_chars: usize) -> fmt::Result {
+    geom.map_coords_in_place(|geo::Coord { x, y }| geo::Coord { x: (x * 1000.0).trunc() / 1000.0, y: (y * 1000.0).trunc() / 1000.0 });
 
     let wkt = geom.to_wkt().unwrap();
 
@@ -51,7 +44,7 @@ impl fmt::Display for Rect<'_, 2> {
 
 macro_rules! impl_fmt {
     ($struct_name:ty) => {
-        impl<O: OffsetSizeTrait> fmt::Display for $struct_name {
+        impl fmt::Display for $struct_name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write_geometry(f, self.to_geo_geometry(), 80)
             }
@@ -59,14 +52,14 @@ macro_rules! impl_fmt {
     };
 }
 
-impl_fmt!(LineString<'_, O, 2>);
-impl_fmt!(Polygon<'_, O, 2>);
-impl_fmt!(MultiPoint<'_, O, 2>);
-impl_fmt!(MultiLineString<'_, O, 2>);
-impl_fmt!(MultiPolygon<'_, O, 2>);
-impl_fmt!(GeometryCollection<'_, O, 2>);
+impl_fmt!(LineString<'_, 2>);
+impl_fmt!(Polygon<'_, 2>);
+impl_fmt!(MultiPoint<'_, 2>);
+impl_fmt!(MultiLineString<'_, 2>);
+impl_fmt!(MultiPolygon<'_, 2>);
+impl_fmt!(GeometryCollection<'_, 2>);
 
-impl<O: OffsetSizeTrait> fmt::Display for Geometry<'_, O, 2> {
+impl fmt::Display for Geometry<'_, 2> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_geometry(f, self.to_geo_geometry(), 80)
     }
@@ -110,8 +103,7 @@ mod test {
     fn test_display_multipolygon() {
         let multipolygon_array = multipolygon::mp_array();
         let result = multipolygon_array.value(0).to_string();
-        let expected =
-            "<MULTIPOLYGON(((-111 45,-111 41,-104 41,-104 45,-111 45)),((-111 45,-111 41,...>";
+        let expected = "<MULTIPOLYGON(((-111 45,-111 41,-104 41,-104 45,-111 45)),((-111 45,-111 41,...>";
         assert_eq!(result, expected);
     }
 

--- a/src/io/display/scalar.rs
+++ b/src/io/display/scalar.rs
@@ -10,8 +10,15 @@ use crate::trait_::NativeScalar;
 /// Write geometry to display formatter
 /// This takes inspiration from Shapely, which prints a max of 80 characters for the geometry:
 /// https://github.com/shapely/shapely/blob/c3ddf310f108a7f589d763d613d755ac12ab5d4f/shapely/geometry/base.py#L163-L177
-pub(crate) fn write_geometry(f: &mut fmt::Formatter<'_>, mut geom: geo::Geometry, max_chars: usize) -> fmt::Result {
-    geom.map_coords_in_place(|geo::Coord { x, y }| geo::Coord { x: (x * 1000.0).trunc() / 1000.0, y: (y * 1000.0).trunc() / 1000.0 });
+pub(crate) fn write_geometry(
+    f: &mut fmt::Formatter<'_>,
+    mut geom: geo::Geometry,
+    max_chars: usize,
+) -> fmt::Result {
+    geom.map_coords_in_place(|geo::Coord { x, y }| geo::Coord {
+        x: (x * 1000.0).trunc() / 1000.0,
+        y: (y * 1000.0).trunc() / 1000.0,
+    });
 
     let wkt = geom.to_wkt().unwrap();
 
@@ -103,7 +110,8 @@ mod test {
     fn test_display_multipolygon() {
         let multipolygon_array = multipolygon::mp_array();
         let result = multipolygon_array.value(0).to_string();
-        let expected = "<MULTIPOLYGON(((-111 45,-111 41,-104 41,-104 45,-111 45)),((-111 45,-111 41,...>";
+        let expected =
+            "<MULTIPOLYGON(((-111 45,-111 41,-104 41,-104 45,-111 45)),((-111 45,-111 41,...>";
         assert_eq!(result, expected);
     }
 

--- a/src/io/flatgeobuf/reader/async.rs
+++ b/src/io/flatgeobuf/reader/async.rs
@@ -14,49 +14,28 @@ use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::io::geozero::table::{GeoTableBuilder, GeoTableBuilderOptions};
 use crate::table::Table;
 
-pub async fn read_flatgeobuf_async(
-    reader: Arc<dyn ObjectStore>,
-    location: Path,
-    options: FlatGeobufReaderOptions,
-) -> Result<Table> {
+pub async fn read_flatgeobuf_async(reader: Arc<dyn ObjectStore>, location: Path, options: FlatGeobufReaderOptions) -> Result<Table> {
     let head = reader.head(&location).await?;
 
-    let object_store_wrapper = ObjectStoreWrapper {
-        reader,
-        location,
-        size: head.size,
-    };
+    let object_store_wrapper = ObjectStoreWrapper { reader, location, size: head.size };
     let async_client = AsyncBufferedHttpRangeClient::with(object_store_wrapper, "");
 
     let reader = HttpFgbReader::new(async_client).await.unwrap();
 
     let header = reader.header();
     if header.has_m() | header.has_t() | header.has_tm() | header.has_z() {
-        return Err(GeoArrowError::General(
-            "Only XY dimensions are supported".to_string(),
-        ));
+        return Err(GeoArrowError::General("Only XY dimensions are supported".to_string()));
     }
 
     let schema = infer_schema(header);
     let geometry_type = header.geometry_type();
 
-    let mut selection = if let Some((min_x, min_y, max_x, max_y)) = options.bbox {
-        reader.select_bbox(min_x, min_y, max_x, max_y).await?
-    } else {
-        reader.select_all().await?
-    };
+    let mut selection = if let Some((min_x, min_y, max_x, max_y)) = options.bbox { reader.select_bbox(min_x, min_y, max_x, max_y).await? } else { reader.select_all().await? };
 
     let features_count = selection.features_count();
 
     // TODO: propagate CRS
-    let options = GeoTableBuilderOptions::new(
-        options.coord_type,
-        true,
-        options.batch_size,
-        Some(Arc::new(schema.finish())),
-        features_count,
-        Default::default(),
-    );
+    let options = GeoTableBuilderOptions::new(options.coord_type, true, options.batch_size, Some(Arc::new(schema.finish())), features_count, Default::default());
 
     match geometry_type {
         GeometryType::Point => {
@@ -65,46 +44,38 @@ pub async fn read_flatgeobuf_async(
             builder.finish()
         }
         GeometryType::LineString => {
-            let mut builder =
-                GeoTableBuilder::<LineStringBuilder<i32, 2>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<LineStringBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::Polygon => {
-            let mut builder = GeoTableBuilder::<PolygonBuilder<i32, 2>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<PolygonBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::MultiPoint => {
-            let mut builder =
-                GeoTableBuilder::<MultiPointBuilder<i32, 2>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MultiPointBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::MultiLineString => {
-            let mut builder =
-                GeoTableBuilder::<MultiLineStringBuilder<i32, 2>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MultiLineStringBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::MultiPolygon => {
-            let mut builder =
-                GeoTableBuilder::<MultiPolygonBuilder<i32, 2>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MultiPolygonBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
         GeometryType::Unknown => {
-            let mut builder =
-                GeoTableBuilder::<MixedGeometryStreamBuilder<i32, 2>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             let table = builder.finish()?;
             table.downcast(true)
         }
         // TODO: Parse into a GeometryCollection array and then downcast to a single-typed array if possible.
-        geom_type => Err(GeoArrowError::NotYetImplemented(format!(
-            "Parsing FlatGeobuf from {:?} geometry type not yet supported",
-            geom_type
-        ))),
+        geom_type => Err(GeoArrowError::NotYetImplemented(format!("Parsing FlatGeobuf from {:?} geometry type not yet supported", geom_type))),
     }
 }
 
@@ -119,24 +90,15 @@ mod test {
     async fn test_countries() {
         let fs = Arc::new(LocalFileSystem::new_with_prefix(current_dir().unwrap()).unwrap());
         let options = FlatGeobufReaderOptions::default();
-        let table =
-            read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/countries.fgb"), options)
-                .await
-                .unwrap();
+        let table = read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/countries.fgb"), options).await.unwrap();
         assert_eq!(table.len(), 179);
     }
 
     #[tokio::test]
     async fn test_countries_bbox() {
         let fs = Arc::new(LocalFileSystem::new_with_prefix(current_dir().unwrap()).unwrap());
-        let options = FlatGeobufReaderOptions {
-            bbox: Some((0., -90., 180., 90.)),
-            ..Default::default()
-        };
-        let table =
-            read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/countries.fgb"), options)
-                .await
-                .unwrap();
+        let options = FlatGeobufReaderOptions { bbox: Some((0., -90., 180., 90.)), ..Default::default() };
+        let table = read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/countries.fgb"), options).await.unwrap();
         assert_eq!(table.len(), 133);
     }
 
@@ -144,12 +106,6 @@ mod test {
     async fn test_nz_buildings() {
         let fs = Arc::new(LocalFileSystem::new_with_prefix(current_dir().unwrap()).unwrap());
         let options = FlatGeobufReaderOptions::default();
-        let _table = read_flatgeobuf_async(
-            fs,
-            Path::from("fixtures/flatgeobuf/nz-building-outlines-small.fgb"),
-            options,
-        )
-        .await
-        .unwrap();
+        let _table = read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/nz-building-outlines-small.fgb"), options).await.unwrap();
     }
 }

--- a/src/io/flatgeobuf/reader/async.rs
+++ b/src/io/flatgeobuf/reader/async.rs
@@ -14,28 +14,49 @@ use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::io::geozero::table::{GeoTableBuilder, GeoTableBuilderOptions};
 use crate::table::Table;
 
-pub async fn read_flatgeobuf_async(reader: Arc<dyn ObjectStore>, location: Path, options: FlatGeobufReaderOptions) -> Result<Table> {
+pub async fn read_flatgeobuf_async(
+    reader: Arc<dyn ObjectStore>,
+    location: Path,
+    options: FlatGeobufReaderOptions,
+) -> Result<Table> {
     let head = reader.head(&location).await?;
 
-    let object_store_wrapper = ObjectStoreWrapper { reader, location, size: head.size };
+    let object_store_wrapper = ObjectStoreWrapper {
+        reader,
+        location,
+        size: head.size,
+    };
     let async_client = AsyncBufferedHttpRangeClient::with(object_store_wrapper, "");
 
     let reader = HttpFgbReader::new(async_client).await.unwrap();
 
     let header = reader.header();
     if header.has_m() | header.has_t() | header.has_tm() | header.has_z() {
-        return Err(GeoArrowError::General("Only XY dimensions are supported".to_string()));
+        return Err(GeoArrowError::General(
+            "Only XY dimensions are supported".to_string(),
+        ));
     }
 
     let schema = infer_schema(header);
     let geometry_type = header.geometry_type();
 
-    let mut selection = if let Some((min_x, min_y, max_x, max_y)) = options.bbox { reader.select_bbox(min_x, min_y, max_x, max_y).await? } else { reader.select_all().await? };
+    let mut selection = if let Some((min_x, min_y, max_x, max_y)) = options.bbox {
+        reader.select_bbox(min_x, min_y, max_x, max_y).await?
+    } else {
+        reader.select_all().await?
+    };
 
     let features_count = selection.features_count();
 
     // TODO: propagate CRS
-    let options = GeoTableBuilderOptions::new(options.coord_type, true, options.batch_size, Some(Arc::new(schema.finish())), features_count, Default::default());
+    let options = GeoTableBuilderOptions::new(
+        options.coord_type,
+        true,
+        options.batch_size,
+        Some(Arc::new(schema.finish())),
+        features_count,
+        Default::default(),
+    );
 
     match geometry_type {
         GeometryType::Point => {
@@ -59,7 +80,8 @@ pub async fn read_flatgeobuf_async(reader: Arc<dyn ObjectStore>, location: Path,
             builder.finish()
         }
         GeometryType::MultiLineString => {
-            let mut builder = GeoTableBuilder::<MultiLineStringBuilder<2>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MultiLineStringBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             builder.finish()
         }
@@ -69,13 +91,17 @@ pub async fn read_flatgeobuf_async(reader: Arc<dyn ObjectStore>, location: Path,
             builder.finish()
         }
         GeometryType::Unknown => {
-            let mut builder = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder).await?;
             let table = builder.finish()?;
             table.downcast(true)
         }
         // TODO: Parse into a GeometryCollection array and then downcast to a single-typed array if possible.
-        geom_type => Err(GeoArrowError::NotYetImplemented(format!("Parsing FlatGeobuf from {:?} geometry type not yet supported", geom_type))),
+        geom_type => Err(GeoArrowError::NotYetImplemented(format!(
+            "Parsing FlatGeobuf from {:?} geometry type not yet supported",
+            geom_type
+        ))),
     }
 }
 
@@ -90,15 +116,24 @@ mod test {
     async fn test_countries() {
         let fs = Arc::new(LocalFileSystem::new_with_prefix(current_dir().unwrap()).unwrap());
         let options = FlatGeobufReaderOptions::default();
-        let table = read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/countries.fgb"), options).await.unwrap();
+        let table =
+            read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/countries.fgb"), options)
+                .await
+                .unwrap();
         assert_eq!(table.len(), 179);
     }
 
     #[tokio::test]
     async fn test_countries_bbox() {
         let fs = Arc::new(LocalFileSystem::new_with_prefix(current_dir().unwrap()).unwrap());
-        let options = FlatGeobufReaderOptions { bbox: Some((0., -90., 180., 90.)), ..Default::default() };
-        let table = read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/countries.fgb"), options).await.unwrap();
+        let options = FlatGeobufReaderOptions {
+            bbox: Some((0., -90., 180., 90.)),
+            ..Default::default()
+        };
+        let table =
+            read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/countries.fgb"), options)
+                .await
+                .unwrap();
         assert_eq!(table.len(), 133);
     }
 
@@ -106,6 +141,12 @@ mod test {
     async fn test_nz_buildings() {
         let fs = Arc::new(LocalFileSystem::new_with_prefix(current_dir().unwrap()).unwrap());
         let options = FlatGeobufReaderOptions::default();
-        let _table = read_flatgeobuf_async(fs, Path::from("fixtures/flatgeobuf/nz-building-outlines-small.fgb"), options).await.unwrap();
+        let _table = read_flatgeobuf_async(
+            fs,
+            Path::from("fixtures/flatgeobuf/nz-building-outlines-small.fgb"),
+            options,
+        )
+        .await
+        .unwrap();
     }
 }

--- a/src/io/flatgeobuf/reader/sync.rs
+++ b/src/io/flatgeobuf/reader/sync.rs
@@ -31,23 +31,39 @@ use std::io::{Read, Seek};
 use std::sync::Arc;
 
 /// Read a FlatGeobuf file to a Table
-pub fn read_flatgeobuf<R: Read + Seek>(file: &mut R, options: FlatGeobufReaderOptions) -> Result<Table> {
+pub fn read_flatgeobuf<R: Read + Seek>(
+    file: &mut R,
+    options: FlatGeobufReaderOptions,
+) -> Result<Table> {
     let reader = FgbReader::open(file)?;
 
     let header = reader.header();
     if header.has_m() | header.has_t() | header.has_tm() | header.has_z() {
-        return Err(GeoArrowError::General("Only XY dimensions are supported".to_string()));
+        return Err(GeoArrowError::General(
+            "Only XY dimensions are supported".to_string(),
+        ));
     }
 
     let schema = infer_schema(header);
     let geometry_type = header.geometry_type();
 
-    let mut selection = if let Some((min_x, min_y, max_x, max_y)) = options.bbox { reader.select_bbox(min_x, min_y, max_x, max_y)? } else { reader.select_all()? };
+    let mut selection = if let Some((min_x, min_y, max_x, max_y)) = options.bbox {
+        reader.select_bbox(min_x, min_y, max_x, max_y)?
+    } else {
+        reader.select_all()?
+    };
 
     let features_count = selection.features_count();
 
     // TODO: propagate CRS
-    let options = GeoTableBuilderOptions::new(options.coord_type, true, options.batch_size, Some(Arc::new(schema.finish())), features_count, Default::default());
+    let options = GeoTableBuilderOptions::new(
+        options.coord_type,
+        true,
+        options.batch_size,
+        Some(Arc::new(schema.finish())),
+        features_count,
+        Default::default(),
+    );
 
     match geometry_type {
         GeometryType::Point => {
@@ -71,7 +87,8 @@ pub fn read_flatgeobuf<R: Read + Seek>(file: &mut R, options: FlatGeobufReaderOp
             builder.finish()
         }
         GeometryType::MultiLineString => {
-            let mut builder = GeoTableBuilder::<MultiLineStringBuilder<2>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MultiLineStringBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder)?;
             builder.finish()
         }
@@ -81,13 +98,17 @@ pub fn read_flatgeobuf<R: Read + Seek>(file: &mut R, options: FlatGeobufReaderOp
             builder.finish()
         }
         GeometryType::Unknown => {
-            let mut builder = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
             selection.process_features(&mut builder)?;
             let table = builder.finish()?;
             table.downcast(true)
         }
         // TODO: Parse into a GeometryCollection array and then downcast to a single-typed array if possible.
-        geom_type => Err(GeoArrowError::NotYetImplemented(format!("Parsing FlatGeobuf from {:?} geometry type not yet supported", geom_type))),
+        geom_type => Err(GeoArrowError::NotYetImplemented(format!(
+            "Parsing FlatGeobuf from {:?} geometry type not yet supported",
+            geom_type
+        ))),
     }
 }
 
@@ -106,7 +127,9 @@ mod test {
 
     #[test]
     fn test_nz_buildings() {
-        let mut filein = BufReader::new(File::open("fixtures/flatgeobuf/nz-building-outlines-small.fgb").unwrap());
+        let mut filein = BufReader::new(
+            File::open("fixtures/flatgeobuf/nz-building-outlines-small.fgb").unwrap(),
+        );
         let _table = read_flatgeobuf(&mut filein, Default::default()).unwrap();
     }
 }

--- a/src/io/geojson/reader.rs
+++ b/src/io/geojson/reader.rs
@@ -20,8 +20,7 @@ pub fn read_geojson<R: Read>(reader: R, batch_size: Option<usize>) -> Result<Tab
         None,
         Default::default(),
     );
-    let mut geo_table =
-        GeoTableBuilder::<MixedGeometryStreamBuilder<i32, 2>>::new_with_options(options);
+    let mut geo_table = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
     geojson.process(&mut geo_table)?;
     geo_table.finish()
 }

--- a/src/io/geojson_lines/reader.rs
+++ b/src/io/geojson_lines/reader.rs
@@ -24,8 +24,7 @@ pub fn read_geojson_lines<R: BufRead>(reader: R, batch_size: Option<usize>) -> R
         None,
         Default::default(),
     );
-    let mut geo_table =
-        GeoTableBuilder::<MixedGeometryStreamBuilder<i32, 2>>::new_with_options(options);
+    let mut geo_table = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
     geojson_line_reader.process(&mut geo_table)?;
     geo_table.finish()
 }

--- a/src/io/geos/array/geometrycollection.rs
+++ b/src/io/geos/array/geometrycollection.rs
@@ -1,26 +1,17 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::{GeometryCollectionArray, GeometryCollectionBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometryCollection;
 
-impl<const D: usize> TryFrom<Vec<geos::Geometry>>
-    for GeometryCollectionBuilder<D>
-{
+impl<const D: usize> TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
-        let geoms: Vec<GEOSGeometryCollection> = value
-            .into_iter()
-            .map(GEOSGeometryCollection::new_unchecked)
-            .collect();
+        let geoms: Vec<GEOSGeometryCollection> = value.into_iter().map(GEOSGeometryCollection::new_unchecked).collect();
         Self::from_geometry_collections(&geoms, Default::default(), Default::default(), false)
     }
 }
 
-impl<const D: usize> TryFrom<Vec<geos::Geometry>>
-    for GeometryCollectionArray<D>
-{
+impl<const D: usize> TryFrom<Vec<geos::Geometry>> for GeometryCollectionArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {

--- a/src/io/geos/array/geometrycollection.rs
+++ b/src/io/geos/array/geometrycollection.rs
@@ -4,8 +4,8 @@ use crate::array::{GeometryCollectionArray, GeometryCollectionBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometryCollection;
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>>
-    for GeometryCollectionBuilder<O, D>
+impl<const D: usize> TryFrom<Vec<geos::Geometry>>
+    for GeometryCollectionBuilder<D>
 {
     type Error = GeoArrowError;
 
@@ -18,13 +18,13 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>>
-    for GeometryCollectionArray<O, D>
+impl<const D: usize> TryFrom<Vec<geos::Geometry>>
+    for GeometryCollectionArray<D>
 {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: GeometryCollectionBuilder<O, D> = value.try_into()?;
+        let mutable_arr: GeometryCollectionBuilder<D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/geometrycollection.rs
+++ b/src/io/geos/array/geometrycollection.rs
@@ -6,7 +6,10 @@ impl<const D: usize> TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder<
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
-        let geoms: Vec<GEOSGeometryCollection> = value.into_iter().map(GEOSGeometryCollection::new_unchecked).collect();
+        let geoms: Vec<GEOSGeometryCollection> = value
+            .into_iter()
+            .map(GEOSGeometryCollection::new_unchecked)
+            .collect();
         Self::from_geometry_collections(&geoms, Default::default(), Default::default(), false)
     }
 }

--- a/src/io/geos/array/linestring.rs
+++ b/src/io/geos/array/linestring.rs
@@ -1,27 +1,18 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::{LineStringArray, LineStringBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSLineString;
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for LineStringBuilder<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for LineStringBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSLineString>> = value
-            .into_iter()
-            .map(|geom| geom.map(GEOSLineString::new_unchecked))
-            .collect();
+        let geos_objects: Vec<Option<GEOSLineString>> = value.into_iter().map(|geom| geom.map(GEOSLineString::new_unchecked)).collect();
         Ok(geos_objects.into())
     }
 }
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for LineStringArray<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for LineStringArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
@@ -40,11 +31,8 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = ls_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr
-            .iter()
-            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-            .collect();
-        let round_trip: LineStringArray<i32, 2> = geos_geoms.try_into().unwrap();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
+        let round_trip: LineStringArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/linestring.rs
+++ b/src/io/geos/array/linestring.rs
@@ -7,7 +7,10 @@ impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for LineStringBuilder<
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSLineString>> = value.into_iter().map(|geom| geom.map(GEOSLineString::new_unchecked)).collect();
+        let geos_objects: Vec<Option<GEOSLineString>> = value
+            .into_iter()
+            .map(|geom| geom.map(GEOSLineString::new_unchecked))
+            .collect();
         Ok(geos_objects.into())
     }
 }
@@ -31,7 +34,10 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = ls_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
         let round_trip: LineStringArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }

--- a/src/io/geos/array/linestring.rs
+++ b/src/io/geos/array/linestring.rs
@@ -4,8 +4,8 @@ use crate::array::{LineStringArray, LineStringBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSLineString;
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for LineStringBuilder<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for LineStringBuilder<D>
 {
     type Error = GeoArrowError;
 
@@ -19,13 +19,13 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for LineStringArray<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for LineStringArray<D>
 {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: LineStringBuilder<O, D> = value.try_into()?;
+        let mutable_arr: LineStringBuilder<D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/mixed.rs
+++ b/src/io/geos/array/mixed.rs
@@ -4,8 +4,8 @@ use crate::array::{MixedGeometryArray, MixedGeometryBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometry;
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>>
-    for MixedGeometryBuilder<O, D>
+impl<const D: usize> TryFrom<Vec<geos::Geometry>>
+    for MixedGeometryBuilder<D>
 {
     type Error = GeoArrowError;
 
@@ -15,11 +15,11 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<geos::Geometry>> for MixedGeometryArray<O, D> {
+impl<const D: usize> TryFrom<Vec<geos::Geometry>> for MixedGeometryArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: MixedGeometryBuilder<O, D> = value.try_into()?;
+        let mutable_arr: MixedGeometryBuilder<D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/mixed.rs
+++ b/src/io/geos/array/mixed.rs
@@ -1,12 +1,8 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::{MixedGeometryArray, MixedGeometryBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometry;
 
-impl<const D: usize> TryFrom<Vec<geos::Geometry>>
-    for MixedGeometryBuilder<D>
-{
+impl<const D: usize> TryFrom<Vec<geos::Geometry>> for MixedGeometryBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {

--- a/src/io/geos/array/multilinestring.rs
+++ b/src/io/geos/array/multilinestring.rs
@@ -4,8 +4,8 @@ use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSMultiLineString;
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiLineStringBuilder<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiLineStringBuilder<D>
 {
     type Error = GeoArrowError;
 
@@ -19,13 +19,13 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiLineStringArray<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiLineStringArray<D>
 {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: MultiLineStringBuilder<O, D> = value.try_into()?;
+        let mutable_arr: MultiLineStringBuilder<D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/multilinestring.rs
+++ b/src/io/geos/array/multilinestring.rs
@@ -7,7 +7,10 @@ impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringBui
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSMultiLineString>> = value.into_iter().map(|geom| geom.map(GEOSMultiLineString::new_unchecked)).collect();
+        let geos_objects: Vec<Option<GEOSMultiLineString>> = value
+            .into_iter()
+            .map(|geom| geom.map(GEOSMultiLineString::new_unchecked))
+            .collect();
         Ok(geos_objects.into())
     }
 }
@@ -31,7 +34,10 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = ml_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
         let round_trip: MultiLineStringArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }

--- a/src/io/geos/array/multilinestring.rs
+++ b/src/io/geos/array/multilinestring.rs
@@ -1,27 +1,18 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSMultiLineString;
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiLineStringBuilder<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSMultiLineString>> = value
-            .into_iter()
-            .map(|geom| geom.map(GEOSMultiLineString::new_unchecked))
-            .collect();
+        let geos_objects: Vec<Option<GEOSMultiLineString>> = value.into_iter().map(|geom| geom.map(GEOSMultiLineString::new_unchecked)).collect();
         Ok(geos_objects.into())
     }
 }
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiLineStringArray<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiLineStringArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -40,11 +31,8 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = ml_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr
-            .iter()
-            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-            .collect();
-        let round_trip: MultiLineStringArray<i32, 2> = geos_geoms.try_into().unwrap();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
+        let round_trip: MultiLineStringArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/multipoint.rs
+++ b/src/io/geos/array/multipoint.rs
@@ -1,27 +1,18 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::{MultiPointArray, MultiPointBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSMultiPoint;
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiPointBuilder<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSMultiPoint>> = value
-            .into_iter()
-            .map(|geom| geom.map(GEOSMultiPoint::new_unchecked))
-            .collect();
+        let geos_objects: Vec<Option<GEOSMultiPoint>> = value.into_iter().map(|geom| geom.map(GEOSMultiPoint::new_unchecked)).collect();
         Ok(geos_objects.into())
     }
 }
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiPointArray<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
@@ -40,11 +31,8 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = mp_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr
-            .iter()
-            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-            .collect();
-        let round_trip: MultiPointArray<i32, 2> = geos_geoms.try_into().unwrap();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
+        let round_trip: MultiPointArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/multipoint.rs
+++ b/src/io/geos/array/multipoint.rs
@@ -7,7 +7,10 @@ impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiPointBuilder<
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSMultiPoint>> = value.into_iter().map(|geom| geom.map(GEOSMultiPoint::new_unchecked)).collect();
+        let geos_objects: Vec<Option<GEOSMultiPoint>> = value
+            .into_iter()
+            .map(|geom| geom.map(GEOSMultiPoint::new_unchecked))
+            .collect();
         Ok(geos_objects.into())
     }
 }
@@ -31,7 +34,10 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = mp_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
         let round_trip: MultiPointArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }

--- a/src/io/geos/array/multipoint.rs
+++ b/src/io/geos/array/multipoint.rs
@@ -4,8 +4,8 @@ use crate::array::{MultiPointArray, MultiPointBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSMultiPoint;
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiPointBuilder<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiPointBuilder<D>
 {
     type Error = GeoArrowError;
 
@@ -19,13 +19,13 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiPointArray<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiPointArray<D>
 {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: MultiPointBuilder<O, D> = value.try_into()?;
+        let mutable_arr: MultiPointBuilder<D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/multipolygon.rs
+++ b/src/io/geos/array/multipolygon.rs
@@ -7,7 +7,10 @@ impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonBuilde
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSMultiPolygon>> = value.into_iter().map(|geom| geom.map(GEOSMultiPolygon::new_unchecked)).collect();
+        let geos_objects: Vec<Option<GEOSMultiPolygon>> = value
+            .into_iter()
+            .map(|geom| geom.map(GEOSMultiPolygon::new_unchecked))
+            .collect();
         Ok(geos_objects.into())
     }
 }
@@ -31,7 +34,10 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = mp_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
         let round_trip: MultiPolygonArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }

--- a/src/io/geos/array/multipolygon.rs
+++ b/src/io/geos/array/multipolygon.rs
@@ -4,8 +4,8 @@ use crate::array::{MultiPolygonArray, MultiPolygonBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSMultiPolygon;
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiPolygonBuilder<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiPolygonBuilder<D>
 {
     type Error = GeoArrowError;
 
@@ -19,13 +19,13 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiPolygonArray<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for MultiPolygonArray<D>
 {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: MultiPolygonBuilder<O, D> = value.try_into()?;
+        let mutable_arr: MultiPolygonBuilder<D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/multipolygon.rs
+++ b/src/io/geos/array/multipolygon.rs
@@ -1,27 +1,18 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::{MultiPolygonArray, MultiPolygonBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSMultiPolygon;
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiPolygonBuilder<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSMultiPolygon>> = value
-            .into_iter()
-            .map(|geom| geom.map(GEOSMultiPolygon::new_unchecked))
-            .collect();
+        let geos_objects: Vec<Option<GEOSMultiPolygon>> = value.into_iter().map(|geom| geom.map(GEOSMultiPolygon::new_unchecked)).collect();
         Ok(geos_objects.into())
     }
 }
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for MultiPolygonArray<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for MultiPolygonArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -40,11 +31,8 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = mp_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr
-            .iter()
-            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-            .collect();
-        let round_trip: MultiPolygonArray<i32, 2> = geos_geoms.try_into().unwrap();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
+        let round_trip: MultiPolygonArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/array/polygon.rs
+++ b/src/io/geos/array/polygon.rs
@@ -4,8 +4,8 @@ use crate::array::{PolygonArray, PolygonBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSPolygon;
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for PolygonBuilder<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for PolygonBuilder<D>
 {
     type Error = GeoArrowError;
 
@@ -20,13 +20,13 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for PolygonArray<O, D>
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
+    for PolygonArray<D>
 {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr: PolygonBuilder<O, D> = value.try_into()?;
+        let mutable_arr: PolygonBuilder<D> = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/src/io/geos/array/polygon.rs
+++ b/src/io/geos/array/polygon.rs
@@ -1,28 +1,19 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::{PolygonArray, PolygonBuilder};
 use crate::error::{GeoArrowError, Result};
 use crate::io::geos::scalar::GEOSPolygon;
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for PolygonBuilder<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for PolygonBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSPolygon>> = value
-            .into_iter()
-            .map(|geom| geom.map(GEOSPolygon::new_unchecked))
-            .collect();
+        let geos_objects: Vec<Option<GEOSPolygon>> = value.into_iter().map(|geom| geom.map(GEOSPolygon::new_unchecked)).collect();
 
         Ok(geos_objects.into())
     }
 }
 
-impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>>
-    for PolygonArray<D>
-{
+impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for PolygonArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
@@ -41,10 +32,7 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = p_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr
-            .iter()
-            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
-            .collect();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
         let round_trip: PolygonArray<i32, 2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }

--- a/src/io/geos/array/polygon.rs
+++ b/src/io/geos/array/polygon.rs
@@ -7,7 +7,10 @@ impl<const D: usize> TryFrom<Vec<Option<geos::Geometry>>> for PolygonBuilder<D> 
 
     fn try_from(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
-        let geos_objects: Vec<Option<GEOSPolygon>> = value.into_iter().map(|geom| geom.map(GEOSPolygon::new_unchecked)).collect();
+        let geos_objects: Vec<Option<GEOSPolygon>> = value
+            .into_iter()
+            .map(|geom| geom.map(GEOSPolygon::new_unchecked))
+            .collect();
 
         Ok(geos_objects.into())
     }
@@ -32,8 +35,11 @@ mod test {
     #[test]
     fn geos_round_trip() {
         let arr = p_array();
-        let geos_geoms: Vec<Option<geos::Geometry>> = arr.iter().map(|opt_x| opt_x.map(|x| x.to_geos().unwrap())).collect();
-        let round_trip: PolygonArray<i32, 2> = geos_geoms.try_into().unwrap();
+        let geos_geoms: Vec<Option<geos::Geometry>> = arr
+            .iter()
+            .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
+            .collect();
+        let round_trip: PolygonArray<2> = geos_geoms.try_into().unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/src/io/geos/scalar/geometry.rs
+++ b/src/io/geos/scalar/geometry.rs
@@ -1,14 +1,7 @@
-use crate::geo_traits::{
-    CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait,
-    MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait,
-};
+use crate::geo_traits::{CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait};
 use crate::io::geos::scalar::coord::GEOSConstCoord;
-use crate::io::geos::scalar::{
-    GEOSGeometryCollection, GEOSLineString, GEOSMultiLineString, GEOSMultiPoint, GEOSMultiPolygon,
-    GEOSPoint, GEOSPolygon,
-};
+use crate::io::geos::scalar::{GEOSGeometryCollection, GEOSLineString, GEOSMultiLineString, GEOSMultiPoint, GEOSMultiPolygon, GEOSPoint, GEOSPolygon};
 use crate::scalar::Geometry;
-use arrow_array::OffsetSizeTrait;
 use geos::Geom;
 
 impl<'a, const D: usize> TryFrom<&'a Geometry<'_, D>> for geos::Geometry {
@@ -43,22 +36,12 @@ impl GEOSGeometry {
     pub fn new(geom: geos::Geometry) -> Self {
         match geom.geometry_type() {
             geos::GeometryTypes::Point => Self::Point(GEOSPoint::new_unchecked(geom)),
-            geos::GeometryTypes::LineString => {
-                Self::LineString(GEOSLineString::new_unchecked(geom))
-            }
+            geos::GeometryTypes::LineString => Self::LineString(GEOSLineString::new_unchecked(geom)),
             geos::GeometryTypes::Polygon => Self::Polygon(GEOSPolygon::new_unchecked(geom)),
-            geos::GeometryTypes::MultiPoint => {
-                Self::MultiPoint(GEOSMultiPoint::new_unchecked(geom))
-            }
-            geos::GeometryTypes::MultiLineString => {
-                Self::MultiLineString(GEOSMultiLineString::new_unchecked(geom))
-            }
-            geos::GeometryTypes::MultiPolygon => {
-                Self::MultiPolygon(GEOSMultiPolygon::new_unchecked(geom))
-            }
-            geos::GeometryTypes::GeometryCollection => {
-                Self::GeometryCollection(GEOSGeometryCollection::new_unchecked(geom))
-            }
+            geos::GeometryTypes::MultiPoint => Self::MultiPoint(GEOSMultiPoint::new_unchecked(geom)),
+            geos::GeometryTypes::MultiLineString => Self::MultiLineString(GEOSMultiLineString::new_unchecked(geom)),
+            geos::GeometryTypes::MultiPolygon => Self::MultiPolygon(GEOSMultiPolygon::new_unchecked(geom)),
+            geos::GeometryTypes::GeometryCollection => Self::GeometryCollection(GEOSGeometryCollection::new_unchecked(geom)),
             geos::GeometryTypes::LinearRing => panic!("GEOS Linear ring not supported"),
             geos::GeometryTypes::__Unknown(x) => panic!("Unknown geometry type {x}"),
         }
@@ -107,19 +90,7 @@ impl GeometryTrait for GEOSGeometry {
         }
     }
 
-    fn as_type(
-        &self,
-    ) -> crate::geo_traits::GeometryType<
-        '_,
-        GEOSPoint,
-        GEOSLineString,
-        GEOSPolygon,
-        GEOSMultiPoint,
-        GEOSMultiLineString,
-        GEOSMultiPolygon,
-        GEOSGeometryCollection,
-        Self::Rect<'_>,
-    > {
+    fn as_type(&self) -> crate::geo_traits::GeometryType<'_, GEOSPoint, GEOSLineString, GEOSPolygon, GEOSMultiPoint, GEOSMultiLineString, GEOSMultiPolygon, GEOSGeometryCollection, Self::Rect<'_>> {
         match self {
             Self::Point(g) => crate::geo_traits::GeometryType::Point(g),
             Self::LineString(g) => crate::geo_traits::GeometryType::LineString(g),

--- a/src/io/geos/scalar/geometry.rs
+++ b/src/io/geos/scalar/geometry.rs
@@ -11,10 +11,10 @@ use crate::scalar::Geometry;
 use arrow_array::OffsetSizeTrait;
 use geos::Geom;
 
-impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a Geometry<'_, O, D>> for geos::Geometry {
+impl<'a, const D: usize> TryFrom<&'a Geometry<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Geometry<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Geometry<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         match value {
             Geometry::Point(g) => g.try_into(),
             Geometry::LineString(g) => g.try_into(),

--- a/src/io/geos/scalar/geometry.rs
+++ b/src/io/geos/scalar/geometry.rs
@@ -1,6 +1,12 @@
-use crate::geo_traits::{CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait};
+use crate::geo_traits::{
+    CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait,
+    MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait,
+};
 use crate::io::geos::scalar::coord::GEOSConstCoord;
-use crate::io::geos::scalar::{GEOSGeometryCollection, GEOSLineString, GEOSMultiLineString, GEOSMultiPoint, GEOSMultiPolygon, GEOSPoint, GEOSPolygon};
+use crate::io::geos::scalar::{
+    GEOSGeometryCollection, GEOSLineString, GEOSMultiLineString, GEOSMultiPoint, GEOSMultiPolygon,
+    GEOSPoint, GEOSPolygon,
+};
 use crate::scalar::Geometry;
 use geos::Geom;
 
@@ -36,12 +42,22 @@ impl GEOSGeometry {
     pub fn new(geom: geos::Geometry) -> Self {
         match geom.geometry_type() {
             geos::GeometryTypes::Point => Self::Point(GEOSPoint::new_unchecked(geom)),
-            geos::GeometryTypes::LineString => Self::LineString(GEOSLineString::new_unchecked(geom)),
+            geos::GeometryTypes::LineString => {
+                Self::LineString(GEOSLineString::new_unchecked(geom))
+            }
             geos::GeometryTypes::Polygon => Self::Polygon(GEOSPolygon::new_unchecked(geom)),
-            geos::GeometryTypes::MultiPoint => Self::MultiPoint(GEOSMultiPoint::new_unchecked(geom)),
-            geos::GeometryTypes::MultiLineString => Self::MultiLineString(GEOSMultiLineString::new_unchecked(geom)),
-            geos::GeometryTypes::MultiPolygon => Self::MultiPolygon(GEOSMultiPolygon::new_unchecked(geom)),
-            geos::GeometryTypes::GeometryCollection => Self::GeometryCollection(GEOSGeometryCollection::new_unchecked(geom)),
+            geos::GeometryTypes::MultiPoint => {
+                Self::MultiPoint(GEOSMultiPoint::new_unchecked(geom))
+            }
+            geos::GeometryTypes::MultiLineString => {
+                Self::MultiLineString(GEOSMultiLineString::new_unchecked(geom))
+            }
+            geos::GeometryTypes::MultiPolygon => {
+                Self::MultiPolygon(GEOSMultiPolygon::new_unchecked(geom))
+            }
+            geos::GeometryTypes::GeometryCollection => {
+                Self::GeometryCollection(GEOSGeometryCollection::new_unchecked(geom))
+            }
             geos::GeometryTypes::LinearRing => panic!("GEOS Linear ring not supported"),
             geos::GeometryTypes::__Unknown(x) => panic!("Unknown geometry type {x}"),
         }
@@ -90,7 +106,19 @@ impl GeometryTrait for GEOSGeometry {
         }
     }
 
-    fn as_type(&self) -> crate::geo_traits::GeometryType<'_, GEOSPoint, GEOSLineString, GEOSPolygon, GEOSMultiPoint, GEOSMultiLineString, GEOSMultiPolygon, GEOSGeometryCollection, Self::Rect<'_>> {
+    fn as_type(
+        &self,
+    ) -> crate::geo_traits::GeometryType<
+        '_,
+        GEOSPoint,
+        GEOSLineString,
+        GEOSPolygon,
+        GEOSMultiPoint,
+        GEOSMultiLineString,
+        GEOSMultiPolygon,
+        GEOSGeometryCollection,
+        Self::Rect<'_>,
+    > {
         match self {
             Self::Point(g) => crate::geo_traits::GeometryType::Point(g),
             Self::LineString(g) => crate::geo_traits::GeometryType::LineString(g),

--- a/src/io/geos/scalar/geometrycollection.rs
+++ b/src/io/geos/scalar/geometrycollection.rs
@@ -4,13 +4,13 @@ use crate::scalar::GeometryCollection;
 use arrow_array::OffsetSizeTrait;
 use geos::Geom;
 
-impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a GeometryCollection<'_, O, D>>
+impl<'a, const D: usize> TryFrom<&'a GeometryCollection<'_, D>>
     for geos::Geometry
 {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a GeometryCollection<'_, O, D>,
+        value: &'a GeometryCollection<'_, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_geometry_collection(
             value

--- a/src/io/geos/scalar/geometrycollection.rs
+++ b/src/io/geos/scalar/geometrycollection.rs
@@ -6,8 +6,15 @@ use geos::Geom;
 impl<'a, const D: usize> TryFrom<&'a GeometryCollection<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a GeometryCollection<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::create_geometry_collection(value.geometries().map(|geometry| (&geometry).try_into()).collect::<std::result::Result<Vec<_>, geos::Error>>()?)
+    fn try_from(
+        value: &'a GeometryCollection<'_, D>,
+    ) -> std::result::Result<geos::Geometry, geos::Error> {
+        geos::Geometry::create_geometry_collection(
+            value
+                .geometries()
+                .map(|geometry| (&geometry).try_into())
+                .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
+        )
     }
 }
 

--- a/src/io/geos/scalar/geometrycollection.rs
+++ b/src/io/geos/scalar/geometrycollection.rs
@@ -1,23 +1,13 @@
 use crate::geo_traits::GeometryCollectionTrait;
 use crate::io::geos::scalar::GEOSGeometry;
 use crate::scalar::GeometryCollection;
-use arrow_array::OffsetSizeTrait;
 use geos::Geom;
 
-impl<'a, const D: usize> TryFrom<&'a GeometryCollection<'_, D>>
-    for geos::Geometry
-{
+impl<'a, const D: usize> TryFrom<&'a GeometryCollection<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(
-        value: &'a GeometryCollection<'_, D>,
-    ) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::create_geometry_collection(
-            value
-                .geometries()
-                .map(|geometry| (&geometry).try_into())
-                .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
-        )
+    fn try_from(value: &'a GeometryCollection<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+        geos::Geometry::create_geometry_collection(value.geometries().map(|geometry| (&geometry).try_into()).collect::<std::result::Result<Vec<_>, geos::Error>>()?)
     }
 }
 

--- a/src/io/geos/scalar/linestring.rs
+++ b/src/io/geos/scalar/linestring.rs
@@ -38,7 +38,9 @@ impl GEOSLineString {
         if matches!(geom.geometry_type(), GeometryTypes::LineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General("Geometry type must be line string".to_string()))
+            Err(GeoArrowError::General(
+                "Geometry type must be line string".to_string(),
+            ))
         }
     }
 }
@@ -99,7 +101,9 @@ impl<'a> GEOSConstLineString<'a> {
         if matches!(geom.geometry_type(), GeometryTypes::LineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General("Geometry type must be line string".to_string()))
+            Err(GeoArrowError::General(
+                "Geometry type must be line string".to_string(),
+            ))
         }
     }
 }

--- a/src/io/geos/scalar/linestring.rs
+++ b/src/io/geos/scalar/linestring.rs
@@ -3,15 +3,12 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::LineStringTrait;
 use crate::io::geos::scalar::GEOSPoint;
 use crate::scalar::LineString;
-use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
 impl<'a, const D: usize> TryFrom<&'a LineString<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(
-        value: &'a LineString<'_, D>,
-    ) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a LineString<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = value.geom_offsets.start_end(value.geom_index);
 
         let sliced_coords = value.coords.clone().slice(start, end - start);
@@ -41,9 +38,7 @@ impl GEOSLineString {
         if matches!(geom.geometry_type(), GeometryTypes::LineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
-                "Geometry type must be line string".to_string(),
-            ))
+            Err(GeoArrowError::General("Geometry type must be line string".to_string()))
         }
     }
 }
@@ -104,9 +99,7 @@ impl<'a> GEOSConstLineString<'a> {
         if matches!(geom.geometry_type(), GeometryTypes::LineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
-                "Geometry type must be line string".to_string(),
-            ))
+            Err(GeoArrowError::General("Geometry type must be line string".to_string()))
         }
     }
 }

--- a/src/io/geos/scalar/linestring.rs
+++ b/src/io/geos/scalar/linestring.rs
@@ -6,11 +6,11 @@ use crate::scalar::LineString;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a LineString<'_, O, D>> for geos::Geometry {
+impl<'a, const D: usize> TryFrom<&'a LineString<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a LineString<'_, O, D>,
+        value: &'a LineString<'_, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = value.geom_offsets.start_end(value.geom_index);
 
@@ -20,7 +20,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a LineString<'_, O, D>> f
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> LineString<'_, O, D> {
+impl<const D: usize> LineString<'_, D> {
     pub fn to_geos_linear_ring(&self) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
 

--- a/src/io/geos/scalar/multilinestring.rs
+++ b/src/io/geos/scalar/multilinestring.rs
@@ -7,8 +7,15 @@ use geos::{Geom, GeometryTypes};
 impl<'a, const D: usize> TryFrom<&'a MultiLineString<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a MultiLineString<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::create_multiline_string(value.lines().map(|line| (&line).try_into()).collect::<std::result::Result<Vec<_>, geos::Error>>()?)
+    fn try_from(
+        value: &'a MultiLineString<'_, D>,
+    ) -> std::result::Result<geos::Geometry, geos::Error> {
+        geos::Geometry::create_multiline_string(
+            value
+                .lines()
+                .map(|line| (&line).try_into())
+                .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
+        )
     }
 }
 /// A GEOS geometry known to be a MultiLineString
@@ -25,7 +32,9 @@ impl GEOSMultiLineString {
         if matches!(geom.geometry_type(), GeometryTypes::MultiLineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General("Geometry type must be multi line string".to_string()))
+            Err(GeoArrowError::General(
+                "Geometry type must be multi line string".to_string(),
+            ))
         }
     }
 
@@ -39,7 +48,9 @@ impl GEOSMultiLineString {
             return None;
         }
 
-        Some(GEOSConstLineString::new_unchecked(self.0.get_geometry_n(i).unwrap()))
+        Some(GEOSConstLineString::new_unchecked(
+            self.0.get_geometry_n(i).unwrap(),
+        ))
     }
 }
 

--- a/src/io/geos/scalar/multilinestring.rs
+++ b/src/io/geos/scalar/multilinestring.rs
@@ -5,13 +5,13 @@ use crate::scalar::MultiLineString;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiLineString<'_, O, D>>
+impl<'a, const D: usize> TryFrom<&'a MultiLineString<'_, D>>
     for geos::Geometry
 {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiLineString<'_, O, D>,
+        value: &'a MultiLineString<'_, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multiline_string(
             value

--- a/src/io/geos/scalar/multilinestring.rs
+++ b/src/io/geos/scalar/multilinestring.rs
@@ -2,23 +2,13 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiLineStringTrait;
 use crate::io::geos::scalar::GEOSConstLineString;
 use crate::scalar::MultiLineString;
-use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, const D: usize> TryFrom<&'a MultiLineString<'_, D>>
-    for geos::Geometry
-{
+impl<'a, const D: usize> TryFrom<&'a MultiLineString<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(
-        value: &'a MultiLineString<'_, D>,
-    ) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::create_multiline_string(
-            value
-                .lines()
-                .map(|line| (&line).try_into())
-                .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
-        )
+    fn try_from(value: &'a MultiLineString<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+        geos::Geometry::create_multiline_string(value.lines().map(|line| (&line).try_into()).collect::<std::result::Result<Vec<_>, geos::Error>>()?)
     }
 }
 /// A GEOS geometry known to be a MultiLineString
@@ -35,9 +25,7 @@ impl GEOSMultiLineString {
         if matches!(geom.geometry_type(), GeometryTypes::MultiLineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
-                "Geometry type must be multi line string".to_string(),
-            ))
+            Err(GeoArrowError::General("Geometry type must be multi line string".to_string()))
         }
     }
 
@@ -51,9 +39,7 @@ impl GEOSMultiLineString {
             return None;
         }
 
-        Some(GEOSConstLineString::new_unchecked(
-            self.0.get_geometry_n(i).unwrap(),
-        ))
+        Some(GEOSConstLineString::new_unchecked(self.0.get_geometry_n(i).unwrap()))
     }
 }
 

--- a/src/io/geos/scalar/multipoint.rs
+++ b/src/io/geos/scalar/multipoint.rs
@@ -5,11 +5,11 @@ use crate::scalar::MultiPoint;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiPoint<'_, O, D>> for geos::Geometry {
+impl<'a, const D: usize> TryFrom<&'a MultiPoint<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiPoint<'_, O, D>,
+        value: &'a MultiPoint<'_, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipoint(
             value

--- a/src/io/geos/scalar/multipoint.rs
+++ b/src/io/geos/scalar/multipoint.rs
@@ -8,7 +8,12 @@ impl<'a, const D: usize> TryFrom<&'a MultiPoint<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(value: &'a MultiPoint<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::create_multipoint(value.points().map(|point| (&point).try_into()).collect::<std::result::Result<Vec<_>, geos::Error>>()?)
+        geos::Geometry::create_multipoint(
+            value
+                .points()
+                .map(|point| (&point).try_into())
+                .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
+        )
     }
 }
 
@@ -25,7 +30,9 @@ impl GEOSMultiPoint {
         if matches!(geom.geometry_type(), GeometryTypes::MultiPoint) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General("Geometry type must be multi point".to_string()))
+            Err(GeoArrowError::General(
+                "Geometry type must be multi point".to_string(),
+            ))
         }
     }
 

--- a/src/io/geos/scalar/multipoint.rs
+++ b/src/io/geos/scalar/multipoint.rs
@@ -2,21 +2,13 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiPointTrait;
 use crate::io::geos::scalar::GEOSConstPoint;
 use crate::scalar::MultiPoint;
-use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
 impl<'a, const D: usize> TryFrom<&'a MultiPoint<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(
-        value: &'a MultiPoint<'_, D>,
-    ) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::create_multipoint(
-            value
-                .points()
-                .map(|point| (&point).try_into())
-                .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
-        )
+    fn try_from(value: &'a MultiPoint<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+        geos::Geometry::create_multipoint(value.points().map(|point| (&point).try_into()).collect::<std::result::Result<Vec<_>, geos::Error>>()?)
     }
 }
 
@@ -33,9 +25,7 @@ impl GEOSMultiPoint {
         if matches!(geom.geometry_type(), GeometryTypes::MultiPoint) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
-                "Geometry type must be multi point".to_string(),
-            ))
+            Err(GeoArrowError::General("Geometry type must be multi point".to_string()))
         }
     }
 

--- a/src/io/geos/scalar/multipolygon.rs
+++ b/src/io/geos/scalar/multipolygon.rs
@@ -5,13 +5,13 @@ use crate::scalar::MultiPolygon;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a MultiPolygon<'_, O, D>>
+impl<'a, const D: usize> TryFrom<&'a MultiPolygon<'_, D>>
     for geos::Geometry
 {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiPolygon<'_, O, D>,
+        value: &'a MultiPolygon<'_, D>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipolygon(
             value

--- a/src/io/geos/scalar/multipolygon.rs
+++ b/src/io/geos/scalar/multipolygon.rs
@@ -2,23 +2,13 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::MultiPolygonTrait;
 use crate::io::geos::scalar::GEOSConstPolygon;
 use crate::scalar::MultiPolygon;
-use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, const D: usize> TryFrom<&'a MultiPolygon<'_, D>>
-    for geos::Geometry
-{
+impl<'a, const D: usize> TryFrom<&'a MultiPolygon<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(
-        value: &'a MultiPolygon<'_, D>,
-    ) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::create_multipolygon(
-            value
-                .polygons()
-                .map(|polygon| (&polygon).try_into())
-                .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
-        )
+    fn try_from(value: &'a MultiPolygon<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+        geos::Geometry::create_multipolygon(value.polygons().map(|polygon| (&polygon).try_into()).collect::<std::result::Result<Vec<_>, geos::Error>>()?)
     }
 }
 
@@ -35,9 +25,7 @@ impl GEOSMultiPolygon {
         if matches!(geom.geometry_type(), GeometryTypes::MultiPolygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
-                "Geometry type must be multi polygon".to_string(),
-            ))
+            Err(GeoArrowError::General("Geometry type must be multi polygon".to_string()))
         }
     }
 }

--- a/src/io/geos/scalar/multipolygon.rs
+++ b/src/io/geos/scalar/multipolygon.rs
@@ -7,8 +7,15 @@ use geos::{Geom, GeometryTypes};
 impl<'a, const D: usize> TryFrom<&'a MultiPolygon<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a MultiPolygon<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
-        geos::Geometry::create_multipolygon(value.polygons().map(|polygon| (&polygon).try_into()).collect::<std::result::Result<Vec<_>, geos::Error>>()?)
+    fn try_from(
+        value: &'a MultiPolygon<'_, D>,
+    ) -> std::result::Result<geos::Geometry, geos::Error> {
+        geos::Geometry::create_multipolygon(
+            value
+                .polygons()
+                .map(|polygon| (&polygon).try_into())
+                .collect::<std::result::Result<Vec<_>, geos::Error>>()?,
+        )
     }
 }
 
@@ -25,7 +32,9 @@ impl GEOSMultiPolygon {
         if matches!(geom.geometry_type(), GeometryTypes::MultiPolygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General("Geometry type must be multi polygon".to_string()))
+            Err(GeoArrowError::General(
+                "Geometry type must be multi polygon".to_string(),
+            ))
         }
     }
 }

--- a/src/io/geos/scalar/polygon.rs
+++ b/src/io/geos/scalar/polygon.rs
@@ -10,7 +10,10 @@ impl<'a, const D: usize> TryFrom<&'a Polygon<'_, D>> for geos::Geometry {
     fn try_from(value: &'a Polygon<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         if let Some(exterior) = value.exterior() {
             let exterior = exterior.to_geos_linear_ring()?;
-            let interiors = value.interiors().map(|interior| interior.to_geos_linear_ring()).collect::<std::result::Result<Vec<_>, geos::Error>>()?;
+            let interiors = value
+                .interiors()
+                .map(|interior| interior.to_geos_linear_ring())
+                .collect::<std::result::Result<Vec<_>, geos::Error>>()?;
             geos::Geometry::create_polygon(exterior, interiors)
         } else {
             geos::Geometry::create_empty_polygon()
@@ -31,7 +34,9 @@ impl GEOSPolygon {
         if matches!(geom.geometry_type(), GeometryTypes::Polygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General("Geometry type must be polygon".to_string()))
+            Err(GeoArrowError::General(
+                "Geometry type must be polygon".to_string(),
+            ))
         }
     }
 
@@ -47,7 +52,9 @@ impl GEOSPolygon {
             return None;
         }
 
-        Some(GEOSConstLinearRing::new_unchecked(self.0.get_exterior_ring().unwrap()))
+        Some(GEOSConstLinearRing::new_unchecked(
+            self.0.get_exterior_ring().unwrap(),
+        ))
     }
 
     #[allow(dead_code)]
@@ -56,7 +63,9 @@ impl GEOSPolygon {
             return None;
         }
 
-        Some(GEOSConstLinearRing::new_unchecked(self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap()))
+        Some(GEOSConstLinearRing::new_unchecked(
+            self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap(),
+        ))
     }
 }
 
@@ -81,11 +90,15 @@ impl PolygonTrait for GEOSPolygon {
             return None;
         }
 
-        Some(GEOSConstLinearRing::new_unchecked(self.0.get_exterior_ring().unwrap()))
+        Some(GEOSConstLinearRing::new_unchecked(
+            self.0.get_exterior_ring().unwrap(),
+        ))
     }
 
     unsafe fn interior_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        GEOSConstLinearRing::new_unchecked(self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap())
+        GEOSConstLinearRing::new_unchecked(
+            self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap(),
+        )
     }
 }
 
@@ -101,7 +114,9 @@ impl<'a> GEOSConstPolygon<'a> {
         if matches!(geom.geometry_type(), GeometryTypes::Polygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General("Geometry type must be polygon".to_string()))
+            Err(GeoArrowError::General(
+                "Geometry type must be polygon".to_string(),
+            ))
         }
     }
 }
@@ -127,10 +142,14 @@ impl<'a> PolygonTrait for GEOSConstPolygon<'a> {
             return None;
         }
 
-        Some(GEOSConstLinearRing::new_unchecked(self.0.get_exterior_ring().unwrap()))
+        Some(GEOSConstLinearRing::new_unchecked(
+            self.0.get_exterior_ring().unwrap(),
+        ))
     }
 
     unsafe fn interior_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        GEOSConstLinearRing::new_unchecked(self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap())
+        GEOSConstLinearRing::new_unchecked(
+            self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap(),
+        )
     }
 }

--- a/src/io/geos/scalar/polygon.rs
+++ b/src/io/geos/scalar/polygon.rs
@@ -2,7 +2,6 @@ use crate::error::{GeoArrowError, Result};
 use crate::geo_traits::PolygonTrait;
 use crate::io::geos::scalar::GEOSConstLinearRing;
 use crate::scalar::Polygon;
-use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
 impl<'a, const D: usize> TryFrom<&'a Polygon<'_, D>> for geos::Geometry {
@@ -11,10 +10,7 @@ impl<'a, const D: usize> TryFrom<&'a Polygon<'_, D>> for geos::Geometry {
     fn try_from(value: &'a Polygon<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         if let Some(exterior) = value.exterior() {
             let exterior = exterior.to_geos_linear_ring()?;
-            let interiors = value
-                .interiors()
-                .map(|interior| interior.to_geos_linear_ring())
-                .collect::<std::result::Result<Vec<_>, geos::Error>>()?;
+            let interiors = value.interiors().map(|interior| interior.to_geos_linear_ring()).collect::<std::result::Result<Vec<_>, geos::Error>>()?;
             geos::Geometry::create_polygon(exterior, interiors)
         } else {
             geos::Geometry::create_empty_polygon()
@@ -35,9 +31,7 @@ impl GEOSPolygon {
         if matches!(geom.geometry_type(), GeometryTypes::Polygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
-                "Geometry type must be polygon".to_string(),
-            ))
+            Err(GeoArrowError::General("Geometry type must be polygon".to_string()))
         }
     }
 
@@ -53,9 +47,7 @@ impl GEOSPolygon {
             return None;
         }
 
-        Some(GEOSConstLinearRing::new_unchecked(
-            self.0.get_exterior_ring().unwrap(),
-        ))
+        Some(GEOSConstLinearRing::new_unchecked(self.0.get_exterior_ring().unwrap()))
     }
 
     #[allow(dead_code)]
@@ -64,9 +56,7 @@ impl GEOSPolygon {
             return None;
         }
 
-        Some(GEOSConstLinearRing::new_unchecked(
-            self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap(),
-        ))
+        Some(GEOSConstLinearRing::new_unchecked(self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap()))
     }
 }
 
@@ -91,15 +81,11 @@ impl PolygonTrait for GEOSPolygon {
             return None;
         }
 
-        Some(GEOSConstLinearRing::new_unchecked(
-            self.0.get_exterior_ring().unwrap(),
-        ))
+        Some(GEOSConstLinearRing::new_unchecked(self.0.get_exterior_ring().unwrap()))
     }
 
     unsafe fn interior_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        GEOSConstLinearRing::new_unchecked(
-            self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap(),
-        )
+        GEOSConstLinearRing::new_unchecked(self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap())
     }
 }
 
@@ -115,9 +101,7 @@ impl<'a> GEOSConstPolygon<'a> {
         if matches!(geom.geometry_type(), GeometryTypes::Polygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
-                "Geometry type must be polygon".to_string(),
-            ))
+            Err(GeoArrowError::General("Geometry type must be polygon".to_string()))
         }
     }
 }
@@ -143,14 +127,10 @@ impl<'a> PolygonTrait for GEOSConstPolygon<'a> {
             return None;
         }
 
-        Some(GEOSConstLinearRing::new_unchecked(
-            self.0.get_exterior_ring().unwrap(),
-        ))
+        Some(GEOSConstLinearRing::new_unchecked(self.0.get_exterior_ring().unwrap()))
     }
 
     unsafe fn interior_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        GEOSConstLinearRing::new_unchecked(
-            self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap(),
-        )
+        GEOSConstLinearRing::new_unchecked(self.0.get_interior_ring_n(i.try_into().unwrap()).unwrap())
     }
 }

--- a/src/io/geos/scalar/polygon.rs
+++ b/src/io/geos/scalar/polygon.rs
@@ -5,10 +5,10 @@ use crate::scalar::Polygon;
 use arrow_array::OffsetSizeTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, O: OffsetSizeTrait, const D: usize> TryFrom<&'a Polygon<'_, O, D>> for geos::Geometry {
+impl<'a, const D: usize> TryFrom<&'a Polygon<'_, D>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Polygon<'_, O, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Polygon<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
         if let Some(exterior) = value.exterior() {
             let exterior = exterior.to_geos_linear_ring()?;
             let interiors = value

--- a/src/io/geozero/api/ewkb.rs
+++ b/src/io/geozero/api/ewkb.rs
@@ -5,9 +5,7 @@ use crate::algorithm::native::Downcast;
 use crate::array::geometrycollection::GeometryCollectionBuilder;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::*;
-use crate::chunked_array::{
-    ChunkedGeometryCollectionArray, ChunkedMixedGeometryArray, ChunkedNativeArray, ChunkedWKBArray,
-};
+use crate::chunked_array::{ChunkedGeometryCollectionArray, ChunkedMixedGeometryArray, ChunkedNativeArray, ChunkedWKBArray};
 use crate::error::Result;
 use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::NativeArray;
@@ -18,26 +16,15 @@ use geozero::wkb::process_ewkb_geom;
 pub trait FromEWKB: Sized {
     type Input<O: OffsetSizeTrait>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self>;
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self>;
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for MixedGeometryArray<OOutput, 2> {
+impl FromEWKB for MixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
         let arr = arr.clone().into_inner();
-        let mut builder =
-            MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
+        let mut builder = MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 process_ewkb_geom(&mut Cursor::new(arr.value(i)), &mut builder)?;
@@ -50,15 +37,10 @@ impl<OOutput: OffsetSizeTrait> FromEWKB for MixedGeometryArray<OOutput, 2> {
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for GeometryCollectionArray<OOutput, 2> {
+impl FromEWKB for GeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
         // TODO: Add GeometryCollectionStreamBuilder and use that instead of going through geo
         let arr = arr.clone().into_inner();
         let mut builder = GeometryCollectionBuilder::new_with_options(coord_type, metadata);
@@ -81,61 +63,33 @@ impl<OOutput: OffsetSizeTrait> FromEWKB for GeometryCollectionArray<OOutput, 2> 
 impl FromEWKB for Arc<dyn NativeArray> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        let geom_arr =
-            GeometryCollectionArray::<i64, 2>::from_ewkb(arr, coord_type, metadata, prefer_multi)?;
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        let geom_arr = GeometryCollectionArray::<i64, 2>::from_ewkb(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedMixedGeometryArray<OOutput, 2> {
+impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedMixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        arr.try_map(|chunk| FromEWKB::from_ewkb(chunk, coord_type, metadata.clone(), prefer_multi))?
-            .try_into()
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        arr.try_map(|chunk| FromEWKB::from_ewkb(chunk, coord_type, metadata.clone(), prefer_multi))?.try_into()
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedGeometryCollectionArray<OOutput, 2> {
+impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedGeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        arr.try_map(|chunk| FromEWKB::from_ewkb(chunk, coord_type, metadata.clone(), prefer_multi))?
-            .try_into()
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        arr.try_map(|chunk| FromEWKB::from_ewkb(chunk, coord_type, metadata.clone(), prefer_multi))?.try_into()
     }
 }
 
 impl FromEWKB for Arc<dyn ChunkedNativeArray> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        let geom_arr = ChunkedGeometryCollectionArray::<i64, 2>::from_ewkb(
-            arr,
-            coord_type,
-            metadata,
-            prefer_multi,
-        )?;
+    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        let geom_arr = ChunkedGeometryCollectionArray::<i64, 2>::from_ewkb(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }

--- a/src/io/geozero/api/ewkb.rs
+++ b/src/io/geozero/api/ewkb.rs
@@ -5,7 +5,9 @@ use crate::algorithm::native::Downcast;
 use crate::array::geometrycollection::GeometryCollectionBuilder;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::*;
-use crate::chunked_array::{ChunkedGeometryCollectionArray, ChunkedMixedGeometryArray, ChunkedNativeArray, ChunkedWKBArray};
+use crate::chunked_array::{
+    ChunkedGeometryCollectionArray, ChunkedMixedGeometryArray, ChunkedNativeArray, ChunkedWKBArray,
+};
 use crate::error::Result;
 use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::NativeArray;
@@ -16,15 +18,26 @@ use geozero::wkb::process_ewkb_geom;
 pub trait FromEWKB: Sized {
     type Input<O: OffsetSizeTrait>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self>;
+    fn from_ewkb<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self>;
 }
 
 impl FromEWKB for MixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+    fn from_ewkb<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
         let arr = arr.clone().into_inner();
-        let mut builder = MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
+        let mut builder =
+            MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 process_ewkb_geom(&mut Cursor::new(arr.value(i)), &mut builder)?;
@@ -40,7 +53,12 @@ impl FromEWKB for MixedGeometryArray<2> {
 impl FromEWKB for GeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+    fn from_ewkb<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
         // TODO: Add GeometryCollectionStreamBuilder and use that instead of going through geo
         let arr = arr.clone().into_inner();
         let mut builder = GeometryCollectionBuilder::new_with_options(coord_type, metadata);
@@ -63,33 +81,61 @@ impl FromEWKB for GeometryCollectionArray<2> {
 impl FromEWKB for Arc<dyn NativeArray> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let geom_arr = GeometryCollectionArray::<i64, 2>::from_ewkb(arr, coord_type, metadata, prefer_multi)?;
+    fn from_ewkb<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let geom_arr =
+            GeometryCollectionArray::<2>::from_ewkb(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedMixedGeometryArray<2> {
+impl FromEWKB for ChunkedMixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        arr.try_map(|chunk| FromEWKB::from_ewkb(chunk, coord_type, metadata.clone(), prefer_multi))?.try_into()
+    fn from_ewkb<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        arr.try_map(|chunk| FromEWKB::from_ewkb(chunk, coord_type, metadata.clone(), prefer_multi))?
+            .try_into()
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromEWKB for ChunkedGeometryCollectionArray<2> {
+impl FromEWKB for ChunkedGeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        arr.try_map(|chunk| FromEWKB::from_ewkb(chunk, coord_type, metadata.clone(), prefer_multi))?.try_into()
+    fn from_ewkb<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        arr.try_map(|chunk| FromEWKB::from_ewkb(chunk, coord_type, metadata.clone(), prefer_multi))?
+            .try_into()
     }
 }
 
 impl FromEWKB for Arc<dyn ChunkedNativeArray> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
-    fn from_ewkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let geom_arr = ChunkedGeometryCollectionArray::<i64, 2>::from_ewkb(arr, coord_type, metadata, prefer_multi)?;
+    fn from_ewkb<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let geom_arr = ChunkedGeometryCollectionArray::<2>::from_ewkb(
+            arr,
+            coord_type,
+            metadata,
+            prefer_multi,
+        )?;
         Ok(geom_arr.downcast(true))
     }
 }

--- a/src/io/geozero/api/wkt.rs
+++ b/src/io/geozero/api/wkt.rs
@@ -4,7 +4,9 @@ use crate::algorithm::native::Downcast;
 use crate::array::geometrycollection::GeometryCollectionBuilder;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::*;
-use crate::chunked_array::{ChunkedArray, ChunkedGeometryCollectionArray, ChunkedMixedGeometryArray, ChunkedNativeArray};
+use crate::chunked_array::{
+    ChunkedArray, ChunkedGeometryCollectionArray, ChunkedMixedGeometryArray, ChunkedNativeArray,
+};
 use crate::error::Result;
 use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::NativeArray;
@@ -14,14 +16,25 @@ use geozero::{GeozeroGeometry, ToGeo};
 pub trait FromWKT: Sized {
     type Input<O: OffsetSizeTrait>;
 
-    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self>;
+    fn from_wkt<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self>;
 }
 
 impl FromWKT for MixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
 
-    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let mut builder = MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
+    fn from_wkt<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let mut builder =
+            MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 let wkt_str = geozero::wkt::Wkt(arr.value(i));
@@ -38,7 +51,12 @@ impl FromWKT for MixedGeometryArray<2> {
 impl FromWKT for GeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
 
-    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+    fn from_wkt<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
         // TODO: Add GeometryCollectionStreamBuilder and use that instead of going through geo
         let mut builder = GeometryCollectionBuilder::new_with_options(coord_type, metadata);
         for i in 0..arr.len() {
@@ -58,8 +76,14 @@ impl FromWKT for GeometryCollectionArray<2> {
 impl FromWKT for Arc<dyn NativeArray> {
     type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
 
-    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let geom_arr = GeometryCollectionArray::<i64, 2>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
+    fn from_wkt<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let geom_arr =
+            GeometryCollectionArray::<2>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
@@ -67,24 +91,42 @@ impl FromWKT for Arc<dyn NativeArray> {
 impl FromWKT for ChunkedMixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedArray<GenericStringArray<O>>;
 
-    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?.try_into()
+    fn from_wkt<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?
+            .try_into()
     }
 }
 
 impl FromWKT for ChunkedGeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedArray<GenericStringArray<O>>;
 
-    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?.try_into()
+    fn from_wkt<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?
+            .try_into()
     }
 }
 
 impl FromWKT for Arc<dyn ChunkedNativeArray> {
     type Input<O: OffsetSizeTrait> = ChunkedArray<GenericStringArray<O>>;
 
-    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
-        let geom_arr = ChunkedGeometryCollectionArray::<i64, 2>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
+    fn from_wkt<O: OffsetSizeTrait>(
+        arr: &Self::Input<O>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let geom_arr =
+            ChunkedGeometryCollectionArray::<2>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
@@ -99,12 +141,18 @@ mod test {
 
     #[test]
     fn test_read_wkt() {
-        let wkt_geoms = ["POINT (30 10)", "LINESTRING (30 10, 10 30, 40 40)", "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"];
+        let wkt_geoms = [
+            "POINT (30 10)",
+            "LINESTRING (30 10, 10 30, 40 40)",
+            "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))",
+        ];
         let mut builder = StringBuilder::new();
         wkt_geoms.iter().for_each(|s| builder.append_value(s));
         let arr = builder.finish();
         // dbg!(arr);
-        let geom_arr = MixedGeometryArray::<i32, 2>::from_wkt(&arr, Default::default(), Default::default(), false).unwrap();
+        let geom_arr =
+            MixedGeometryArray::<2>::from_wkt(&arr, Default::default(), Default::default(), false)
+                .unwrap();
         let geo_point = geo::Point::try_from(geom_arr.value(0).to_geo().unwrap()).unwrap();
         assert_eq!(geo_point.x(), 30.0);
         assert_eq!(geo_point.y(), 10.0);
@@ -117,8 +165,13 @@ mod test {
         wkt_geoms.iter().for_each(|s| builder.append_value(s));
         let arr = builder.finish();
         // dbg!(arr);
-        let geom_arr = MixedGeometryArray::<i32, 2>::from_wkt(&arr, Default::default(), Default::default(), true).unwrap();
+        let geom_arr =
+            MixedGeometryArray::<2>::from_wkt(&arr, Default::default(), Default::default(), true)
+                .unwrap();
         let geom_arr = geom_arr.downcast(true);
-        assert!(matches!(geom_arr.data_type(), NativeType::Point(_, Dimension::XY)));
+        assert!(matches!(
+            geom_arr.data_type(),
+            NativeType::Point(_, Dimension::XY)
+        ));
     }
 }

--- a/src/io/geozero/api/wkt.rs
+++ b/src/io/geozero/api/wkt.rs
@@ -4,9 +4,7 @@ use crate::algorithm::native::Downcast;
 use crate::array::geometrycollection::GeometryCollectionBuilder;
 use crate::array::metadata::ArrayMetadata;
 use crate::array::*;
-use crate::chunked_array::{
-    ChunkedArray, ChunkedGeometryCollectionArray, ChunkedMixedGeometryArray, ChunkedNativeArray,
-};
+use crate::chunked_array::{ChunkedArray, ChunkedGeometryCollectionArray, ChunkedMixedGeometryArray, ChunkedNativeArray};
 use crate::error::Result;
 use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::NativeArray;
@@ -16,25 +14,14 @@ use geozero::{GeozeroGeometry, ToGeo};
 pub trait FromWKT: Sized {
     type Input<O: OffsetSizeTrait>;
 
-    fn from_wkt<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self>;
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self>;
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKT for MixedGeometryArray<OOutput, 2> {
+impl FromWKT for MixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
 
-    fn from_wkt<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        let mut builder =
-            MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        let mut builder = MixedGeometryStreamBuilder::new_with_options(coord_type, metadata, prefer_multi);
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 let wkt_str = geozero::wkt::Wkt(arr.value(i));
@@ -48,15 +35,10 @@ impl<OOutput: OffsetSizeTrait> FromWKT for MixedGeometryArray<OOutput, 2> {
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKT for GeometryCollectionArray<OOutput, 2> {
+impl FromWKT for GeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
 
-    fn from_wkt<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
         // TODO: Add GeometryCollectionStreamBuilder and use that instead of going through geo
         let mut builder = GeometryCollectionBuilder::new_with_options(coord_type, metadata);
         for i in 0..arr.len() {
@@ -76,61 +58,33 @@ impl<OOutput: OffsetSizeTrait> FromWKT for GeometryCollectionArray<OOutput, 2> {
 impl FromWKT for Arc<dyn NativeArray> {
     type Input<O: OffsetSizeTrait> = GenericStringArray<O>;
 
-    fn from_wkt<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        let geom_arr =
-            GeometryCollectionArray::<i64, 2>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        let geom_arr = GeometryCollectionArray::<i64, 2>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedMixedGeometryArray<OOutput, 2> {
+impl FromWKT for ChunkedMixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedArray<GenericStringArray<O>>;
 
-    fn from_wkt<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?
-            .try_into()
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?.try_into()
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKT for ChunkedGeometryCollectionArray<OOutput, 2> {
+impl FromWKT for ChunkedGeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedArray<GenericStringArray<O>>;
 
-    fn from_wkt<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?
-            .try_into()
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        arr.try_map(|chunk| FromWKT::from_wkt(chunk, coord_type, metadata.clone(), prefer_multi))?.try_into()
     }
 }
 
 impl FromWKT for Arc<dyn ChunkedNativeArray> {
     type Input<O: OffsetSizeTrait> = ChunkedArray<GenericStringArray<O>>;
 
-    fn from_wkt<O: OffsetSizeTrait>(
-        arr: &Self::Input<O>,
-        coord_type: CoordType,
-        metadata: Arc<ArrayMetadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        let geom_arr = ChunkedGeometryCollectionArray::<i64, 2>::from_wkt(
-            arr,
-            coord_type,
-            metadata,
-            prefer_multi,
-        )?;
+    fn from_wkt<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Result<Self> {
+        let geom_arr = ChunkedGeometryCollectionArray::<i64, 2>::from_wkt(arr, coord_type, metadata, prefer_multi)?;
         Ok(geom_arr.downcast(true))
     }
 }
@@ -145,22 +99,12 @@ mod test {
 
     #[test]
     fn test_read_wkt() {
-        let wkt_geoms = [
-            "POINT (30 10)",
-            "LINESTRING (30 10, 10 30, 40 40)",
-            "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))",
-        ];
+        let wkt_geoms = ["POINT (30 10)", "LINESTRING (30 10, 10 30, 40 40)", "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"];
         let mut builder = StringBuilder::new();
         wkt_geoms.iter().for_each(|s| builder.append_value(s));
         let arr = builder.finish();
         // dbg!(arr);
-        let geom_arr = MixedGeometryArray::<i32, 2>::from_wkt(
-            &arr,
-            Default::default(),
-            Default::default(),
-            false,
-        )
-        .unwrap();
+        let geom_arr = MixedGeometryArray::<i32, 2>::from_wkt(&arr, Default::default(), Default::default(), false).unwrap();
         let geo_point = geo::Point::try_from(geom_arr.value(0).to_geo().unwrap()).unwrap();
         assert_eq!(geo_point.x(), 30.0);
         assert_eq!(geo_point.y(), 10.0);
@@ -173,17 +117,8 @@ mod test {
         wkt_geoms.iter().for_each(|s| builder.append_value(s));
         let arr = builder.finish();
         // dbg!(arr);
-        let geom_arr = MixedGeometryArray::<i32, 2>::from_wkt(
-            &arr,
-            Default::default(),
-            Default::default(),
-            true,
-        )
-        .unwrap();
+        let geom_arr = MixedGeometryArray::<i32, 2>::from_wkt(&arr, Default::default(), Default::default(), true).unwrap();
         let geom_arr = geom_arr.downcast(true);
-        assert!(matches!(
-            geom_arr.data_type(),
-            NativeType::Point(_, Dimension::XY)
-        ));
+        assert!(matches!(geom_arr.data_type(), NativeType::Point(_, Dimension::XY)));
     }
 }

--- a/src/io/geozero/array/dynamic.rs
+++ b/src/io/geozero/array/dynamic.rs
@@ -26,57 +26,30 @@ impl GeozeroGeometry for NativeArrayDyn {
         match self.inner().data_type() {
             Point(_, XY) => impl_process!(as_point, 2),
             LineString(_, XY) => impl_process!(as_line_string, 2),
-            LargeLineString(_, XY) => impl_process!(as_large_line_string, 2),
             Polygon(_, XY) => impl_process!(as_polygon, 2),
-            LargePolygon(_, XY) => impl_process!(as_large_polygon, 2),
             MultiPoint(_, XY) => impl_process!(as_multi_point, 2),
-            LargeMultiPoint(_, XY) => impl_process!(as_large_multi_point, 2),
             MultiLineString(_, XY) => {
                 impl_process!(as_multi_line_string, 2)
             }
-            LargeMultiLineString(_, XY) => {
-                impl_process!(as_large_multi_line_string, 2)
-            }
             MultiPolygon(_, XY) => impl_process!(as_multi_polygon, 2),
-            LargeMultiPolygon(_, XY) => {
-                impl_process!(as_large_multi_polygon, 2)
-            }
             Mixed(_, XY) => impl_process!(as_mixed, 2),
-            LargeMixed(_, XY) => impl_process!(as_large_mixed, 2),
             GeometryCollection(_, XY) => {
                 impl_process!(as_geometry_collection, 2)
             }
-            LargeGeometryCollection(_, XY) => {
-                impl_process!(as_large_geometry_collection, 2)
-            }
             Point(_, XYZ) => impl_process!(as_point, 3),
             LineString(_, XYZ) => impl_process!(as_line_string, 3),
-            LargeLineString(_, XYZ) => impl_process!(as_large_line_string, 3),
             Polygon(_, XYZ) => impl_process!(as_polygon, 3),
-            LargePolygon(_, XYZ) => impl_process!(as_large_polygon, 3),
             MultiPoint(_, XYZ) => impl_process!(as_multi_point, 3),
-            LargeMultiPoint(_, XYZ) => impl_process!(as_large_multi_point, 3),
             MultiLineString(_, XYZ) => {
                 impl_process!(as_multi_line_string, 3)
             }
-            LargeMultiLineString(_, XYZ) => {
-                impl_process!(as_large_multi_line_string, 3)
-            }
             MultiPolygon(_, XYZ) => impl_process!(as_multi_polygon, 3),
-            LargeMultiPolygon(_, XYZ) => {
-                impl_process!(as_large_multi_polygon, 3)
-            }
             Mixed(_, XYZ) => impl_process!(as_mixed, 3),
-            LargeMixed(_, XYZ) => impl_process!(as_large_mixed, 3),
             GeometryCollection(_, XYZ) => {
                 impl_process!(as_geometry_collection, 3)
             }
-            LargeGeometryCollection(_, XYZ) => {
-                impl_process!(as_large_geometry_collection, 3)
-            }
             _ => todo!(),
             // WKB => impl_process!(as_wkb),
-            // LargeWKB => impl_process!(as_large_wkb),
             // Rect(XY) => impl_process!(as_rect, 2)
             // Rect(XYZ) => impl_process!(as_rect, 3)
         }

--- a/src/io/geozero/array/geometrycollection.rs
+++ b/src/io/geozero/array/geometrycollection.rs
@@ -2,7 +2,6 @@ use crate::array::GeometryCollectionArray;
 use crate::io::geozero::scalar::process_geometry_collection;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
 impl<const D: usize> GeozeroGeometry for GeometryCollectionArray<D> {

--- a/src/io/geozero/array/geometrycollection.rs
+++ b/src/io/geozero/array/geometrycollection.rs
@@ -5,7 +5,7 @@ use crate::ArrayBase;
 use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for GeometryCollectionArray<O, D> {
+impl<const D: usize> GeozeroGeometry for GeometryCollectionArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/array/linestring.rs
+++ b/src/io/geozero/array/linestring.rs
@@ -1,4 +1,3 @@
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::linestring::LineStringCapacity;
@@ -99,7 +98,7 @@ mod test {
     #[test]
     fn from_geozero() -> Result<()> {
         let geo = Geometry::GeometryCollection(vec![ls0(), ls1()].into_iter().map(Geometry::LineString).collect());
-        let multi_point_array: LineStringArray<i32, 2> = geo.to_line_string_array().unwrap();
+        let multi_point_array: LineStringArray<2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), ls0());
         assert_eq!(multi_point_array.value_as_geo(1), ls1());
         Ok(())

--- a/src/io/geozero/array/linestring.rs
+++ b/src/io/geozero/array/linestring.rs
@@ -7,7 +7,7 @@ use crate::io::geozero::scalar::process_line_string;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for LineStringArray<O, D> {
+impl<const D: usize> GeozeroGeometry for LineStringArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -25,20 +25,20 @@ impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for LineStringArray<O, 
 }
 
 /// GeoZero trait to convert to GeoArrow LineStringArray.
-pub trait ToLineStringArray<O: OffsetSizeTrait, const D: usize> {
+pub trait ToLineStringArray<const D: usize> {
     /// Convert to GeoArrow LineStringArray
-    fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<O, D>>;
+    fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<D>>;
 
     /// Convert to a GeoArrow LineStringBuilder
-    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<O, D>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<D>>;
 }
 
-impl<T: GeozeroGeometry, O: OffsetSizeTrait, const D: usize> ToLineStringArray<O, D> for T {
-    fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<O, D>> {
+impl<T: GeozeroGeometry, const D: usize> ToLineStringArray<D> for T {
+    fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<D>> {
         Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<O, D>> {
+    fn to_line_string_builder(&self) -> geozero::error::Result<LineStringBuilder<D>> {
         let mut mutable_array = LineStringBuilder::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
@@ -46,7 +46,7 @@ impl<T: GeozeroGeometry, O: OffsetSizeTrait, const D: usize> ToLineStringArray<O
 }
 
 #[allow(unused_variables)]
-impl<O: OffsetSizeTrait, const D: usize> GeomProcessor for LineStringBuilder<O, D> {
+impl<const D: usize> GeomProcessor for LineStringBuilder<D> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         let capacity = LineStringCapacity::new(0, size);
         self.reserve(capacity);
@@ -66,12 +66,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeomProcessor for LineStringBuilder<O, 
         Ok(())
     }
 
-    fn linestring_begin(
-        &mut self,
-        tagged: bool,
-        size: usize,
-        idx: usize,
-    ) -> geozero::error::Result<()> {
+    fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
         let capacity = LineStringCapacity::new(size, 0);
         self.reserve(capacity);
         self.try_push_length(size).unwrap();
@@ -94,7 +89,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> geozero::error::Result<()> {
-        let arr: LineStringArray<i64, 2> = vec![ls0(), ls1()].as_slice().into();
+        let arr: LineStringArray<2> = vec![ls0(), ls1()].as_slice().into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(LINESTRING(0 1,1 2),LINESTRING(3 4,5 6))";
         assert_eq!(wkt, expected);
@@ -103,12 +98,7 @@ mod test {
 
     #[test]
     fn from_geozero() -> Result<()> {
-        let geo = Geometry::GeometryCollection(
-            vec![ls0(), ls1()]
-                .into_iter()
-                .map(Geometry::LineString)
-                .collect(),
-        );
+        let geo = Geometry::GeometryCollection(vec![ls0(), ls1()].into_iter().map(Geometry::LineString).collect());
         let multi_point_array: LineStringArray<i32, 2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), ls0());
         assert_eq!(multi_point_array.value_as_geo(1), ls1());

--- a/src/io/geozero/array/linestring.rs
+++ b/src/io/geozero/array/linestring.rs
@@ -65,7 +65,12 @@ impl<const D: usize> GeomProcessor for LineStringBuilder<D> {
         Ok(())
     }
 
-    fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
+    fn linestring_begin(
+        &mut self,
+        tagged: bool,
+        size: usize,
+        idx: usize,
+    ) -> geozero::error::Result<()> {
         let capacity = LineStringCapacity::new(size, 0);
         self.reserve(capacity);
         self.try_push_length(size).unwrap();
@@ -97,7 +102,12 @@ mod test {
 
     #[test]
     fn from_geozero() -> Result<()> {
-        let geo = Geometry::GeometryCollection(vec![ls0(), ls1()].into_iter().map(Geometry::LineString).collect());
+        let geo = Geometry::GeometryCollection(
+            vec![ls0(), ls1()]
+                .into_iter()
+                .map(Geometry::LineString)
+                .collect(),
+        );
         let multi_point_array: LineStringArray<2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), ls0());
         assert_eq!(multi_point_array.value_as_geo(1), ls1());

--- a/src/io/geozero/array/mixed.rs
+++ b/src/io/geozero/array/mixed.rs
@@ -10,7 +10,7 @@ use crate::NativeArray;
 use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MixedGeometryArray<O, D> {
+impl<const D: usize> GeozeroGeometry for MixedGeometryArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -29,20 +29,20 @@ impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MixedGeometryArray<
 
 // TODO: Add "promote to multi" here
 /// GeoZero trait to convert to GeoArrow MixedArray.
-pub trait ToMixedArray<O: OffsetSizeTrait, const D: usize> {
+pub trait ToMixedArray<const D: usize> {
     /// Convert to GeoArrow MixedArray
-    fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<O, D>>;
+    fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<D>>;
 
     /// Convert to a GeoArrow MixedArrayBuilder
-    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<O, D>>;
+    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<D>>;
 }
 
-impl<T: GeozeroGeometry, O: OffsetSizeTrait, const D: usize> ToMixedArray<O, D> for T {
-    fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<O, D>> {
+impl<T: GeozeroGeometry, const D: usize> ToMixedArray<D> for T {
+    fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<D>> {
         Ok(self.to_mixed_geometry_builder()?.into())
     }
 
-    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<O, D>> {
+    fn to_mixed_geometry_builder(&self) -> geozero::error::Result<MixedGeometryBuilder<D>> {
         let mut stream_builder = MixedGeometryStreamBuilder::new();
         self.process_geom(&mut stream_builder)?;
         Ok(stream_builder.builder)
@@ -56,8 +56,8 @@ impl<T: GeozeroGeometry, O: OffsetSizeTrait, const D: usize> ToMixedArray<O, D> 
 ///
 /// Converting an [`MixedGeometryStreamBuilder`] into a [`MixedGeometryArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct MixedGeometryStreamBuilder<O: OffsetSizeTrait, const D: usize> {
-    builder: MixedGeometryBuilder<O, D>,
+pub struct MixedGeometryStreamBuilder<const D: usize> {
+    builder: MixedGeometryBuilder<D>,
     // Note: we don't know if, when `linestring_end` is called, that means a ring of a polygon has
     // finished or if a tagged line string has finished. This means we can't have an "unknown" enum
     // type, because we'll never be able to set it to unknown after a line string is done, meaning
@@ -67,7 +67,7 @@ pub struct MixedGeometryStreamBuilder<O: OffsetSizeTrait, const D: usize> {
     prefer_multi: bool,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> MixedGeometryStreamBuilder<O, D> {
+impl<const D: usize> MixedGeometryStreamBuilder<D> {
     pub fn new() -> Self {
         Self {
             builder: MixedGeometryBuilder::new(),
@@ -92,19 +92,19 @@ impl<O: OffsetSizeTrait, const D: usize> MixedGeometryStreamBuilder<O, D> {
         self.builder.push_null()
     }
 
-    pub fn finish(self) -> MixedGeometryArray<O, D> {
+    pub fn finish(self) -> MixedGeometryArray<D> {
         self.builder.finish()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> Default for MixedGeometryStreamBuilder<O, D> {
+impl<const D: usize> Default for MixedGeometryStreamBuilder<D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
 #[allow(unused_variables)]
-impl<O: OffsetSizeTrait, const D: usize> GeomProcessor for MixedGeometryStreamBuilder<O, D> {
+impl<const D: usize> GeomProcessor for MixedGeometryStreamBuilder<D> {
     fn xy(&mut self, x: f64, y: f64, idx: usize) -> geozero::error::Result<()> {
         match self.current_geom_type {
             GeometryType::Point => {
@@ -266,7 +266,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeomProcessor for MixedGeometryStreamBu
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryArrayBuilder for MixedGeometryStreamBuilder<O, D> {
+impl<const D: usize> GeometryArrayBuilder for MixedGeometryStreamBuilder<D> {
     fn len(&self) -> usize {
         self.builder.len()
     }

--- a/src/io/geozero/array/mixed.rs
+++ b/src/io/geozero/array/mixed.rs
@@ -68,11 +68,23 @@ pub struct MixedGeometryStreamBuilder<const D: usize> {
 
 impl<const D: usize> MixedGeometryStreamBuilder<D> {
     pub fn new() -> Self {
-        Self { builder: MixedGeometryBuilder::new(), current_geom_type: GeometryType::Point, prefer_multi: true }
+        Self {
+            builder: MixedGeometryBuilder::new(),
+            current_geom_type: GeometryType::Point,
+            prefer_multi: true,
+        }
     }
 
-    pub fn new_with_options(coord_type: CoordType, metadata: Arc<ArrayMetadata>, prefer_multi: bool) -> Self {
-        Self { builder: MixedGeometryBuilder::new_with_options(coord_type, metadata), current_geom_type: GeometryType::Point, prefer_multi }
+    pub fn new_with_options(
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Self {
+        Self {
+            builder: MixedGeometryBuilder::new_with_options(coord_type, metadata),
+            current_geom_type: GeometryType::Point,
+            prefer_multi,
+        }
     }
 
     pub fn push_null(&mut self) {
@@ -125,7 +137,10 @@ impl<const D: usize> GeomProcessor for MixedGeometryStreamBuilder<D> {
     fn empty_point(&mut self, idx: usize) -> geozero::error::Result<()> {
         if self.prefer_multi {
             self.builder.add_multi_point_type();
-            self.builder.multi_points.push_point(None::<&geo::Point<f64>>).unwrap();
+            self.builder
+                .multi_points
+                .push_point(None::<&geo::Point<f64>>)
+                .unwrap();
         } else {
             self.builder.add_point_type();
             self.builder.points.push_empty();
@@ -154,7 +169,12 @@ impl<const D: usize> GeomProcessor for MixedGeometryStreamBuilder<D> {
         self.builder.multi_points.multipoint_begin(size, idx)
     }
 
-    fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
+    fn linestring_begin(
+        &mut self,
+        tagged: bool,
+        size: usize,
+        idx: usize,
+    ) -> geozero::error::Result<()> {
         if tagged {
             self.current_geom_type = GeometryType::LineString;
             if self.prefer_multi {
@@ -167,31 +187,53 @@ impl<const D: usize> GeomProcessor for MixedGeometryStreamBuilder<D> {
         match self.current_geom_type {
             GeometryType::LineString => {
                 if self.prefer_multi {
-                    self.builder.multi_line_strings.linestring_begin(tagged, size, idx)
+                    self.builder
+                        .multi_line_strings
+                        .linestring_begin(tagged, size, idx)
                 } else {
-                    self.builder.line_strings.linestring_begin(tagged, size, idx)
+                    self.builder
+                        .line_strings
+                        .linestring_begin(tagged, size, idx)
                 }
             }
-            GeometryType::MultiLineString => self.builder.multi_line_strings.linestring_begin(tagged, size, idx),
+            GeometryType::MultiLineString => self
+                .builder
+                .multi_line_strings
+                .linestring_begin(tagged, size, idx),
             GeometryType::Polygon => {
                 if self.prefer_multi {
-                    self.builder.multi_polygons.linestring_begin(tagged, size, idx)
+                    self.builder
+                        .multi_polygons
+                        .linestring_begin(tagged, size, idx)
                 } else {
                     self.builder.polygons.linestring_begin(tagged, size, idx)
                 }
             }
-            GeometryType::MultiPolygon => self.builder.multi_polygons.linestring_begin(tagged, size, idx),
-            _ => panic!("unexpected linestring_begin for {:?}", self.current_geom_type),
+            GeometryType::MultiPolygon => self
+                .builder
+                .multi_polygons
+                .linestring_begin(tagged, size, idx),
+            _ => panic!(
+                "unexpected linestring_begin for {:?}",
+                self.current_geom_type
+            ),
         }
     }
 
     fn multilinestring_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         self.current_geom_type = GeometryType::MultiLineString;
         self.builder.add_multi_line_string_type();
-        self.builder.multi_line_strings.multilinestring_begin(size, idx)
+        self.builder
+            .multi_line_strings
+            .multilinestring_begin(size, idx)
     }
 
-    fn polygon_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
+    fn polygon_begin(
+        &mut self,
+        tagged: bool,
+        size: usize,
+        idx: usize,
+    ) -> geozero::error::Result<()> {
         if tagged {
             self.current_geom_type = GeometryType::Polygon;
             if self.prefer_multi {
@@ -209,7 +251,9 @@ impl<const D: usize> GeomProcessor for MixedGeometryStreamBuilder<D> {
                     self.builder.polygons.polygon_begin(tagged, size, idx)
                 }
             }
-            GeometryType::MultiPolygon => self.builder.multi_polygons.polygon_begin(tagged, size, idx),
+            GeometryType::MultiPolygon => {
+                self.builder.multi_polygons.polygon_begin(tagged, size, idx)
+            }
             _ => panic!("unexpected polygon_begin for {:?}", self.current_geom_type),
         }
     }
@@ -239,7 +283,11 @@ impl<const D: usize> GeometryArrayBuilder for MixedGeometryStreamBuilder<D> {
         self.builder.into_array_ref()
     }
 
-    fn with_geom_capacity_and_options(_geom_capacity: usize, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
+    fn with_geom_capacity_and_options(
+        _geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
         Self::new_with_options(coord_type, metadata, true)
     }
 

--- a/src/io/geozero/array/multilinestring.rs
+++ b/src/io/geozero/array/multilinestring.rs
@@ -1,4 +1,3 @@
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::multilinestring::MultiLineStringCapacity;
@@ -127,7 +126,7 @@ mod test {
     #[test]
     fn from_geozero() -> Result<()> {
         let geo = Geometry::GeometryCollection(vec![ml0(), ml1()].into_iter().map(Geometry::MultiLineString).collect());
-        let multi_point_array: MultiLineStringArray<i32, 2> = geo.to_line_string_array().unwrap();
+        let multi_point_array: MultiLineStringArray<2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), ml0());
         assert_eq!(multi_point_array.value_as_geo(1), ml1());
         Ok(())

--- a/src/io/geozero/array/multilinestring.rs
+++ b/src/io/geozero/array/multilinestring.rs
@@ -7,7 +7,7 @@ use crate::io::geozero::scalar::process_multi_line_string;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MultiLineStringArray<O, D> {
+impl<const D: usize> GeozeroGeometry for MultiLineStringArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -25,20 +25,20 @@ impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MultiLineStringArra
 }
 
 /// GeoZero trait to convert to GeoArrow MultiLineStringArray.
-pub trait ToMultiLineStringArray<O: OffsetSizeTrait, const D: usize> {
+pub trait ToMultiLineStringArray<const D: usize> {
     /// Convert to GeoArrow MultiLineStringArray
-    fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<O, D>>;
+    fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<D>>;
 
     /// Convert to a GeoArrow MultiLineStringBuilder
-    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<O, D>>;
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<D>>;
 }
 
-impl<T: GeozeroGeometry, O: OffsetSizeTrait, const D: usize> ToMultiLineStringArray<O, D> for T {
-    fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<O, D>> {
+impl<T: GeozeroGeometry, const D: usize> ToMultiLineStringArray<D> for T {
+    fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<D>> {
         Ok(self.to_line_string_builder()?.into())
     }
 
-    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<O, D>> {
+    fn to_line_string_builder(&self) -> geozero::error::Result<MultiLineStringBuilder<D>> {
         let mut mutable_array = MultiLineStringBuilder::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
@@ -46,7 +46,7 @@ impl<T: GeozeroGeometry, O: OffsetSizeTrait, const D: usize> ToMultiLineStringAr
 }
 
 #[allow(unused_variables)]
-impl<O: OffsetSizeTrait, const D: usize> GeomProcessor for MultiLineStringBuilder<O, D> {
+impl<const D: usize> GeomProcessor for MultiLineStringBuilder<D> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         let capacity = MultiLineStringCapacity::new(0, 0, size);
@@ -80,12 +80,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeomProcessor for MultiLineStringBuilde
         Ok(())
     }
 
-    fn linestring_begin(
-        &mut self,
-        tagged: bool,
-        size: usize,
-        idx: usize,
-    ) -> geozero::error::Result<()> {
+    fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
         // > An untagged LineString is either a Polygon ring or part of a MultiLineString
         // So if tagged, we need to update the geometry offsets array.
         if tagged {
@@ -122,7 +117,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> geozero::error::Result<()> {
-        let arr: MultiLineStringArray<i64, 2> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(MULTILINESTRING((-111 45,-111 41,-104 41,-104 45)),MULTILINESTRING((-111 45,-111 41,-104 41,-104 45),(-110 44,-110 42,-105 42,-105 44)))";
         assert_eq!(wkt, expected);
@@ -131,12 +126,7 @@ mod test {
 
     #[test]
     fn from_geozero() -> Result<()> {
-        let geo = Geometry::GeometryCollection(
-            vec![ml0(), ml1()]
-                .into_iter()
-                .map(Geometry::MultiLineString)
-                .collect(),
-        );
+        let geo = Geometry::GeometryCollection(vec![ml0(), ml1()].into_iter().map(Geometry::MultiLineString).collect());
         let multi_point_array: MultiLineStringArray<i32, 2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), ml0());
         assert_eq!(multi_point_array.value_as_geo(1), ml1());

--- a/src/io/geozero/array/multilinestring.rs
+++ b/src/io/geozero/array/multilinestring.rs
@@ -79,7 +79,12 @@ impl<const D: usize> GeomProcessor for MultiLineStringBuilder<D> {
         Ok(())
     }
 
-    fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
+    fn linestring_begin(
+        &mut self,
+        tagged: bool,
+        size: usize,
+        idx: usize,
+    ) -> geozero::error::Result<()> {
         // > An untagged LineString is either a Polygon ring or part of a MultiLineString
         // So if tagged, we need to update the geometry offsets array.
         if tagged {
@@ -125,7 +130,12 @@ mod test {
 
     #[test]
     fn from_geozero() -> Result<()> {
-        let geo = Geometry::GeometryCollection(vec![ml0(), ml1()].into_iter().map(Geometry::MultiLineString).collect());
+        let geo = Geometry::GeometryCollection(
+            vec![ml0(), ml1()]
+                .into_iter()
+                .map(Geometry::MultiLineString)
+                .collect(),
+        );
         let multi_point_array: MultiLineStringArray<2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), ml0());
         assert_eq!(multi_point_array.value_as_geo(1), ml1());

--- a/src/io/geozero/array/multipoint.rs
+++ b/src/io/geozero/array/multipoint.rs
@@ -102,7 +102,12 @@ mod test {
 
     #[test]
     fn from_geozero() -> Result<()> {
-        let geo = Geometry::GeometryCollection(vec![mp0(), mp1()].into_iter().map(Geometry::MultiPoint).collect());
+        let geo = Geometry::GeometryCollection(
+            vec![mp0(), mp1()]
+                .into_iter()
+                .map(Geometry::MultiPoint)
+                .collect(),
+        );
         let multi_point_array: MultiPointArray<2> = geo.to_multi_point_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), mp0());
         assert_eq!(multi_point_array.value_as_geo(1), mp1());

--- a/src/io/geozero/array/multipoint.rs
+++ b/src/io/geozero/array/multipoint.rs
@@ -6,7 +6,7 @@ use crate::ArrayBase;
 use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MultiPointArray<O, D> {
+impl<const D: usize> GeozeroGeometry for MultiPointArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -24,20 +24,20 @@ impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MultiPointArray<O, 
 }
 
 /// GeoZero trait to convert to GeoArrow MultiPointArray.
-pub trait ToMultiPointArray<O: OffsetSizeTrait, const D: usize> {
+pub trait ToMultiPointArray<const D: usize> {
     /// Convert to GeoArrow MultiPointArray
-    fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<O, D>>;
+    fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<D>>;
 
     /// Convert to a GeoArrow MultiPointBuilder
-    fn to_multi_point_builder(&self) -> geozero::error::Result<MultiPointBuilder<O, D>>;
+    fn to_multi_point_builder(&self) -> geozero::error::Result<MultiPointBuilder<D>>;
 }
 
-impl<T: GeozeroGeometry, O: OffsetSizeTrait, const D: usize> ToMultiPointArray<O, D> for T {
-    fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<O, D>> {
+impl<T: GeozeroGeometry, const D: usize> ToMultiPointArray<D> for T {
+    fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<D>> {
         Ok(self.to_multi_point_builder()?.into())
     }
 
-    fn to_multi_point_builder(&self) -> geozero::error::Result<MultiPointBuilder<O, D>> {
+    fn to_multi_point_builder(&self) -> geozero::error::Result<MultiPointBuilder<D>> {
         let mut mutable_array = MultiPointBuilder::new();
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
@@ -45,7 +45,7 @@ impl<T: GeozeroGeometry, O: OffsetSizeTrait, const D: usize> ToMultiPointArray<O
 }
 
 #[allow(unused_variables)]
-impl<O: OffsetSizeTrait, const D: usize> GeomProcessor for MultiPointBuilder<O, D> {
+impl<const D: usize> GeomProcessor for MultiPointBuilder<D> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         let capacity = MultiPointCapacity::new(0, size);
         self.reserve(capacity);

--- a/src/io/geozero/array/multipoint.rs
+++ b/src/io/geozero/array/multipoint.rs
@@ -3,7 +3,6 @@ use crate::array::{MultiPointArray, MultiPointBuilder};
 use crate::io::geozero::scalar::process_multi_point;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
 impl<const D: usize> GeozeroGeometry for MultiPointArray<D> {
@@ -94,7 +93,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> Result<()> {
-        let arr: MultiPointArray<i64, 2> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPointArray<2> = vec![mp0(), mp1()].as_slice().into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(MULTIPOINT(0 1,1 2),MULTIPOINT(3 4,5 6))";
         assert_eq!(wkt, expected);
@@ -103,13 +102,8 @@ mod test {
 
     #[test]
     fn from_geozero() -> Result<()> {
-        let geo = Geometry::GeometryCollection(
-            vec![mp0(), mp1()]
-                .into_iter()
-                .map(Geometry::MultiPoint)
-                .collect(),
-        );
-        let multi_point_array: MultiPointArray<i32, 2> = geo.to_multi_point_array().unwrap();
+        let geo = Geometry::GeometryCollection(vec![mp0(), mp1()].into_iter().map(Geometry::MultiPoint).collect());
+        let multi_point_array: MultiPointArray<2> = geo.to_multi_point_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), mp0());
         assert_eq!(multi_point_array.value_as_geo(1), mp1());
         Ok(())

--- a/src/io/geozero/array/multipolygon.rs
+++ b/src/io/geozero/array/multipolygon.rs
@@ -1,4 +1,3 @@
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::multipolygon::MultiPolygonCapacity;
@@ -139,7 +138,7 @@ mod test {
     #[test]
     fn from_geozero() -> Result<()> {
         let geo = Geometry::GeometryCollection(vec![mp0(), mp1()].into_iter().map(Geometry::MultiPolygon).collect());
-        let multi_point_array: MultiPolygonArray<i32, 2> = geo.to_line_string_array().unwrap();
+        let multi_point_array: MultiPolygonArray<2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), mp0());
         assert_eq!(multi_point_array.value_as_geo(1), mp1());
         Ok(())

--- a/src/io/geozero/array/multipolygon.rs
+++ b/src/io/geozero/array/multipolygon.rs
@@ -78,7 +78,12 @@ impl<const D: usize> GeomProcessor for MultiPolygonBuilder<D> {
         Ok(())
     }
 
-    fn polygon_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
+    fn polygon_begin(
+        &mut self,
+        tagged: bool,
+        size: usize,
+        idx: usize,
+    ) -> geozero::error::Result<()> {
         // > An untagged Polygon is part of a MultiPolygon
         if tagged {
             // reserve 1 polygon
@@ -102,7 +107,12 @@ impl<const D: usize> GeomProcessor for MultiPolygonBuilder<D> {
         Ok(())
     }
 
-    fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
+    fn linestring_begin(
+        &mut self,
+        tagged: bool,
+        size: usize,
+        idx: usize,
+    ) -> geozero::error::Result<()> {
         assert!(!tagged);
 
         // reserve `size` coordinates
@@ -137,7 +147,12 @@ mod test {
 
     #[test]
     fn from_geozero() -> Result<()> {
-        let geo = Geometry::GeometryCollection(vec![mp0(), mp1()].into_iter().map(Geometry::MultiPolygon).collect());
+        let geo = Geometry::GeometryCollection(
+            vec![mp0(), mp1()]
+                .into_iter()
+                .map(Geometry::MultiPolygon)
+                .collect(),
+        );
         let multi_point_array: MultiPolygonArray<2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), mp0());
         assert_eq!(multi_point_array.value_as_geo(1), mp1());

--- a/src/io/geozero/array/polygon.rs
+++ b/src/io/geozero/array/polygon.rs
@@ -66,7 +66,12 @@ impl<const D: usize> GeomProcessor for PolygonBuilder<D> {
     }
 
     // Here, size is the number of rings in the polygon
-    fn polygon_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
+    fn polygon_begin(
+        &mut self,
+        tagged: bool,
+        size: usize,
+        idx: usize,
+    ) -> geozero::error::Result<()> {
         // reserve `size` rings
         let capacity = PolygonCapacity::new(0, size, 0);
         self.reserve(capacity);
@@ -78,7 +83,12 @@ impl<const D: usize> GeomProcessor for PolygonBuilder<D> {
         Ok(())
     }
 
-    fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> geozero::error::Result<()> {
+    fn linestring_begin(
+        &mut self,
+        tagged: bool,
+        size: usize,
+        idx: usize,
+    ) -> geozero::error::Result<()> {
         // reserve `size` coordinates
         let capacity = PolygonCapacity::new(size, 0, 0);
         self.reserve(capacity);
@@ -111,8 +121,13 @@ mod test {
 
     #[test]
     fn from_geozero() -> Result<()> {
-        let geo = Geometry::GeometryCollection(vec![p0(), p1()].into_iter().map(Geometry::Polygon).collect());
-        let multi_point_array: PolygonArray<i32, 2> = geo.to_line_string_array().unwrap();
+        let geo = Geometry::GeometryCollection(
+            vec![p0(), p1()]
+                .into_iter()
+                .map(Geometry::Polygon)
+                .collect(),
+        );
+        let multi_point_array: PolygonArray<2> = geo.to_line_string_array().unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), p0());
         assert_eq!(multi_point_array.value_as_geo(1), p1());
         Ok(())

--- a/src/io/geozero/array/polygon.rs
+++ b/src/io/geozero/array/polygon.rs
@@ -3,7 +3,6 @@ use crate::array::{PolygonArray, PolygonBuilder};
 use crate::io::geozero::scalar::process_polygon;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
 impl<const D: usize> GeozeroGeometry for PolygonArray<D> {

--- a/src/io/geozero/scalar/geometry.rs
+++ b/src/io/geozero/scalar/geometry.rs
@@ -32,7 +32,7 @@ pub(crate) fn process_geometry<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for Geometry<'_, O, D> {
+impl<const D: usize> GeozeroGeometry for Geometry<'_, D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -42,11 +42,11 @@ impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for Geometry<'_, O, D> 
 }
 
 pub trait ToGeometry<O: OffsetSizeTrait> {
-    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<O, 2>>;
+    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<2>>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToGeometry<O> for T {
-    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<O, 2>> {
+    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<2>> {
         let arr = self.to_mixed_geometry_array()?;
         assert_eq!(arr.len(), 1);
         Ok(OwnedGeometry::from(arr.value(0)))

--- a/src/io/geozero/scalar/geometry_array.rs
+++ b/src/io/geozero/scalar/geometry_array.rs
@@ -41,49 +41,25 @@ pub fn process_geometry_scalar_array<P: GeomProcessor>(
     match geom.data_type() {
         Point(_, XY) => impl_process!(process_point, as_point, 2),
         LineString(_, XY) => impl_process!(process_line_string, as_line_string, 2),
-        LargeLineString(_, XY) => impl_process!(process_line_string, as_large_line_string, 2),
         Polygon(_, XY) => impl_process!(process_polygon, true, as_polygon, 2),
-        LargePolygon(_, XY) => impl_process!(process_polygon, true, as_large_polygon, 2),
         MultiPoint(_, XY) => impl_process!(process_multi_point, as_multi_point, 2),
-        LargeMultiPoint(_, XY) => impl_process!(process_multi_point, as_large_multi_point, 2),
         MultiLineString(_, XY) => impl_process!(process_multi_line_string, as_multi_line_string, 2),
-        LargeMultiLineString(_, XY) => {
-            impl_process!(process_multi_line_string, as_large_multi_line_string, 2)
-        }
         MultiPolygon(_, XY) => impl_process!(process_multi_polygon, as_multi_polygon, 2),
-        LargeMultiPolygon(_, XY) => impl_process!(process_multi_polygon, as_large_multi_polygon, 2),
         Mixed(_, XY) => impl_process!(process_geometry, as_mixed, 2),
-        LargeMixed(_, XY) => impl_process!(process_geometry, as_large_mixed, 2),
         GeometryCollection(_, XY) => {
             impl_process!(process_geometry_collection, as_geometry_collection, 2)
         }
-        LargeGeometryCollection(_, XY) => {
-            impl_process!(process_geometry_collection, as_large_geometry_collection, 2)
-        }
         Point(_, XYZ) => impl_process!(process_point, as_point, 3),
         LineString(_, XYZ) => impl_process!(process_line_string, as_line_string, 3),
-        LargeLineString(_, XYZ) => impl_process!(process_line_string, as_large_line_string, 3),
         Polygon(_, XYZ) => impl_process!(process_polygon, true, as_polygon, 3),
-        LargePolygon(_, XYZ) => impl_process!(process_polygon, true, as_large_polygon, 3),
         MultiPoint(_, XYZ) => impl_process!(process_multi_point, as_multi_point, 3),
-        LargeMultiPoint(_, XYZ) => impl_process!(process_multi_point, as_large_multi_point, 3),
         MultiLineString(_, XYZ) => {
             impl_process!(process_multi_line_string, as_multi_line_string, 3)
         }
-        LargeMultiLineString(_, XYZ) => {
-            impl_process!(process_multi_line_string, as_large_multi_line_string, 3)
-        }
         MultiPolygon(_, XYZ) => impl_process!(process_multi_polygon, as_multi_polygon, 3),
-        LargeMultiPolygon(_, XYZ) => {
-            impl_process!(process_multi_polygon, as_large_multi_polygon, 3)
-        }
         Mixed(_, XYZ) => impl_process!(process_geometry, as_mixed, 3),
-        LargeMixed(_, XYZ) => impl_process!(process_geometry, as_large_mixed, 3),
         GeometryCollection(_, XYZ) => {
             impl_process!(process_geometry_collection, as_geometry_collection, 3)
-        }
-        LargeGeometryCollection(_, XYZ) => {
-            impl_process!(process_geometry_collection, as_large_geometry_collection, 3)
         }
         // WKB => {
         //     let arr = &geom.inner().as_ref();

--- a/src/io/geozero/scalar/geometry_collection.rs
+++ b/src/io/geozero/scalar/geometry_collection.rs
@@ -1,14 +1,9 @@
 use crate::geo_traits::GeometryCollectionTrait;
 use crate::io::geozero::scalar::geometry::process_geometry;
 use crate::scalar::GeometryCollection;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_geometry_collection<P: GeomProcessor>(
-    geom: &impl GeometryCollectionTrait<T = f64>,
-    geom_idx: usize,
-    processor: &mut P,
-) -> geozero::error::Result<()> {
+pub(crate) fn process_geometry_collection<P: GeomProcessor>(geom: &impl GeometryCollectionTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
     processor.geometrycollection_begin(geom.num_geometries(), geom_idx)?;
 
     for (i, geometry) in geom.geometries().enumerate() {

--- a/src/io/geozero/scalar/geometry_collection.rs
+++ b/src/io/geozero/scalar/geometry_collection.rs
@@ -3,7 +3,11 @@ use crate::io::geozero::scalar::geometry::process_geometry;
 use crate::scalar::GeometryCollection;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_geometry_collection<P: GeomProcessor>(geom: &impl GeometryCollectionTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
+pub(crate) fn process_geometry_collection<P: GeomProcessor>(
+    geom: &impl GeometryCollectionTrait<T = f64>,
+    geom_idx: usize,
+    processor: &mut P,
+) -> geozero::error::Result<()> {
     processor.geometrycollection_begin(geom.num_geometries(), geom_idx)?;
 
     for (i, geometry) in geom.geometries().enumerate() {

--- a/src/io/geozero/scalar/geometry_collection.rs
+++ b/src/io/geozero/scalar/geometry_collection.rs
@@ -19,7 +19,7 @@ pub(crate) fn process_geometry_collection<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for GeometryCollection<'_, O, D> {
+impl<const D: usize> GeozeroGeometry for GeometryCollection<'_, D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/linestring.rs
+++ b/src/io/geozero/scalar/linestring.rs
@@ -3,7 +3,11 @@ use crate::io::geozero::scalar::process_coord;
 use crate::scalar::LineString;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_line_string<P: GeomProcessor>(geom: &impl LineStringTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
+pub(crate) fn process_line_string<P: GeomProcessor>(
+    geom: &impl LineStringTrait<T = f64>,
+    geom_idx: usize,
+    processor: &mut P,
+) -> geozero::error::Result<()> {
     processor.linestring_begin(true, geom.num_coords(), geom_idx)?;
 
     for (coord_idx, coord) in geom.coords().enumerate() {

--- a/src/io/geozero/scalar/linestring.rs
+++ b/src/io/geozero/scalar/linestring.rs
@@ -1,14 +1,9 @@
 use crate::geo_traits::LineStringTrait;
 use crate::io::geozero::scalar::process_coord;
 use crate::scalar::LineString;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_line_string<P: GeomProcessor>(
-    geom: &impl LineStringTrait<T = f64>,
-    geom_idx: usize,
-    processor: &mut P,
-) -> geozero::error::Result<()> {
+pub(crate) fn process_line_string<P: GeomProcessor>(geom: &impl LineStringTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
     processor.linestring_begin(true, geom.num_coords(), geom_idx)?;
 
     for (coord_idx, coord) in geom.coords().enumerate() {

--- a/src/io/geozero/scalar/linestring.rs
+++ b/src/io/geozero/scalar/linestring.rs
@@ -19,7 +19,7 @@ pub(crate) fn process_line_string<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for LineString<'_, O, D> {
+impl<const D: usize> GeozeroGeometry for LineString<'_, D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multilinestring.rs
+++ b/src/io/geozero/scalar/multilinestring.rs
@@ -25,7 +25,7 @@ pub(crate) fn process_multi_line_string<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MultiLineString<'_, O, D> {
+impl<const D: usize> GeozeroGeometry for MultiLineString<'_, D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multilinestring.rs
+++ b/src/io/geozero/scalar/multilinestring.rs
@@ -3,7 +3,11 @@ use crate::io::geozero::scalar::process_coord;
 use crate::scalar::MultiLineString;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_multi_line_string<P: GeomProcessor>(geom: &impl MultiLineStringTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
+pub(crate) fn process_multi_line_string<P: GeomProcessor>(
+    geom: &impl MultiLineStringTrait<T = f64>,
+    geom_idx: usize,
+    processor: &mut P,
+) -> geozero::error::Result<()> {
     processor.multilinestring_begin(geom.num_lines(), geom_idx)?;
 
     for (line_idx, line) in geom.lines().enumerate() {

--- a/src/io/geozero/scalar/multilinestring.rs
+++ b/src/io/geozero/scalar/multilinestring.rs
@@ -1,14 +1,9 @@
 use crate::geo_traits::{LineStringTrait, MultiLineStringTrait};
 use crate::io::geozero::scalar::process_coord;
 use crate::scalar::MultiLineString;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_multi_line_string<P: GeomProcessor>(
-    geom: &impl MultiLineStringTrait<T = f64>,
-    geom_idx: usize,
-    processor: &mut P,
-) -> geozero::error::Result<()> {
+pub(crate) fn process_multi_line_string<P: GeomProcessor>(geom: &impl MultiLineStringTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
     processor.multilinestring_begin(geom.num_lines(), geom_idx)?;
 
     for (line_idx, line) in geom.lines().enumerate() {

--- a/src/io/geozero/scalar/multipoint.rs
+++ b/src/io/geozero/scalar/multipoint.rs
@@ -1,14 +1,9 @@
 use crate::geo_traits::MultiPointTrait;
 use crate::io::geozero::scalar::process_point_as_coord;
 use crate::scalar::MultiPoint;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_multi_point<P: GeomProcessor>(
-    geom: &impl MultiPointTrait<T = f64>,
-    geom_idx: usize,
-    processor: &mut P,
-) -> geozero::error::Result<()> {
+pub(crate) fn process_multi_point<P: GeomProcessor>(geom: &impl MultiPointTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
     processor.multipoint_begin(geom.num_points(), geom_idx)?;
 
     for (point_idx, point) in geom.points().enumerate() {

--- a/src/io/geozero/scalar/multipoint.rs
+++ b/src/io/geozero/scalar/multipoint.rs
@@ -19,7 +19,7 @@ pub(crate) fn process_multi_point<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MultiPoint<'_, O, D> {
+impl<const D: usize> GeozeroGeometry for MultiPoint<'_, D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multipoint.rs
+++ b/src/io/geozero/scalar/multipoint.rs
@@ -3,7 +3,11 @@ use crate::io::geozero::scalar::process_point_as_coord;
 use crate::scalar::MultiPoint;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_multi_point<P: GeomProcessor>(geom: &impl MultiPointTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
+pub(crate) fn process_multi_point<P: GeomProcessor>(
+    geom: &impl MultiPointTrait<T = f64>,
+    geom_idx: usize,
+    processor: &mut P,
+) -> geozero::error::Result<()> {
     processor.multipoint_begin(geom.num_points(), geom_idx)?;
 
     for (point_idx, point) in geom.points().enumerate() {

--- a/src/io/geozero/scalar/multipolygon.rs
+++ b/src/io/geozero/scalar/multipolygon.rs
@@ -3,7 +3,11 @@ use crate::io::geozero::scalar::polygon::process_polygon;
 use crate::scalar::MultiPolygon;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_multi_polygon<P: GeomProcessor>(geom: &impl MultiPolygonTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
+pub(crate) fn process_multi_polygon<P: GeomProcessor>(
+    geom: &impl MultiPolygonTrait<T = f64>,
+    geom_idx: usize,
+    processor: &mut P,
+) -> geozero::error::Result<()> {
     processor.multipolygon_begin(geom.num_polygons(), geom_idx)?;
 
     for (polygon_idx, polygon) in geom.polygons().enumerate() {

--- a/src/io/geozero/scalar/multipolygon.rs
+++ b/src/io/geozero/scalar/multipolygon.rs
@@ -19,7 +19,7 @@ pub(crate) fn process_multi_polygon<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for MultiPolygon<'_, O, D> {
+impl<const D: usize> GeozeroGeometry for MultiPolygon<'_, D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/multipolygon.rs
+++ b/src/io/geozero/scalar/multipolygon.rs
@@ -1,14 +1,9 @@
 use crate::geo_traits::MultiPolygonTrait;
 use crate::io::geozero::scalar::polygon::process_polygon;
 use crate::scalar::MultiPolygon;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-pub(crate) fn process_multi_polygon<P: GeomProcessor>(
-    geom: &impl MultiPolygonTrait<T = f64>,
-    geom_idx: usize,
-    processor: &mut P,
-) -> geozero::error::Result<()> {
+pub(crate) fn process_multi_polygon<P: GeomProcessor>(geom: &impl MultiPolygonTrait<T = f64>, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
     processor.multipolygon_begin(geom.num_polygons(), geom_idx)?;
 
     for (polygon_idx, polygon) in geom.polygons().enumerate() {

--- a/src/io/geozero/scalar/polygon.rs
+++ b/src/io/geozero/scalar/polygon.rs
@@ -40,7 +40,7 @@ pub(crate) fn process_polygon<P: GeomProcessor>(
     Ok(())
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeozeroGeometry for Polygon<'_, O, D> {
+impl<const D: usize> GeozeroGeometry for Polygon<'_, D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/src/io/geozero/scalar/polygon.rs
+++ b/src/io/geozero/scalar/polygon.rs
@@ -1,14 +1,9 @@
 use crate::geo_traits::{LineStringTrait, PolygonTrait};
 use crate::io::geozero::scalar::process_coord;
 use crate::scalar::Polygon;
-use arrow_array::OffsetSizeTrait;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-fn process_ring<P: GeomProcessor>(
-    ring: impl LineStringTrait<T = f64>,
-    ring_idx: usize,
-    processor: &mut P,
-) -> geozero::error::Result<()> {
+fn process_ring<P: GeomProcessor>(ring: impl LineStringTrait<T = f64>, ring_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
     processor.linestring_begin(false, ring.num_coords(), ring_idx)?;
 
     for (coord_idx, coord) in ring.coords().enumerate() {
@@ -19,12 +14,7 @@ fn process_ring<P: GeomProcessor>(
     Ok(())
 }
 
-pub(crate) fn process_polygon<P: GeomProcessor>(
-    geom: &impl PolygonTrait<T = f64>,
-    tagged: bool,
-    geom_idx: usize,
-    processor: &mut P,
-) -> geozero::error::Result<()> {
+pub(crate) fn process_polygon<P: GeomProcessor>(geom: &impl PolygonTrait<T = f64>, tagged: bool, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
     processor.polygon_begin(tagged, geom.num_interiors() + 1, geom_idx)?;
 
     if let Some(exterior) = geom.exterior() {

--- a/src/io/geozero/scalar/polygon.rs
+++ b/src/io/geozero/scalar/polygon.rs
@@ -3,7 +3,11 @@ use crate::io::geozero::scalar::process_coord;
 use crate::scalar::Polygon;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-fn process_ring<P: GeomProcessor>(ring: impl LineStringTrait<T = f64>, ring_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
+fn process_ring<P: GeomProcessor>(
+    ring: impl LineStringTrait<T = f64>,
+    ring_idx: usize,
+    processor: &mut P,
+) -> geozero::error::Result<()> {
     processor.linestring_begin(false, ring.num_coords(), ring_idx)?;
 
     for (coord_idx, coord) in ring.coords().enumerate() {
@@ -14,7 +18,12 @@ fn process_ring<P: GeomProcessor>(ring: impl LineStringTrait<T = f64>, ring_idx:
     Ok(())
 }
 
-pub(crate) fn process_polygon<P: GeomProcessor>(geom: &impl PolygonTrait<T = f64>, tagged: bool, geom_idx: usize, processor: &mut P) -> geozero::error::Result<()> {
+pub(crate) fn process_polygon<P: GeomProcessor>(
+    geom: &impl PolygonTrait<T = f64>,
+    tagged: bool,
+    geom_idx: usize,
+    processor: &mut P,
+) -> geozero::error::Result<()> {
     processor.polygon_begin(tagged, geom.num_interiors() + 1, geom_idx)?;
 
     if let Some(exterior) = geom.exterior() {

--- a/src/io/geozero/table/data_source.rs
+++ b/src/io/geozero/table/data_source.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use crate::array::{from_arrow_array, AsNativeArray};
 use crate::datatypes::{Dimension, NativeType};
-use crate::io::geozero::scalar::{process_geometry, process_geometry_collection, process_line_string, process_multi_line_string, process_multi_point, process_multi_polygon, process_point, process_polygon};
+use crate::io::geozero::scalar::{
+    process_geometry, process_geometry_collection, process_line_string, process_multi_line_string,
+    process_multi_point, process_multi_polygon, process_point, process_polygon,
+};
 use crate::io::geozero::table::json_encoder::{make_encoder, EncoderOptions};
 use crate::io::stream::RecordBatchReader;
 use crate::schema::GeoSchemaExt;
@@ -22,17 +25,31 @@ use geozero::{ColumnValue, FeatureProcessor, GeomProcessor, GeozeroDatasource, P
 
 impl GeozeroDatasource for RecordBatchReader {
     fn process<P: FeatureProcessor>(&mut self, processor: &mut P) -> Result<(), GeozeroError> {
-        let reader = self.take().ok_or(GeozeroError::Dataset("Cannot read from closed RecordBatchReader".to_string()))?;
+        let reader = self.take().ok_or(GeozeroError::Dataset(
+            "Cannot read from closed RecordBatchReader".to_string(),
+        ))?;
         let schema = reader.schema();
         let geom_indices = schema.as_ref().geometry_columns();
-        let geometry_column_index = if geom_indices.len() != 1 { Err(GeozeroError::Dataset("Writing through geozero not supported with multiple geometries".to_string()))? } else { geom_indices[0] };
+        let geometry_column_index = if geom_indices.len() != 1 {
+            Err(GeozeroError::Dataset(
+                "Writing through geozero not supported with multiple geometries".to_string(),
+            ))?
+        } else {
+            geom_indices[0]
+        };
 
         processor.dataset_begin(None)?;
 
         let mut overall_row_idx = 0;
         for batch in reader.into_iter() {
             let batch = batch.map_err(|err| GeozeroError::Dataset(err.to_string()))?;
-            process_batch(&batch, &schema, geometry_column_index, overall_row_idx, processor)?;
+            process_batch(
+                &batch,
+                &schema,
+                geometry_column_index,
+                overall_row_idx,
+                processor,
+            )?;
             overall_row_idx += batch.num_rows();
         }
 
@@ -48,16 +65,29 @@ impl GeozeroDatasource for Table {
     }
 }
 
-fn process_geotable<P: FeatureProcessor>(table: &mut Table, processor: &mut P) -> Result<(), GeozeroError> {
+fn process_geotable<P: FeatureProcessor>(
+    table: &mut Table,
+    processor: &mut P,
+) -> Result<(), GeozeroError> {
     let schema = table.schema();
     let batches = table.batches();
-    let geometry_column_index = table.default_geometry_column_idx().map_err(|_err| GeozeroError::Dataset("Writing through geozero not supported with multiple geometries".to_string()))?;
+    let geometry_column_index = table.default_geometry_column_idx().map_err(|_err| {
+        GeozeroError::Dataset(
+            "Writing through geozero not supported with multiple geometries".to_string(),
+        )
+    })?;
 
     processor.dataset_begin(None)?;
 
     let mut overall_row_idx = 0;
     for batch in batches {
-        process_batch(batch, schema, geometry_column_index, overall_row_idx, processor)?;
+        process_batch(
+            batch,
+            schema,
+            geometry_column_index,
+            overall_row_idx,
+            processor,
+        )?;
         overall_row_idx += batch.num_rows();
     }
 
@@ -66,17 +96,30 @@ fn process_geotable<P: FeatureProcessor>(table: &mut Table, processor: &mut P) -
     Ok(())
 }
 
-fn process_batch<P: FeatureProcessor>(batch: &RecordBatch, schema: &Schema, geometry_column_index: usize, batch_start_idx: usize, processor: &mut P) -> Result<(), GeozeroError> {
+fn process_batch<P: FeatureProcessor>(
+    batch: &RecordBatch,
+    schema: &Schema,
+    geometry_column_index: usize,
+    batch_start_idx: usize,
+    processor: &mut P,
+) -> Result<(), GeozeroError> {
     let num_rows = batch.num_rows();
     let geometry_field = schema.field(geometry_column_index);
     let geometry_column_box = &batch.columns()[geometry_column_index];
-    let geometry_column = from_arrow_array(&geometry_column_box, geometry_field).map_err(|err| GeozeroError::Dataset(err.to_string()))?;
+    let geometry_column = from_arrow_array(&geometry_column_box, geometry_field)
+        .map_err(|err| GeozeroError::Dataset(err.to_string()))?;
 
     for within_batch_row_idx in 0..num_rows {
         processor.feature_begin((within_batch_row_idx + batch_start_idx) as u64)?;
 
         processor.properties_begin()?;
-        process_properties(batch, schema, within_batch_row_idx, geometry_column_index, processor)?;
+        process_properties(
+            batch,
+            schema,
+            within_batch_row_idx,
+            geometry_column_index,
+            processor,
+        )?;
         processor.properties_end()?;
 
         processor.geometry_begin()?;
@@ -89,11 +132,18 @@ fn process_batch<P: FeatureProcessor>(batch: &RecordBatch, schema: &Schema, geom
     Ok(())
 }
 
-fn process_properties<P: PropertyProcessor>(batch: &RecordBatch, schema: &Schema, within_batch_row_idx: usize, geometry_column_index: usize, processor: &mut P) -> Result<(), GeozeroError> {
+fn process_properties<P: PropertyProcessor>(
+    batch: &RecordBatch,
+    schema: &Schema,
+    within_batch_row_idx: usize,
+    geometry_column_index: usize,
+    processor: &mut P,
+) -> Result<(), GeozeroError> {
     // Note: the `column_idx` will be off by one if the geometry column is not the last column in
     // the table, so we maintain a separate property index counter
     let mut property_idx = 0;
-    for (column_idx, (field, array)) in schema.fields.iter().zip(batch.columns().iter()).enumerate() {
+    for (column_idx, (field, array)) in schema.fields.iter().zip(batch.columns().iter()).enumerate()
+    {
         // Don't include geometry column in properties
         if column_idx == geometry_column_index {
             continue;
@@ -108,74 +158,148 @@ fn process_properties<P: PropertyProcessor>(batch: &RecordBatch, schema: &Schema
         match field.data_type() {
             DataType::Boolean => {
                 let arr = array.as_boolean();
-                processor.property(property_idx, name, &ColumnValue::Bool(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Bool(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::UInt8 => {
                 let arr = array.as_primitive::<UInt8Type>();
-                processor.property(property_idx, name, &ColumnValue::UByte(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::UByte(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::Int8 => {
                 let arr = array.as_primitive::<Int8Type>();
-                processor.property(property_idx, name, &ColumnValue::Byte(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Byte(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::UInt16 => {
                 let arr = array.as_primitive::<UInt16Type>();
-                processor.property(property_idx, name, &ColumnValue::UShort(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::UShort(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::Int16 => {
                 let arr = array.as_primitive::<Int16Type>();
-                processor.property(property_idx, name, &ColumnValue::Short(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Short(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::UInt32 => {
                 let arr = array.as_primitive::<UInt32Type>();
-                processor.property(property_idx, name, &ColumnValue::UInt(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::UInt(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::Int32 => {
                 let arr = array.as_primitive::<Int32Type>();
-                processor.property(property_idx, name, &ColumnValue::Int(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Int(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::UInt64 => {
                 let arr = array.as_primitive::<UInt64Type>();
-                processor.property(property_idx, name, &ColumnValue::ULong(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::ULong(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::Int64 => {
                 let arr = array.as_primitive::<Int64Type>();
-                processor.property(property_idx, name, &ColumnValue::Long(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Long(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::Float16 => {
                 let arr = array.as_primitive::<Float16Type>();
-                processor.property(property_idx, name, &ColumnValue::Float(arr.value(within_batch_row_idx).to_f32()))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Float(arr.value(within_batch_row_idx).to_f32()),
+                )?;
             }
             DataType::Float32 => {
                 let arr = array.as_primitive::<Float32Type>();
-                processor.property(property_idx, name, &ColumnValue::Float(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Float(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::Float64 => {
                 let arr = array.as_primitive::<Float64Type>();
-                processor.property(property_idx, name, &ColumnValue::Double(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Double(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::Utf8 => {
                 let arr = array.as_string::<i32>();
-                processor.property(property_idx, name, &ColumnValue::String(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::String(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::LargeUtf8 => {
                 let arr = array.as_string::<i64>();
-                processor.property(property_idx, name, &ColumnValue::String(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::String(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::Binary => {
                 let arr = array.as_binary::<i32>();
-                processor.property(property_idx, name, &ColumnValue::Binary(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Binary(arr.value(within_batch_row_idx)),
+                )?;
             }
             DataType::LargeBinary => {
                 let arr = array.as_binary::<i64>();
-                processor.property(property_idx, name, &ColumnValue::Binary(arr.value(within_batch_row_idx)))?;
+                processor.property(
+                    property_idx,
+                    name,
+                    &ColumnValue::Binary(arr.value(within_batch_row_idx)),
+                )?;
             }
-            DataType::Struct(_) | DataType::List(_) | DataType::LargeList(_) | DataType::Map(_, _) => {
+            DataType::Struct(_)
+            | DataType::List(_)
+            | DataType::LargeList(_)
+            | DataType::Map(_, _) => {
                 if array.is_valid(within_batch_row_idx) {
-                    let mut encoder = make_encoder(array, &EncoderOptions { explicit_nulls: false }).map_err(|err| GeozeroError::Property(err.to_string()))?;
+                    let mut encoder = make_encoder(
+                        array,
+                        &EncoderOptions {
+                            explicit_nulls: false,
+                        },
+                    )
+                    .map_err(|err| GeozeroError::Property(err.to_string()))?;
                     let mut buf = vec![];
                     encoder.encode(within_batch_row_idx, &mut buf);
-                    let json_string = String::from_utf8(buf).map_err(|err| GeozeroError::Property(err.to_string()))?;
+                    let json_string = String::from_utf8(buf)
+                        .map_err(|err| GeozeroError::Property(err.to_string()))?;
                     processor.property(property_idx, name, &ColumnValue::Json(&json_string))?;
                 }
             }
@@ -196,12 +320,25 @@ fn process_properties<P: PropertyProcessor>(batch: &RecordBatch, schema: &Schema
                 }
             }
             DataType::Timestamp(unit, tz) => {
-                let arrow_tz = if let Some(tz) = tz { Some(Tz::from_str(tz).map_err(|err| GeozeroError::Property(err.to_string()))?) } else { None };
+                let arrow_tz = if let Some(tz) = tz {
+                    Some(Tz::from_str(tz).map_err(|err| GeozeroError::Property(err.to_string()))?)
+                } else {
+                    None
+                };
 
                 macro_rules! impl_timestamp {
                     ($arrow_type:ty) => {{
                         let arr = array.as_primitive::<$arrow_type>();
-                        let dt_str = if let Some(arrow_tz) = arrow_tz { arr.value_as_datetime_with_tz(within_batch_row_idx, arrow_tz).unwrap().to_rfc3339() } else { arr.value_as_datetime(within_batch_row_idx).unwrap().and_utc().to_rfc3339() };
+                        let dt_str = if let Some(arrow_tz) = arrow_tz {
+                            arr.value_as_datetime_with_tz(within_batch_row_idx, arrow_tz)
+                                .unwrap()
+                                .to_rfc3339()
+                        } else {
+                            arr.value_as_datetime(within_batch_row_idx)
+                                .unwrap()
+                                .and_utc()
+                                .to_rfc3339()
+                        };
                         processor.property(property_idx, name, &ColumnValue::DateTime(&dt_str))?;
                     }};
                 }
@@ -223,7 +360,11 @@ fn process_properties<P: PropertyProcessor>(batch: &RecordBatch, schema: &Schema
     Ok(())
 }
 
-fn process_geometry_n<P: GeomProcessor>(geometry_column: &Arc<dyn NativeArray>, within_batch_row_idx: usize, processor: &mut P) -> Result<(), GeozeroError> {
+fn process_geometry_n<P: GeomProcessor>(
+    geometry_column: &Arc<dyn NativeArray>,
+    within_batch_row_idx: usize,
+    processor: &mut P,
+) -> Result<(), GeozeroError> {
     let arr = geometry_column.as_ref();
     let i = within_batch_row_idx;
     use NativeType::*;

--- a/src/io/geozero/table/json_encoder.rs
+++ b/src/io/geozero/table/json_encoder.rs
@@ -45,10 +45,7 @@ pub trait Encoder {
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>);
 }
 
-pub fn make_encoder<'a>(
-    array: &'a dyn Array,
-    options: &EncoderOptions,
-) -> Result<Box<dyn Encoder + 'a>, ArrowError> {
+pub fn make_encoder<'a>(array: &'a dyn Array, options: &EncoderOptions) -> Result<Box<dyn Encoder + 'a>, ArrowError> {
     let (encoder, _nulls) = make_encoder_impl(array, options)?;
     // Note: we comment this out because we're encoding _inner_ columns, our struct array does not
     // represent a RecordBatch.
@@ -56,10 +53,7 @@ pub fn make_encoder<'a>(
     Ok(encoder)
 }
 
-fn make_encoder_impl<'a>(
-    array: &'a dyn Array,
-    options: &EncoderOptions,
-) -> Result<(Box<dyn Encoder + 'a>, Option<NullBuffer>), ArrowError> {
+fn make_encoder_impl<'a>(array: &'a dyn Array, options: &EncoderOptions) -> Result<(Box<dyn Encoder + 'a>, Option<NullBuffer>), ArrowError> {
     macro_rules! primitive_helper {
         ($t:ty) => {{
             let array = array.as_primitive::<$t>();
@@ -261,10 +255,7 @@ struct PrimitiveEncoder<N: PrimitiveEncode> {
 
 impl<N: PrimitiveEncode> PrimitiveEncoder<N> {
     fn new<P: ArrowPrimitiveType<Native = N>>(array: &PrimitiveArray<P>) -> Self {
-        Self {
-            values: array.values().clone(),
-            buffer: N::init_buffer(),
-        }
+        Self { values: array.values().clone(), buffer: N::init_buffer() }
     }
 }
 
@@ -300,16 +291,9 @@ struct ListEncoder<'a, O: OffsetSizeTrait> {
 }
 
 impl<'a, O: OffsetSizeTrait> ListEncoder<'a, O> {
-    fn try_new(
-        array: &'a GenericListArray<O>,
-        options: &EncoderOptions,
-    ) -> Result<Self, ArrowError> {
+    fn try_new(array: &'a GenericListArray<O>, options: &EncoderOptions) -> Result<Self, ArrowError> {
         let (encoder, nulls) = make_encoder_impl(array.values().as_ref(), options)?;
-        Ok(Self {
-            offsets: array.offsets().clone(),
-            encoder,
-            nulls,
-        })
+        Ok(Self { offsets: array.offsets().clone(), encoder, nulls })
     }
 }
 
@@ -346,16 +330,9 @@ struct FixedSizeListEncoder<'a> {
 }
 
 impl<'a> FixedSizeListEncoder<'a> {
-    fn try_new(
-        array: &'a FixedSizeListArray,
-        options: &EncoderOptions,
-    ) -> Result<Self, ArrowError> {
+    fn try_new(array: &'a FixedSizeListArray, options: &EncoderOptions) -> Result<Self, ArrowError> {
         let (encoder, nulls) = make_encoder_impl(array.values().as_ref(), options)?;
-        Ok(Self {
-            encoder,
-            nulls,
-            value_length: array.value_length().as_usize(),
-        })
+        Ok(Self { encoder, nulls, value_length: array.value_length().as_usize() })
     }
 }
 
@@ -392,16 +369,10 @@ struct DictionaryEncoder<'a, K: ArrowDictionaryKeyType> {
 }
 
 impl<'a, K: ArrowDictionaryKeyType> DictionaryEncoder<'a, K> {
-    fn try_new(
-        array: &'a DictionaryArray<K>,
-        options: &EncoderOptions,
-    ) -> Result<Self, ArrowError> {
+    fn try_new(array: &'a DictionaryArray<K>, options: &EncoderOptions) -> Result<Self, ArrowError> {
         let encoder = make_encoder(array.values().as_ref(), options)?;
 
-        Ok(Self {
-            keys: array.keys().values().clone(),
-            encoder,
-        })
+        Ok(Self { keys: array.keys().values().clone(), encoder })
     }
 }
 
@@ -443,10 +414,7 @@ impl<'a> MapEncoder<'a> {
         let keys = array.keys();
 
         if !matches!(keys.data_type(), DataType::Utf8 | DataType::LargeUtf8) {
-            return Err(ArrowError::JsonError(format!(
-                "Only UTF8 keys supported by JSON MapArray Writer: got {:?}",
-                keys.data_type()
-            )));
+            return Err(ArrowError::JsonError(format!("Only UTF8 keys supported by JSON MapArray Writer: got {:?}", keys.data_type())));
         }
 
         let (keys, key_nulls) = make_encoder_impl(keys, options)?;
@@ -454,24 +422,14 @@ impl<'a> MapEncoder<'a> {
 
         // We sanity check nulls as these are currently not enforced by MapArray (#1697)
         if key_nulls.is_some_and(|x| x.null_count() != 0) {
-            return Err(ArrowError::InvalidArgumentError(
-                "Encountered nulls in MapArray keys".to_string(),
-            ));
+            return Err(ArrowError::InvalidArgumentError("Encountered nulls in MapArray keys".to_string()));
         }
 
         if array.entries().nulls().is_some_and(|x| x.null_count() != 0) {
-            return Err(ArrowError::InvalidArgumentError(
-                "Encountered nulls in MapArray entries".to_string(),
-            ));
+            return Err(ArrowError::InvalidArgumentError("Encountered nulls in MapArray entries".to_string()));
         }
 
-        Ok(Self {
-            offsets: array.offsets().clone(),
-            keys,
-            values,
-            value_nulls,
-            explicit_nulls: options.explicit_nulls,
-        })
+        Ok(Self { offsets: array.offsets().clone(), keys, values, value_nulls, explicit_nulls: options.explicit_nulls })
     }
 }
 

--- a/src/io/parquet/metadata.rs
+++ b/src/io/parquet/metadata.rs
@@ -46,33 +46,17 @@ pub enum GeoParquetColumnEncoding {
 
 impl GeoParquetColumnEncoding {
     /// Construct a new column encoding based on the user's desired encoding
-    pub(crate) fn try_new(
-        writer_encoding: GeoParquetWriterEncoding,
-        data_type: &NativeType,
-    ) -> Result<Self> {
+    pub(crate) fn try_new(writer_encoding: GeoParquetWriterEncoding, data_type: &NativeType) -> Result<Self> {
         let new_encoding = match writer_encoding {
             GeoParquetWriterEncoding::WKB => Self::WKB,
             GeoParquetWriterEncoding::Native => match data_type {
                 NativeType::Point(_, _) => Self::Point,
-                NativeType::LineString(_, _) | NativeType::LargeLineString(_, _) => {
-                    Self::LineString
-                }
-                NativeType::Polygon(_, _) | NativeType::LargePolygon(_, _) => Self::Polygon,
-                NativeType::MultiPoint(_, _) | NativeType::LargeMultiPoint(_, _) => {
-                    Self::MultiPoint
-                }
-                NativeType::MultiLineString(_, _) | NativeType::LargeMultiLineString(_, _) => {
-                    Self::MultiLineString
-                }
-                NativeType::MultiPolygon(_, _) | NativeType::LargeMultiPolygon(_, _) => {
-                    Self::MultiPolygon
-                }
-                dt => {
-                    return Err(GeoArrowError::General(format!(
-                        "unsupported data type for native encoding: {:?}",
-                        dt
-                    )))
-                }
+                NativeType::LineString(_, _) => Self::LineString,
+                NativeType::Polygon(_, _) => Self::Polygon,
+                NativeType::MultiPoint(_, _) => Self::MultiPoint,
+                NativeType::MultiLineString(_, _) => Self::MultiLineString,
+                NativeType::MultiPolygon(_, _) => Self::MultiPolygon,
+                dt => return Err(GeoArrowError::General(format!("unsupported data type for native encoding: {:?}", dt))),
             },
         };
         Ok(new_encoding)
@@ -153,11 +137,7 @@ impl FromStr for GeoParquetGeometryType {
             "MultiLineString Z" => Self::MultiLineStringZ,
             "MultiPolygon Z" => Self::MultiPolygonZ,
             "GeometryCollection Z" => Self::GeometryCollectionZ,
-            other => {
-                return Err(GeoArrowError::General(format!(
-                    "Unknown value for geometry_type: {other}"
-                )))
-            }
+            other => return Err(GeoArrowError::General(format!("Unknown value for geometry_type: {other}"))),
         };
         Ok(out)
     }
@@ -191,20 +171,8 @@ impl GeoParquetGeometryType {
 
     pub(crate) fn has_z(&self) -> bool {
         match self {
-            Self::Point
-            | Self::LineString
-            | Self::Polygon
-            | Self::MultiPoint
-            | Self::MultiLineString
-            | Self::MultiPolygon
-            | Self::GeometryCollection => false,
-            Self::PointZ
-            | Self::LineStringZ
-            | Self::PolygonZ
-            | Self::MultiPointZ
-            | Self::MultiLineStringZ
-            | Self::MultiPolygonZ
-            | Self::GeometryCollectionZ => false,
+            Self::Point | Self::LineString | Self::Polygon | Self::MultiPoint | Self::MultiLineString | Self::MultiPolygon | Self::GeometryCollection => false,
+            Self::PointZ | Self::LineStringZ | Self::PolygonZ | Self::MultiPointZ | Self::MultiLineStringZ | Self::MultiPolygonZ | Self::GeometryCollectionZ => false,
         }
     }
 }
@@ -265,10 +233,7 @@ impl GeoParquetBboxCovering {
     /// Infer a bbox covering from a native geoarrow encoding
     ///
     /// Note: for now this infers 2D boxes only
-    pub(crate) fn infer_from_native(
-        column_name: &str,
-        column_metadata: &GeoParquetColumnMetadata,
-    ) -> Option<Self> {
+    pub(crate) fn infer_from_native(column_name: &str, column_metadata: &GeoParquetColumnMetadata) -> Option<Self> {
         use GeoParquetColumnEncoding::*;
         let (x, y) = match column_metadata.encoding {
             WKB => return None,
@@ -278,106 +243,33 @@ impl GeoParquetBboxCovering {
                 (x, y)
             }
             LineString => {
-                let x = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "x".to_string(),
-                ];
-                let y = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "y".to_string(),
-                ];
+                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
+                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
                 (x, y)
             }
             Polygon => {
-                let x = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "x".to_string(),
-                ];
-                let y = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "y".to_string(),
-                ];
+                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
+                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
                 (x, y)
             }
             MultiPoint => {
-                let x = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "x".to_string(),
-                ];
-                let y = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "y".to_string(),
-                ];
+                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
+                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
                 (x, y)
             }
             MultiLineString => {
-                let x = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "x".to_string(),
-                ];
-                let y = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "y".to_string(),
-                ];
+                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
+                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
                 (x, y)
             }
             MultiPolygon => {
-                let x = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "x".to_string(),
-                ];
-                let y = vec![
-                    column_name.to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "list".to_string(),
-                    "element".to_string(),
-                    "y".to_string(),
-                ];
+                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
+                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
                 (x, y)
             }
         };
 
-        Some(Self {
-            xmin: x.clone(),
-            ymin: y.clone(),
-            zmin: None,
-            xmax: x,
-            ymax: y,
-            zmax: None,
-        })
+        Some(Self { xmin: x.clone(), ymin: y.clone(), zmin: None, xmax: x, ymax: y, zmax: None })
     }
 }
 
@@ -489,9 +381,7 @@ impl GeoParquetMetadata {
             }
         }
 
-        Err(GeoArrowError::General(
-            "expected a 'geo' key in GeoParquet metadata".to_string(),
-        ))
+        Err(GeoArrowError::General("expected a 'geo' key in GeoParquet metadata".to_string()))
     }
 
     /// Update a GeoParquetMetadata from another file's metadata
@@ -559,64 +449,39 @@ impl GeoParquetMetadata {
     /// Assert that this metadata is compatible with another metadata instance, erroring if not
     pub fn try_compatible_with(&self, other: &GeoParquetMetadata) -> Result<()> {
         if self.version.as_str() != other.version.as_str() {
-            return Err(GeoArrowError::General(
-                "Different GeoParquet versions".to_string(),
-            ));
+            return Err(GeoArrowError::General("Different GeoParquet versions".to_string()));
         }
 
         if self.primary_column.as_str() != other.primary_column.as_str() {
-            return Err(GeoArrowError::General(
-                "Different GeoParquet primary columns".to_string(),
-            ));
+            return Err(GeoArrowError::General("Different GeoParquet primary columns".to_string()));
         }
 
         for key in self.columns.keys() {
             let left = self.columns.get(key).unwrap();
-            let right = other
-                .columns
-                .get(key)
-                .ok_or(GeoArrowError::General(format!(
-                    "Other GeoParquet metadata missing column {}",
-                    key
-                )))?;
+            let right = other.columns.get(key).ok_or(GeoArrowError::General(format!("Other GeoParquet metadata missing column {}", key)))?;
 
             if left.encoding != right.encoding {
-                return Err(GeoArrowError::General(format!(
-                    "Different GeoParquet encodings for column {}",
-                    key
-                )));
+                return Err(GeoArrowError::General(format!("Different GeoParquet encodings for column {}", key)));
             }
 
             if left.geometry_types != right.geometry_types {
-                return Err(GeoArrowError::General(format!(
-                    "Different GeoParquet geometry types for column {}",
-                    key
-                )));
+                return Err(GeoArrowError::General(format!("Different GeoParquet geometry types for column {}", key)));
             }
 
             if let (Some(left_bbox), Some(right_bbox)) = (&left.bbox, &right.bbox) {
                 if left_bbox.len() != right_bbox.len() {
-                    return Err(GeoArrowError::General(format!(
-                        "Different bbox dimensions for column {}",
-                        key
-                    )));
+                    return Err(GeoArrowError::General(format!("Different bbox dimensions for column {}", key)));
                 }
             }
 
             match (left.crs.as_ref(), right.crs.as_ref()) {
                 (Some(left_crs), Some(right_crs)) => {
                     if left_crs != right_crs {
-                        return Err(GeoArrowError::General(format!(
-                            "Different GeoParquet CRS for column {}",
-                            key
-                        )));
+                        return Err(GeoArrowError::General(format!("Different GeoParquet CRS for column {}", key)));
                     }
                 }
                 (Some(_), None) | (None, Some(_)) => {
-                    return Err(GeoArrowError::General(format!(
-                        "Different GeoParquet CRS for column {}",
-                        key
-                    )));
+                    return Err(GeoArrowError::General(format!("Different GeoParquet CRS for column {}", key)));
                 }
                 (None, None) => (),
             }
@@ -629,22 +494,13 @@ impl GeoParquetMetadata {
     ///
     /// If the desired column does not have covering metadata, if it is a native encoding its
     /// covering will be inferred.
-    pub(crate) fn bbox_covering(
-        &self,
-        column_name: Option<&str>,
-    ) -> Result<Option<GeoParquetBboxCovering>> {
+    pub(crate) fn bbox_covering(&self, column_name: Option<&str>) -> Result<Option<GeoParquetBboxCovering>> {
         let column_name = column_name.unwrap_or(&self.primary_column);
-        let column_meta = self
-            .columns
-            .get(column_name)
-            .ok_or(GeoArrowError::General(format!(
-                "Column name {column_name} not found in metadata"
-            )))?;
+        let column_meta = self.columns.get(column_name).ok_or(GeoArrowError::General(format!("Column name {column_name} not found in metadata")))?;
         if let Some(covering) = &column_meta.covering {
             Ok(Some(covering.bbox.clone()))
         } else {
-            let inferred_covering =
-                GeoParquetBboxCovering::infer_from_native(column_name, column_meta);
+            let inferred_covering = GeoParquetBboxCovering::infer_from_native(column_name, column_meta);
             Ok(inferred_covering)
         }
     }
@@ -661,10 +517,7 @@ impl From<GeoParquetColumnMetadata> for ArrayMetadata {
         } else {
             None
         };
-        ArrayMetadata {
-            crs: value.crs,
-            edges,
-        }
+        ArrayMetadata { crs: value.crs, edges }
     }
 }
 
@@ -674,10 +527,7 @@ impl From<&GeoParquetColumnMetadata> for ArrayMetadata {
     }
 }
 // TODO: deduplicate with `resolve_types` in `downcast.rs`
-pub(crate) fn infer_geo_data_type(
-    geometry_types: &HashSet<GeoParquetGeometryType>,
-    coord_type: CoordType,
-) -> Result<Option<NativeType>> {
+pub(crate) fn infer_geo_data_type(geometry_types: &HashSet<GeoParquetGeometryType>, coord_type: CoordType) -> Result<Option<NativeType>> {
     use GeoParquetGeometryType::*;
 
     match geometry_types.len() {
@@ -747,10 +597,7 @@ pub(crate) fn infer_geo_data_type(
             }
 
             if geometry_types.len() == linestring_count {
-                return Ok(Some(NativeType::MultiLineString(
-                    coord_type,
-                    Dimension::XYZ,
-                )));
+                return Ok(Some(NativeType::MultiLineString(coord_type, Dimension::XYZ)));
             }
 
             // Check if we can cast to MultiPolygon
@@ -788,25 +635,14 @@ pub(crate) fn infer_geo_data_type(
 }
 
 /// Find all geometry columns in the Arrow schema, constructing their NativeTypes
-pub(crate) fn find_geoparquet_geom_columns(
-    metadata: &FileMetaData,
-    schema: &Schema,
-    coord_type: CoordType,
-) -> Result<Vec<(usize, Option<NativeType>)>> {
+pub(crate) fn find_geoparquet_geom_columns(metadata: &FileMetaData, schema: &Schema, coord_type: CoordType) -> Result<Vec<(usize, Option<NativeType>)>> {
     let meta = GeoParquetMetadata::from_parquet_meta(metadata)?;
 
     meta.columns
         .iter()
         .map(|(col_name, col_meta)| {
-            let geometry_column_index = schema
-                .fields()
-                .iter()
-                .position(|field| field.name().as_str() == col_name.as_str())
-                .unwrap();
-            Ok((
-                geometry_column_index,
-                infer_geo_data_type(&col_meta.geometry_types, coord_type)?,
-            ))
+            let geometry_column_index = schema.fields().iter().position(|field| field.name().as_str() == col_name.as_str()).unwrap();
+            Ok((geometry_column_index, infer_geo_data_type(&col_meta.geometry_types, coord_type)?))
         })
         .collect()
 }
@@ -826,10 +662,7 @@ mod test {
         }"#;
         let meta: GeoParquetColumnMetadata = serde_json::from_str(s).unwrap();
         assert_eq!(meta.encoding, GeoParquetColumnEncoding::WKB);
-        assert_eq!(
-            meta.geometry_types.iter().next().unwrap(),
-            &GeoParquetGeometryType::Point
-        );
+        assert_eq!(meta.geometry_types.iter().next().unwrap(), &GeoParquetGeometryType::Point);
 
         dbg!(&meta);
     }

--- a/src/io/parquet/metadata.rs
+++ b/src/io/parquet/metadata.rs
@@ -46,7 +46,10 @@ pub enum GeoParquetColumnEncoding {
 
 impl GeoParquetColumnEncoding {
     /// Construct a new column encoding based on the user's desired encoding
-    pub(crate) fn try_new(writer_encoding: GeoParquetWriterEncoding, data_type: &NativeType) -> Result<Self> {
+    pub(crate) fn try_new(
+        writer_encoding: GeoParquetWriterEncoding,
+        data_type: &NativeType,
+    ) -> Result<Self> {
         let new_encoding = match writer_encoding {
             GeoParquetWriterEncoding::WKB => Self::WKB,
             GeoParquetWriterEncoding::Native => match data_type {
@@ -56,7 +59,12 @@ impl GeoParquetColumnEncoding {
                 NativeType::MultiPoint(_, _) => Self::MultiPoint,
                 NativeType::MultiLineString(_, _) => Self::MultiLineString,
                 NativeType::MultiPolygon(_, _) => Self::MultiPolygon,
-                dt => return Err(GeoArrowError::General(format!("unsupported data type for native encoding: {:?}", dt))),
+                dt => {
+                    return Err(GeoArrowError::General(format!(
+                        "unsupported data type for native encoding: {:?}",
+                        dt
+                    )))
+                }
             },
         };
         Ok(new_encoding)
@@ -137,7 +145,11 @@ impl FromStr for GeoParquetGeometryType {
             "MultiLineString Z" => Self::MultiLineStringZ,
             "MultiPolygon Z" => Self::MultiPolygonZ,
             "GeometryCollection Z" => Self::GeometryCollectionZ,
-            other => return Err(GeoArrowError::General(format!("Unknown value for geometry_type: {other}"))),
+            other => {
+                return Err(GeoArrowError::General(format!(
+                    "Unknown value for geometry_type: {other}"
+                )))
+            }
         };
         Ok(out)
     }
@@ -171,8 +183,20 @@ impl GeoParquetGeometryType {
 
     pub(crate) fn has_z(&self) -> bool {
         match self {
-            Self::Point | Self::LineString | Self::Polygon | Self::MultiPoint | Self::MultiLineString | Self::MultiPolygon | Self::GeometryCollection => false,
-            Self::PointZ | Self::LineStringZ | Self::PolygonZ | Self::MultiPointZ | Self::MultiLineStringZ | Self::MultiPolygonZ | Self::GeometryCollectionZ => false,
+            Self::Point
+            | Self::LineString
+            | Self::Polygon
+            | Self::MultiPoint
+            | Self::MultiLineString
+            | Self::MultiPolygon
+            | Self::GeometryCollection => false,
+            Self::PointZ
+            | Self::LineStringZ
+            | Self::PolygonZ
+            | Self::MultiPointZ
+            | Self::MultiLineStringZ
+            | Self::MultiPolygonZ
+            | Self::GeometryCollectionZ => false,
         }
     }
 }
@@ -233,7 +257,10 @@ impl GeoParquetBboxCovering {
     /// Infer a bbox covering from a native geoarrow encoding
     ///
     /// Note: for now this infers 2D boxes only
-    pub(crate) fn infer_from_native(column_name: &str, column_metadata: &GeoParquetColumnMetadata) -> Option<Self> {
+    pub(crate) fn infer_from_native(
+        column_name: &str,
+        column_metadata: &GeoParquetColumnMetadata,
+    ) -> Option<Self> {
         use GeoParquetColumnEncoding::*;
         let (x, y) = match column_metadata.encoding {
             WKB => return None,
@@ -243,33 +270,106 @@ impl GeoParquetBboxCovering {
                 (x, y)
             }
             LineString => {
-                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
-                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
+                let x = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "x".to_string(),
+                ];
+                let y = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "y".to_string(),
+                ];
                 (x, y)
             }
             Polygon => {
-                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
-                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
+                let x = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "x".to_string(),
+                ];
+                let y = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "y".to_string(),
+                ];
                 (x, y)
             }
             MultiPoint => {
-                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
-                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
+                let x = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "x".to_string(),
+                ];
+                let y = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "y".to_string(),
+                ];
                 (x, y)
             }
             MultiLineString => {
-                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
-                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
+                let x = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "x".to_string(),
+                ];
+                let y = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "y".to_string(),
+                ];
                 (x, y)
             }
             MultiPolygon => {
-                let x = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "x".to_string()];
-                let y = vec![column_name.to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "list".to_string(), "element".to_string(), "y".to_string()];
+                let x = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "x".to_string(),
+                ];
+                let y = vec![
+                    column_name.to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "list".to_string(),
+                    "element".to_string(),
+                    "y".to_string(),
+                ];
                 (x, y)
             }
         };
 
-        Some(Self { xmin: x.clone(), ymin: y.clone(), zmin: None, xmax: x, ymax: y, zmax: None })
+        Some(Self {
+            xmin: x.clone(),
+            ymin: y.clone(),
+            zmin: None,
+            xmax: x,
+            ymax: y,
+            zmax: None,
+        })
     }
 }
 
@@ -381,7 +481,9 @@ impl GeoParquetMetadata {
             }
         }
 
-        Err(GeoArrowError::General("expected a 'geo' key in GeoParquet metadata".to_string()))
+        Err(GeoArrowError::General(
+            "expected a 'geo' key in GeoParquet metadata".to_string(),
+        ))
     }
 
     /// Update a GeoParquetMetadata from another file's metadata
@@ -449,39 +551,64 @@ impl GeoParquetMetadata {
     /// Assert that this metadata is compatible with another metadata instance, erroring if not
     pub fn try_compatible_with(&self, other: &GeoParquetMetadata) -> Result<()> {
         if self.version.as_str() != other.version.as_str() {
-            return Err(GeoArrowError::General("Different GeoParquet versions".to_string()));
+            return Err(GeoArrowError::General(
+                "Different GeoParquet versions".to_string(),
+            ));
         }
 
         if self.primary_column.as_str() != other.primary_column.as_str() {
-            return Err(GeoArrowError::General("Different GeoParquet primary columns".to_string()));
+            return Err(GeoArrowError::General(
+                "Different GeoParquet primary columns".to_string(),
+            ));
         }
 
         for key in self.columns.keys() {
             let left = self.columns.get(key).unwrap();
-            let right = other.columns.get(key).ok_or(GeoArrowError::General(format!("Other GeoParquet metadata missing column {}", key)))?;
+            let right = other
+                .columns
+                .get(key)
+                .ok_or(GeoArrowError::General(format!(
+                    "Other GeoParquet metadata missing column {}",
+                    key
+                )))?;
 
             if left.encoding != right.encoding {
-                return Err(GeoArrowError::General(format!("Different GeoParquet encodings for column {}", key)));
+                return Err(GeoArrowError::General(format!(
+                    "Different GeoParquet encodings for column {}",
+                    key
+                )));
             }
 
             if left.geometry_types != right.geometry_types {
-                return Err(GeoArrowError::General(format!("Different GeoParquet geometry types for column {}", key)));
+                return Err(GeoArrowError::General(format!(
+                    "Different GeoParquet geometry types for column {}",
+                    key
+                )));
             }
 
             if let (Some(left_bbox), Some(right_bbox)) = (&left.bbox, &right.bbox) {
                 if left_bbox.len() != right_bbox.len() {
-                    return Err(GeoArrowError::General(format!("Different bbox dimensions for column {}", key)));
+                    return Err(GeoArrowError::General(format!(
+                        "Different bbox dimensions for column {}",
+                        key
+                    )));
                 }
             }
 
             match (left.crs.as_ref(), right.crs.as_ref()) {
                 (Some(left_crs), Some(right_crs)) => {
                     if left_crs != right_crs {
-                        return Err(GeoArrowError::General(format!("Different GeoParquet CRS for column {}", key)));
+                        return Err(GeoArrowError::General(format!(
+                            "Different GeoParquet CRS for column {}",
+                            key
+                        )));
                     }
                 }
                 (Some(_), None) | (None, Some(_)) => {
-                    return Err(GeoArrowError::General(format!("Different GeoParquet CRS for column {}", key)));
+                    return Err(GeoArrowError::General(format!(
+                        "Different GeoParquet CRS for column {}",
+                        key
+                    )));
                 }
                 (None, None) => (),
             }
@@ -494,13 +621,22 @@ impl GeoParquetMetadata {
     ///
     /// If the desired column does not have covering metadata, if it is a native encoding its
     /// covering will be inferred.
-    pub(crate) fn bbox_covering(&self, column_name: Option<&str>) -> Result<Option<GeoParquetBboxCovering>> {
+    pub(crate) fn bbox_covering(
+        &self,
+        column_name: Option<&str>,
+    ) -> Result<Option<GeoParquetBboxCovering>> {
         let column_name = column_name.unwrap_or(&self.primary_column);
-        let column_meta = self.columns.get(column_name).ok_or(GeoArrowError::General(format!("Column name {column_name} not found in metadata")))?;
+        let column_meta = self
+            .columns
+            .get(column_name)
+            .ok_or(GeoArrowError::General(format!(
+                "Column name {column_name} not found in metadata"
+            )))?;
         if let Some(covering) = &column_meta.covering {
             Ok(Some(covering.bbox.clone()))
         } else {
-            let inferred_covering = GeoParquetBboxCovering::infer_from_native(column_name, column_meta);
+            let inferred_covering =
+                GeoParquetBboxCovering::infer_from_native(column_name, column_meta);
             Ok(inferred_covering)
         }
     }
@@ -517,7 +653,10 @@ impl From<GeoParquetColumnMetadata> for ArrayMetadata {
         } else {
             None
         };
-        ArrayMetadata { crs: value.crs, edges }
+        ArrayMetadata {
+            crs: value.crs,
+            edges,
+        }
     }
 }
 
@@ -527,7 +666,10 @@ impl From<&GeoParquetColumnMetadata> for ArrayMetadata {
     }
 }
 // TODO: deduplicate with `resolve_types` in `downcast.rs`
-pub(crate) fn infer_geo_data_type(geometry_types: &HashSet<GeoParquetGeometryType>, coord_type: CoordType) -> Result<Option<NativeType>> {
+pub(crate) fn infer_geo_data_type(
+    geometry_types: &HashSet<GeoParquetGeometryType>,
+    coord_type: CoordType,
+) -> Result<Option<NativeType>> {
     use GeoParquetGeometryType::*;
 
     match geometry_types.len() {
@@ -597,7 +739,10 @@ pub(crate) fn infer_geo_data_type(geometry_types: &HashSet<GeoParquetGeometryTyp
             }
 
             if geometry_types.len() == linestring_count {
-                return Ok(Some(NativeType::MultiLineString(coord_type, Dimension::XYZ)));
+                return Ok(Some(NativeType::MultiLineString(
+                    coord_type,
+                    Dimension::XYZ,
+                )));
             }
 
             // Check if we can cast to MultiPolygon
@@ -635,14 +780,25 @@ pub(crate) fn infer_geo_data_type(geometry_types: &HashSet<GeoParquetGeometryTyp
 }
 
 /// Find all geometry columns in the Arrow schema, constructing their NativeTypes
-pub(crate) fn find_geoparquet_geom_columns(metadata: &FileMetaData, schema: &Schema, coord_type: CoordType) -> Result<Vec<(usize, Option<NativeType>)>> {
+pub(crate) fn find_geoparquet_geom_columns(
+    metadata: &FileMetaData,
+    schema: &Schema,
+    coord_type: CoordType,
+) -> Result<Vec<(usize, Option<NativeType>)>> {
     let meta = GeoParquetMetadata::from_parquet_meta(metadata)?;
 
     meta.columns
         .iter()
         .map(|(col_name, col_meta)| {
-            let geometry_column_index = schema.fields().iter().position(|field| field.name().as_str() == col_name.as_str()).unwrap();
-            Ok((geometry_column_index, infer_geo_data_type(&col_meta.geometry_types, coord_type)?))
+            let geometry_column_index = schema
+                .fields()
+                .iter()
+                .position(|field| field.name().as_str() == col_name.as_str())
+                .unwrap();
+            Ok((
+                geometry_column_index,
+                infer_geo_data_type(&col_meta.geometry_types, coord_type)?,
+            ))
         })
         .collect()
 }
@@ -662,7 +818,10 @@ mod test {
         }"#;
         let meta: GeoParquetColumnMetadata = serde_json::from_str(s).unwrap();
         assert_eq!(meta.encoding, GeoParquetColumnEncoding::WKB);
-        assert_eq!(meta.geometry_types.iter().next().unwrap(), &GeoParquetGeometryType::Point);
+        assert_eq!(
+            meta.geometry_types.iter().next().unwrap(),
+            &GeoParquetGeometryType::Point
+        );
 
         dbg!(&meta);
     }

--- a/src/io/parquet/reader/parse.rs
+++ b/src/io/parquet/reader/parse.rs
@@ -6,24 +6,14 @@ use std::sync::Arc;
 use arrow_array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 
-use crate::array::{
-    CoordType, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray,
-    PointArray, PolygonArray, WKBArray,
-};
+use crate::array::{CoordType, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray};
 use crate::datatypes::{AnyType, Dimension, NativeType, SerializedType};
 use crate::error::{GeoArrowError, Result};
-use crate::io::parquet::metadata::{
-    infer_geo_data_type, GeoParquetColumnEncoding, GeoParquetColumnMetadata,
-    GeoParquetGeometryType, GeoParquetMetadata,
-};
+use crate::io::parquet::metadata::{infer_geo_data_type, GeoParquetColumnEncoding, GeoParquetColumnMetadata, GeoParquetGeometryType, GeoParquetMetadata};
 use crate::io::wkb::from_wkb;
 use crate::ArrayBase;
 
-pub fn infer_target_schema(
-    existing_schema: &Schema,
-    geo_meta: &GeoParquetMetadata,
-    coord_type: CoordType,
-) -> Result<SchemaRef> {
+pub fn infer_target_schema(existing_schema: &Schema, geo_meta: &GeoParquetMetadata, coord_type: CoordType) -> Result<SchemaRef> {
     let mut new_fields: Vec<FieldRef> = Vec::with_capacity(existing_schema.fields().len());
     for existing_field in existing_schema.fields() {
         if let Some(column_meta) = geo_meta.columns.get(existing_field.name()) {
@@ -33,106 +23,62 @@ pub fn infer_target_schema(
         }
     }
 
-    Ok(Arc::new(Schema::new_with_metadata(
-        new_fields,
-        existing_schema.metadata().clone(),
-    )))
+    Ok(Arc::new(Schema::new_with_metadata(new_fields, existing_schema.metadata().clone())))
 }
 
 /// For native encodings we always load to the separated encoding so that we don't need an extra
 /// copy.
-fn infer_target_field(
-    existing_field: &Field,
-    column_meta: &GeoParquetColumnMetadata,
-    coord_type: CoordType,
-) -> Result<FieldRef> {
+fn infer_target_field(existing_field: &Field, column_meta: &GeoParquetColumnMetadata, coord_type: CoordType) -> Result<FieldRef> {
     let target_geo_data_type: NativeType = match column_meta.encoding {
-        GeoParquetColumnEncoding::WKB => {
-            infer_target_wkb_type(&column_meta.geometry_types, coord_type)?
-        }
+        GeoParquetColumnEncoding::WKB => infer_target_wkb_type(&column_meta.geometry_types, coord_type)?,
         GeoParquetColumnEncoding::Point => {
-            if column_meta
-                .geometry_types
-                .contains(&GeoParquetGeometryType::PointZ)
-            {
+            if column_meta.geometry_types.contains(&GeoParquetGeometryType::PointZ) {
                 NativeType::Point(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::Point(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::LineString => {
-            if column_meta
-                .geometry_types
-                .contains(&GeoParquetGeometryType::LineStringZ)
-            {
+            if column_meta.geometry_types.contains(&GeoParquetGeometryType::LineStringZ) {
                 NativeType::LineString(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::LineString(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::Polygon => {
-            if column_meta
-                .geometry_types
-                .contains(&GeoParquetGeometryType::LineStringZ)
-            {
+            if column_meta.geometry_types.contains(&GeoParquetGeometryType::LineStringZ) {
                 NativeType::Polygon(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::Polygon(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::MultiPoint => {
-            if column_meta
-                .geometry_types
-                .contains(&GeoParquetGeometryType::PointZ)
-                || column_meta
-                    .geometry_types
-                    .contains(&GeoParquetGeometryType::MultiPointZ)
-            {
+            if column_meta.geometry_types.contains(&GeoParquetGeometryType::PointZ) || column_meta.geometry_types.contains(&GeoParquetGeometryType::MultiPointZ) {
                 NativeType::MultiPoint(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::MultiPoint(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::MultiLineString => {
-            if column_meta
-                .geometry_types
-                .contains(&GeoParquetGeometryType::LineStringZ)
-                || column_meta
-                    .geometry_types
-                    .contains(&GeoParquetGeometryType::MultiLineStringZ)
-            {
+            if column_meta.geometry_types.contains(&GeoParquetGeometryType::LineStringZ) || column_meta.geometry_types.contains(&GeoParquetGeometryType::MultiLineStringZ) {
                 NativeType::MultiLineString(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::MultiLineString(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::MultiPolygon => {
-            if column_meta
-                .geometry_types
-                .contains(&GeoParquetGeometryType::PolygonZ)
-                || column_meta
-                    .geometry_types
-                    .contains(&GeoParquetGeometryType::MultiPolygonZ)
-            {
+            if column_meta.geometry_types.contains(&GeoParquetGeometryType::PolygonZ) || column_meta.geometry_types.contains(&GeoParquetGeometryType::MultiPolygonZ) {
                 NativeType::MultiPolygon(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::MultiPolygon(CoordType::Separated, Dimension::XY)
             }
         }
     };
-    Ok(Arc::new(target_geo_data_type.to_field_with_metadata(
-        existing_field.name(),
-        existing_field.is_nullable(),
-        &column_meta.into(),
-    )))
+    Ok(Arc::new(target_geo_data_type.to_field_with_metadata(existing_field.name(), existing_field.is_nullable(), &column_meta.into())))
 }
 
-fn infer_target_wkb_type(
-    geometry_types: &HashSet<GeoParquetGeometryType>,
-    coord_type: CoordType,
-) -> Result<NativeType> {
-    Ok(infer_geo_data_type(geometry_types, coord_type)?
-        .unwrap_or(NativeType::Mixed(coord_type, Dimension::XY)))
+fn infer_target_wkb_type(geometry_types: &HashSet<GeoParquetGeometryType>, coord_type: CoordType) -> Result<NativeType> {
+    Ok(infer_geo_data_type(geometry_types, coord_type)?.unwrap_or(NativeType::Mixed(coord_type, Dimension::XY)))
 }
 
 /// Parse a record batch to a GeoArrow record batch.
@@ -140,20 +86,12 @@ pub fn parse_record_batch(batch: RecordBatch, target_schema: SchemaRef) -> Resul
     let orig_columns = batch.columns().to_vec();
     let mut output_columns = Vec::with_capacity(orig_columns.len());
 
-    for ((orig_field, target_field), column) in batch
-        .schema_ref()
-        .fields()
-        .iter()
-        .zip(target_schema.fields())
-        .zip(orig_columns)
-    {
+    for ((orig_field, target_field), column) in batch.schema_ref().fields().iter().zip(target_schema.fields()).zip(orig_columns) {
         // Invariant: the target schema has the same column ordering as the original, just that
         // some fields are desired to be parsed.
         assert_eq!(orig_field.name(), target_field.name());
 
-        if orig_field.data_type() != target_field.data_type()
-            || orig_field.metadata() != target_field.metadata()
-        {
+        if orig_field.data_type() != target_field.data_type() || orig_field.metadata() != target_field.metadata() {
             let output_column = parse_array(column, orig_field, target_field)?;
             output_columns.push(output_column);
         } else {
@@ -165,11 +103,7 @@ pub fn parse_record_batch(batch: RecordBatch, target_schema: SchemaRef) -> Resul
 }
 
 /// Parse a single column based on provided GeoParquet metadata and target field
-fn parse_array(
-    array: ArrayRef,
-    orig_field: &Field,
-    target_field: &Field,
-) -> Result<Arc<dyn Array>> {
+fn parse_array(array: ArrayRef, orig_field: &Field, target_field: &Field) -> Result<Arc<dyn Array>> {
     use Dimension::*;
     use NativeType::*;
 
@@ -189,19 +123,14 @@ fn parse_array(
             MultiPoint(_, XYZ) => parse_multi_point_column::<3>(arr),
             MultiLineString(_, XYZ) => parse_multi_line_string_column::<3>(arr),
             MultiPolygon(_, XYZ) => parse_multi_polygon_column::<3>(arr),
-            other => Err(GeoArrowError::General(format!(
-                "Unexpected geometry encoding: {:?}",
-                other
-            ))),
+            other => Err(GeoArrowError::General(format!("Unexpected geometry encoding: {:?}", other))),
         },
         AnyType::Serialized(t) => {
             use SerializedType::*;
             let target_geo_data_type: NativeType = target_field.try_into()?;
             match t {
                 WKB | LargeWKB => parse_wkb_column(arr, target_geo_data_type),
-                WKT | LargeWKT => Err(GeoArrowError::General(
-                    "WKT input not supported in GeoParquet.".to_string(),
-                )),
+                WKT | LargeWKT => Err(GeoArrowError::General("WKT input not supported in GeoParquet.".to_string())),
             }
         }
     }
@@ -219,10 +148,7 @@ fn parse_wkb_column(arr: &dyn Array, target_geo_data_type: NativeType) -> Result
             let geom_arr = from_wkb(&wkb_arr, target_geo_data_type, true)?;
             Ok(geom_arr.to_array_ref())
         }
-        dt => Err(GeoArrowError::General(format!(
-            "Expected WKB array to have binary data type, got {}",
-            dt
-        ))),
+        dt => Err(GeoArrowError::General(format!("Expected WKB array to have binary data type, got {}", dt))),
     }
 }
 
@@ -243,33 +169,14 @@ macro_rules! impl_parse_fn {
                     let geom_arr: $large_geoarrow_type = array.try_into()?;
                     Ok(geom_arr.into_array_ref())
                 }
-                dt => Err(GeoArrowError::General(format!(
-                    "Unexpected Arrow data type: {}",
-                    dt
-                ))),
+                dt => Err(GeoArrowError::General(format!("Unexpected Arrow data type: {}", dt))),
             }
         }
     };
 }
 
-impl_parse_fn!(
-    parse_line_string_column,
-    LineStringArray<i32, D>,
-    LineStringArray<i64, D>
-);
-impl_parse_fn!(parse_polygon_column, PolygonArray<i32, D>, PolygonArray<i64, D>);
-impl_parse_fn!(
-    parse_multi_point_column,
-    MultiPointArray<i32, D>,
-    MultiPointArray<i64, D>
-);
-impl_parse_fn!(
-    parse_multi_line_string_column,
-    MultiLineStringArray<i32, D>,
-    MultiLineStringArray<i64, D>
-);
-impl_parse_fn!(
-    parse_multi_polygon_column,
-    MultiPolygonArray<i32, D>,
-    MultiPolygonArray<i64, D>
-);
+impl_parse_fn!(parse_line_string_column, LineStringArray<D>);
+impl_parse_fn!(parse_polygon_column, PolygonArray<D>);
+impl_parse_fn!(parse_multi_point_column, MultiPointArray<D>);
+impl_parse_fn!(parse_multi_line_string_column, MultiLineStringArray<D>);
+impl_parse_fn!(parse_multi_polygon_column, MultiPolygonArray<D>);

--- a/src/io/parquet/reader/parse.rs
+++ b/src/io/parquet/reader/parse.rs
@@ -178,23 +178,17 @@ fn parse_array(
     match orig_type {
         AnyType::Native(t) => match t {
             Point(_, XY) => parse_point_column::<2>(arr),
-            LineString(_, XY) | LargeLineString(_, XY) => parse_line_string_column::<2>(arr),
-            Polygon(_, XY) | LargePolygon(_, XY) => parse_polygon_column::<2>(arr),
-            MultiPoint(_, XY) | LargeMultiPoint(_, XY) => parse_multi_point_column::<2>(arr),
-            MultiLineString(_, XY) | LargeMultiLineString(_, XY) => {
-                parse_multi_line_string_column::<2>(arr)
-            }
-            MultiPolygon(_, XY) | LargeMultiPolygon(_, XY) => parse_multi_polygon_column::<2>(arr),
+            LineString(_, XY) => parse_line_string_column::<2>(arr),
+            Polygon(_, XY) => parse_polygon_column::<2>(arr),
+            MultiPoint(_, XY) => parse_multi_point_column::<2>(arr),
+            MultiLineString(_, XY) => parse_multi_line_string_column::<2>(arr),
+            MultiPolygon(_, XY) => parse_multi_polygon_column::<2>(arr),
             Point(_, XYZ) => parse_point_column::<3>(arr),
-            LineString(_, XYZ) | LargeLineString(_, XYZ) => parse_line_string_column::<3>(arr),
-            Polygon(_, XYZ) | LargePolygon(_, XYZ) => parse_polygon_column::<3>(arr),
-            MultiPoint(_, XYZ) | LargeMultiPoint(_, XYZ) => parse_multi_point_column::<3>(arr),
-            MultiLineString(_, XYZ) | LargeMultiLineString(_, XYZ) => {
-                parse_multi_line_string_column::<3>(arr)
-            }
-            MultiPolygon(_, XYZ) | LargeMultiPolygon(_, XYZ) => {
-                parse_multi_polygon_column::<3>(arr)
-            }
+            LineString(_, XYZ) => parse_line_string_column::<3>(arr),
+            Polygon(_, XYZ) => parse_polygon_column::<3>(arr),
+            MultiPoint(_, XYZ) => parse_multi_point_column::<3>(arr),
+            MultiLineString(_, XYZ) => parse_multi_line_string_column::<3>(arr),
+            MultiPolygon(_, XYZ) => parse_multi_polygon_column::<3>(arr),
             other => Err(GeoArrowError::General(format!(
                 "Unexpected geometry encoding: {:?}",
                 other

--- a/src/io/parquet/reader/parse.rs
+++ b/src/io/parquet/reader/parse.rs
@@ -6,14 +6,24 @@ use std::sync::Arc;
 use arrow_array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 
-use crate::array::{CoordType, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray};
+use crate::array::{
+    CoordType, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray,
+    PointArray, PolygonArray, WKBArray,
+};
 use crate::datatypes::{AnyType, Dimension, NativeType, SerializedType};
 use crate::error::{GeoArrowError, Result};
-use crate::io::parquet::metadata::{infer_geo_data_type, GeoParquetColumnEncoding, GeoParquetColumnMetadata, GeoParquetGeometryType, GeoParquetMetadata};
+use crate::io::parquet::metadata::{
+    infer_geo_data_type, GeoParquetColumnEncoding, GeoParquetColumnMetadata,
+    GeoParquetGeometryType, GeoParquetMetadata,
+};
 use crate::io::wkb::from_wkb;
 use crate::ArrayBase;
 
-pub fn infer_target_schema(existing_schema: &Schema, geo_meta: &GeoParquetMetadata, coord_type: CoordType) -> Result<SchemaRef> {
+pub fn infer_target_schema(
+    existing_schema: &Schema,
+    geo_meta: &GeoParquetMetadata,
+    coord_type: CoordType,
+) -> Result<SchemaRef> {
     let mut new_fields: Vec<FieldRef> = Vec::with_capacity(existing_schema.fields().len());
     for existing_field in existing_schema.fields() {
         if let Some(column_meta) = geo_meta.columns.get(existing_field.name()) {
@@ -23,62 +33,106 @@ pub fn infer_target_schema(existing_schema: &Schema, geo_meta: &GeoParquetMetada
         }
     }
 
-    Ok(Arc::new(Schema::new_with_metadata(new_fields, existing_schema.metadata().clone())))
+    Ok(Arc::new(Schema::new_with_metadata(
+        new_fields,
+        existing_schema.metadata().clone(),
+    )))
 }
 
 /// For native encodings we always load to the separated encoding so that we don't need an extra
 /// copy.
-fn infer_target_field(existing_field: &Field, column_meta: &GeoParquetColumnMetadata, coord_type: CoordType) -> Result<FieldRef> {
+fn infer_target_field(
+    existing_field: &Field,
+    column_meta: &GeoParquetColumnMetadata,
+    coord_type: CoordType,
+) -> Result<FieldRef> {
     let target_geo_data_type: NativeType = match column_meta.encoding {
-        GeoParquetColumnEncoding::WKB => infer_target_wkb_type(&column_meta.geometry_types, coord_type)?,
+        GeoParquetColumnEncoding::WKB => {
+            infer_target_wkb_type(&column_meta.geometry_types, coord_type)?
+        }
         GeoParquetColumnEncoding::Point => {
-            if column_meta.geometry_types.contains(&GeoParquetGeometryType::PointZ) {
+            if column_meta
+                .geometry_types
+                .contains(&GeoParquetGeometryType::PointZ)
+            {
                 NativeType::Point(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::Point(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::LineString => {
-            if column_meta.geometry_types.contains(&GeoParquetGeometryType::LineStringZ) {
+            if column_meta
+                .geometry_types
+                .contains(&GeoParquetGeometryType::LineStringZ)
+            {
                 NativeType::LineString(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::LineString(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::Polygon => {
-            if column_meta.geometry_types.contains(&GeoParquetGeometryType::LineStringZ) {
+            if column_meta
+                .geometry_types
+                .contains(&GeoParquetGeometryType::LineStringZ)
+            {
                 NativeType::Polygon(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::Polygon(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::MultiPoint => {
-            if column_meta.geometry_types.contains(&GeoParquetGeometryType::PointZ) || column_meta.geometry_types.contains(&GeoParquetGeometryType::MultiPointZ) {
+            if column_meta
+                .geometry_types
+                .contains(&GeoParquetGeometryType::PointZ)
+                || column_meta
+                    .geometry_types
+                    .contains(&GeoParquetGeometryType::MultiPointZ)
+            {
                 NativeType::MultiPoint(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::MultiPoint(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::MultiLineString => {
-            if column_meta.geometry_types.contains(&GeoParquetGeometryType::LineStringZ) || column_meta.geometry_types.contains(&GeoParquetGeometryType::MultiLineStringZ) {
+            if column_meta
+                .geometry_types
+                .contains(&GeoParquetGeometryType::LineStringZ)
+                || column_meta
+                    .geometry_types
+                    .contains(&GeoParquetGeometryType::MultiLineStringZ)
+            {
                 NativeType::MultiLineString(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::MultiLineString(CoordType::Separated, Dimension::XY)
             }
         }
         GeoParquetColumnEncoding::MultiPolygon => {
-            if column_meta.geometry_types.contains(&GeoParquetGeometryType::PolygonZ) || column_meta.geometry_types.contains(&GeoParquetGeometryType::MultiPolygonZ) {
+            if column_meta
+                .geometry_types
+                .contains(&GeoParquetGeometryType::PolygonZ)
+                || column_meta
+                    .geometry_types
+                    .contains(&GeoParquetGeometryType::MultiPolygonZ)
+            {
                 NativeType::MultiPolygon(CoordType::Separated, Dimension::XYZ)
             } else {
                 NativeType::MultiPolygon(CoordType::Separated, Dimension::XY)
             }
         }
     };
-    Ok(Arc::new(target_geo_data_type.to_field_with_metadata(existing_field.name(), existing_field.is_nullable(), &column_meta.into())))
+    Ok(Arc::new(target_geo_data_type.to_field_with_metadata(
+        existing_field.name(),
+        existing_field.is_nullable(),
+        &column_meta.into(),
+    )))
 }
 
-fn infer_target_wkb_type(geometry_types: &HashSet<GeoParquetGeometryType>, coord_type: CoordType) -> Result<NativeType> {
-    Ok(infer_geo_data_type(geometry_types, coord_type)?.unwrap_or(NativeType::Mixed(coord_type, Dimension::XY)))
+fn infer_target_wkb_type(
+    geometry_types: &HashSet<GeoParquetGeometryType>,
+    coord_type: CoordType,
+) -> Result<NativeType> {
+    Ok(infer_geo_data_type(geometry_types, coord_type)?
+        .unwrap_or(NativeType::Mixed(coord_type, Dimension::XY)))
 }
 
 /// Parse a record batch to a GeoArrow record batch.
@@ -86,12 +140,20 @@ pub fn parse_record_batch(batch: RecordBatch, target_schema: SchemaRef) -> Resul
     let orig_columns = batch.columns().to_vec();
     let mut output_columns = Vec::with_capacity(orig_columns.len());
 
-    for ((orig_field, target_field), column) in batch.schema_ref().fields().iter().zip(target_schema.fields()).zip(orig_columns) {
+    for ((orig_field, target_field), column) in batch
+        .schema_ref()
+        .fields()
+        .iter()
+        .zip(target_schema.fields())
+        .zip(orig_columns)
+    {
         // Invariant: the target schema has the same column ordering as the original, just that
         // some fields are desired to be parsed.
         assert_eq!(orig_field.name(), target_field.name());
 
-        if orig_field.data_type() != target_field.data_type() || orig_field.metadata() != target_field.metadata() {
+        if orig_field.data_type() != target_field.data_type()
+            || orig_field.metadata() != target_field.metadata()
+        {
             let output_column = parse_array(column, orig_field, target_field)?;
             output_columns.push(output_column);
         } else {
@@ -103,7 +165,11 @@ pub fn parse_record_batch(batch: RecordBatch, target_schema: SchemaRef) -> Resul
 }
 
 /// Parse a single column based on provided GeoParquet metadata and target field
-fn parse_array(array: ArrayRef, orig_field: &Field, target_field: &Field) -> Result<Arc<dyn Array>> {
+fn parse_array(
+    array: ArrayRef,
+    orig_field: &Field,
+    target_field: &Field,
+) -> Result<Arc<dyn Array>> {
     use Dimension::*;
     use NativeType::*;
 
@@ -123,14 +189,19 @@ fn parse_array(array: ArrayRef, orig_field: &Field, target_field: &Field) -> Res
             MultiPoint(_, XYZ) => parse_multi_point_column::<3>(arr),
             MultiLineString(_, XYZ) => parse_multi_line_string_column::<3>(arr),
             MultiPolygon(_, XYZ) => parse_multi_polygon_column::<3>(arr),
-            other => Err(GeoArrowError::General(format!("Unexpected geometry encoding: {:?}", other))),
+            other => Err(GeoArrowError::General(format!(
+                "Unexpected geometry encoding: {:?}",
+                other
+            ))),
         },
         AnyType::Serialized(t) => {
             use SerializedType::*;
             let target_geo_data_type: NativeType = target_field.try_into()?;
             match t {
                 WKB | LargeWKB => parse_wkb_column(arr, target_geo_data_type),
-                WKT | LargeWKT => Err(GeoArrowError::General("WKT input not supported in GeoParquet.".to_string())),
+                WKT | LargeWKT => Err(GeoArrowError::General(
+                    "WKT input not supported in GeoParquet.".to_string(),
+                )),
             }
         }
     }
@@ -148,7 +219,10 @@ fn parse_wkb_column(arr: &dyn Array, target_geo_data_type: NativeType) -> Result
             let geom_arr = from_wkb(&wkb_arr, target_geo_data_type, true)?;
             Ok(geom_arr.to_array_ref())
         }
-        dt => Err(GeoArrowError::General(format!("Expected WKB array to have binary data type, got {}", dt))),
+        dt => Err(GeoArrowError::General(format!(
+            "Expected WKB array to have binary data type, got {}",
+            dt
+        ))),
     }
 }
 
@@ -158,18 +232,17 @@ fn parse_point_column<const D: usize>(array: &dyn Array) -> Result<Arc<dyn Array
 }
 
 macro_rules! impl_parse_fn {
-    ($fn_name:ident, $small_geoarrow_type:ty, $large_geoarrow_type:ty) => {
+    ($fn_name:ident, $geoarrow_type:ty) => {
         fn $fn_name<const D: usize>(array: &dyn Array) -> Result<Arc<dyn Array>> {
             match array.data_type() {
-                DataType::List(_) => {
-                    let geom_arr: $small_geoarrow_type = array.try_into()?;
+                DataType::List(_) | DataType::LargeList(_) => {
+                    let geom_arr: $geoarrow_type = array.try_into()?;
                     Ok(geom_arr.into_array_ref())
                 }
-                DataType::LargeList(_) => {
-                    let geom_arr: $large_geoarrow_type = array.try_into()?;
-                    Ok(geom_arr.into_array_ref())
-                }
-                dt => Err(GeoArrowError::General(format!("Unexpected Arrow data type: {}", dt))),
+                dt => Err(GeoArrowError::General(format!(
+                    "Unexpected Arrow data type: {}",
+                    dt
+                ))),
             }
         }
     };

--- a/src/io/parquet/test.rs
+++ b/src/io/parquet/test.rs
@@ -41,7 +41,7 @@ fn round_trip_nybb() -> Result<()> {
 // Test from https://github.com/geoarrow/geoarrow-rs/pull/717
 #[test]
 fn mixed_geometry_roundtrip() {
-    let mut builder = MixedGeometryBuilder::<i32, 2>::new();
+    let mut builder = MixedGeometryBuilder::<2>::new();
     builder.push_point(Some(&geo::point!(x: -105., y: 40.)));
     let geometry = ChunkedNativeArrayDyn::from_geoarrow_chunks(&[&builder.finish()])
         .unwrap()

--- a/src/io/postgis/reader.rs
+++ b/src/io/postgis/reader.rs
@@ -20,7 +20,9 @@ use crate::trait_::GeometryArrayBuilder;
 pub struct PostgisEWKBGeometry<'a>(&'a [u8]);
 
 impl<'a, 'r: 'a> Decode<'r, Postgres> for PostgisEWKBGeometry<'a> {
-    fn decode(value: <Postgres as sqlx::database::HasValueRef<'r>>::ValueRef) -> std::prelude::v1::Result<Self, sqlx::error::BoxDynError> {
+    fn decode(
+        value: <Postgres as sqlx::database::HasValueRef<'r>>::ValueRef,
+    ) -> std::prelude::v1::Result<Self, sqlx::error::BoxDynError> {
         Ok(Self(value.as_bytes()?))
     }
 }
@@ -58,7 +60,9 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
         for (i, column) in row.columns().iter().enumerate() {
             let column_name = column.name();
             let upstream_type_info = column.type_info();
-            if let Some(our_type_info) = super::type_info::PgTypeInfo::from_upstream(upstream_type_info) {
+            if let Some(our_type_info) =
+                super::type_info::PgTypeInfo::from_upstream(upstream_type_info)
+            {
                 use super::type_info::PgType::*;
                 let column_value = match our_type_info.0 {
                     Bool => Some(ColumnValue::Bool(row.try_get(i)?)),
@@ -68,7 +72,9 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     Int8 => Some(ColumnValue::Long(row.try_get(i)?)),
                     Float4 => Some(ColumnValue::Float(row.try_get(i)?)),
                     Float8 => Some(ColumnValue::Double(row.try_get(i)?)),
-                    Text | Varchar | Char | Json | Jsonb => Some(ColumnValue::String(row.try_get(i)?)),
+                    Text | Varchar | Char | Json | Jsonb => {
+                        Some(ColumnValue::String(row.try_get(i)?))
+                    }
                     _ => None,
                 };
 
@@ -80,11 +86,13 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     match our_type_info.0 {
                         Timestamp => {
                             let value: DateTime<Utc> = row.try_get(i)?;
-                            self.properties_builder_mut().add_timestamp_property(column_name, value)?;
+                            self.properties_builder_mut()
+                                .add_timestamp_property(column_name, value)?;
                         }
                         Timestamptz => {
                             let value: DateTime<Utc> = row.try_get(i)?;
-                            self.properties_builder_mut().add_timestamp_property(column_name, value)?;
+                            self.properties_builder_mut()
+                                .add_timestamp_property(column_name, value)?;
                         }
 
                         v => todo!("unimplemented type in column value: {}", v.display_name()),
@@ -95,7 +103,12 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     "geometry" | "geography" => {
                         geometry = Some(row.try_get(i)?);
                     }
-                    other => return Err(GeoArrowError::General(format!("unknown non-standard type: {}", other))),
+                    other => {
+                        return Err(GeoArrowError::General(format!(
+                            "unknown non-standard type: {}",
+                            other
+                        )))
+                    }
                 }
             };
         }
@@ -111,7 +124,9 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
         for column in row.columns() {
             let column_name = column.name();
             let upstream_type_info = column.type_info();
-            if let Some(our_type_info) = super::type_info::PgTypeInfo::from_upstream(upstream_type_info) {
+            if let Some(our_type_info) =
+                super::type_info::PgTypeInfo::from_upstream(upstream_type_info)
+            {
                 use super::type_info::PgType::*;
                 let data_type = match our_type_info.0 {
                     Bool => DataType::Boolean,
@@ -133,7 +148,12 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
                     "geometry" | "geography" => {
                         continue;
                     }
-                    other => return Err(GeoArrowError::General(format!("unknown non-standard type in initialization: {}", other))),
+                    other => {
+                        return Err(GeoArrowError::General(format!(
+                            "unknown non-standard type in initialization: {}",
+                            other
+                        )))
+                    }
                 }
             };
         }
@@ -146,7 +166,10 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
     }
 }
 
-pub async fn read_postgis<'c, E: Executor<'c, Database = Postgres>>(executor: E, sql: &str) -> Result<Option<Table>> {
+pub async fn read_postgis<'c, E: Executor<'c, Database = Postgres>>(
+    executor: E,
+    sql: &str,
+) -> Result<Option<Table>> {
     let query = sqlx::query::<Postgres>(sql);
     let mut result_stream = query.fetch(executor);
     let mut table_builder: Option<GeoTableBuilder<MixedGeometryStreamBuilder<2>>> = None;
@@ -160,7 +183,10 @@ pub async fn read_postgis<'c, E: Executor<'c, Database = Postgres>>(executor: E,
         } else {
             // Initialize table builder
             let table_builder_options = GeoTableBuilderOptions::default();
-            table_builder = Some(GeoTableBuilder::initialize_from_row(&row, table_builder_options)?)
+            table_builder = Some(GeoTableBuilder::initialize_from_row(
+                &row,
+                table_builder_options,
+            )?)
         };
         row_idx += 1;
     }

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -34,7 +34,7 @@ impl FromWKB for PointArray<2> {
 
 macro_rules! impl_from_wkb {
     ($array:ty, $builder:ty) => {
-        impl<OOutput: OffsetSizeTrait> FromWKB for $array {
+        impl FromWKB for $array {
             type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
             fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
@@ -46,31 +46,28 @@ macro_rules! impl_from_wkb {
     };
 }
 
-impl_from_wkb!(LineStringArray<OOutput, 2>, LineStringBuilder<OOutput, 2>);
-impl_from_wkb!(PolygonArray<OOutput, 2>, PolygonBuilder<OOutput, 2>);
-impl_from_wkb!(MultiPointArray<OOutput, 2>, MultiPointBuilder<OOutput, 2>);
-impl_from_wkb!(
-    MultiLineStringArray<OOutput, 2>,
-    MultiLineStringBuilder<OOutput, 2>
-);
-impl_from_wkb!(MultiPolygonArray<OOutput, 2>, MultiPolygonBuilder<OOutput, 2>);
+impl_from_wkb!(LineStringArray<2>, LineStringBuilder<2>);
+impl_from_wkb!(PolygonArray<2>, PolygonBuilder<2>);
+impl_from_wkb!(MultiPointArray<2>, MultiPointBuilder<2>);
+impl_from_wkb!(MultiLineStringArray<2>, MultiLineStringBuilder<2>);
+impl_from_wkb!(MultiPolygonArray<2>, MultiPolygonBuilder<2>);
 
-impl<OOutput: OffsetSizeTrait> FromWKB for MixedGeometryArray<OOutput, 2> {
+impl FromWKB for MixedGeometryArray<2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = MixedGeometryBuilder::<OOutput, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), true)?;
+        let builder = MixedGeometryBuilder::<2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), true)?;
         Ok(builder.finish())
     }
 }
 
-impl<OOutput: OffsetSizeTrait> FromWKB for GeometryCollectionArray<OOutput, 2> {
+impl FromWKB for GeometryCollectionArray<2> {
     type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = GeometryCollectionBuilder::<OOutput, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), true)?;
+        let builder = GeometryCollectionBuilder::<2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), true)?;
         Ok(builder.finish())
     }
 }
@@ -95,7 +92,7 @@ impl FromWKB for ChunkedPointArray<2> {
 
 macro_rules! impl_chunked {
     ($chunked_array:ty) => {
-        impl<OOutput: OffsetSizeTrait> FromWKB for $chunked_array {
+        impl FromWKB for $chunked_array {
             type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
             fn from_wkb<O: OffsetSizeTrait>(arr: &ChunkedWKBArray<O>, coord_type: CoordType) -> Result<Self> {
@@ -105,13 +102,13 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<OOutput, 2>);
-impl_chunked!(ChunkedPolygonArray<OOutput, 2>);
-impl_chunked!(ChunkedMultiPointArray<OOutput, 2>);
-impl_chunked!(ChunkedMultiLineStringArray<OOutput, 2>);
-impl_chunked!(ChunkedMultiPolygonArray<OOutput, 2>);
-impl_chunked!(ChunkedMixedGeometryArray<OOutput, 2>);
-impl_chunked!(ChunkedGeometryCollectionArray<OOutput, 2>);
+impl_chunked!(ChunkedLineStringArray<2>);
+impl_chunked!(ChunkedPolygonArray<2>);
+impl_chunked!(ChunkedMultiPointArray<2>);
+impl_chunked!(ChunkedMultiLineStringArray<2>);
+impl_chunked!(ChunkedMultiPolygonArray<2>);
+impl_chunked!(ChunkedMixedGeometryArray<2>);
+impl_chunked!(ChunkedGeometryCollectionArray<2>);
 
 impl FromWKB for Arc<dyn ChunkedNativeArray> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;

--- a/src/io/wkb/api.rs
+++ b/src/io/wkb/api.rs
@@ -37,10 +37,7 @@ macro_rules! impl_from_wkb {
         impl<OOutput: OffsetSizeTrait> FromWKB for $array {
             type Input<O: OffsetSizeTrait> = WKBArray<O>;
 
-            fn from_wkb<O: OffsetSizeTrait>(
-                arr: &WKBArray<O>,
-                coord_type: CoordType,
-            ) -> Result<Self> {
+            fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
                 let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
                 let builder = <$builder>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
                 Ok(builder.finish())
@@ -63,12 +60,7 @@ impl<OOutput: OffsetSizeTrait> FromWKB for MixedGeometryArray<OOutput, 2> {
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = MixedGeometryBuilder::<OOutput, 2>::from_wkb(
-            &wkb_objects,
-            Some(coord_type),
-            arr.metadata(),
-            true,
-        )?;
+        let builder = MixedGeometryBuilder::<OOutput, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), true)?;
         Ok(builder.finish())
     }
 }
@@ -78,12 +70,7 @@ impl<OOutput: OffsetSizeTrait> FromWKB for GeometryCollectionArray<OOutput, 2> {
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = GeometryCollectionBuilder::<OOutput, 2>::from_wkb(
-            &wkb_objects,
-            Some(coord_type),
-            arr.metadata(),
-            true,
-        )?;
+        let builder = GeometryCollectionBuilder::<OOutput, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), true)?;
         Ok(builder.finish())
     }
 }
@@ -93,12 +80,7 @@ impl FromWKB for Arc<dyn NativeArray> {
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = arr.iter().collect();
-        let builder = GeometryCollectionBuilder::<i32, 2>::from_wkb(
-            &wkb_objects,
-            Some(coord_type),
-            arr.metadata(),
-            true,
-        )?;
+        let builder = GeometryCollectionBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), true)?;
         Ok(builder.finish().downcast(true))
     }
 }
@@ -107,8 +89,7 @@ impl FromWKB for ChunkedPointArray<2> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
     fn from_wkb<O: OffsetSizeTrait>(arr: &Self::Input<O>, coord_type: CoordType) -> Result<Self> {
-        arr.try_map(|chunk| FromWKB::from_wkb(chunk, coord_type))?
-            .try_into()
+        arr.try_map(|chunk| FromWKB::from_wkb(chunk, coord_type))?.try_into()
     }
 }
 
@@ -117,12 +98,8 @@ macro_rules! impl_chunked {
         impl<OOutput: OffsetSizeTrait> FromWKB for $chunked_array {
             type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
-            fn from_wkb<O: OffsetSizeTrait>(
-                arr: &ChunkedWKBArray<O>,
-                coord_type: CoordType,
-            ) -> Result<Self> {
-                arr.try_map(|chunk| FromWKB::from_wkb(chunk, coord_type))?
-                    .try_into()
+            fn from_wkb<O: OffsetSizeTrait>(arr: &ChunkedWKBArray<O>, coord_type: CoordType) -> Result<Self> {
+                arr.try_map(|chunk| FromWKB::from_wkb(chunk, coord_type))?.try_into()
             }
         }
     };
@@ -139,10 +116,7 @@ impl_chunked!(ChunkedGeometryCollectionArray<OOutput, 2>);
 impl FromWKB for Arc<dyn ChunkedNativeArray> {
     type Input<O: OffsetSizeTrait> = ChunkedWKBArray<O>;
 
-    fn from_wkb<O: OffsetSizeTrait>(
-        arr: &ChunkedWKBArray<O>,
-        coord_type: CoordType,
-    ) -> Result<Self> {
+    fn from_wkb<O: OffsetSizeTrait>(arr: &ChunkedWKBArray<O>, coord_type: CoordType) -> Result<Self> {
         let geom_arr = ChunkedGeometryCollectionArray::<i32, 2>::from_wkb(arr, coord_type)?;
         Ok(geom_arr.downcast(true))
     }
@@ -151,249 +125,76 @@ impl FromWKB for Arc<dyn ChunkedNativeArray> {
 /// Parse an ISO [WKBArray] to a GeometryArray with GeoArrow native encoding.
 ///
 /// Does not downcast automatically
-pub fn from_wkb<O: OffsetSizeTrait>(
-    arr: &WKBArray<O>,
-    target_geo_data_type: NativeType,
-    prefer_multi: bool,
-) -> Result<Arc<dyn NativeArray>> {
+pub fn from_wkb<O: OffsetSizeTrait>(arr: &WKBArray<O>, target_geo_data_type: NativeType, prefer_multi: bool) -> Result<Arc<dyn NativeArray>> {
     use NativeType::*;
 
     let wkb_objects: Vec<Option<crate::scalar::WKB<'_, O>>> = arr.iter().collect();
     match target_geo_data_type {
         Point(coord_type, Dimension::XY) => {
-            let builder =
-                PointBuilder::<2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder = PointBuilder::<2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         LineString(coord_type, Dimension::XY) => {
-            let builder = LineStringBuilder::<i32, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeLineString(coord_type, Dimension::XY) => {
-            let builder = LineStringBuilder::<i64, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+            let builder = LineStringBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         Polygon(coord_type, Dimension::XY) => {
-            let builder =
-                PolygonBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargePolygon(coord_type, Dimension::XY) => {
-            let builder =
-                PolygonBuilder::<i64, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder = PolygonBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiPoint(coord_type, Dimension::XY) => {
-            let builder = MultiPointBuilder::<i32, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeMultiPoint(coord_type, Dimension::XY) => {
-            let builder = MultiPointBuilder::<i64, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+            let builder = MultiPointBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiLineString(coord_type, Dimension::XY) => {
-            let builder = MultiLineStringBuilder::<i32, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeMultiLineString(coord_type, Dimension::XY) => {
-            let builder = MultiLineStringBuilder::<i64, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+            let builder = MultiLineStringBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiPolygon(coord_type, Dimension::XY) => {
-            let builder = MultiPolygonBuilder::<i32, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeMultiPolygon(coord_type, Dimension::XY) => {
-            let builder = MultiPolygonBuilder::<i64, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+            let builder = MultiPolygonBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         Mixed(coord_type, Dimension::XY) => {
-            let builder = MixedGeometryBuilder::<i32, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-                prefer_multi,
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeMixed(coord_type, Dimension::XY) => {
-            let builder = MixedGeometryBuilder::<i64, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-                prefer_multi,
-            )?;
+            let builder = MixedGeometryBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), prefer_multi)?;
             Ok(Arc::new(builder.finish()))
         }
         GeometryCollection(coord_type, Dimension::XY) => {
-            let builder = GeometryCollectionBuilder::<i32, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-                prefer_multi,
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeGeometryCollection(coord_type, Dimension::XY) => {
-            let builder = GeometryCollectionBuilder::<i64, 2>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-                prefer_multi,
-            )?;
+            let builder = GeometryCollectionBuilder::<i32, 2>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), prefer_multi)?;
             Ok(Arc::new(builder.finish()))
         }
         Point(coord_type, Dimension::XYZ) => {
-            let builder =
-                PointBuilder::<3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder = PointBuilder::<3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         LineString(coord_type, Dimension::XYZ) => {
-            let builder = LineStringBuilder::<i32, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeLineString(coord_type, Dimension::XYZ) => {
-            let builder = LineStringBuilder::<i64, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+            let builder = LineStringBuilder::<i32, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         Polygon(coord_type, Dimension::XYZ) => {
-            let builder =
-                PolygonBuilder::<i32, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargePolygon(coord_type, Dimension::XYZ) => {
-            let builder =
-                PolygonBuilder::<i64, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
+            let builder = PolygonBuilder::<i32, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiPoint(coord_type, Dimension::XYZ) => {
-            let builder = MultiPointBuilder::<i32, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeMultiPoint(coord_type, Dimension::XYZ) => {
-            let builder = MultiPointBuilder::<i64, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+            let builder = MultiPointBuilder::<i32, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiLineString(coord_type, Dimension::XYZ) => {
-            let builder = MultiLineStringBuilder::<i32, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeMultiLineString(coord_type, Dimension::XYZ) => {
-            let builder = MultiLineStringBuilder::<i64, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+            let builder = MultiLineStringBuilder::<i32, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         MultiPolygon(coord_type, Dimension::XYZ) => {
-            let builder = MultiPolygonBuilder::<i32, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeMultiPolygon(coord_type, Dimension::XYZ) => {
-            let builder = MultiPolygonBuilder::<i64, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+            let builder = MultiPolygonBuilder::<i32, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
         Mixed(coord_type, Dimension::XYZ) => {
-            let builder = MixedGeometryBuilder::<i32, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-                prefer_multi,
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LargeMixed(coord_type, Dimension::XYZ) => {
-            let builder = MixedGeometryBuilder::<i64, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-                prefer_multi,
-            )?;
+            let builder = MixedGeometryBuilder::<i32, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), prefer_multi)?;
             Ok(Arc::new(builder.finish()))
         }
         GeometryCollection(coord_type, Dimension::XYZ) => {
-            let builder = GeometryCollectionBuilder::<i32, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-                prefer_multi,
-            )?;
+            let builder = GeometryCollectionBuilder::<i32, 3>::from_wkb(&wkb_objects, Some(coord_type), arr.metadata(), prefer_multi)?;
             Ok(Arc::new(builder.finish()))
         }
-        LargeGeometryCollection(coord_type, Dimension::XYZ) => {
-            let builder = GeometryCollectionBuilder::<i64, 3>::from_wkb(
-                &wkb_objects,
-                Some(coord_type),
-                arr.metadata(),
-                prefer_multi,
-            )?;
-            Ok(Arc::new(builder.finish()))
-        }
-        Rect(_) => Err(GeoArrowError::General(format!(
-            "Unexpected data type {:?}",
-            target_geo_data_type,
-        ))),
+        Rect(_) => Err(GeoArrowError::General(format!("Unexpected data type {:?}", target_geo_data_type,))),
     }
 }
 
@@ -418,35 +219,21 @@ impl ToWKB for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => self.as_point::<2>().into(),
             LineString(_, XY) => self.as_line_string::<2>().into(),
-            LargeLineString(_, XY) => self.as_large_line_string::<2>().into(),
             Polygon(_, XY) => self.as_polygon::<2>().into(),
-            LargePolygon(_, XY) => self.as_large_polygon::<2>().into(),
             MultiPoint(_, XY) => self.as_multi_point::<2>().into(),
-            LargeMultiPoint(_, XY) => self.as_large_multi_point::<2>().into(),
             MultiLineString(_, XY) => self.as_multi_line_string::<2>().into(),
-            LargeMultiLineString(_, XY) => self.as_large_multi_line_string::<2>().into(),
             MultiPolygon(_, XY) => self.as_multi_polygon::<2>().into(),
-            LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().into(),
             Mixed(_, XY) => self.as_mixed::<2>().into(),
-            LargeMixed(_, XY) => self.as_large_mixed::<2>().into(),
             GeometryCollection(_, XY) => self.as_geometry_collection::<2>().into(),
-            LargeGeometryCollection(_, XY) => self.as_large_geometry_collection::<2>().into(),
 
             Point(_, XYZ) => self.as_point::<3>().into(),
             LineString(_, XYZ) => self.as_line_string::<3>().into(),
-            LargeLineString(_, XYZ) => self.as_large_line_string::<3>().into(),
             Polygon(_, XYZ) => self.as_polygon::<3>().into(),
-            LargePolygon(_, XYZ) => self.as_large_polygon::<3>().into(),
             MultiPoint(_, XYZ) => self.as_multi_point::<3>().into(),
-            LargeMultiPoint(_, XYZ) => self.as_large_multi_point::<3>().into(),
             MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().into(),
-            LargeMultiLineString(_, XYZ) => self.as_large_multi_line_string::<3>().into(),
             MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().into(),
-            LargeMultiPolygon(_, XYZ) => self.as_large_multi_polygon::<3>().into(),
             Mixed(_, XYZ) => self.as_mixed::<3>().into(),
-            LargeMixed(_, XYZ) => self.as_large_mixed::<3>().into(),
             GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().into(),
-            LargeGeometryCollection(_, XYZ) => self.as_large_geometry_collection::<3>().into(),
             Rect(_) => todo!(),
         }
     }
@@ -459,100 +246,22 @@ impl ToWKB for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, Dimension::XY) => {
-                ChunkedGeometryArray::new(self.as_point::<2>().map(|chunk| chunk.into()))
-            }
-            LineString(_, Dimension::XY) => {
-                ChunkedGeometryArray::new(self.as_line_string::<2>().map(|chunk| chunk.into()))
-            }
-            LargeLineString(_, Dimension::XY) => ChunkedGeometryArray::new(
-                self.as_large_line_string::<2>().map(|chunk| chunk.into()),
-            ),
-            Polygon(_, Dimension::XY) => {
-                ChunkedGeometryArray::new(self.as_polygon::<2>().map(|chunk| chunk.into()))
-            }
-            LargePolygon(_, Dimension::XY) => {
-                ChunkedGeometryArray::new(self.as_large_polygon::<2>().map(|chunk| chunk.into()))
-            }
-            MultiPoint(_, Dimension::XY) => {
-                ChunkedGeometryArray::new(self.as_multi_point::<2>().map(|chunk| chunk.into()))
-            }
-            LargeMultiPoint(_, Dimension::XY) => ChunkedGeometryArray::new(
-                self.as_large_multi_point::<2>().map(|chunk| chunk.into()),
-            ),
-            MultiLineString(_, Dimension::XY) => ChunkedGeometryArray::new(
-                self.as_multi_line_string::<2>().map(|chunk| chunk.into()),
-            ),
-            LargeMultiLineString(_, Dimension::XY) => ChunkedGeometryArray::new(
-                self.as_large_multi_line_string::<2>()
-                    .map(|chunk| chunk.into()),
-            ),
-            MultiPolygon(_, Dimension::XY) => {
-                ChunkedGeometryArray::new(self.as_multi_polygon::<2>().map(|chunk| chunk.into()))
-            }
-            LargeMultiPolygon(_, Dimension::XY) => ChunkedGeometryArray::new(
-                self.as_large_multi_polygon::<2>().map(|chunk| chunk.into()),
-            ),
-            Mixed(_, Dimension::XY) => {
-                ChunkedGeometryArray::new(self.as_mixed::<2>().map(|chunk| chunk.into()))
-            }
-            LargeMixed(_, Dimension::XY) => {
-                ChunkedGeometryArray::new(self.as_large_mixed::<2>().map(|chunk| chunk.into()))
-            }
-            GeometryCollection(_, Dimension::XY) => ChunkedGeometryArray::new(
-                self.as_geometry_collection::<2>().map(|chunk| chunk.into()),
-            ),
-            LargeGeometryCollection(_, Dimension::XY) => ChunkedGeometryArray::new(
-                self.as_large_geometry_collection::<2>()
-                    .map(|chunk| chunk.into()),
-            ),
-            Point(_, Dimension::XYZ) => {
-                ChunkedGeometryArray::new(self.as_point::<3>().map(|chunk| chunk.into()))
-            }
-            LineString(_, Dimension::XYZ) => {
-                ChunkedGeometryArray::new(self.as_line_string::<3>().map(|chunk| chunk.into()))
-            }
-            LargeLineString(_, Dimension::XYZ) => ChunkedGeometryArray::new(
-                self.as_large_line_string::<3>().map(|chunk| chunk.into()),
-            ),
-            Polygon(_, Dimension::XYZ) => {
-                ChunkedGeometryArray::new(self.as_polygon::<3>().map(|chunk| chunk.into()))
-            }
-            LargePolygon(_, Dimension::XYZ) => {
-                ChunkedGeometryArray::new(self.as_large_polygon::<3>().map(|chunk| chunk.into()))
-            }
-            MultiPoint(_, Dimension::XYZ) => {
-                ChunkedGeometryArray::new(self.as_multi_point::<3>().map(|chunk| chunk.into()))
-            }
-            LargeMultiPoint(_, Dimension::XYZ) => ChunkedGeometryArray::new(
-                self.as_large_multi_point::<3>().map(|chunk| chunk.into()),
-            ),
-            MultiLineString(_, Dimension::XYZ) => ChunkedGeometryArray::new(
-                self.as_multi_line_string::<3>().map(|chunk| chunk.into()),
-            ),
-            LargeMultiLineString(_, Dimension::XYZ) => ChunkedGeometryArray::new(
-                self.as_large_multi_line_string::<3>()
-                    .map(|chunk| chunk.into()),
-            ),
-            MultiPolygon(_, Dimension::XYZ) => {
-                ChunkedGeometryArray::new(self.as_multi_polygon::<3>().map(|chunk| chunk.into()))
-            }
-            LargeMultiPolygon(_, Dimension::XYZ) => ChunkedGeometryArray::new(
-                self.as_large_multi_polygon::<3>().map(|chunk| chunk.into()),
-            ),
-            Mixed(_, Dimension::XYZ) => {
-                ChunkedGeometryArray::new(self.as_mixed::<3>().map(|chunk| chunk.into()))
-            }
-            LargeMixed(_, Dimension::XYZ) => {
-                ChunkedGeometryArray::new(self.as_large_mixed::<3>().map(|chunk| chunk.into()))
-            }
-            GeometryCollection(_, Dimension::XYZ) => ChunkedGeometryArray::new(
-                self.as_geometry_collection::<3>().map(|chunk| chunk.into()),
-            ),
-            LargeGeometryCollection(_, Dimension::XYZ) => ChunkedGeometryArray::new(
-                self.as_large_geometry_collection::<3>()
-                    .map(|chunk| chunk.into()),
-            ),
+            Point(_, Dimension::XY) => ChunkedGeometryArray::new(self.as_point::<2>().map(|chunk| chunk.into())),
+            LineString(_, Dimension::XY) => ChunkedGeometryArray::new(self.as_line_string::<2>().map(|chunk| chunk.into())),
+            Polygon(_, Dimension::XY) => ChunkedGeometryArray::new(self.as_polygon::<2>().map(|chunk| chunk.into())),
+            MultiPoint(_, Dimension::XY) => ChunkedGeometryArray::new(self.as_multi_point::<2>().map(|chunk| chunk.into())),
+            MultiLineString(_, Dimension::XY) => ChunkedGeometryArray::new(self.as_multi_line_string::<2>().map(|chunk| chunk.into())),
+            MultiPolygon(_, Dimension::XY) => ChunkedGeometryArray::new(self.as_multi_polygon::<2>().map(|chunk| chunk.into())),
+            Mixed(_, Dimension::XY) => ChunkedGeometryArray::new(self.as_mixed::<2>().map(|chunk| chunk.into())),
+            GeometryCollection(_, Dimension::XY) => ChunkedGeometryArray::new(self.as_geometry_collection::<2>().map(|chunk| chunk.into())),
+            Point(_, Dimension::XYZ) => ChunkedGeometryArray::new(self.as_point::<3>().map(|chunk| chunk.into())),
+            LineString(_, Dimension::XYZ) => ChunkedGeometryArray::new(self.as_line_string::<3>().map(|chunk| chunk.into())),
+            Polygon(_, Dimension::XYZ) => ChunkedGeometryArray::new(self.as_polygon::<3>().map(|chunk| chunk.into())),
+            MultiPoint(_, Dimension::XYZ) => ChunkedGeometryArray::new(self.as_multi_point::<3>().map(|chunk| chunk.into())),
+            MultiLineString(_, Dimension::XYZ) => ChunkedGeometryArray::new(self.as_multi_line_string::<3>().map(|chunk| chunk.into())),
+            MultiPolygon(_, Dimension::XYZ) => ChunkedGeometryArray::new(self.as_multi_polygon::<3>().map(|chunk| chunk.into())),
+            Mixed(_, Dimension::XYZ) => ChunkedGeometryArray::new(self.as_mixed::<3>().map(|chunk| chunk.into())),
+            GeometryCollection(_, Dimension::XYZ) => ChunkedGeometryArray::new(self.as_geometry_collection::<3>().map(|chunk| chunk.into())),
             Rect(_) => todo!(),
         }
     }
@@ -565,36 +274,20 @@ pub fn to_wkb<O: OffsetSizeTrait>(arr: &dyn NativeArray) -> WKBArray<O> {
     match arr.data_type() {
         Point(_, Dimension::XY) => arr.as_point::<2>().into(),
         LineString(_, Dimension::XY) => arr.as_line_string::<2>().into(),
-        LargeLineString(_, Dimension::XY) => arr.as_large_line_string::<2>().into(),
         Polygon(_, Dimension::XY) => arr.as_polygon::<2>().into(),
-        LargePolygon(_, Dimension::XY) => arr.as_large_polygon::<2>().into(),
         MultiPoint(_, Dimension::XY) => arr.as_multi_point::<2>().into(),
-        LargeMultiPoint(_, Dimension::XY) => arr.as_large_multi_point::<2>().into(),
         MultiLineString(_, Dimension::XY) => arr.as_multi_line_string::<2>().into(),
-        LargeMultiLineString(_, Dimension::XY) => arr.as_large_multi_line_string::<2>().into(),
         MultiPolygon(_, Dimension::XY) => arr.as_multi_polygon::<2>().into(),
-        LargeMultiPolygon(_, Dimension::XY) => arr.as_large_multi_polygon::<2>().into(),
         Mixed(_, Dimension::XY) => arr.as_mixed::<2>().into(),
-        LargeMixed(_, Dimension::XY) => arr.as_large_mixed::<2>().into(),
         GeometryCollection(_, Dimension::XY) => arr.as_geometry_collection::<2>().into(),
-        LargeGeometryCollection(_, Dimension::XY) => arr.as_large_geometry_collection::<2>().into(),
         Point(_, Dimension::XYZ) => arr.as_point::<3>().into(),
         LineString(_, Dimension::XYZ) => arr.as_line_string::<3>().into(),
-        LargeLineString(_, Dimension::XYZ) => arr.as_large_line_string::<3>().into(),
         Polygon(_, Dimension::XYZ) => arr.as_polygon::<3>().into(),
-        LargePolygon(_, Dimension::XYZ) => arr.as_large_polygon::<3>().into(),
         MultiPoint(_, Dimension::XYZ) => arr.as_multi_point::<3>().into(),
-        LargeMultiPoint(_, Dimension::XYZ) => arr.as_large_multi_point::<3>().into(),
         MultiLineString(_, Dimension::XYZ) => arr.as_multi_line_string::<3>().into(),
-        LargeMultiLineString(_, Dimension::XYZ) => arr.as_large_multi_line_string::<3>().into(),
         MultiPolygon(_, Dimension::XYZ) => arr.as_multi_polygon::<3>().into(),
-        LargeMultiPolygon(_, Dimension::XYZ) => arr.as_large_multi_polygon::<3>().into(),
         Mixed(_, Dimension::XYZ) => arr.as_mixed::<3>().into(),
-        LargeMixed(_, Dimension::XYZ) => arr.as_large_mixed::<3>().into(),
         GeometryCollection(_, Dimension::XYZ) => arr.as_geometry_collection::<3>().into(),
-        LargeGeometryCollection(_, Dimension::XYZ) => {
-            arr.as_large_geometry_collection::<3>().into()
-        }
         Rect(_) => todo!(),
     }
 }
@@ -608,12 +301,7 @@ mod test {
     fn point_round_trip_explicit_casting() {
         let arr = point::point_array();
         let wkb_arr: WKBArray<i32> = to_wkb(&arr);
-        let roundtrip = from_wkb(
-            &wkb_arr,
-            NativeType::Point(CoordType::Interleaved, Dimension::XY),
-            true,
-        )
-        .unwrap();
+        let roundtrip = from_wkb(&wkb_arr, NativeType::Point(CoordType::Interleaved, Dimension::XY), true).unwrap();
         let rt_point_arr = roundtrip.as_ref();
         let rt_point_arr_ref = rt_point_arr.as_point::<2>();
         assert_eq!(&arr, rt_point_arr_ref);
@@ -623,12 +311,7 @@ mod test {
     fn point_round_trip() {
         let arr = point::point_array();
         let wkb_arr: WKBArray<i32> = to_wkb(&arr);
-        let roundtrip = from_wkb(
-            &wkb_arr,
-            NativeType::Mixed(CoordType::Interleaved, Dimension::XY),
-            true,
-        )
-        .unwrap();
+        let roundtrip = from_wkb(&wkb_arr, NativeType::Mixed(CoordType::Interleaved, Dimension::XY), true).unwrap();
         let rt_ref = roundtrip.as_ref();
         let rt_mixed_arr = rt_ref.as_mixed::<2>();
         let downcasted = rt_mixed_arr.downcast(true);
@@ -641,22 +324,12 @@ mod test {
     fn point_3d_round_trip() {
         let arr = point::point_z_array();
         let wkb_arr: WKBArray<i32> = to_wkb(&arr);
-        let roundtrip_mixed = from_wkb(
-            &wkb_arr,
-            NativeType::Mixed(CoordType::Interleaved, Dimension::XYZ),
-            false,
-        )
-        .unwrap();
+        let roundtrip_mixed = from_wkb(&wkb_arr, NativeType::Mixed(CoordType::Interleaved, Dimension::XYZ), false).unwrap();
         let rt_ref = roundtrip_mixed.as_ref();
         let rt_mixed_arr = rt_ref.as_mixed::<3>();
         assert!(rt_mixed_arr.has_points());
 
-        let roundtrip_point = from_wkb(
-            &wkb_arr,
-            NativeType::Point(CoordType::Interleaved, Dimension::XYZ),
-            false,
-        )
-        .unwrap();
+        let roundtrip_point = from_wkb(&wkb_arr, NativeType::Point(CoordType::Interleaved, Dimension::XYZ), false).unwrap();
         let rt_ref = roundtrip_point.as_ref();
         let rt_arr = rt_ref.as_point::<3>();
         assert_eq!(rt_arr, &arr);

--- a/src/io/wkb/writer/geometry.rs
+++ b/src/io/wkb/writer/geometry.rs
@@ -53,11 +53,9 @@ pub fn write_geometry_as_wkb<W: Write>(
     }
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MixedGeometryArray<A, D>>
-    for WKBArray<B>
-{
-    fn from(value: &MixedGeometryArray<A, D>) -> Self {
-        let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
+impl<O: OffsetSizeTrait, const D: usize> From<&MixedGeometryArray<D>> for WKBArray<O> {
+    fn from(value: &MixedGeometryArray<D>) -> Self {
+        let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
@@ -80,7 +78,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MixedGeometry
         };
 
         let binary_arr =
-            GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
+            GenericBinaryArray::<O>::new(offsets.into(), values.into(), value.nulls().cloned());
         WKBArray::new(binary_arr, value.metadata())
     }
 }

--- a/src/io/wkb/writer/geometrycollection.rs
+++ b/src/io/wkb/writer/geometrycollection.rs
@@ -56,11 +56,9 @@ pub fn write_geometry_collection_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&GeometryCollectionArray<A, D>>
-    for WKBArray<B>
-{
-    fn from(value: &GeometryCollectionArray<A, D>) -> Self {
-        let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
+impl<O: OffsetSizeTrait, const D: usize> From<&GeometryCollectionArray<D>> for WKBArray<O> {
+    fn from(value: &GeometryCollectionArray<D>) -> Self {
+        let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
@@ -74,7 +72,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&GeometryColle
         }
 
         let values = {
-            let values = Vec::with_capacity(offsets.last().to_usize().unwrap());
+            let values = Vec::with_capacity(offsets.last().as_usize());
             let mut writer = Cursor::new(values);
 
             for geom in value.iter().flatten() {

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -19,38 +19,49 @@ pub fn line_string_wkb_size(geom: &impl LineStringTrait) -> usize {
 }
 
 /// Write a LineString geometry to a Writer encoded as WKB
-pub fn write_line_string_as_wkb<W: Write>(mut writer: W, geom: &impl LineStringTrait<T = f64>) -> Result<()> {
+pub fn write_line_string_as_wkb<W: Write>(
+    mut writer: W,
+    geom: &impl LineStringTrait<T = f64>,
+) -> Result<()> {
     // Byte order
     writer.write_u8(Endianness::LittleEndian.into()).unwrap();
 
     match geom.dim() {
         2 => {
-            writer.write_u32::<LittleEndian>(WKBType::LineString.into()).unwrap();
+            writer
+                .write_u32::<LittleEndian>(WKBType::LineString.into())
+                .unwrap();
         }
         3 => {
-            writer.write_u32::<LittleEndian>(WKBType::LineStringZ.into()).unwrap();
+            writer
+                .write_u32::<LittleEndian>(WKBType::LineStringZ.into())
+                .unwrap();
         }
         _ => panic!(),
     }
 
     // numPoints
-    writer.write_u32::<LittleEndian>(geom.num_coords().try_into().unwrap()).unwrap();
+    writer
+        .write_u32::<LittleEndian>(geom.num_coords().try_into().unwrap())
+        .unwrap();
 
     for coord in geom.coords() {
         writer.write_f64::<LittleEndian>(coord.x()).unwrap();
         writer.write_f64::<LittleEndian>(coord.y()).unwrap();
 
         if geom.dim() == 3 {
-            writer.write_f64::<LittleEndian>(coord.nth_unchecked(2)).unwrap();
+            writer
+                .write_f64::<LittleEndian>(coord.nth_unchecked(2))
+                .unwrap();
         }
     }
 
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&LineStringArray<A, D>> for WKBArray<B> {
-    fn from(value: &LineStringArray<A, D>) -> Self {
-        let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
+impl<O: OffsetSizeTrait, const D: usize> From<&LineStringArray<D>> for WKBArray<O> {
+    fn from(value: &LineStringArray<D>) -> Self {
+        let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
@@ -72,7 +83,8 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&LineStringArr
             writer.into_inner()
         };
 
-        let binary_arr = GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
+        let binary_arr =
+            GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
         WKBArray::new(binary_arr, value.metadata())
     }
 }

--- a/src/io/wkb/writer/multilinestring.rs
+++ b/src/io/wkb/writer/multilinestring.rs
@@ -22,22 +22,31 @@ pub fn multi_line_string_wkb_size(geom: &impl MultiLineStringTrait) -> usize {
 }
 
 /// Write a MultiLineString geometry to a Writer encoded as WKB
-pub fn write_multi_line_string_as_wkb<W: Write>(mut writer: W, geom: &impl MultiLineStringTrait<T = f64>) -> Result<()> {
+pub fn write_multi_line_string_as_wkb<W: Write>(
+    mut writer: W,
+    geom: &impl MultiLineStringTrait<T = f64>,
+) -> Result<()> {
     // Byte order
     writer.write_u8(Endianness::LittleEndian.into()).unwrap();
 
     match geom.dim() {
         2 => {
-            writer.write_u32::<LittleEndian>(WKBType::MultiLineString.into()).unwrap();
+            writer
+                .write_u32::<LittleEndian>(WKBType::MultiLineString.into())
+                .unwrap();
         }
         3 => {
-            writer.write_u32::<LittleEndian>(WKBType::MultiLineStringZ.into()).unwrap();
+            writer
+                .write_u32::<LittleEndian>(WKBType::MultiLineStringZ.into())
+                .unwrap();
         }
         _ => panic!(),
     }
 
     // numPoints
-    writer.write_u32::<LittleEndian>(geom.num_lines().try_into().unwrap()).unwrap();
+    writer
+        .write_u32::<LittleEndian>(geom.num_lines().try_into().unwrap())
+        .unwrap();
 
     for line_string in geom.lines() {
         write_line_string_as_wkb(&mut writer, &line_string).unwrap();
@@ -46,14 +55,16 @@ pub fn write_multi_line_string_as_wkb<W: Write>(mut writer: W, geom: &impl Multi
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MultiLineStringArray<A, D>> for WKBArray<B> {
-    fn from(value: &MultiLineStringArray<A, D>) -> Self {
-        let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
+impl<O: OffsetSizeTrait, const D: usize> From<&MultiLineStringArray<D>> for WKBArray<O> {
+    fn from(value: &MultiLineStringArray<D>) -> Self {
+        let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
             if let Some(geom) = maybe_geom {
-                offsets.try_push_usize(multi_line_string_wkb_size(&geom)).unwrap();
+                offsets
+                    .try_push_usize(multi_line_string_wkb_size(&geom))
+                    .unwrap();
             } else {
                 offsets.extend_constant(1);
             }
@@ -70,7 +81,8 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MultiLineStri
             writer.into_inner()
         };
 
-        let binary_arr = GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
+        let binary_arr =
+            GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
         WKBArray::new(binary_arr, value.metadata())
     }
 }

--- a/src/io/wkb/writer/multipoint.rs
+++ b/src/io/wkb/writer/multipoint.rs
@@ -17,31 +17,22 @@ pub fn multi_point_wkb_size(geom: &impl MultiPointTrait) -> usize {
 }
 
 /// Write a MultiPoint geometry to a Writer encoded as WKB
-pub fn write_multi_point_as_wkb<W: Write>(
-    mut writer: W,
-    geom: &impl MultiPointTrait<T = f64>,
-) -> Result<()> {
+pub fn write_multi_point_as_wkb<W: Write>(mut writer: W, geom: &impl MultiPointTrait<T = f64>) -> Result<()> {
     // Byte order
     writer.write_u8(Endianness::LittleEndian.into()).unwrap();
 
     match geom.dim() {
         2 => {
-            writer
-                .write_u32::<LittleEndian>(WKBType::MultiPoint.into())
-                .unwrap();
+            writer.write_u32::<LittleEndian>(WKBType::MultiPoint.into()).unwrap();
         }
         3 => {
-            writer
-                .write_u32::<LittleEndian>(WKBType::MultiPointZ.into())
-                .unwrap();
+            writer.write_u32::<LittleEndian>(WKBType::MultiPointZ.into()).unwrap();
         }
         _ => panic!(),
     }
 
     // numPoints
-    writer
-        .write_u32::<LittleEndian>(geom.num_points().try_into().unwrap())
-        .unwrap();
+    writer.write_u32::<LittleEndian>(geom.num_points().try_into().unwrap()).unwrap();
 
     for point in geom.points() {
         write_point_as_wkb(&mut writer, &point).unwrap();
@@ -50,9 +41,7 @@ pub fn write_multi_point_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MultiPointArray<A, D>>
-    for WKBArray<B>
-{
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MultiPointArray<A, D>> for WKBArray<B> {
     fn from(value: &MultiPointArray<A, D>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
@@ -76,8 +65,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MultiPointArr
             writer.into_inner()
         };
 
-        let binary_arr =
-            GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
+        let binary_arr = GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
         WKBArray::new(binary_arr, value.metadata())
     }
 }
@@ -89,9 +77,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiPointArray<i32, 2> = vec![Some(mp0()), Some(mp1()), None].into();
+        let orig_arr: MultiPointArray<2> = vec![Some(mp0()), Some(mp1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiPointArray<i32, 2> = wkb_arr.try_into().unwrap();
+        let new_arr: MultiPointArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/src/io/wkb/writer/multipolygon.rs
+++ b/src/io/wkb/writer/multipolygon.rs
@@ -22,31 +22,22 @@ pub fn multi_polygon_wkb_size(geom: &impl MultiPolygonTrait) -> usize {
 }
 
 /// Write a MultiPolygon geometry to a Writer encoded as WKB
-pub fn write_multi_polygon_as_wkb<W: Write>(
-    mut writer: W,
-    geom: &impl MultiPolygonTrait<T = f64>,
-) -> Result<()> {
+pub fn write_multi_polygon_as_wkb<W: Write>(mut writer: W, geom: &impl MultiPolygonTrait<T = f64>) -> Result<()> {
     // Byte order
     writer.write_u8(Endianness::LittleEndian.into()).unwrap();
 
     match geom.dim() {
         2 => {
-            writer
-                .write_u32::<LittleEndian>(WKBType::MultiPolygon.into())
-                .unwrap();
+            writer.write_u32::<LittleEndian>(WKBType::MultiPolygon.into()).unwrap();
         }
         3 => {
-            writer
-                .write_u32::<LittleEndian>(WKBType::MultiPolygonZ.into())
-                .unwrap();
+            writer.write_u32::<LittleEndian>(WKBType::MultiPolygonZ.into()).unwrap();
         }
         _ => panic!(),
     }
 
     // numPolygons
-    writer
-        .write_u32::<LittleEndian>(geom.num_polygons().try_into().unwrap())
-        .unwrap();
+    writer.write_u32::<LittleEndian>(geom.num_polygons().try_into().unwrap()).unwrap();
 
     for polygon in geom.polygons() {
         write_polygon_as_wkb(&mut writer, &polygon).unwrap();
@@ -55,18 +46,14 @@ pub fn write_multi_polygon_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MultiPolygonArray<A, D>>
-    for WKBArray<B>
-{
+impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MultiPolygonArray<A, D>> for WKBArray<B> {
     fn from(value: &MultiPolygonArray<A, D>) -> Self {
         let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
             if let Some(geom) = maybe_geom {
-                offsets
-                    .try_push_usize(multi_polygon_wkb_size(&geom))
-                    .unwrap();
+                offsets.try_push_usize(multi_polygon_wkb_size(&geom)).unwrap();
             } else {
                 offsets.extend_constant(1);
             }
@@ -83,8 +70,7 @@ impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&MultiPolygonA
             writer.into_inner()
         };
 
-        let binary_arr =
-            GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
+        let binary_arr = GenericBinaryArray::new(offsets.into(), values.into(), value.nulls().cloned());
         WKBArray::new(binary_arr, value.metadata())
     }
 }
@@ -96,9 +82,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiPolygonArray<i32, 2> = vec![Some(mp0()), Some(mp1()), None].into();
+        let orig_arr: MultiPolygonArray<2> = vec![Some(mp0()), Some(mp1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiPolygonArray<i32, 2> = wkb_arr.try_into().unwrap();
+        let new_arr: MultiPolygonArray<2> = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/src/io/wkb/writer/point.rs
+++ b/src/io/wkb/writer/point.rs
@@ -31,10 +31,14 @@ pub fn write_point_as_wkb<W: Write>(mut writer: W, geom: &impl PointTrait<T = f6
 
     match geom.dim() {
         2 => {
-            writer.write_u32::<LittleEndian>(WKBType::Point.into()).unwrap();
+            writer
+                .write_u32::<LittleEndian>(WKBType::Point.into())
+                .unwrap();
         }
         3 => {
-            writer.write_u32::<LittleEndian>(WKBType::PointZ.into()).unwrap();
+            writer
+                .write_u32::<LittleEndian>(WKBType::PointZ.into())
+                .unwrap();
         }
         _ => panic!(),
     }
@@ -43,7 +47,9 @@ pub fn write_point_as_wkb<W: Write>(mut writer: W, geom: &impl PointTrait<T = f6
     writer.write_f64::<LittleEndian>(geom.y()).unwrap();
 
     if geom.dim() == 3 {
-        writer.write_f64::<LittleEndian>(geom.nth_unchecked(2)).unwrap();
+        writer
+            .write_f64::<LittleEndian>(geom.nth_unchecked(2))
+            .unwrap();
     }
 
     Ok(())
@@ -51,7 +57,9 @@ pub fn write_point_as_wkb<W: Write>(mut writer: W, geom: &impl PointTrait<T = f6
 
 impl<O: OffsetSizeTrait, const D: usize> From<&PointArray<D>> for WKBArray<O> {
     fn from(value: &PointArray<D>) -> Self {
-        let non_null_count = value.nulls().map_or(value.len(), |validity| value.len() - validity.null_count());
+        let non_null_count = value
+            .nulls()
+            .map_or(value.len(), |validity| value.len() - validity.null_count());
 
         let validity = value.nulls().cloned();
         // only allocate space for a WKBPoint for non-null items

--- a/src/io/wkb/writer/point.rs
+++ b/src/io/wkb/writer/point.rs
@@ -31,14 +31,10 @@ pub fn write_point_as_wkb<W: Write>(mut writer: W, geom: &impl PointTrait<T = f6
 
     match geom.dim() {
         2 => {
-            writer
-                .write_u32::<LittleEndian>(WKBType::Point.into())
-                .unwrap();
+            writer.write_u32::<LittleEndian>(WKBType::Point.into()).unwrap();
         }
         3 => {
-            writer
-                .write_u32::<LittleEndian>(WKBType::PointZ.into())
-                .unwrap();
+            writer.write_u32::<LittleEndian>(WKBType::PointZ.into()).unwrap();
         }
         _ => panic!(),
     }
@@ -47,9 +43,7 @@ pub fn write_point_as_wkb<W: Write>(mut writer: W, geom: &impl PointTrait<T = f6
     writer.write_f64::<LittleEndian>(geom.y()).unwrap();
 
     if geom.dim() == 3 {
-        writer
-            .write_f64::<LittleEndian>(geom.nth_unchecked(2))
-            .unwrap();
+        writer.write_f64::<LittleEndian>(geom.nth_unchecked(2)).unwrap();
     }
 
     Ok(())
@@ -57,9 +51,7 @@ pub fn write_point_as_wkb<W: Write>(mut writer: W, geom: &impl PointTrait<T = f6
 
 impl<O: OffsetSizeTrait, const D: usize> From<&PointArray<D>> for WKBArray<O> {
     fn from(value: &PointArray<D>) -> Self {
-        let non_null_count = value
-            .nulls()
-            .map_or(value.len(), |validity| value.len() - validity.null_count());
+        let non_null_count = value.nulls().map_or(value.len(), |validity| value.len() - validity.null_count());
 
         let validity = value.nulls().cloned();
         // only allocate space for a WKBPoint for non-null items

--- a/src/io/wkb/writer/polygon.rs
+++ b/src/io/wkb/writer/polygon.rs
@@ -90,11 +90,9 @@ pub fn write_polygon_as_wkb<W: Write>(
     Ok(())
 }
 
-impl<A: OffsetSizeTrait, B: OffsetSizeTrait, const D: usize> From<&PolygonArray<A, D>>
-    for WKBArray<B>
-{
-    fn from(value: &PolygonArray<A, D>) -> Self {
-        let mut offsets: OffsetsBuilder<B> = OffsetsBuilder::with_capacity(value.len());
+impl<O: OffsetSizeTrait, const D: usize> From<&PolygonArray<D>> for WKBArray<O> {
+    fn from(value: &PolygonArray<D>) -> Self {
+        let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
@@ -131,9 +129,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: PolygonArray<i32, 2> = vec![Some(p0()), Some(p1()), None].into();
+        let orig_arr: PolygonArray<2> = vec![Some(p0()), Some(p1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: PolygonArray<i32, 2> = wkb_arr.clone().try_into().unwrap();
+        let new_arr: PolygonArray<2> = wkb_arr.clone().try_into().unwrap();
 
         let wkb0 = geo::Geometry::Polygon(p0())
             .to_wkb(CoordDimensions::xy())

--- a/src/io/wkt/reader/mod.rs
+++ b/src/io/wkt/reader/mod.rs
@@ -20,7 +20,7 @@ impl<O: OffsetSizeTrait> ParseWKT for GenericStringArray<O> {
     type Output = Arc<dyn NativeArray>;
 
     fn parse_wkt(&self, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self::Output {
-        let mut builder = MixedGeometryBuilder::<O, 2>::new_with_options(coord_type, metadata);
+        let mut builder = MixedGeometryBuilder::<2>::new_with_options(coord_type, metadata);
         for i in 0..self.len() {
             if self.is_valid(i) {
                 let w = wkt::Wkt::<f64>::from_str(self.value(i)).unwrap();

--- a/src/io/wkt/writer/api.rs
+++ b/src/io/wkt/writer/api.rs
@@ -4,7 +4,10 @@ use arrow_array::OffsetSizeTrait;
 use crate::array::{AsChunkedNativeArray, AsNativeArray, WKTArray};
 use crate::chunked_array::{ChunkedGeometryArray, ChunkedNativeArray};
 use crate::datatypes::{Dimension, NativeType};
-use crate::io::wkt::writer::scalar::{geometry_collection_to_wkt, geometry_to_wkt, line_string_to_wkt, multi_line_string_to_wkt, multi_point_to_wkt, multi_polygon_to_wkt, point_to_wkt, polygon_to_wkt, rect_to_wkt};
+use crate::io::wkt::writer::scalar::{
+    geometry_collection_to_wkt, geometry_to_wkt, line_string_to_wkt, multi_line_string_to_wkt,
+    multi_point_to_wkt, multi_polygon_to_wkt, point_to_wkt, polygon_to_wkt, rect_to_wkt,
+};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
 
@@ -27,7 +30,8 @@ impl ToWKT for &dyn NativeArray {
         macro_rules! impl_to_wkt {
             ($cast_func:ident, $dim:expr, $to_wkt_func:expr) => {
                 for maybe_geom in self.$cast_func::<$dim>().iter() {
-                    output_array.append_option(maybe_geom.map(|geom| $to_wkt_func(&geom).to_string()));
+                    output_array
+                        .append_option(maybe_geom.map(|geom| $to_wkt_func(&geom).to_string()));
                 }
             };
         }
@@ -74,7 +78,10 @@ impl ToWKT for &dyn ChunkedNativeArray {
 
         macro_rules! impl_to_wkt {
             ($cast_func:ident, $dim:expr) => {
-                ChunkedGeometryArray::new(self.$cast_func::<$dim>().map(|chunk| chunk.as_ref().to_wkt()))
+                ChunkedGeometryArray::new(
+                    self.$cast_func::<$dim>()
+                        .map(|chunk| chunk.as_ref().to_wkt()),
+                )
             };
         }
 

--- a/src/io/wkt/writer/api.rs
+++ b/src/io/wkt/writer/api.rs
@@ -4,10 +4,7 @@ use arrow_array::OffsetSizeTrait;
 use crate::array::{AsChunkedNativeArray, AsNativeArray, WKTArray};
 use crate::chunked_array::{ChunkedGeometryArray, ChunkedNativeArray};
 use crate::datatypes::{Dimension, NativeType};
-use crate::io::wkt::writer::scalar::{
-    geometry_collection_to_wkt, geometry_to_wkt, line_string_to_wkt, multi_line_string_to_wkt,
-    multi_point_to_wkt, multi_polygon_to_wkt, point_to_wkt, polygon_to_wkt, rect_to_wkt,
-};
+use crate::io::wkt::writer::scalar::{geometry_collection_to_wkt, geometry_to_wkt, line_string_to_wkt, multi_line_string_to_wkt, multi_point_to_wkt, multi_polygon_to_wkt, point_to_wkt, polygon_to_wkt, rect_to_wkt};
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
 
@@ -30,8 +27,7 @@ impl ToWKT for &dyn NativeArray {
         macro_rules! impl_to_wkt {
             ($cast_func:ident, $dim:expr, $to_wkt_func:expr) => {
                 for maybe_geom in self.$cast_func::<$dim>().iter() {
-                    output_array
-                        .append_option(maybe_geom.map(|geom| $to_wkt_func(&geom).to_string()));
+                    output_array.append_option(maybe_geom.map(|geom| $to_wkt_func(&geom).to_string()));
                 }
             };
         }
@@ -39,53 +35,27 @@ impl ToWKT for &dyn NativeArray {
         match self.data_type() {
             Point(_, XY) => impl_to_wkt!(as_point, 2, point_to_wkt),
             LineString(_, XY) => impl_to_wkt!(as_line_string, 2, line_string_to_wkt),
-            LargeLineString(_, XY) => impl_to_wkt!(as_large_line_string, 2, line_string_to_wkt),
             Polygon(_, XY) => impl_to_wkt!(as_polygon, 2, polygon_to_wkt),
-            LargePolygon(_, XY) => impl_to_wkt!(as_large_polygon, 2, polygon_to_wkt),
             MultiPoint(_, XY) => impl_to_wkt!(as_multi_point, 2, multi_point_to_wkt),
-            LargeMultiPoint(_, XY) => impl_to_wkt!(as_large_multi_point, 2, multi_point_to_wkt),
             MultiLineString(_, XY) => {
                 impl_to_wkt!(as_multi_line_string, 2, multi_line_string_to_wkt)
             }
-            LargeMultiLineString(_, XY) => {
-                impl_to_wkt!(as_large_multi_line_string, 2, multi_line_string_to_wkt)
-            }
             MultiPolygon(_, XY) => impl_to_wkt!(as_multi_polygon, 2, multi_polygon_to_wkt),
-            LargeMultiPolygon(_, XY) => {
-                impl_to_wkt!(as_large_multi_polygon, 2, multi_polygon_to_wkt)
-            }
             Mixed(_, XY) => impl_to_wkt!(as_mixed, 2, geometry_to_wkt),
-            LargeMixed(_, XY) => impl_to_wkt!(as_large_mixed, 2, geometry_to_wkt),
             GeometryCollection(_, XY) => {
                 impl_to_wkt!(as_geometry_collection, 2, geometry_collection_to_wkt)
             }
-            LargeGeometryCollection(_, XY) => {
-                impl_to_wkt!(as_large_geometry_collection, 2, geometry_collection_to_wkt)
-            }
             Point(_, XYZ) => impl_to_wkt!(as_point, 3, point_to_wkt),
             LineString(_, XYZ) => impl_to_wkt!(as_line_string, 3, line_string_to_wkt),
-            LargeLineString(_, XYZ) => impl_to_wkt!(as_large_line_string, 3, line_string_to_wkt),
             Polygon(_, XYZ) => impl_to_wkt!(as_polygon, 3, polygon_to_wkt),
-            LargePolygon(_, XYZ) => impl_to_wkt!(as_large_polygon, 3, polygon_to_wkt),
             MultiPoint(_, XYZ) => impl_to_wkt!(as_multi_point, 3, multi_point_to_wkt),
-            LargeMultiPoint(_, XYZ) => impl_to_wkt!(as_large_multi_point, 3, multi_point_to_wkt),
             MultiLineString(_, XYZ) => {
                 impl_to_wkt!(as_multi_line_string, 3, multi_line_string_to_wkt)
             }
-            LargeMultiLineString(_, XYZ) => {
-                impl_to_wkt!(as_large_multi_line_string, 3, multi_line_string_to_wkt)
-            }
             MultiPolygon(_, XYZ) => impl_to_wkt!(as_multi_polygon, 3, multi_polygon_to_wkt),
-            LargeMultiPolygon(_, XYZ) => {
-                impl_to_wkt!(as_large_multi_polygon, 3, multi_polygon_to_wkt)
-            }
             Mixed(_, XYZ) => impl_to_wkt!(as_mixed, 3, geometry_to_wkt),
-            LargeMixed(_, XYZ) => impl_to_wkt!(as_large_mixed, 3, geometry_to_wkt),
             GeometryCollection(_, XYZ) => {
                 impl_to_wkt!(as_geometry_collection, 3, geometry_collection_to_wkt)
-            }
-            LargeGeometryCollection(_, XYZ) => {
-                impl_to_wkt!(as_large_geometry_collection, 3, geometry_collection_to_wkt)
             }
             Rect(XY) => impl_to_wkt!(as_rect, 2, rect_to_wkt),
             Rect(XYZ) => impl_to_wkt!(as_rect, 3, rect_to_wkt),
@@ -104,46 +74,29 @@ impl ToWKT for &dyn ChunkedNativeArray {
 
         macro_rules! impl_to_wkt {
             ($cast_func:ident, $dim:expr) => {
-                ChunkedGeometryArray::new(
-                    self.$cast_func::<$dim>()
-                        .map(|chunk| chunk.as_ref().to_wkt()),
-                )
+                ChunkedGeometryArray::new(self.$cast_func::<$dim>().map(|chunk| chunk.as_ref().to_wkt()))
             };
         }
 
         match self.data_type() {
             Point(_, XY) => impl_to_wkt!(as_point, 2),
             LineString(_, XY) => impl_to_wkt!(as_line_string, 2),
-            LargeLineString(_, XY) => impl_to_wkt!(as_large_line_string, 2),
             Polygon(_, XY) => impl_to_wkt!(as_polygon, 2),
-            LargePolygon(_, XY) => impl_to_wkt!(as_large_polygon, 2),
             MultiPoint(_, XY) => impl_to_wkt!(as_multi_point, 2),
-            LargeMultiPoint(_, XY) => impl_to_wkt!(as_large_multi_point, 2),
             MultiLineString(_, XY) => impl_to_wkt!(as_multi_line_string, 2),
-            LargeMultiLineString(_, XY) => impl_to_wkt!(as_large_multi_line_string, 2),
             MultiPolygon(_, XY) => impl_to_wkt!(as_multi_polygon, 2),
-            LargeMultiPolygon(_, XY) => impl_to_wkt!(as_large_multi_polygon, 2),
             Mixed(_, XY) => impl_to_wkt!(as_mixed, 2),
-            LargeMixed(_, XY) => impl_to_wkt!(as_large_mixed, 2),
             GeometryCollection(_, XY) => impl_to_wkt!(as_geometry_collection, 2),
-            LargeGeometryCollection(_, XY) => impl_to_wkt!(as_large_geometry_collection, 2),
             Rect(XY) => impl_to_wkt!(as_rect, 2),
 
             Point(_, XYZ) => impl_to_wkt!(as_point, 3),
             LineString(_, XYZ) => impl_to_wkt!(as_line_string, 3),
-            LargeLineString(_, XYZ) => impl_to_wkt!(as_large_line_string, 3),
             Polygon(_, XYZ) => impl_to_wkt!(as_polygon, 3),
-            LargePolygon(_, XYZ) => impl_to_wkt!(as_large_polygon, 3),
             MultiPoint(_, XYZ) => impl_to_wkt!(as_multi_point, 3),
-            LargeMultiPoint(_, XYZ) => impl_to_wkt!(as_large_multi_point, 3),
             MultiLineString(_, XYZ) => impl_to_wkt!(as_multi_line_string, 3),
-            LargeMultiLineString(_, XYZ) => impl_to_wkt!(as_large_multi_line_string, 3),
             MultiPolygon(_, XYZ) => impl_to_wkt!(as_multi_polygon, 3),
-            LargeMultiPolygon(_, XYZ) => impl_to_wkt!(as_large_multi_polygon, 3),
             Mixed(_, XYZ) => impl_to_wkt!(as_mixed, 3),
-            LargeMixed(_, XYZ) => impl_to_wkt!(as_large_mixed, 3),
             GeometryCollection(_, XYZ) => impl_to_wkt!(as_geometry_collection, 3),
-            LargeGeometryCollection(_, XYZ) => impl_to_wkt!(as_large_geometry_collection, 3),
             Rect(XYZ) => impl_to_wkt!(as_rect, 3),
         }
     }

--- a/src/scalar/geometry/owned.rs
+++ b/src/scalar/geometry/owned.rs
@@ -7,19 +7,19 @@ use crate::scalar::*;
 #[derive(Clone, Debug)]
 // TODO: come back to this in #449
 #[allow(clippy::large_enum_variant)]
-pub enum OwnedGeometry<O: OffsetSizeTrait, const D: usize> {
+pub enum OwnedGeometry<const D: usize> {
     Point(crate::scalar::OwnedPoint<D>),
-    LineString(crate::scalar::OwnedLineString<O, D>),
-    Polygon(crate::scalar::OwnedPolygon<O, D>),
-    MultiPoint(crate::scalar::OwnedMultiPoint<O, D>),
-    MultiLineString(crate::scalar::OwnedMultiLineString<O, D>),
-    MultiPolygon(crate::scalar::OwnedMultiPolygon<O, D>),
-    GeometryCollection(crate::scalar::OwnedGeometryCollection<O, D>),
+    LineString(crate::scalar::OwnedLineString<D>),
+    Polygon(crate::scalar::OwnedPolygon<D>),
+    MultiPoint(crate::scalar::OwnedMultiPoint<D>),
+    MultiLineString(crate::scalar::OwnedMultiLineString<D>),
+    MultiPolygon(crate::scalar::OwnedMultiPolygon<D>),
+    GeometryCollection(crate::scalar::OwnedGeometryCollection<D>),
     Rect(crate::scalar::OwnedRect<D>),
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedGeometry<O, D>> for Geometry<'a, O, D> {
-    fn from(value: &'a OwnedGeometry<O, D>) -> Self {
+impl<'a, const D: usize> From<&'a OwnedGeometry<D>> for Geometry<'a, D> {
+    fn from(value: &'a OwnedGeometry<D>) -> Self {
         use OwnedGeometry::*;
         match value {
             Point(geom) => Geometry::Point(geom.into()),
@@ -34,15 +34,15 @@ impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedGeometry<O, D>> for G
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometry<O, 2>> for geo::Geometry {
-    fn from(value: &'a OwnedGeometry<O, 2>) -> Self {
+impl<'a> From<&'a OwnedGeometry<2>> for geo::Geometry {
+    fn from(value: &'a OwnedGeometry<2>) -> Self {
         let geom = Geometry::from(value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<Geometry<'a, O, D>> for OwnedGeometry<O, D> {
-    fn from(value: Geometry<'a, O, D>) -> Self {
+impl<'a, const D: usize> From<Geometry<'a, D>> for OwnedGeometry<D> {
+    fn from(value: Geometry<'a, D>) -> Self {
         use OwnedGeometry::*;
         match value {
             Geometry::Point(geom) => Point(geom.into()),
@@ -64,34 +64,22 @@ impl<'a, O: OffsetSizeTrait, const D: usize> From<Geometry<'a, O, D>> for OwnedG
 //     }
 // }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryTrait for OwnedGeometry<O, D> {
+impl<const D: usize> GeometryTrait for OwnedGeometry<D> {
     type T = f64;
     type Point<'b> = OwnedPoint<D> where Self: 'b;
-    type LineString<'b> = OwnedLineString<O, D> where Self: 'b;
-    type Polygon<'b> = OwnedPolygon<O, D> where Self: 'b;
-    type MultiPoint<'b> = OwnedMultiPoint<O, D> where Self: 'b;
-    type MultiLineString<'b> = OwnedMultiLineString<O, D> where Self: 'b;
-    type MultiPolygon<'b> = OwnedMultiPolygon<O, D> where Self: 'b;
-    type GeometryCollection<'b> = OwnedGeometryCollection<O, D> where Self: 'b;
+    type LineString<'b> = OwnedLineString<D> where Self: 'b;
+    type Polygon<'b> = OwnedPolygon<D> where Self: 'b;
+    type MultiPoint<'b> = OwnedMultiPoint<D> where Self: 'b;
+    type MultiLineString<'b> = OwnedMultiLineString<D> where Self: 'b;
+    type MultiPolygon<'b> = OwnedMultiPolygon<D> where Self: 'b;
+    type GeometryCollection<'b> = OwnedGeometryCollection<D> where Self: 'b;
     type Rect<'b> = OwnedRect<D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
     }
 
-    fn as_type(
-        &self,
-    ) -> crate::geo_traits::GeometryType<
-        '_,
-        OwnedPoint<D>,
-        OwnedLineString<O, D>,
-        OwnedPolygon<O, D>,
-        OwnedMultiPoint<O, D>,
-        OwnedMultiLineString<O, D>,
-        OwnedMultiPolygon<O, D>,
-        OwnedGeometryCollection<O, D>,
-        OwnedRect<D>,
-    > {
+    fn as_type(&self) -> crate::geo_traits::GeometryType<'_, OwnedPoint<D>, OwnedLineString<D>, OwnedPolygon<D>, OwnedMultiPoint<D>, OwnedMultiLineString<D>, OwnedMultiPolygon<D>, OwnedGeometryCollection<D>, OwnedRect<D>> {
         match self {
             Self::Point(p) => GeometryType::Point(p),
             Self::LineString(p) => GeometryType::LineString(p),
@@ -105,7 +93,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryTrait for OwnedGeometry<O, D> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> PartialEq<G> for OwnedGeometry<O, 2> {
+impl<G: GeometryTrait<T = f64>> PartialEq<G> for OwnedGeometry<2> {
     fn eq(&self, other: &G) -> bool {
         geometry_eq(self, other)
     }

--- a/src/scalar/geometry/owned.rs
+++ b/src/scalar/geometry/owned.rs
@@ -77,7 +77,19 @@ impl<const D: usize> GeometryTrait for OwnedGeometry<D> {
         D
     }
 
-    fn as_type(&self) -> crate::geo_traits::GeometryType<'_, OwnedPoint<D>, OwnedLineString<D>, OwnedPolygon<D>, OwnedMultiPoint<D>, OwnedMultiLineString<D>, OwnedMultiPolygon<D>, OwnedGeometryCollection<D>, OwnedRect<D>> {
+    fn as_type(
+        &self,
+    ) -> crate::geo_traits::GeometryType<
+        '_,
+        OwnedPoint<D>,
+        OwnedLineString<D>,
+        OwnedPolygon<D>,
+        OwnedMultiPoint<D>,
+        OwnedMultiLineString<D>,
+        OwnedMultiPolygon<D>,
+        OwnedGeometryCollection<D>,
+        OwnedRect<D>,
+    > {
         match self {
             Self::Point(p) => GeometryType::Point(p),
             Self::LineString(p) => GeometryType::LineString(p),

--- a/src/scalar/geometry/owned.rs
+++ b/src/scalar/geometry/owned.rs
@@ -1,5 +1,3 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::algorithm::native::eq::geometry_eq;
 use crate::geo_traits::{GeometryTrait, GeometryType};
 use crate::scalar::*;

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -61,7 +61,19 @@ impl<'a, const D: usize> GeometryTrait for Geometry<'a, D> {
         D
     }
 
-    fn as_type(&self) -> crate::geo_traits::GeometryType<'_, Point<'_, D>, LineString<'_, D>, Polygon<'_, D>, MultiPoint<'_, D>, MultiLineString<'_, D>, MultiPolygon<'_, D>, GeometryCollection<'_, D>, Rect<'_, D>> {
+    fn as_type(
+        &self,
+    ) -> crate::geo_traits::GeometryType<
+        '_,
+        Point<'_, D>,
+        LineString<'_, D>,
+        Polygon<'_, D>,
+        MultiPoint<'_, D>,
+        MultiLineString<'_, D>,
+        MultiPolygon<'_, D>,
+        GeometryCollection<'_, D>,
+        Rect<'_, D>,
+    > {
         match self {
             Geometry::Point(p) => GeometryType::Point(p),
             Geometry::LineString(p) => GeometryType::LineString(p),
@@ -90,7 +102,19 @@ impl<'a, const D: usize> GeometryTrait for &'a Geometry<'a, D> {
         D
     }
 
-    fn as_type(&self) -> crate::geo_traits::GeometryType<'a, Point<'a, D>, LineString<'a, D>, Polygon<'a, D>, MultiPoint<'a, D>, MultiLineString<'a, D>, MultiPolygon<'a, D>, GeometryCollection<'a, D>, Rect<'a, D>> {
+    fn as_type(
+        &self,
+    ) -> crate::geo_traits::GeometryType<
+        'a,
+        Point<'a, D>,
+        LineString<'a, D>,
+        Polygon<'a, D>,
+        MultiPoint<'a, D>,
+        MultiLineString<'a, D>,
+        MultiPolygon<'a, D>,
+        GeometryCollection<'a, D>,
+        Rect<'a, D>,
+    > {
         match self {
             Geometry::Point(p) => GeometryType::Point(p),
             Geometry::LineString(p) => GeometryType::LineString(p),

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -10,18 +10,18 @@ use rstar::{RTreeObject, AABB};
 ///
 /// Notably this does _not_ include [`WKB`] as a variant, because that is not zero-copy to parse.
 #[derive(Debug)]
-pub enum Geometry<'a, O: OffsetSizeTrait, const D: usize> {
+pub enum Geometry<'a, const D: usize> {
     Point(crate::scalar::Point<'a, D>),
-    LineString(crate::scalar::LineString<'a, O, D>),
-    Polygon(crate::scalar::Polygon<'a, O, D>),
-    MultiPoint(crate::scalar::MultiPoint<'a, O, D>),
-    MultiLineString(crate::scalar::MultiLineString<'a, O, D>),
-    MultiPolygon(crate::scalar::MultiPolygon<'a, O, D>),
-    GeometryCollection(crate::scalar::GeometryCollection<'a, O, D>),
+    LineString(crate::scalar::LineString<'a, D>),
+    Polygon(crate::scalar::Polygon<'a, D>),
+    MultiPoint(crate::scalar::MultiPoint<'a, D>),
+    MultiLineString(crate::scalar::MultiLineString<'a, D>),
+    MultiPolygon(crate::scalar::MultiPolygon<'a, D>),
+    GeometryCollection(crate::scalar::GeometryCollection<'a, D>),
     Rect(crate::scalar::Rect<'a, D>),
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> NativeScalar for Geometry<'a, O, D> {
+impl<'a, const D: usize> NativeScalar for Geometry<'a, D> {
     type ScalarGeo = geo::Geometry;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -47,15 +47,15 @@ impl<'a, O: OffsetSizeTrait, const D: usize> NativeScalar for Geometry<'a, O, D>
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for Geometry<'a, O, D> {
+impl<'a, const D: usize> GeometryTrait for Geometry<'a, D> {
     type T = f64;
     type Point<'b> = Point<'b, D> where Self: 'b;
-    type LineString<'b> = LineString<'b, O, D> where Self: 'b;
-    type Polygon<'b> = Polygon<'b, O, D> where Self: 'b;
-    type MultiPoint<'b> = MultiPoint<'b, O, D> where Self: 'b;
-    type MultiLineString<'b> = MultiLineString<'b, O, D> where Self: 'b;
-    type MultiPolygon<'b> = MultiPolygon<'b, O, D> where Self: 'b;
-    type GeometryCollection<'b> = GeometryCollection<'b, O, D> where Self: 'b;
+    type LineString<'b> = LineString<'b, D> where Self: 'b;
+    type Polygon<'b> = Polygon<'b, D> where Self: 'b;
+    type MultiPoint<'b> = MultiPoint<'b, D> where Self: 'b;
+    type MultiLineString<'b> = MultiLineString<'b, D> where Self: 'b;
+    type MultiPolygon<'b> = MultiPolygon<'b, D> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<'b, D> where Self: 'b;
     type Rect<'b> = Rect<'b, D> where Self: 'b;
 
     fn dim(&self) -> usize {
@@ -67,12 +67,12 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for Geometry<'a, O, D
     ) -> crate::geo_traits::GeometryType<
         '_,
         Point<'_, D>,
-        LineString<'_, O, D>,
-        Polygon<'_, O, D>,
-        MultiPoint<'_, O, D>,
-        MultiLineString<'_, O, D>,
-        MultiPolygon<'_, O, D>,
-        GeometryCollection<'_, O, D>,
+        LineString<'_, D>,
+        Polygon<'_, D>,
+        MultiPoint<'_, D>,
+        MultiLineString<'_, D>,
+        MultiPolygon<'_, D>,
+        GeometryCollection<'_, D>,
         Rect<'_, D>,
     > {
         match self {
@@ -88,15 +88,15 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for Geometry<'a, O, D
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for &'a Geometry<'a, O, D> {
+impl<'a, const D: usize> GeometryTrait for &'a Geometry<'a, D> {
     type T = f64;
     type Point<'b> = Point<'a, D> where Self: 'b;
-    type LineString<'b> = LineString<'a, O, D> where Self: 'b;
-    type Polygon<'b> = Polygon<'a, O, D> where Self: 'b;
-    type MultiPoint<'b> = MultiPoint<'a, O, D> where Self: 'b;
-    type MultiLineString<'b> = MultiLineString<'a, O, D> where Self: 'b;
-    type MultiPolygon<'b> = MultiPolygon<'a, O, D> where Self: 'b;
-    type GeometryCollection<'b> = GeometryCollection<'a, O, D> where Self: 'b;
+    type LineString<'b> = LineString<'a, D> where Self: 'b;
+    type Polygon<'b> = Polygon<'a, D> where Self: 'b;
+    type MultiPoint<'b> = MultiPoint<'a, D> where Self: 'b;
+    type MultiLineString<'b> = MultiLineString<'a, D> where Self: 'b;
+    type MultiPolygon<'b> = MultiPolygon<'a, D> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<'a, D> where Self: 'b;
     type Rect<'b> = Rect<'a, D> where Self: 'b;
 
     fn dim(&self) -> usize {
@@ -108,12 +108,12 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for &'a Geometry<'a, 
     ) -> crate::geo_traits::GeometryType<
         'a,
         Point<'a, D>,
-        LineString<'a, O, D>,
-        Polygon<'a, O, D>,
-        MultiPoint<'a, O, D>,
-        MultiLineString<'a, O, D>,
-        MultiPolygon<'a, O, D>,
-        GeometryCollection<'a, O, D>,
+        LineString<'a, D>,
+        Polygon<'a, D>,
+        MultiPoint<'a, D>,
+        MultiLineString<'a, D>,
+        MultiPolygon<'a, D>,
+        GeometryCollection<'a, D>,
         Rect<'a, D>,
     > {
         match self {
@@ -129,7 +129,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryTrait for &'a Geometry<'a, 
     }
 }
 
-impl<O: OffsetSizeTrait> RTreeObject for Geometry<'_, O, 2> {
+impl RTreeObject for Geometry<'_, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -146,21 +146,19 @@ impl<O: OffsetSizeTrait> RTreeObject for Geometry<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<Geometry<'_, O, D>> for geo::Geometry {
-    fn from(value: Geometry<'_, O, D>) -> Self {
+impl<const D: usize> From<Geometry<'_, D>> for geo::Geometry {
+    fn from(value: Geometry<'_, D>) -> Self {
         geometry_to_geo(&value)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<&Geometry<'_, O, D>> for geo::Geometry {
-    fn from(value: &Geometry<'_, O, D>) -> Self {
+impl<const D: usize> From<&Geometry<'_, D>> for geo::Geometry {
+    fn from(value: &Geometry<'_, D>) -> Self {
         geometry_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize, G: GeometryTrait<T = f64>> PartialEq<G>
-    for Geometry<'_, O, D>
-{
+impl<const D: usize, G: GeometryTrait<T = f64>> PartialEq<G> for Geometry<'_, D> {
     fn eq(&self, other: &G) -> bool {
         geometry_eq(self, other)
     }

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -3,7 +3,6 @@ use crate::geo_traits::{GeometryTrait, GeometryType};
 use crate::io::geo::geometry_to_geo;
 use crate::scalar::*;
 use crate::trait_::NativeScalar;
-use arrow_array::OffsetSizeTrait;
 use rstar::{RTreeObject, AABB};
 
 /// A Geometry is an enum over the various underlying _zero copy_ GeoArrow scalar types.
@@ -62,19 +61,7 @@ impl<'a, const D: usize> GeometryTrait for Geometry<'a, D> {
         D
     }
 
-    fn as_type(
-        &self,
-    ) -> crate::geo_traits::GeometryType<
-        '_,
-        Point<'_, D>,
-        LineString<'_, D>,
-        Polygon<'_, D>,
-        MultiPoint<'_, D>,
-        MultiLineString<'_, D>,
-        MultiPolygon<'_, D>,
-        GeometryCollection<'_, D>,
-        Rect<'_, D>,
-    > {
+    fn as_type(&self) -> crate::geo_traits::GeometryType<'_, Point<'_, D>, LineString<'_, D>, Polygon<'_, D>, MultiPoint<'_, D>, MultiLineString<'_, D>, MultiPolygon<'_, D>, GeometryCollection<'_, D>, Rect<'_, D>> {
         match self {
             Geometry::Point(p) => GeometryType::Point(p),
             Geometry::LineString(p) => GeometryType::LineString(p),
@@ -103,19 +90,7 @@ impl<'a, const D: usize> GeometryTrait for &'a Geometry<'a, D> {
         D
     }
 
-    fn as_type(
-        &self,
-    ) -> crate::geo_traits::GeometryType<
-        'a,
-        Point<'a, D>,
-        LineString<'a, D>,
-        Polygon<'a, D>,
-        MultiPoint<'a, D>,
-        MultiLineString<'a, D>,
-        MultiPolygon<'a, D>,
-        GeometryCollection<'a, D>,
-        Rect<'a, D>,
-    > {
+    fn as_type(&self) -> crate::geo_traits::GeometryType<'a, Point<'a, D>, LineString<'a, D>, Polygon<'a, D>, MultiPoint<'a, D>, MultiLineString<'a, D>, MultiPolygon<'a, D>, GeometryCollection<'a, D>, Rect<'a, D>> {
         match self {
             Geometry::Point(p) => GeometryType::Point(p),
             Geometry::LineString(p) => GeometryType::LineString(p),

--- a/src/scalar/geometrycollection/owned.rs
+++ b/src/scalar/geometrycollection/owned.rs
@@ -15,8 +15,16 @@ pub struct OwnedGeometryCollection<const D: usize> {
 }
 
 impl<const D: usize> OwnedGeometryCollection<D> {
-    pub fn new(array: MixedGeometryArray<D>, geom_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
-        Self { array, geom_offsets, geom_index }
+    pub fn new(
+        array: MixedGeometryArray<D>,
+        geom_offsets: OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
+        Self {
+            array,
+            geom_offsets,
+            geom_index,
+        }
     }
 }
 

--- a/src/scalar/geometrycollection/owned.rs
+++ b/src/scalar/geometrycollection/owned.rs
@@ -6,64 +6,50 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedGeometryCollection<O: OffsetSizeTrait, const D: usize> {
-    array: MixedGeometryArray<O, D>,
+pub struct OwnedGeometryCollection<const D: usize> {
+    array: MixedGeometryArray<D>,
 
     /// Offsets into the geometry array where each geometry starts
-    geom_offsets: OffsetBuffer<O>,
+    geom_offsets: OffsetBuffer<i32>,
 
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> OwnedGeometryCollection<O, D> {
-    pub fn new(
-        array: MixedGeometryArray<O, D>,
-        geom_offsets: OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self {
-            array,
-            geom_offsets,
-            geom_index,
-        }
+impl<const D: usize> OwnedGeometryCollection<D> {
+    pub fn new(array: MixedGeometryArray<D>, geom_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
+        Self { array, geom_offsets, geom_index }
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedGeometryCollection<O, D>>
-    for GeometryCollection<'a, O, D>
-{
-    fn from(value: &'a OwnedGeometryCollection<O, D>) -> Self {
+impl<'a, const D: usize> From<&'a OwnedGeometryCollection<D>> for GeometryCollection<'a, D> {
+    fn from(value: &'a OwnedGeometryCollection<D>) -> Self {
         Self::new(&value.array, &value.geom_offsets, value.geom_index)
     }
 }
 
-impl<'a, O: OffsetSizeTrait> From<&'a OwnedGeometryCollection<O, 2>> for geo::GeometryCollection {
-    fn from(value: &'a OwnedGeometryCollection<O, 2>) -> Self {
+impl<'a> From<&'a OwnedGeometryCollection<2>> for geo::GeometryCollection {
+    fn from(value: &'a OwnedGeometryCollection<2>) -> Self {
         let geom = GeometryCollection::from(value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<GeometryCollection<'a, O, D>>
-    for OwnedGeometryCollection<O, D>
-{
-    fn from(value: GeometryCollection<'a, O, D>) -> Self {
+impl<'a, const D: usize> From<GeometryCollection<'a, D>> for OwnedGeometryCollection<D> {
+    fn from(value: GeometryCollection<'a, D>) -> Self {
         let (array, geom_offsets, geom_index) = value.into_inner();
         Self::new(array.clone(), geom_offsets.clone(), geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<OwnedGeometryCollection<O, D>>
-    for GeometryCollectionArray<O, D>
-{
-    fn from(value: OwnedGeometryCollection<O, D>) -> Self {
+impl<const D: usize> From<OwnedGeometryCollection<D>> for GeometryCollectionArray<D> {
+    fn from(value: OwnedGeometryCollection<D>) -> Self {
         Self::new(value.array, value.geom_offsets, None, Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait for OwnedGeometryCollection<O, D> {
+impl<const D: usize> GeometryCollectionTrait for OwnedGeometryCollection<D> {
     type T = f64;
-    type ItemType<'b> = Geometry<'b, O, D> where Self: 'b;
+    type ItemType<'b> = Geometry<'b, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -78,9 +64,7 @@ impl<O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait for OwnedGeomet
     }
 }
 
-impl<O: OffsetSizeTrait, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
-    for OwnedGeometryCollection<O, 2>
-{
+impl<G: GeometryCollectionTrait<T = f64>> PartialEq<G> for OwnedGeometryCollection<2> {
     fn eq(&self, other: &G) -> bool {
         geometry_collection_eq(self, other)
     }

--- a/src/scalar/geometrycollection/owned.rs
+++ b/src/scalar/geometrycollection/owned.rs
@@ -2,7 +2,6 @@ use crate::algorithm::native::eq::geometry_collection_eq;
 use crate::array::{GeometryCollectionArray, MixedGeometryArray};
 use crate::geo_traits::GeometryCollectionTrait;
 use crate::scalar::{Geometry, GeometryCollection};
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -23,9 +23,18 @@ pub struct GeometryCollection<'a, const D: usize> {
 }
 
 impl<'a, const D: usize> GeometryCollection<'a, D> {
-    pub fn new(array: &'a MixedGeometryArray<D>, geom_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
+    pub fn new(
+        array: &'a MixedGeometryArray<D>,
+        geom_offsets: &'a OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self { array, geom_offsets, geom_index, start_offset }
+        Self {
+            array,
+            geom_offsets,
+            geom_index,
+            start_offset,
+        }
     }
 
     pub fn into_inner(&self) -> (&MixedGeometryArray<D>, &OffsetBuffer<i32>, usize) {
@@ -114,7 +123,9 @@ impl RTreeObject for GeometryCollection<'_, 2> {
     }
 }
 
-impl<const D: usize, G: GeometryCollectionTrait<T = f64>> PartialEq<G> for GeometryCollection<'_, D> {
+impl<const D: usize, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
+    for GeometryCollection<'_, D>
+{
     fn eq(&self, other: &G) -> bool {
         geometry_collection_eq(self, other)
     }

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -6,7 +6,6 @@ use crate::io::geo::geometry_collection_to_geo;
 use crate::scalar::Geometry;
 use crate::trait_::ArrayAccessor;
 use crate::trait_::NativeScalar;
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
 

--- a/src/scalar/geometrycollection/scalar.rs
+++ b/src/scalar/geometrycollection/scalar.rs
@@ -12,38 +12,29 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a GeometryCollection
 #[derive(Debug, Clone)]
-pub struct GeometryCollection<'a, O: OffsetSizeTrait, const D: usize> {
-    pub(crate) array: &'a MixedGeometryArray<O, D>,
+pub struct GeometryCollection<'a, const D: usize> {
+    pub(crate) array: &'a MixedGeometryArray<D>,
 
     /// Offsets into the geometry array where each geometry starts
-    pub(crate) geom_offsets: &'a OffsetBuffer<O>,
+    pub(crate) geom_offsets: &'a OffsetBuffer<i32>,
 
     pub(crate) geom_index: usize,
 
     start_offset: usize,
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollection<'a, O, D> {
-    pub fn new(
-        array: &'a MixedGeometryArray<O, D>,
-        geom_offsets: &'a OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
+impl<'a, const D: usize> GeometryCollection<'a, D> {
+    pub fn new(array: &'a MixedGeometryArray<D>, geom_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self {
-            array,
-            geom_offsets,
-            geom_index,
-            start_offset,
-        }
+        Self { array, geom_offsets, geom_index, start_offset }
     }
 
-    pub fn into_inner(&self) -> (&MixedGeometryArray<O, D>, &OffsetBuffer<O>, usize) {
+    pub fn into_inner(&self) -> (&MixedGeometryArray<D>, &OffsetBuffer<i32>, usize) {
         (self.array, self.geom_offsets, self.geom_index)
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> NativeScalar for GeometryCollection<'a, O, D> {
+impl<'a, const D: usize> NativeScalar for GeometryCollection<'a, D> {
     type ScalarGeo = geo::GeometryCollection;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -60,11 +51,9 @@ impl<'a, O: OffsetSizeTrait, const D: usize> NativeScalar for GeometryCollection
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
-    for GeometryCollection<'a, O, D>
-{
+impl<'a, const D: usize> GeometryCollectionTrait for GeometryCollection<'a, D> {
     type T = f64;
-    type ItemType<'b> = Geometry<'a, O, D> where Self: 'b;
+    type ItemType<'b> = Geometry<'a, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -80,11 +69,9 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
-    for &'a GeometryCollection<'a, O, D>
-{
+impl<'a, const D: usize> GeometryCollectionTrait for &'a GeometryCollection<'a, D> {
     type T = f64;
-    type ItemType<'b> = Geometry<'a, O, D> where Self: 'b;
+    type ItemType<'b> = Geometry<'a, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -100,27 +87,25 @@ impl<'a, O: OffsetSizeTrait, const D: usize> GeometryCollectionTrait
     }
 }
 
-// impl<O: OffsetSizeTrait> From<GeometryCollection<'_, O, 2>> for geo::GeometryCollection {
-//     fn from(value: GeometryCollection<'_, O, 2>) -> Self {
+// impl<O: OffsetSizeTrait> From<GeometryCollection<'_, 2>> for geo::GeometryCollection {
+//     fn from(value: GeometryCollection<'_, 2>) -> Self {
 //         (&value).into()
 //     }
 // }
 
-impl<O: OffsetSizeTrait, const D: usize> From<&GeometryCollection<'_, O, D>>
-    for geo::GeometryCollection
-{
-    fn from(value: &GeometryCollection<'_, O, D>) -> Self {
+impl<const D: usize> From<&GeometryCollection<'_, D>> for geo::GeometryCollection {
+    fn from(value: &GeometryCollection<'_, D>) -> Self {
         geometry_collection_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<GeometryCollection<'_, O, D>> for geo::Geometry {
-    fn from(value: GeometryCollection<'_, O, D>) -> Self {
+impl<const D: usize> From<GeometryCollection<'_, D>> for geo::Geometry {
+    fn from(value: GeometryCollection<'_, D>) -> Self {
         geo::Geometry::GeometryCollection(value.into())
     }
 }
 
-impl<O: OffsetSizeTrait> RTreeObject for GeometryCollection<'_, O, 2> {
+impl RTreeObject for GeometryCollection<'_, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -130,9 +115,7 @@ impl<O: OffsetSizeTrait> RTreeObject for GeometryCollection<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
-    for GeometryCollection<'_, O, D>
-{
+impl<const D: usize, G: GeometryCollectionTrait<T = f64>> PartialEq<G> for GeometryCollection<'_, D> {
     fn eq(&self, other: &G) -> bool {
         geometry_collection_eq(self, other)
     }

--- a/src/scalar/linestring/owned.rs
+++ b/src/scalar/linestring/owned.rs
@@ -2,7 +2,6 @@ use crate::algorithm::native::eq::line_string_eq;
 use crate::array::{CoordBuffer, LineStringArray};
 use crate::geo_traits::LineStringTrait;
 use crate::scalar::{LineString, Point};
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]

--- a/src/scalar/linestring/owned.rs
+++ b/src/scalar/linestring/owned.rs
@@ -16,7 +16,11 @@ pub struct OwnedLineString<const D: usize> {
 
 impl<const D: usize> OwnedLineString<D> {
     pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
-        Self { coords, geom_offsets, geom_index }
+        Self {
+            coords,
+            geom_offsets,
+            geom_index,
+        }
     }
 }
 

--- a/src/scalar/linestring/scalar.rs
+++ b/src/scalar/linestring/scalar.rs
@@ -23,13 +23,27 @@ pub struct LineString<'a, const D: usize> {
 }
 
 impl<'a, const D: usize> LineString<'a, D> {
-    pub fn new(coords: &'a CoordBuffer<D>, geom_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
+    pub fn new(
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self { coords, geom_offsets, geom_index, start_offset }
+        Self {
+            coords,
+            geom_offsets,
+            geom_index,
+            start_offset,
+        }
     }
 
     pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, usize) {
-        let arr = LineStringArray::new(self.coords.clone(), self.geom_offsets.clone(), None, Default::default());
+        let arr = LineStringArray::new(
+            self.coords.clone(),
+            self.geom_offsets.clone(),
+            None,
+            Default::default(),
+        );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         let (coords, geom_offsets, _validity) = sliced_arr.into_inner();
         (coords, geom_offsets, 0)

--- a/src/scalar/linestring/scalar.rs
+++ b/src/scalar/linestring/scalar.rs
@@ -6,7 +6,6 @@ use crate::geo_traits::LineStringTrait;
 use crate::io::geo::line_string_to_geo;
 use crate::scalar::Point;
 use crate::trait_::NativeScalar;
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
 
@@ -132,8 +131,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: LineStringArray<i32, 2> = vec![ls0(), ls1()].as_slice().into();
-        let arr2: LineStringArray<i32, 2> = vec![ls0(), ls0()].as_slice().into();
+        let arr1: LineStringArray<2> = vec![ls0(), ls1()].as_slice().into();
+        let arr2: LineStringArray<2> = vec![ls0(), ls0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/src/scalar/multilinestring/owned.rs
+++ b/src/scalar/multilinestring/owned.rs
@@ -6,79 +6,52 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedMultiLineString<O: OffsetSizeTrait, const D: usize> {
+pub struct OwnedMultiLineString<const D: usize> {
     coords: CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
-    geom_offsets: OffsetBuffer<O>,
+    geom_offsets: OffsetBuffer<i32>,
 
-    ring_offsets: OffsetBuffer<O>,
+    ring_offsets: OffsetBuffer<i32>,
 
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> OwnedMultiLineString<O, D> {
-    pub fn new(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self {
-            coords,
-            geom_offsets,
-            ring_offsets,
-            geom_index,
-        }
+impl<const D: usize> OwnedMultiLineString<D> {
+    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
+        Self { coords, geom_offsets, ring_offsets, geom_index }
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiLineString<O, D>>
-    for MultiLineString<'a, O, D>
-{
-    fn from(value: &'a OwnedMultiLineString<O, D>) -> Self {
-        Self::new(
-            &value.coords,
-            &value.geom_offsets,
-            &value.ring_offsets,
-            value.geom_index,
-        )
+impl<'a, const D: usize> From<&'a OwnedMultiLineString<D>> for MultiLineString<'a, D> {
+    fn from(value: &'a OwnedMultiLineString<D>) -> Self {
+        Self::new(&value.coords, &value.geom_offsets, &value.ring_offsets, value.geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedMultiLineString<O, 2>> for geo::MultiLineString {
-    fn from(value: OwnedMultiLineString<O, 2>) -> Self {
+impl From<OwnedMultiLineString<2>> for geo::MultiLineString {
+    fn from(value: OwnedMultiLineString<2>) -> Self {
         let geom = MultiLineString::from(&value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<MultiLineString<'a, O, D>>
-    for OwnedMultiLineString<O, D>
-{
-    fn from(value: MultiLineString<'a, O, D>) -> Self {
+impl<'a, const D: usize> From<MultiLineString<'a, D>> for OwnedMultiLineString<D> {
+    fn from(value: MultiLineString<'a, D>) -> Self {
         let (coords, geom_offsets, ring_offsets, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_offsets, ring_offsets, geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<OwnedMultiLineString<O, D>>
-    for MultiLineStringArray<O, D>
-{
-    fn from(value: OwnedMultiLineString<O, D>) -> Self {
-        Self::new(
-            value.coords,
-            value.geom_offsets,
-            value.ring_offsets,
-            None,
-            Default::default(),
-        )
+impl<const D: usize> From<OwnedMultiLineString<D>> for MultiLineStringArray<D> {
+    fn from(value: OwnedMultiLineString<D>) -> Self {
+        Self::new(value.coords, value.geom_offsets, value.ring_offsets, None, Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> MultiLineStringTrait for OwnedMultiLineString<O, D> {
+impl<const D: usize> MultiLineStringTrait for OwnedMultiLineString<D> {
     type T = f64;
-    type ItemType<'b> = LineString<'b, O, D> where Self: 'b;
+    type ItemType<'b> = LineString<'b, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -93,9 +66,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiLineStringTrait for OwnedMultiLine
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> PartialEq<G>
-    for OwnedMultiLineString<O, 2>
-{
+impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for OwnedMultiLineString<2> {
     fn eq(&self, other: &G) -> bool {
         multi_line_string_eq(self, other)
     }

--- a/src/scalar/multilinestring/owned.rs
+++ b/src/scalar/multilinestring/owned.rs
@@ -17,14 +17,29 @@ pub struct OwnedMultiLineString<const D: usize> {
 }
 
 impl<const D: usize> OwnedMultiLineString<D> {
-    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
-        Self { coords, geom_offsets, ring_offsets, geom_index }
+    pub fn new(
+        coords: CoordBuffer<D>,
+        geom_offsets: OffsetBuffer<i32>,
+        ring_offsets: OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
+        Self {
+            coords,
+            geom_offsets,
+            ring_offsets,
+            geom_index,
+        }
     }
 }
 
 impl<'a, const D: usize> From<&'a OwnedMultiLineString<D>> for MultiLineString<'a, D> {
     fn from(value: &'a OwnedMultiLineString<D>) -> Self {
-        Self::new(&value.coords, &value.geom_offsets, &value.ring_offsets, value.geom_index)
+        Self::new(
+            &value.coords,
+            &value.geom_offsets,
+            &value.ring_offsets,
+            value.geom_index,
+        )
     }
 }
 
@@ -44,7 +59,13 @@ impl<'a, const D: usize> From<MultiLineString<'a, D>> for OwnedMultiLineString<D
 
 impl<const D: usize> From<OwnedMultiLineString<D>> for MultiLineStringArray<D> {
     fn from(value: OwnedMultiLineString<D>) -> Self {
-        Self::new(value.coords, value.geom_offsets, value.ring_offsets, None, Default::default())
+        Self::new(
+            value.coords,
+            value.geom_offsets,
+            value.ring_offsets,
+            None,
+            Default::default(),
+        )
     }
 }
 

--- a/src/scalar/multilinestring/owned.rs
+++ b/src/scalar/multilinestring/owned.rs
@@ -2,7 +2,6 @@ use crate::algorithm::native::eq::multi_line_string_eq;
 use crate::array::{CoordBuffer, MultiLineStringArray};
 use crate::geo_traits::MultiLineStringTrait;
 use crate::scalar::{LineString, MultiLineString};
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -26,15 +26,37 @@ pub struct MultiLineString<'a, const D: usize> {
 }
 
 impl<'a, const D: usize> MultiLineString<'a, D> {
-    pub fn new(coords: &'a CoordBuffer<D>, geom_offsets: &'a OffsetBuffer<i32>, ring_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
+    pub fn new(
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<i32>,
+        ring_offsets: &'a OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self { coords, geom_offsets, ring_offsets, geom_index, start_offset }
+        Self {
+            coords,
+            geom_offsets,
+            ring_offsets,
+            geom_index,
+            start_offset,
+        }
     }
 
     pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, OffsetBuffer<i32>, usize) {
-        let arr = MultiLineStringArray::new(self.coords.clone(), self.geom_offsets.clone(), self.ring_offsets.clone(), None, Default::default());
+        let arr = MultiLineStringArray::new(
+            self.coords.clone(),
+            self.geom_offsets.clone(),
+            self.ring_offsets.clone(),
+            None,
+            Default::default(),
+        );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
-        (sliced_arr.coords, sliced_arr.geom_offsets, sliced_arr.ring_offsets, 0)
+        (
+            sliced_arr.coords,
+            sliced_arr.geom_offsets,
+            sliced_arr.ring_offsets,
+            0,
+        )
     }
 }
 

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -12,56 +12,34 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a MultiLineString
 #[derive(Debug, Clone)]
-pub struct MultiLineString<'a, O: OffsetSizeTrait, const D: usize> {
+pub struct MultiLineString<'a, const D: usize> {
     pub(crate) coords: &'a CoordBuffer<D>,
 
     /// Offsets into the ring array where each geometry starts
-    pub(crate) geom_offsets: &'a OffsetBuffer<O>,
+    pub(crate) geom_offsets: &'a OffsetBuffer<i32>,
 
     /// Offsets into the coordinate array where each ring starts
-    pub(crate) ring_offsets: &'a OffsetBuffer<O>,
+    pub(crate) ring_offsets: &'a OffsetBuffer<i32>,
 
     pub(crate) geom_index: usize,
 
     start_offset: usize,
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineString<'a, O, D> {
-    pub fn new(
-        coords: &'a CoordBuffer<D>,
-        geom_offsets: &'a OffsetBuffer<O>,
-        ring_offsets: &'a OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
+impl<'a, const D: usize> MultiLineString<'a, D> {
+    pub fn new(coords: &'a CoordBuffer<D>, geom_offsets: &'a OffsetBuffer<i32>, ring_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self {
-            coords,
-            geom_offsets,
-            ring_offsets,
-            geom_index,
-            start_offset,
-        }
+        Self { coords, geom_offsets, ring_offsets, geom_index, start_offset }
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<O>, OffsetBuffer<O>, usize) {
-        let arr = MultiLineStringArray::new(
-            self.coords.clone(),
-            self.geom_offsets.clone(),
-            self.ring_offsets.clone(),
-            None,
-            Default::default(),
-        );
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, OffsetBuffer<i32>, usize) {
+        let arr = MultiLineStringArray::new(self.coords.clone(), self.geom_offsets.clone(), self.ring_offsets.clone(), None, Default::default());
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
-        (
-            sliced_arr.coords,
-            sliced_arr.geom_offsets,
-            sliced_arr.ring_offsets,
-            0,
-        )
+        (sliced_arr.coords, sliced_arr.geom_offsets, sliced_arr.ring_offsets, 0)
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> NativeScalar for MultiLineString<'a, O, D> {
+impl<'a, const D: usize> NativeScalar for MultiLineString<'a, D> {
     type ScalarGeo = geo::MultiLineString;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -78,9 +56,9 @@ impl<'a, O: OffsetSizeTrait, const D: usize> NativeScalar for MultiLineString<'a
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineStringTrait for MultiLineString<'a, O, D> {
+impl<'a, const D: usize> MultiLineStringTrait for MultiLineString<'a, D> {
     type T = f64;
-    type ItemType<'b> = LineString<'a, O, D> where Self: 'b;
+    type ItemType<'b> = LineString<'a, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -96,11 +74,9 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineStringTrait for MultiLineS
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineStringTrait
-    for &'a MultiLineString<'a, O, D>
-{
+impl<'a, const D: usize> MultiLineStringTrait for &'a MultiLineString<'a, D> {
     type T = f64;
-    type ItemType<'b> = LineString<'a, O, D> where Self: 'b;
+    type ItemType<'b> = LineString<'a, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -116,25 +92,25 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiLineStringTrait
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<MultiLineString<'_, O, D>> for geo::MultiLineString {
-    fn from(value: MultiLineString<'_, O, D>) -> Self {
+impl<const D: usize> From<MultiLineString<'_, D>> for geo::MultiLineString {
+    fn from(value: MultiLineString<'_, D>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<&MultiLineString<'_, O, D>> for geo::MultiLineString {
-    fn from(value: &MultiLineString<'_, O, D>) -> Self {
+impl<const D: usize> From<&MultiLineString<'_, D>> for geo::MultiLineString {
+    fn from(value: &MultiLineString<'_, D>) -> Self {
         multi_line_string_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<MultiLineString<'_, O, D>> for geo::Geometry {
-    fn from(value: MultiLineString<'_, O, D>) -> Self {
+impl<const D: usize> From<MultiLineString<'_, D>> for geo::Geometry {
+    fn from(value: MultiLineString<'_, D>) -> Self {
         geo::Geometry::MultiLineString(value.into())
     }
 }
 
-impl<O: OffsetSizeTrait> RTreeObject for MultiLineString<'_, O, 2> {
+impl RTreeObject for MultiLineString<'_, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -143,9 +119,7 @@ impl<O: OffsetSizeTrait> RTreeObject for MultiLineString<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiLineStringTrait<T = f64>> PartialEq<G>
-    for MultiLineString<'_, O, 2>
-{
+impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for MultiLineString<'_, 2> {
     fn eq(&self, other: &G) -> bool {
         multi_line_string_eq(self, other)
     }

--- a/src/scalar/multilinestring/scalar.rs
+++ b/src/scalar/multilinestring/scalar.rs
@@ -6,7 +6,6 @@ use crate::geo_traits::MultiLineStringTrait;
 use crate::io::geo::multi_line_string_to_geo;
 use crate::scalar::LineString;
 use crate::trait_::NativeScalar;
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
 
@@ -134,8 +133,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiLineStringArray<i32, 2> = vec![ml0(), ml1()].as_slice().into();
-        let arr2: MultiLineStringArray<i32, 2> = vec![ml0(), ml0()].as_slice().into();
+        let arr1: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
+        let arr2: MultiLineStringArray<2> = vec![ml0(), ml0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/src/scalar/multipoint/owned.rs
+++ b/src/scalar/multipoint/owned.rs
@@ -2,7 +2,6 @@ use crate::algorithm::native::eq::multi_point_eq;
 use crate::array::{CoordBuffer, MultiPointArray};
 use crate::geo_traits::MultiPointTrait;
 use crate::scalar::{MultiPoint, Point};
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]

--- a/src/scalar/multipoint/owned.rs
+++ b/src/scalar/multipoint/owned.rs
@@ -16,7 +16,11 @@ pub struct OwnedMultiPoint<const D: usize> {
 
 impl<const D: usize> OwnedMultiPoint<D> {
     pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
-        Self { coords, geom_offsets, geom_index }
+        Self {
+            coords,
+            geom_offsets,
+            geom_index,
+        }
     }
 }
 

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -24,13 +24,27 @@ pub struct MultiPoint<'a, const D: usize> {
 }
 
 impl<'a, const D: usize> MultiPoint<'a, D> {
-    pub fn new(coords: &'a CoordBuffer<D>, geom_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
+    pub fn new(
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self { coords, geom_offsets, geom_index, start_offset }
+        Self {
+            coords,
+            geom_offsets,
+            geom_index,
+            start_offset,
+        }
     }
 
     pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, usize) {
-        let arr = MultiPointArray::new(self.coords.clone(), self.geom_offsets.clone(), None, Default::default());
+        let arr = MultiPointArray::new(
+            self.coords.clone(),
+            self.geom_offsets.clone(),
+            None,
+            Default::default(),
+        );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         let (coords, geom_offsets, _validity) = sliced_arr.into_inner();
         (coords, geom_offsets, 0)

--- a/src/scalar/multipoint/scalar.rs
+++ b/src/scalar/multipoint/scalar.rs
@@ -6,7 +6,6 @@ use crate::geo_traits::MultiPointTrait;
 use crate::io::geo::multi_point_to_geo;
 use crate::scalar::Point;
 use crate::trait_::NativeScalar;
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
 
@@ -133,8 +132,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiPointArray<i32, 2> = vec![mp0(), mp1()].as_slice().into();
-        let arr2: MultiPointArray<i32, 2> = vec![mp0(), mp0()].as_slice().into();
+        let arr1: MultiPointArray<2> = vec![mp0(), mp1()].as_slice().into();
+        let arr2: MultiPointArray<2> = vec![mp0(), mp0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/src/scalar/multipolygon/owned.rs
+++ b/src/scalar/multipolygon/owned.rs
@@ -6,90 +6,54 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedMultiPolygon<O: OffsetSizeTrait, const D: usize> {
+pub struct OwnedMultiPolygon<const D: usize> {
     coords: CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
-    geom_offsets: OffsetBuffer<O>,
+    geom_offsets: OffsetBuffer<i32>,
 
-    polygon_offsets: OffsetBuffer<O>,
+    polygon_offsets: OffsetBuffer<i32>,
 
-    ring_offsets: OffsetBuffer<O>,
+    ring_offsets: OffsetBuffer<i32>,
 
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> OwnedMultiPolygon<O, D> {
-    pub fn new(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        polygon_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
-        Self {
-            coords,
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            geom_index,
-        }
+impl<const D: usize> OwnedMultiPolygon<D> {
+    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, polygon_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
+        Self { coords, geom_offsets, polygon_offsets, ring_offsets, geom_index }
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedMultiPolygon<O, D>>
-    for MultiPolygon<'a, O, D>
-{
-    fn from(value: &'a OwnedMultiPolygon<O, D>) -> Self {
-        Self::new(
-            &value.coords,
-            &value.geom_offsets,
-            &value.polygon_offsets,
-            &value.ring_offsets,
-            value.geom_index,
-        )
+impl<'a, const D: usize> From<&'a OwnedMultiPolygon<D>> for MultiPolygon<'a, D> {
+    fn from(value: &'a OwnedMultiPolygon<D>) -> Self {
+        Self::new(&value.coords, &value.geom_offsets, &value.polygon_offsets, &value.ring_offsets, value.geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedMultiPolygon<O, 2>> for geo::MultiPolygon {
-    fn from(value: OwnedMultiPolygon<O, 2>) -> Self {
+impl From<OwnedMultiPolygon<2>> for geo::MultiPolygon {
+    fn from(value: OwnedMultiPolygon<2>) -> Self {
         let geom = MultiPolygon::from(&value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<MultiPolygon<'a, O, D>>
-    for OwnedMultiPolygon<O, D>
-{
-    fn from(value: MultiPolygon<'a, O, D>) -> Self {
-        let (coords, geom_offsets, polygon_offsets, ring_offsets, geom_index) =
-            value.into_owned_inner();
-        Self::new(
-            coords,
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            geom_index,
-        )
+impl<'a, const D: usize> From<MultiPolygon<'a, D>> for OwnedMultiPolygon<D> {
+    fn from(value: MultiPolygon<'a, D>) -> Self {
+        let (coords, geom_offsets, polygon_offsets, ring_offsets, geom_index) = value.into_owned_inner();
+        Self::new(coords, geom_offsets, polygon_offsets, ring_offsets, geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<OwnedMultiPolygon<O, D>> for MultiPolygonArray<O, D> {
-    fn from(value: OwnedMultiPolygon<O, D>) -> Self {
-        Self::new(
-            value.coords,
-            value.geom_offsets,
-            value.polygon_offsets,
-            value.ring_offsets,
-            None,
-            Default::default(),
-        )
+impl<const D: usize> From<OwnedMultiPolygon<D>> for MultiPolygonArray<D> {
+    fn from(value: OwnedMultiPolygon<D>) -> Self {
+        Self::new(value.coords, value.geom_offsets, value.polygon_offsets, value.ring_offsets, None, Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> MultiPolygonTrait for OwnedMultiPolygon<O, D> {
+impl<const D: usize> MultiPolygonTrait for OwnedMultiPolygon<D> {
     type T = f64;
-    type ItemType<'b> = Polygon<'b, O, D> where Self: 'b;
+    type ItemType<'b> = Polygon<'b, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -104,7 +68,7 @@ impl<O: OffsetSizeTrait, const D: usize> MultiPolygonTrait for OwnedMultiPolygon
     }
 }
 
-impl<O: OffsetSizeTrait, G: MultiPolygonTrait<T = f64>> PartialEq<G> for OwnedMultiPolygon<O, 2> {
+impl<G: MultiPolygonTrait<T = f64>> PartialEq<G> for OwnedMultiPolygon<2> {
     fn eq(&self, other: &G) -> bool {
         multi_polygon_eq(self, other)
     }

--- a/src/scalar/multipolygon/owned.rs
+++ b/src/scalar/multipolygon/owned.rs
@@ -19,14 +19,32 @@ pub struct OwnedMultiPolygon<const D: usize> {
 }
 
 impl<const D: usize> OwnedMultiPolygon<D> {
-    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, polygon_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
-        Self { coords, geom_offsets, polygon_offsets, ring_offsets, geom_index }
+    pub fn new(
+        coords: CoordBuffer<D>,
+        geom_offsets: OffsetBuffer<i32>,
+        polygon_offsets: OffsetBuffer<i32>,
+        ring_offsets: OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
+        Self {
+            coords,
+            geom_offsets,
+            polygon_offsets,
+            ring_offsets,
+            geom_index,
+        }
     }
 }
 
 impl<'a, const D: usize> From<&'a OwnedMultiPolygon<D>> for MultiPolygon<'a, D> {
     fn from(value: &'a OwnedMultiPolygon<D>) -> Self {
-        Self::new(&value.coords, &value.geom_offsets, &value.polygon_offsets, &value.ring_offsets, value.geom_index)
+        Self::new(
+            &value.coords,
+            &value.geom_offsets,
+            &value.polygon_offsets,
+            &value.ring_offsets,
+            value.geom_index,
+        )
     }
 }
 
@@ -39,14 +57,28 @@ impl From<OwnedMultiPolygon<2>> for geo::MultiPolygon {
 
 impl<'a, const D: usize> From<MultiPolygon<'a, D>> for OwnedMultiPolygon<D> {
     fn from(value: MultiPolygon<'a, D>) -> Self {
-        let (coords, geom_offsets, polygon_offsets, ring_offsets, geom_index) = value.into_owned_inner();
-        Self::new(coords, geom_offsets, polygon_offsets, ring_offsets, geom_index)
+        let (coords, geom_offsets, polygon_offsets, ring_offsets, geom_index) =
+            value.into_owned_inner();
+        Self::new(
+            coords,
+            geom_offsets,
+            polygon_offsets,
+            ring_offsets,
+            geom_index,
+        )
     }
 }
 
 impl<const D: usize> From<OwnedMultiPolygon<D>> for MultiPolygonArray<D> {
     fn from(value: OwnedMultiPolygon<D>) -> Self {
-        Self::new(value.coords, value.geom_offsets, value.polygon_offsets, value.ring_offsets, None, Default::default())
+        Self::new(
+            value.coords,
+            value.geom_offsets,
+            value.polygon_offsets,
+            value.ring_offsets,
+            None,
+            Default::default(),
+        )
     }
 }
 

--- a/src/scalar/multipolygon/owned.rs
+++ b/src/scalar/multipolygon/owned.rs
@@ -2,7 +2,6 @@ use crate::algorithm::native::eq::multi_polygon_eq;
 use crate::array::{CoordBuffer, MultiPolygonArray};
 use crate::geo_traits::MultiPolygonTrait;
 use crate::scalar::{MultiPolygon, Polygon};
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -29,13 +29,41 @@ pub struct MultiPolygon<'a, const D: usize> {
 }
 
 impl<'a, const D: usize> MultiPolygon<'a, D> {
-    pub fn new(coords: &'a CoordBuffer<D>, geom_offsets: &'a OffsetBuffer<i32>, polygon_offsets: &'a OffsetBuffer<i32>, ring_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
+    pub fn new(
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<i32>,
+        polygon_offsets: &'a OffsetBuffer<i32>,
+        ring_offsets: &'a OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self { coords, geom_offsets, polygon_offsets, ring_offsets, geom_index, start_offset }
+        Self {
+            coords,
+            geom_offsets,
+            polygon_offsets,
+            ring_offsets,
+            geom_index,
+            start_offset,
+        }
     }
 
-    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, OffsetBuffer<i32>, OffsetBuffer<i32>, usize) {
-        let arr = MultiPolygonArray::new(self.coords.clone(), self.geom_offsets.clone(), self.polygon_offsets.clone(), self.ring_offsets.clone(), None, Default::default());
+    pub fn into_owned_inner(
+        self,
+    ) -> (
+        CoordBuffer<D>,
+        OffsetBuffer<i32>,
+        OffsetBuffer<i32>,
+        OffsetBuffer<i32>,
+        usize,
+    ) {
+        let arr = MultiPolygonArray::new(
+            self.coords.clone(),
+            self.geom_offsets.clone(),
+            self.polygon_offsets.clone(),
+            self.ring_offsets.clone(),
+            None,
+            Default::default(),
+        );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         let (coords, geom_offsets, polygon_offsets, ring_offsets) = sliced_arr.into_inner();
 
@@ -74,7 +102,12 @@ impl<'a, const D: usize> MultiPolygonTrait for MultiPolygon<'a, D> {
     }
 
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        Polygon::new(self.coords, self.polygon_offsets, self.ring_offsets, self.start_offset + i)
+        Polygon::new(
+            self.coords,
+            self.polygon_offsets,
+            self.ring_offsets,
+            self.start_offset + i,
+        )
     }
 }
 
@@ -92,7 +125,12 @@ impl<'a, const D: usize> MultiPolygonTrait for &'a MultiPolygon<'a, D> {
     }
 
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        Polygon::new(self.coords, self.polygon_offsets, self.ring_offsets, self.start_offset + i)
+        Polygon::new(
+            self.coords,
+            self.polygon_offsets,
+            self.ring_offsets,
+            self.start_offset + i,
+        )
     }
 }
 

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -12,59 +12,31 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a MultiPolygon
 #[derive(Debug, Clone)]
-pub struct MultiPolygon<'a, O: OffsetSizeTrait, const D: usize> {
+pub struct MultiPolygon<'a, const D: usize> {
     pub(crate) coords: &'a CoordBuffer<D>,
 
     /// Offsets into the polygon array where each geometry starts
-    pub(crate) geom_offsets: &'a OffsetBuffer<O>,
+    pub(crate) geom_offsets: &'a OffsetBuffer<i32>,
 
     /// Offsets into the ring array where each polygon starts
-    pub(crate) polygon_offsets: &'a OffsetBuffer<O>,
+    pub(crate) polygon_offsets: &'a OffsetBuffer<i32>,
 
     /// Offsets into the coordinate array where each ring starts
-    pub(crate) ring_offsets: &'a OffsetBuffer<O>,
+    pub(crate) ring_offsets: &'a OffsetBuffer<i32>,
 
     pub(crate) geom_index: usize,
 
     start_offset: usize,
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygon<'a, O, D> {
-    pub fn new(
-        coords: &'a CoordBuffer<D>,
-        geom_offsets: &'a OffsetBuffer<O>,
-        polygon_offsets: &'a OffsetBuffer<O>,
-        ring_offsets: &'a OffsetBuffer<O>,
-        geom_index: usize,
-    ) -> Self {
+impl<'a, const D: usize> MultiPolygon<'a, D> {
+    pub fn new(coords: &'a CoordBuffer<D>, geom_offsets: &'a OffsetBuffer<i32>, polygon_offsets: &'a OffsetBuffer<i32>, ring_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self {
-            coords,
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            geom_index,
-            start_offset,
-        }
+        Self { coords, geom_offsets, polygon_offsets, ring_offsets, geom_index, start_offset }
     }
 
-    pub fn into_owned_inner(
-        self,
-    ) -> (
-        CoordBuffer<D>,
-        OffsetBuffer<O>,
-        OffsetBuffer<O>,
-        OffsetBuffer<O>,
-        usize,
-    ) {
-        let arr = MultiPolygonArray::new(
-            self.coords.clone(),
-            self.geom_offsets.clone(),
-            self.polygon_offsets.clone(),
-            self.ring_offsets.clone(),
-            None,
-            Default::default(),
-        );
+    pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, OffsetBuffer<i32>, OffsetBuffer<i32>, usize) {
+        let arr = MultiPolygonArray::new(self.coords.clone(), self.geom_offsets.clone(), self.polygon_offsets.clone(), self.ring_offsets.clone(), None, Default::default());
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
         let (coords, geom_offsets, polygon_offsets, ring_offsets) = sliced_arr.into_inner();
 
@@ -72,7 +44,7 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygon<'a, O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> NativeScalar for MultiPolygon<'a, O, D> {
+impl<'a, const D: usize> NativeScalar for MultiPolygon<'a, D> {
     type ScalarGeo = geo::MultiPolygon;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -89,9 +61,9 @@ impl<'a, O: OffsetSizeTrait, const D: usize> NativeScalar for MultiPolygon<'a, O
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygonTrait for MultiPolygon<'a, O, D> {
+impl<'a, const D: usize> MultiPolygonTrait for MultiPolygon<'a, D> {
     type T = f64;
-    type ItemType<'b> = Polygon<'a, O, D> where Self: 'b;
+    type ItemType<'b> = Polygon<'a, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -103,18 +75,13 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygonTrait for MultiPolygon<
     }
 
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        Polygon::new(
-            self.coords,
-            self.polygon_offsets,
-            self.ring_offsets,
-            self.start_offset + i,
-        )
+        Polygon::new(self.coords, self.polygon_offsets, self.ring_offsets, self.start_offset + i)
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygonTrait for &'a MultiPolygon<'a, O, D> {
+impl<'a, const D: usize> MultiPolygonTrait for &'a MultiPolygon<'a, D> {
     type T = f64;
-    type ItemType<'b> = Polygon<'a, O, D> where Self: 'b;
+    type ItemType<'b> = Polygon<'a, D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -126,34 +93,29 @@ impl<'a, O: OffsetSizeTrait, const D: usize> MultiPolygonTrait for &'a MultiPoly
     }
 
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::ItemType<'_> {
-        Polygon::new(
-            self.coords,
-            self.polygon_offsets,
-            self.ring_offsets,
-            self.start_offset + i,
-        )
+        Polygon::new(self.coords, self.polygon_offsets, self.ring_offsets, self.start_offset + i)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygon<'_, O, D>> for geo::MultiPolygon {
-    fn from(value: MultiPolygon<'_, O, D>) -> Self {
+impl<const D: usize> From<MultiPolygon<'_, D>> for geo::MultiPolygon {
+    fn from(value: MultiPolygon<'_, D>) -> Self {
         (&value).into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<&MultiPolygon<'_, O, D>> for geo::MultiPolygon {
-    fn from(value: &MultiPolygon<'_, O, D>) -> Self {
+impl<const D: usize> From<&MultiPolygon<'_, D>> for geo::MultiPolygon {
+    fn from(value: &MultiPolygon<'_, D>) -> Self {
         multi_polygon_to_geo(value)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<MultiPolygon<'_, O, D>> for geo::Geometry {
-    fn from(value: MultiPolygon<'_, O, D>) -> Self {
+impl<const D: usize> From<MultiPolygon<'_, D>> for geo::Geometry {
+    fn from(value: MultiPolygon<'_, D>) -> Self {
         geo::Geometry::MultiPolygon(value.into())
     }
 }
 
-impl<O: OffsetSizeTrait> RTreeObject for MultiPolygon<'_, O, 2> {
+impl RTreeObject for MultiPolygon<'_, 2> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -162,9 +124,7 @@ impl<O: OffsetSizeTrait> RTreeObject for MultiPolygon<'_, O, 2> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize, G: MultiPolygonTrait<T = f64>> PartialEq<G>
-    for MultiPolygon<'_, O, D>
-{
+impl<const D: usize, G: MultiPolygonTrait<T = f64>> PartialEq<G> for MultiPolygon<'_, D> {
     fn eq(&self, other: &G) -> bool {
         multi_polygon_eq(self, other)
     }

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -6,7 +6,6 @@ use crate::geo_traits::MultiPolygonTrait;
 use crate::io::geo::multi_polygon_to_geo;
 use crate::scalar::Polygon;
 use crate::trait_::NativeScalar;
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
 
@@ -139,8 +138,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiPolygonArray<i32, 2> = vec![mp0(), mp1()].as_slice().into();
-        let arr2: MultiPolygonArray<i32, 2> = vec![mp0(), mp0()].as_slice().into();
+        let arr1: MultiPolygonArray<2> = vec![mp0(), mp1()].as_slice().into();
+        let arr2: MultiPolygonArray<2> = vec![mp0(), mp0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/src/scalar/polygon/owned.rs
+++ b/src/scalar/polygon/owned.rs
@@ -6,22 +6,22 @@ use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
-pub struct OwnedPolygon<O: OffsetSizeTrait, const D: usize> {
+pub struct OwnedPolygon<const D: usize> {
     coords: CoordBuffer<D>,
 
     /// Offsets into the coordinate array where each geometry starts
-    geom_offsets: OffsetBuffer<O>,
+    geom_offsets: OffsetBuffer<i32>,
 
-    ring_offsets: OffsetBuffer<O>,
+    ring_offsets: OffsetBuffer<i32>,
 
     geom_index: usize,
 }
 
-impl<O: OffsetSizeTrait, const D: usize> OwnedPolygon<O, D> {
+impl<const D: usize> OwnedPolygon<D> {
     pub fn new(
         coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<O>,
-        ring_offsets: OffsetBuffer<O>,
+        geom_offsets: OffsetBuffer<i32>,
+        ring_offsets: OffsetBuffer<i32>,
         geom_index: usize,
     ) -> Self {
         Self {
@@ -33,8 +33,8 @@ impl<O: OffsetSizeTrait, const D: usize> OwnedPolygon<O, D> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedPolygon<O, D>> for Polygon<'a, O, D> {
-    fn from(value: &'a OwnedPolygon<O, D>) -> Self {
+impl<'a, const D: usize> From<&'a OwnedPolygon<D>> for Polygon<'a, D> {
+    fn from(value: &'a OwnedPolygon<D>) -> Self {
         Self::new(
             &value.coords,
             &value.geom_offsets,
@@ -44,22 +44,22 @@ impl<'a, O: OffsetSizeTrait, const D: usize> From<&'a OwnedPolygon<O, D>> for Po
     }
 }
 
-impl<O: OffsetSizeTrait> From<OwnedPolygon<O, 2>> for geo::Polygon {
-    fn from(value: OwnedPolygon<O, 2>) -> Self {
+impl From<OwnedPolygon<2>> for geo::Polygon {
+    fn from(value: OwnedPolygon<2>) -> Self {
         let geom = Polygon::from(&value);
         geom.into()
     }
 }
 
-impl<'a, O: OffsetSizeTrait, const D: usize> From<Polygon<'a, O, D>> for OwnedPolygon<O, D> {
-    fn from(value: Polygon<'a, O, D>) -> Self {
+impl<'a, const D: usize> From<Polygon<'a, D>> for OwnedPolygon<D> {
+    fn from(value: Polygon<'a, D>) -> Self {
         let (coords, geom_offsets, ring_offsets, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_offsets, ring_offsets, geom_index)
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> From<OwnedPolygon<O, D>> for PolygonArray<O, D> {
-    fn from(value: OwnedPolygon<O, D>) -> Self {
+impl<const D: usize> From<OwnedPolygon<D>> for PolygonArray<D> {
+    fn from(value: OwnedPolygon<D>) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -70,9 +70,9 @@ impl<O: OffsetSizeTrait, const D: usize> From<OwnedPolygon<O, D>> for PolygonArr
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> PolygonTrait for OwnedPolygon<O, D> {
+impl<const D: usize> PolygonTrait for OwnedPolygon<D> {
     type T = f64;
-    type ItemType<'b> = LineString<'b, O, D> where Self: 'b;
+    type ItemType<'b> = LineString<'b,  D> where Self: 'b;
 
     fn dim(&self) -> usize {
         D
@@ -91,7 +91,7 @@ impl<O: OffsetSizeTrait, const D: usize> PolygonTrait for OwnedPolygon<O, D> {
     }
 }
 
-impl<O: OffsetSizeTrait, G: PolygonTrait<T = f64>> PartialEq<G> for OwnedPolygon<O, 2> {
+impl<G: PolygonTrait<T = f64>> PartialEq<G> for OwnedPolygon<2> {
     fn eq(&self, other: &G) -> bool {
         polygon_eq(self, other)
     }

--- a/src/scalar/polygon/owned.rs
+++ b/src/scalar/polygon/owned.rs
@@ -17,14 +17,29 @@ pub struct OwnedPolygon<const D: usize> {
 }
 
 impl<const D: usize> OwnedPolygon<D> {
-    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
-        Self { coords, geom_offsets, ring_offsets, geom_index }
+    pub fn new(
+        coords: CoordBuffer<D>,
+        geom_offsets: OffsetBuffer<i32>,
+        ring_offsets: OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
+        Self {
+            coords,
+            geom_offsets,
+            ring_offsets,
+            geom_index,
+        }
     }
 }
 
 impl<'a, const D: usize> From<&'a OwnedPolygon<D>> for Polygon<'a, D> {
     fn from(value: &'a OwnedPolygon<D>) -> Self {
-        Self::new(&value.coords, &value.geom_offsets, &value.ring_offsets, value.geom_index)
+        Self::new(
+            &value.coords,
+            &value.geom_offsets,
+            &value.ring_offsets,
+            value.geom_index,
+        )
     }
 }
 
@@ -44,7 +59,13 @@ impl<'a, const D: usize> From<Polygon<'a, D>> for OwnedPolygon<D> {
 
 impl<const D: usize> From<OwnedPolygon<D>> for PolygonArray<D> {
     fn from(value: OwnedPolygon<D>) -> Self {
-        Self::new(value.coords, value.geom_offsets, value.ring_offsets, None, Default::default())
+        Self::new(
+            value.coords,
+            value.geom_offsets,
+            value.ring_offsets,
+            None,
+            Default::default(),
+        )
     }
 }
 

--- a/src/scalar/polygon/owned.rs
+++ b/src/scalar/polygon/owned.rs
@@ -2,7 +2,6 @@ use crate::algorithm::native::eq::polygon_eq;
 use crate::array::{CoordBuffer, PolygonArray};
 use crate::geo_traits::PolygonTrait;
 use crate::scalar::{LineString, Polygon};
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
 #[derive(Clone, Debug)]
@@ -18,29 +17,14 @@ pub struct OwnedPolygon<const D: usize> {
 }
 
 impl<const D: usize> OwnedPolygon<D> {
-    pub fn new(
-        coords: CoordBuffer<D>,
-        geom_offsets: OffsetBuffer<i32>,
-        ring_offsets: OffsetBuffer<i32>,
-        geom_index: usize,
-    ) -> Self {
-        Self {
-            coords,
-            geom_offsets,
-            ring_offsets,
-            geom_index,
-        }
+    pub fn new(coords: CoordBuffer<D>, geom_offsets: OffsetBuffer<i32>, ring_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
+        Self { coords, geom_offsets, ring_offsets, geom_index }
     }
 }
 
 impl<'a, const D: usize> From<&'a OwnedPolygon<D>> for Polygon<'a, D> {
     fn from(value: &'a OwnedPolygon<D>) -> Self {
-        Self::new(
-            &value.coords,
-            &value.geom_offsets,
-            &value.ring_offsets,
-            value.geom_index,
-        )
+        Self::new(&value.coords, &value.geom_offsets, &value.ring_offsets, value.geom_index)
     }
 }
 
@@ -60,13 +44,7 @@ impl<'a, const D: usize> From<Polygon<'a, D>> for OwnedPolygon<D> {
 
 impl<const D: usize> From<OwnedPolygon<D>> for PolygonArray<D> {
     fn from(value: OwnedPolygon<D>) -> Self {
-        Self::new(
-            value.coords,
-            value.geom_offsets,
-            value.ring_offsets,
-            None,
-            Default::default(),
-        )
+        Self::new(value.coords, value.geom_offsets, value.ring_offsets, None, Default::default())
     }
 }
 

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -6,7 +6,6 @@ use crate::geo_traits::PolygonTrait;
 use crate::io::geo::polygon_to_geo;
 use crate::scalar::LineString;
 use crate::trait_::NativeScalar;
-use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use rstar::{RTreeObject, AABB};
 
@@ -27,38 +26,16 @@ pub struct Polygon<'a, const D: usize> {
 }
 
 impl<'a, const D: usize> Polygon<'a, D> {
-    pub fn new(
-        coords: &'a CoordBuffer<D>,
-        geom_offsets: &'a OffsetBuffer<i32>,
-        ring_offsets: &'a OffsetBuffer<i32>,
-        geom_index: usize,
-    ) -> Self {
+    pub fn new(coords: &'a CoordBuffer<D>, geom_offsets: &'a OffsetBuffer<i32>, ring_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self {
-            coords,
-            geom_offsets,
-            ring_offsets,
-            geom_index,
-            start_offset,
-        }
+        Self { coords, geom_offsets, ring_offsets, geom_index, start_offset }
     }
 
     pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, OffsetBuffer<i32>, usize) {
-        let arr = PolygonArray::new(
-            self.coords.clone(),
-            self.geom_offsets.clone(),
-            self.ring_offsets.clone(),
-            None,
-            Default::default(),
-        );
+        let arr = PolygonArray::new(self.coords.clone(), self.geom_offsets.clone(), self.ring_offsets.clone(), None, Default::default());
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
 
-        (
-            sliced_arr.coords,
-            sliced_arr.geom_offsets,
-            sliced_arr.ring_offsets,
-            0,
-        )
+        (sliced_arr.coords, sliced_arr.geom_offsets, sliced_arr.ring_offsets, 0)
     }
 }
 

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -26,16 +26,38 @@ pub struct Polygon<'a, const D: usize> {
 }
 
 impl<'a, const D: usize> Polygon<'a, D> {
-    pub fn new(coords: &'a CoordBuffer<D>, geom_offsets: &'a OffsetBuffer<i32>, ring_offsets: &'a OffsetBuffer<i32>, geom_index: usize) -> Self {
+    pub fn new(
+        coords: &'a CoordBuffer<D>,
+        geom_offsets: &'a OffsetBuffer<i32>,
+        ring_offsets: &'a OffsetBuffer<i32>,
+        geom_index: usize,
+    ) -> Self {
         let (start_offset, _) = geom_offsets.start_end(geom_index);
-        Self { coords, geom_offsets, ring_offsets, geom_index, start_offset }
+        Self {
+            coords,
+            geom_offsets,
+            ring_offsets,
+            geom_index,
+            start_offset,
+        }
     }
 
     pub fn into_owned_inner(self) -> (CoordBuffer<D>, OffsetBuffer<i32>, OffsetBuffer<i32>, usize) {
-        let arr = PolygonArray::new(self.coords.clone(), self.geom_offsets.clone(), self.ring_offsets.clone(), None, Default::default());
+        let arr = PolygonArray::new(
+            self.coords.clone(),
+            self.geom_offsets.clone(),
+            self.ring_offsets.clone(),
+            None,
+            Default::default(),
+        );
         let sliced_arr = arr.owned_slice(self.geom_index, 1);
 
-        (sliced_arr.coords, sliced_arr.geom_offsets, sliced_arr.ring_offsets, 0)
+        (
+            sliced_arr.coords,
+            sliced_arr.geom_offsets,
+            sliced_arr.ring_offsets,
+            0,
+        )
     }
 }
 
@@ -152,8 +174,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: PolygonArray<i32, 2> = vec![p0(), p1()].as_slice().into();
-        let arr2: PolygonArray<i32, 2> = vec![p0(), p0()].as_slice().into();
+        let arr1: PolygonArray<2> = vec![p0(), p1()].as_slice().into();
+        let arr2: PolygonArray<2> = vec![p0(), p0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/src/scalar/scalar.rs
+++ b/src/scalar/scalar.rs
@@ -1,4 +1,7 @@
-use crate::array::{AsNativeArray, GeometryCollectionArray, LineStringArray, MixedGeometryArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, RectArray};
+use crate::array::{
+    AsNativeArray, GeometryCollectionArray, LineStringArray, MixedGeometryArray,
+    MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, RectArray,
+};
 use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::Geometry;
@@ -15,7 +18,10 @@ pub struct GeometryScalar(NativeArrayRef);
 impl GeometryScalar {
     pub fn try_new(array: NativeArrayRef) -> Result<Self> {
         if array.len() != 1 {
-            Err(GeoArrowError::General(format!("Expected array with length 1, got {}", array.len())))
+            Err(GeoArrowError::General(format!(
+                "Expected array with length 1, got {}",
+                array.len()
+            )))
         } else {
             Ok(Self(array))
         }
@@ -36,7 +42,15 @@ impl GeometryScalar {
     pub fn dimension(&self) -> Dimension {
         use NativeType::*;
         match self.data_type() {
-            Point(_, dim) | LineString(_, dim) | Polygon(_, dim) | MultiPoint(_, dim) | MultiLineString(_, dim) | MultiPolygon(_, dim) | Mixed(_, dim) | GeometryCollection(_, dim) | Rect(dim) => dim,
+            Point(_, dim)
+            | LineString(_, dim)
+            | Polygon(_, dim)
+            | MultiPoint(_, dim)
+            | MultiLineString(_, dim)
+            | MultiPolygon(_, dim)
+            | Mixed(_, dim)
+            | GeometryCollection(_, dim)
+            | Rect(dim) => dim,
             // WKB => {
             //     let arr = self.0.as_ref();
             //     let wkb_arr = arr.as_wkb().value(0);
@@ -63,7 +77,11 @@ impl GeometryScalar {
                 arr.get(0).map(Geometry::Point)
             }
             LineString(_, _) => {
-                let arr = self.0.as_any().downcast_ref::<LineStringArray<D>>().unwrap();
+                let arr = self
+                    .0
+                    .as_any()
+                    .downcast_ref::<LineStringArray<D>>()
+                    .unwrap();
                 arr.get(0).map(Geometry::LineString)
             }
             Polygon(_, _) => {
@@ -71,23 +89,43 @@ impl GeometryScalar {
                 arr.get(0).map(Geometry::Polygon)
             }
             MultiPoint(_, _) => {
-                let arr = self.0.as_any().downcast_ref::<MultiPointArray<D>>().unwrap();
+                let arr = self
+                    .0
+                    .as_any()
+                    .downcast_ref::<MultiPointArray<D>>()
+                    .unwrap();
                 arr.get(0).map(Geometry::MultiPoint)
             }
             MultiLineString(_, _) => {
-                let arr = self.0.as_any().downcast_ref::<MultiLineStringArray<D>>().unwrap();
+                let arr = self
+                    .0
+                    .as_any()
+                    .downcast_ref::<MultiLineStringArray<D>>()
+                    .unwrap();
                 arr.get(0).map(Geometry::MultiLineString)
             }
             MultiPolygon(_, _) => {
-                let arr = self.0.as_any().downcast_ref::<MultiPolygonArray<D>>().unwrap();
+                let arr = self
+                    .0
+                    .as_any()
+                    .downcast_ref::<MultiPolygonArray<D>>()
+                    .unwrap();
                 arr.get(0).map(Geometry::MultiPolygon)
             }
             Mixed(_, _) => {
-                let arr = self.0.as_any().downcast_ref::<MixedGeometryArray<D>>().unwrap();
+                let arr = self
+                    .0
+                    .as_any()
+                    .downcast_ref::<MixedGeometryArray<D>>()
+                    .unwrap();
                 arr.get(0)
             }
             GeometryCollection(_, _) => {
-                let arr = self.0.as_any().downcast_ref::<GeometryCollectionArray<D>>().unwrap();
+                let arr = self
+                    .0
+                    .as_any()
+                    .downcast_ref::<GeometryCollectionArray<D>>()
+                    .unwrap();
                 arr.get(0).map(Geometry::GeometryCollection)
             }
             Rect(_) => {
@@ -100,7 +138,11 @@ impl GeometryScalar {
     pub fn to_geo(&self) -> geo::Geometry {
         macro_rules! impl_to_geo {
             ($cast_func:ident, $dim:expr) => {{
-                self.0.as_ref().$cast_func::<$dim>().value(0).to_geo_geometry()
+                self.0
+                    .as_ref()
+                    .$cast_func::<$dim>()
+                    .value(0)
+                    .to_geo_geometry()
             }};
         }
 
@@ -152,42 +194,60 @@ impl GeometryScalar {
     pub fn to_geo_point(&self) -> Result<geo::Point> {
         match self.to_geo() {
             geo::Geometry::Point(g) => Ok(g),
-            dt => Err(GeoArrowError::General(format!("Expected Point, got {:?}", dt))),
+            dt => Err(GeoArrowError::General(format!(
+                "Expected Point, got {:?}",
+                dt
+            ))),
         }
     }
 
     pub fn to_geo_line_string(&self) -> Result<geo::LineString> {
         match self.to_geo() {
             geo::Geometry::LineString(g) => Ok(g),
-            dt => Err(GeoArrowError::General(format!("Expected LineString, got {:?}", dt))),
+            dt => Err(GeoArrowError::General(format!(
+                "Expected LineString, got {:?}",
+                dt
+            ))),
         }
     }
 
     pub fn to_geo_polygon(&self) -> Result<geo::Polygon> {
         match self.to_geo() {
             geo::Geometry::Polygon(g) => Ok(g),
-            dt => Err(GeoArrowError::General(format!("Expected Polygon, got {:?}", dt))),
+            dt => Err(GeoArrowError::General(format!(
+                "Expected Polygon, got {:?}",
+                dt
+            ))),
         }
     }
 
     pub fn to_geo_multi_point(&self) -> Result<geo::MultiPoint> {
         match self.to_geo() {
             geo::Geometry::MultiPoint(g) => Ok(g),
-            dt => Err(GeoArrowError::General(format!("Expected MultiPoint, got {:?}", dt))),
+            dt => Err(GeoArrowError::General(format!(
+                "Expected MultiPoint, got {:?}",
+                dt
+            ))),
         }
     }
 
     pub fn to_geo_multi_line_string(&self) -> Result<geo::MultiLineString> {
         match self.to_geo() {
             geo::Geometry::MultiLineString(g) => Ok(g),
-            dt => Err(GeoArrowError::General(format!("Expected MultiLineString, got {:?}", dt))),
+            dt => Err(GeoArrowError::General(format!(
+                "Expected MultiLineString, got {:?}",
+                dt
+            ))),
         }
     }
 
     pub fn to_geo_multi_polygon(&self) -> Result<geo::MultiPolygon> {
         match self.to_geo() {
             geo::Geometry::MultiPolygon(g) => Ok(g),
-            dt => Err(GeoArrowError::General(format!("Expected MultiPolygon, got {:?}", dt))),
+            dt => Err(GeoArrowError::General(format!(
+                "Expected MultiPolygon, got {:?}",
+                dt
+            ))),
         }
     }
 }

--- a/src/scalar/scalar.rs
+++ b/src/scalar/scalar.rs
@@ -1,5 +1,3 @@
-use arrow_array::OffsetSizeTrait;
-
 use crate::array::{AsNativeArray, GeometryCollectionArray, LineStringArray, MixedGeometryArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, RectArray};
 use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};

--- a/src/table.rs
+++ b/src/table.rs
@@ -70,13 +70,7 @@ impl Table {
             // TODO: I have some issues in the Parquet reader where the batches are missing the
             // schema metadata.
             if batch.schema().fields() != schema.fields() {
-                return Err(GeoArrowError::General(format!(
-                    "Schema is not consistent across batches. Expected {}, got {}. With expected metadata: {:?}, got {:?}",
-                    schema,
-                    batch.schema(),
-                    schema.metadata(),
-                    batch.schema().metadata()
-                )));
+                return Err(GeoArrowError::General(format!("Schema is not consistent across batches. Expected {}, got {}. With expected metadata: {:?}, got {:?}", schema, batch.schema(), schema.metadata(), batch.schema().metadata())));
             }
         }
 
@@ -118,11 +112,7 @@ impl Table {
     ///
     /// let table = Table::from_arrow_and_geometry(vec![batch], schema_ref, Arc::new(chunked_array)).unwrap();
     /// ```
-    pub fn from_arrow_and_geometry(
-        batches: Vec<RecordBatch>,
-        schema: SchemaRef,
-        geometry: Arc<dyn ChunkedNativeArray>,
-    ) -> Result<Self> {
+    pub fn from_arrow_and_geometry(batches: Vec<RecordBatch>, schema: SchemaRef, geometry: Arc<dyn ChunkedNativeArray>) -> Result<Self> {
         if batches.is_empty() {
             return Err(GeoArrowError::General("empty input".to_string()));
         }
@@ -162,14 +152,8 @@ impl Table {
     pub fn cast_geometry(&mut self, index: usize, to_type: &NativeType) -> Result<()> {
         let orig_field = self.schema().field(index);
 
-        let array_slices = self
-            .batches()
-            .iter()
-            .map(|batch| batch.column(index).as_ref())
-            .collect::<Vec<_>>();
-        let chunked_geometry =
-            ChunkedNativeArrayDyn::from_arrow_chunks(array_slices.as_slice(), orig_field)?
-                .into_inner();
+        let array_slices = self.batches().iter().map(|batch| batch.column(index).as_ref()).collect::<Vec<_>>();
+        let chunked_geometry = ChunkedNativeArrayDyn::from_arrow_chunks(array_slices.as_slice(), orig_field)?.into_inner();
         let casted_geometry = chunked_geometry.as_ref().cast(to_type)?;
         let casted_arrays = casted_geometry.array_refs();
         let casted_field = to_type.to_field(orig_field.name(), orig_field.is_nullable());
@@ -186,14 +170,9 @@ impl Table {
     /// # Examples
     ///
     /// TODO
-    pub fn parse_serialized_geometry(
-        &self,
-        index: usize,
-        target_geo_data_type: Option<NativeType>,
-    ) -> Result<Self> {
+    pub fn parse_serialized_geometry(&self, index: usize, target_geo_data_type: Option<NativeType>) -> Result<Self> {
         // TODO: don't always default to XY
-        let target_geo_data_type = target_geo_data_type
-            .unwrap_or(NativeType::LargeMixed(Default::default(), Dimension::XY));
+        let target_geo_data_type = target_geo_data_type.unwrap_or(NativeType::Mixed(Default::default(), Dimension::XY));
 
         let orig_field = self.schema().field(index);
         let geoarray_metadata = ArrayMetadata::try_from(orig_field)?;
@@ -203,11 +182,7 @@ impl Table {
         // `chunked_geometry.data_type`.
         if self.is_empty() {
             let mut new_table = self.clone();
-            let new_field = target_geo_data_type.to_field_with_metadata(
-                orig_field.name(),
-                orig_field.is_nullable(),
-                &geoarray_metadata,
-            );
+            let new_field = target_geo_data_type.to_field_with_metadata(orig_field.name(), orig_field.is_nullable(), &geoarray_metadata);
             let new_arrays = vec![];
             new_table.set_column(index, new_field.into(), new_arrays)?;
             return Ok(new_table);
@@ -217,56 +192,24 @@ impl Table {
         match orig_type {
             AnyType::Native(_) => Ok(self.clone()),
             AnyType::Serialized(typ) => {
-                let array_slices = self
-                    .batches()
-                    .iter()
-                    .map(|batch| batch.column(index).as_ref())
-                    .collect::<Vec<_>>();
+                let array_slices = self.batches().iter().map(|batch| batch.column(index).as_ref()).collect::<Vec<_>>();
                 let new_geometry = match typ {
                     SerializedType::WKB => {
-                        let wkb_chunks = array_slices
-                            .iter()
-                            .map(|arr| WKBArray::<i32>::try_from((*arr, orig_field)))
-                            .collect::<Result<Vec<_>>>()?;
-                        let parsed_chunks = wkb_chunks
-                            .into_iter()
-                            .map(|chunk| from_wkb(&chunk, target_geo_data_type, true))
-                            .collect::<Result<Vec<_>>>()?;
-                        let parsed_chunks_refs = parsed_chunks
-                            .iter()
-                            .map(|chunk| chunk.as_ref())
-                            .collect::<Vec<_>>();
-                        ChunkedNativeArrayDyn::from_geoarrow_chunks(parsed_chunks_refs.as_slice())?
-                            .into_inner()
-                            .as_ref()
-                            .downcast(true)
+                        let wkb_chunks = array_slices.iter().map(|arr| WKBArray::<i32>::try_from((*arr, orig_field))).collect::<Result<Vec<_>>>()?;
+                        let parsed_chunks = wkb_chunks.into_iter().map(|chunk| from_wkb(&chunk, target_geo_data_type, true)).collect::<Result<Vec<_>>>()?;
+                        let parsed_chunks_refs = parsed_chunks.iter().map(|chunk| chunk.as_ref()).collect::<Vec<_>>();
+                        ChunkedNativeArrayDyn::from_geoarrow_chunks(parsed_chunks_refs.as_slice())?.into_inner().as_ref().downcast(true)
                     }
                     SerializedType::LargeWKB => {
-                        let wkb_chunks = array_slices
-                            .iter()
-                            .map(|arr| WKBArray::<i64>::try_from((*arr, orig_field)))
-                            .collect::<Result<Vec<_>>>()?;
-                        let parsed_chunks = wkb_chunks
-                            .into_iter()
-                            .map(|chunk| from_wkb(&chunk, target_geo_data_type, true))
-                            .collect::<Result<Vec<_>>>()?;
-                        let parsed_chunks_refs = parsed_chunks
-                            .iter()
-                            .map(|chunk| chunk.as_ref())
-                            .collect::<Vec<_>>();
-                        ChunkedNativeArrayDyn::from_geoarrow_chunks(parsed_chunks_refs.as_slice())?
-                            .into_inner()
-                            .as_ref()
-                            .downcast(true)
+                        let wkb_chunks = array_slices.iter().map(|arr| WKBArray::<i64>::try_from((*arr, orig_field))).collect::<Result<Vec<_>>>()?;
+                        let parsed_chunks = wkb_chunks.into_iter().map(|chunk| from_wkb(&chunk, target_geo_data_type, true)).collect::<Result<Vec<_>>>()?;
+                        let parsed_chunks_refs = parsed_chunks.iter().map(|chunk| chunk.as_ref()).collect::<Vec<_>>();
+                        ChunkedNativeArrayDyn::from_geoarrow_chunks(parsed_chunks_refs.as_slice())?.into_inner().as_ref().downcast(true)
                     }
                     _ => panic!("WKT input not supported yet"),
                 };
 
-                let new_field = new_geometry.data_type().to_field_with_metadata(
-                    orig_field.name(),
-                    orig_field.is_nullable(),
-                    &geoarray_metadata,
-                );
+                let new_field = new_geometry.data_type().to_field_with_metadata(orig_field.name(), orig_field.is_nullable(), &geoarray_metadata);
                 let new_arrays = new_geometry.array_refs();
 
                 let mut new_table = self.clone();
@@ -387,10 +330,7 @@ impl Table {
     pub fn default_geometry_column_idx(&self) -> Result<usize> {
         let geom_col_indices = self.schema.as_ref().geometry_columns();
         if geom_col_indices.len() != 1 {
-            Err(GeoArrowError::General(
-                "Cannot use default geometry column when multiple geometry columns exist in table"
-                    .to_string(),
-            ))
+            Err(GeoArrowError::General("Cannot use default geometry column when multiple geometry columns exist in table".to_string()))
         } else {
             Ok(geom_col_indices[0])
         }
@@ -424,18 +364,12 @@ impl Table {
             if geom_indices.len() == 1 {
                 geom_indices[0]
             } else {
-                return Err(GeoArrowError::General(
-                    "`index` must be provided when multiple geometry columns exist.".to_string(),
-                ));
+                return Err(GeoArrowError::General("`index` must be provided when multiple geometry columns exist.".to_string()));
             }
         };
 
         let field = self.schema.field(index);
-        let array_refs = self
-            .batches
-            .iter()
-            .map(|batch| batch.column(index).as_ref())
-            .collect::<Vec<_>>();
+        let array_refs = self.batches.iter().map(|batch| batch.column(index).as_ref()).collect::<Vec<_>>();
         Ok(ChunkedNativeArrayDyn::from_arrow_chunks(array_refs.as_slice(), field)?.into_inner())
     }
 
@@ -458,12 +392,7 @@ impl Table {
     /// # }
     /// ```
     pub fn geometry_columns(&self) -> Result<Vec<Arc<dyn ChunkedNativeArray>>> {
-        self.schema
-            .as_ref()
-            .geometry_columns()
-            .into_iter()
-            .map(|index| self.geometry_column(Some(index)))
-            .collect()
+        self.schema.as_ref().geometry_columns().into_iter().map(|index| self.geometry_column(Some(index))).collect()
     }
 
     /// Returns the number of columns in this table.
@@ -503,18 +432,10 @@ impl Table {
     /// table.set_column(0, field.into(), vec![Arc::new(array)]).unwrap();
     /// # }
     /// ```
-    pub fn set_column(
-        &mut self,
-        i: usize,
-        field: FieldRef,
-        column: Vec<Arc<dyn Array>>,
-    ) -> Result<()> {
+    pub fn set_column(&mut self, i: usize, field: FieldRef, column: Vec<Arc<dyn Array>>) -> Result<()> {
         let mut fields = self.schema().fields().deref().to_vec();
         fields[i] = field;
-        let schema = Arc::new(Schema::new_with_metadata(
-            fields,
-            self.schema().metadata().clone(),
-        ));
+        let schema = Arc::new(Schema::new_with_metadata(fields, self.schema().metadata().clone()));
 
         let batches = self
             .batches
@@ -536,11 +457,7 @@ impl Table {
     pub(crate) fn remove_column(&mut self, i: usize) -> ChunkedArray<ArrayRef> {
         // NOTE: remove_column drops schema metadata as of
         // https://github.com/apache/arrow-rs/issues/5327
-        let removed_chunks = self
-            .batches
-            .iter_mut()
-            .map(|batch| batch.remove_column(i))
-            .collect::<Vec<_>>();
+        let removed_chunks = self.batches.iter_mut().map(|batch| batch.remove_column(i)).collect::<Vec<_>>();
 
         let mut schema_builder = SchemaBuilder::from(self.schema.as_ref().clone());
         schema_builder.remove(i);
@@ -582,10 +499,7 @@ impl Table {
 
                 let mut columns = batch.columns().to_vec();
                 columns.push(array);
-                Ok(RecordBatch::try_new(
-                    schema_builder.finish().into(),
-                    columns,
-                )?)
+                Ok(RecordBatch::try_new(schema_builder.finish().into(), columns)?)
                 // let schema = batch.schema()
             })
             .collect::<Result<Vec<_>>>()?;
@@ -601,31 +515,21 @@ impl Table {
 
     /// Convert this table into a [RecordBatchIterator]
     pub fn into_record_batch_reader(self) -> Box<dyn RecordBatchReader + Send> {
-        Box::new(RecordBatchIterator::new(
-            self.batches.into_iter().map(Ok),
-            self.schema,
-        ))
+        Box::new(RecordBatchIterator::new(self.batches.into_iter().map(Ok), self.schema))
     }
 
     /// Convert this table into a [RecordBatchIterator], cloning each internal [RecordBatch]
     pub fn to_record_batch_reader<'a>(&'a self) -> Box<dyn RecordBatchReader + Send + 'a> {
-        Box::new(RecordBatchIterator::new(
-            self.batches.iter().map(|batch| Ok(batch.clone())),
-            self.schema.clone(),
-        ))
+        Box::new(RecordBatchIterator::new(self.batches.iter().map(|batch| Ok(batch.clone())), self.schema.clone()))
     }
 }
 
 impl TryFrom<Box<dyn arrow_array::RecordBatchReader>> for Table {
     type Error = GeoArrowError;
 
-    fn try_from(
-        value: Box<dyn arrow_array::RecordBatchReader>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: Box<dyn arrow_array::RecordBatchReader>) -> std::result::Result<Self, Self::Error> {
         let schema = value.schema();
-        let batches = value
-            .into_iter()
-            .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
+        let batches = value.into_iter().collect::<std::result::Result<Vec<_>, ArrowError>>()?;
         Table::try_new(batches, schema)
     }
 }
@@ -633,13 +537,9 @@ impl TryFrom<Box<dyn arrow_array::RecordBatchReader>> for Table {
 impl TryFrom<Box<dyn arrow_array::RecordBatchReader + Send>> for Table {
     type Error = GeoArrowError;
 
-    fn try_from(
-        value: Box<dyn arrow_array::RecordBatchReader + Send>,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: Box<dyn arrow_array::RecordBatchReader + Send>) -> std::result::Result<Self, Self::Error> {
         let schema = value.schema();
-        let batches = value
-            .into_iter()
-            .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
+        let batches = value.into_iter().collect::<std::result::Result<Vec<_>, ArrowError>>()?;
         Table::try_new(batches, schema)
     }
 }

--- a/src/test/geoarrow_data/mod.rs
+++ b/src/test/geoarrow_data/mod.rs
@@ -6,7 +6,10 @@ use crate::test::geoarrow_data::util::read_geometry_column;
 macro_rules! geoarrow_data_impl {
     ($fn_name:ident, $file_part:tt, $return_type:ty) => {
         pub(crate) fn $fn_name() -> $return_type {
-            let path = format!("fixtures/geoarrow-data/example/example-{}.arrow", $file_part);
+            let path = format!(
+                "fixtures/geoarrow-data/example/example-{}.arrow",
+                $file_part
+            );
             let geometry_dyn_column = read_geometry_column(&path);
             geometry_dyn_column.as_ref().try_into().unwrap()
         }
@@ -14,31 +17,75 @@ macro_rules! geoarrow_data_impl {
 }
 
 // Point
-geoarrow_data_impl!(example_point_interleaved, "point-interleaved", PointArray<2>);
+geoarrow_data_impl!(
+    example_point_interleaved,
+    "point-interleaved",
+    PointArray<2>
+);
 geoarrow_data_impl!(example_point_separated, "point", PointArray<2>);
 geoarrow_data_impl!(example_point_wkb, "point-wkb", WKBArray<i64>);
 
 // LineString
-geoarrow_data_impl!(example_linestring_interleaved, "linestring-interleaved", LineStringArray<2>);
-geoarrow_data_impl!(example_linestring_separated, "linestring", LineStringArray<2>);
+geoarrow_data_impl!(
+    example_linestring_interleaved,
+    "linestring-interleaved",
+    LineStringArray<2>
+);
+geoarrow_data_impl!(
+    example_linestring_separated,
+    "linestring",
+    LineStringArray<2>
+);
 geoarrow_data_impl!(example_linestring_wkb, "linestring-wkb", WKBArray<i64>);
 
 // Polygon
-geoarrow_data_impl!(example_polygon_interleaved, "polygon-interleaved", PolygonArray<2>);
+geoarrow_data_impl!(
+    example_polygon_interleaved,
+    "polygon-interleaved",
+    PolygonArray<2>
+);
 geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray<2>);
 geoarrow_data_impl!(example_polygon_wkb, "polygon-wkb", WKBArray<i64>);
 
 // MultiPoint
-geoarrow_data_impl!(example_multipoint_interleaved, "multipoint-interleaved", MultiPointArray<2>);
-geoarrow_data_impl!(example_multipoint_separated, "multipoint", MultiPointArray<2>);
+geoarrow_data_impl!(
+    example_multipoint_interleaved,
+    "multipoint-interleaved",
+    MultiPointArray<2>
+);
+geoarrow_data_impl!(
+    example_multipoint_separated,
+    "multipoint",
+    MultiPointArray<2>
+);
 geoarrow_data_impl!(example_multipoint_wkb, "multipoint-wkb", WKBArray<i64>);
 
 // MultiLineString
-geoarrow_data_impl!(example_multilinestring_interleaved, "multilinestring-interleaved", MultiLineStringArray<2>);
-geoarrow_data_impl!(example_multilinestring_separated, "multilinestring", MultiLineStringArray<2>);
-geoarrow_data_impl!(example_multilinestring_wkb, "multilinestring-wkb", WKBArray<i64>);
+geoarrow_data_impl!(
+    example_multilinestring_interleaved,
+    "multilinestring-interleaved",
+    MultiLineStringArray<2>
+);
+geoarrow_data_impl!(
+    example_multilinestring_separated,
+    "multilinestring",
+    MultiLineStringArray<2>
+);
+geoarrow_data_impl!(
+    example_multilinestring_wkb,
+    "multilinestring-wkb",
+    WKBArray<i64>
+);
 
 // MultiPolygon
-geoarrow_data_impl!(example_multipolygon_interleaved, "multipolygon-interleaved", MultiPolygonArray<2>);
-geoarrow_data_impl!(example_multipolygon_separated, "multipolygon", MultiPolygonArray<2>);
+geoarrow_data_impl!(
+    example_multipolygon_interleaved,
+    "multipolygon-interleaved",
+    MultiPolygonArray<2>
+);
+geoarrow_data_impl!(
+    example_multipolygon_separated,
+    "multipolygon",
+    MultiPolygonArray<2>
+);
 geoarrow_data_impl!(example_multipolygon_wkb, "multipolygon-wkb", WKBArray<i64>);

--- a/src/test/geoarrow_data/mod.rs
+++ b/src/test/geoarrow_data/mod.rs
@@ -6,10 +6,7 @@ use crate::test::geoarrow_data::util::read_geometry_column;
 macro_rules! geoarrow_data_impl {
     ($fn_name:ident, $file_part:tt, $return_type:ty) => {
         pub(crate) fn $fn_name() -> $return_type {
-            let path = format!(
-                "fixtures/geoarrow-data/example/example-{}.arrow",
-                $file_part
-            );
+            let path = format!("fixtures/geoarrow-data/example/example-{}.arrow", $file_part);
             let geometry_dyn_column = read_geometry_column(&path);
             geometry_dyn_column.as_ref().try_into().unwrap()
         }
@@ -17,11 +14,7 @@ macro_rules! geoarrow_data_impl {
 }
 
 // Point
-geoarrow_data_impl!(
-    example_point_interleaved,
-    "point-interleaved",
-    PointArray<2>
-);
+geoarrow_data_impl!(example_point_interleaved, "point-interleaved", PointArray<2>);
 geoarrow_data_impl!(example_point_separated, "point", PointArray<2>);
 geoarrow_data_impl!(example_point_wkb, "point-wkb", WKBArray<i64>);
 
@@ -39,12 +32,8 @@ geoarrow_data_impl!(
 geoarrow_data_impl!(example_linestring_wkb, "linestring-wkb", WKBArray<i64>);
 
 // Polygon
-geoarrow_data_impl!(
-    example_polygon_interleaved,
-    "polygon-interleaved",
-    PolygonArray<i64, 2>
-);
-geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray<i64, 2>);
+geoarrow_data_impl!(example_polygon_interleaved, "polygon-interleaved", PolygonArray<2>);
+geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray<2>);
 geoarrow_data_impl!(example_polygon_wkb, "polygon-wkb", WKBArray<i64>);
 
 // MultiPoint
@@ -71,21 +60,9 @@ geoarrow_data_impl!(
     "multilinestring",
     MultiLineStringArray<i64, 2>
 );
-geoarrow_data_impl!(
-    example_multilinestring_wkb,
-    "multilinestring-wkb",
-    WKBArray<i64>
-);
+geoarrow_data_impl!(example_multilinestring_wkb, "multilinestring-wkb", WKBArray<i64>);
 
 // MultiPolygon
-geoarrow_data_impl!(
-    example_multipolygon_interleaved,
-    "multipolygon-interleaved",
-    MultiPolygonArray<i64, 2>
-);
-geoarrow_data_impl!(
-    example_multipolygon_separated,
-    "multipolygon",
-    MultiPolygonArray<i64, 2>
-);
+geoarrow_data_impl!(example_multipolygon_interleaved, "multipolygon-interleaved", MultiPolygonArray<2>);
+geoarrow_data_impl!(example_multipolygon_separated, "multipolygon", MultiPolygonArray<2>);
 geoarrow_data_impl!(example_multipolygon_wkb, "multipolygon-wkb", WKBArray<i64>);

--- a/src/test/geoarrow_data/mod.rs
+++ b/src/test/geoarrow_data/mod.rs
@@ -19,16 +19,8 @@ geoarrow_data_impl!(example_point_separated, "point", PointArray<2>);
 geoarrow_data_impl!(example_point_wkb, "point-wkb", WKBArray<i64>);
 
 // LineString
-geoarrow_data_impl!(
-    example_linestring_interleaved,
-    "linestring-interleaved",
-    LineStringArray<i64, 2>
-);
-geoarrow_data_impl!(
-    example_linestring_separated,
-    "linestring",
-    LineStringArray<i64, 2>
-);
+geoarrow_data_impl!(example_linestring_interleaved, "linestring-interleaved", LineStringArray<2>);
+geoarrow_data_impl!(example_linestring_separated, "linestring", LineStringArray<2>);
 geoarrow_data_impl!(example_linestring_wkb, "linestring-wkb", WKBArray<i64>);
 
 // Polygon
@@ -37,29 +29,13 @@ geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray<2>);
 geoarrow_data_impl!(example_polygon_wkb, "polygon-wkb", WKBArray<i64>);
 
 // MultiPoint
-geoarrow_data_impl!(
-    example_multipoint_interleaved,
-    "multipoint-interleaved",
-    MultiPointArray<i64, 2>
-);
-geoarrow_data_impl!(
-    example_multipoint_separated,
-    "multipoint",
-    MultiPointArray<i64, 2>
-);
+geoarrow_data_impl!(example_multipoint_interleaved, "multipoint-interleaved", MultiPointArray<2>);
+geoarrow_data_impl!(example_multipoint_separated, "multipoint", MultiPointArray<2>);
 geoarrow_data_impl!(example_multipoint_wkb, "multipoint-wkb", WKBArray<i64>);
 
 // MultiLineString
-geoarrow_data_impl!(
-    example_multilinestring_interleaved,
-    "multilinestring-interleaved",
-    MultiLineStringArray<i64, 2>
-);
-geoarrow_data_impl!(
-    example_multilinestring_separated,
-    "multilinestring",
-    MultiLineStringArray<i64, 2>
-);
+geoarrow_data_impl!(example_multilinestring_interleaved, "multilinestring-interleaved", MultiLineStringArray<2>);
+geoarrow_data_impl!(example_multilinestring_separated, "multilinestring", MultiLineStringArray<2>);
 geoarrow_data_impl!(example_multilinestring_wkb, "multilinestring-wkb", WKBArray<i64>);
 
 // MultiPolygon

--- a/src/test/linestring.rs
+++ b/src/test/linestring.rs
@@ -21,6 +21,6 @@ pub(crate) fn ls_array() -> LineStringArray<i32, 2> {
     vec![ls0(), ls1()].as_slice().into()
 }
 
-pub(crate) fn large_ls_array() -> LineStringArray<i64, 2> {
+pub(crate) fn large_ls_array() -> LineStringArray<2> {
     vec![ls0(), ls1()].as_slice().into()
 }

--- a/src/test/linestring.rs
+++ b/src/test/linestring.rs
@@ -17,7 +17,7 @@ pub(crate) fn ls1() -> LineString {
 }
 
 #[allow(dead_code)]
-pub(crate) fn ls_array() -> LineStringArray<i32, 2> {
+pub(crate) fn ls_array() -> LineStringArray<2> {
     vec![ls0(), ls1()].as_slice().into()
 }
 

--- a/src/test/multilinestring.rs
+++ b/src/test/multilinestring.rs
@@ -28,6 +28,6 @@ pub(crate) fn ml1() -> MultiLineString {
     ])
 }
 
-pub(crate) fn ml_array() -> MultiLineStringArray<i32, 2> {
+pub(crate) fn ml_array() -> MultiLineStringArray<2> {
     vec![ml0(), ml1()].as_slice().into()
 }

--- a/src/test/multipoint.rs
+++ b/src/test/multipoint.rs
@@ -24,6 +24,6 @@ pub(crate) fn mp1() -> MultiPoint {
     ])
 }
 
-pub(crate) fn mp_array() -> MultiPointArray<i32, 2> {
+pub(crate) fn mp_array() -> MultiPointArray<2> {
     vec![mp0(), mp1()].as_slice().into()
 }

--- a/src/test/multipolygon.rs
+++ b/src/test/multipolygon.rs
@@ -46,6 +46,6 @@ pub(crate) fn mp1() -> MultiPolygon {
     ])
 }
 
-pub(crate) fn mp_array() -> MultiPolygonArray<i32, 2> {
+pub(crate) fn mp_array() -> MultiPolygonArray<2> {
     vec![mp0(), mp1()].as_slice().into()
 }

--- a/src/test/polygon.rs
+++ b/src/test/polygon.rs
@@ -29,6 +29,6 @@ pub(crate) fn p1() -> Polygon {
     )
 }
 
-pub(crate) fn p_array() -> PolygonArray<i32, 2> {
+pub(crate) fn p_array() -> PolygonArray<2> {
     vec![p0(), p1()].as_slice().into()
 }


### PR DESCRIPTION
### Change list

- Remove the `O: OffsetSizeTrait` generic from all native geometry array and scalar structs. 
- Keep the `O: OffsetSizeTrait` generic on `WKBArray` and `WKTArray`, since those are much smaller code paths, and since those are in theory more likely to actually be necessary with i64 offsets.

Closes https://github.com/geoarrow/geoarrow-rs/issues/802