### PR TITLE
Set pyo3-geoarrow to 0.1.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow"
-version = "0.3.0"
+version = "0.4.0-beta.1"
 dependencies = [
  "approx",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geoarrow"
-version = "0.3.0"
+version = "0.4.0-beta.1"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1053,6 +1053,8 @@ dependencies = [
  "object_store",
  "parquet",
  "phf",
+ "polylabel",
+ "rayon",
  "rstar",
  "serde",
  "serde_json",
@@ -1064,39 +1066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "geoarrow"
-version = "0.4.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74fea52cea0d624c98eb72d67c59578d7234cef1cd796831c568bb83e02caa4"
-dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "byteorder",
- "chrono",
- "geo",
- "geo-index",
- "geozero",
- "half",
- "indexmap",
- "lexical-core",
- "num_enum",
- "phf",
- "polylabel",
- "rayon",
- "rstar",
- "serde",
- "serde_json",
- "shapefile",
- "thiserror",
- "wkt",
-]
-
-[[package]]
 name = "geoarrow-rust-compute"
 version = "0.3.0"
 dependencies = [
@@ -1104,7 +1073,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "geo",
- "geoarrow 0.4.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geoarrow",
  "geozero",
  "numpy",
  "pyo3",
@@ -1123,7 +1092,7 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "geo",
- "geoarrow 0.4.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geoarrow",
  "geozero",
  "numpy",
  "pyo3",
@@ -1143,7 +1112,7 @@ dependencies = [
  "flatgeobuf",
  "futures",
  "geo",
- "geoarrow 0.4.0-beta.1",
+ "geoarrow",
  "object_store",
  "openssl",
  "parquet",
@@ -2364,7 +2333,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "geo",
- "geoarrow 0.4.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "geoarrow",
  "geozero",
  "indexmap",
  "pyo3",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow"
-version = "0.3.0"
+version = "0.4.0-beta.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1053,8 +1053,6 @@ dependencies = [
  "object_store",
  "parquet",
  "phf",
- "polylabel",
- "rayon",
  "rstar",
  "serde",
  "serde_json",
@@ -1066,6 +1064,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "geoarrow"
+version = "0.4.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74fea52cea0d624c98eb72d67c59578d7234cef1cd796831c568bb83e02caa4"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "byteorder",
+ "chrono",
+ "geo",
+ "geo-index",
+ "geozero",
+ "half",
+ "indexmap",
+ "lexical-core",
+ "num_enum",
+ "phf",
+ "polylabel",
+ "rayon",
+ "rstar",
+ "serde",
+ "serde_json",
+ "shapefile",
+ "thiserror",
+ "wkt",
+]
+
+[[package]]
 name = "geoarrow-rust-compute"
 version = "0.3.0"
 dependencies = [
@@ -1073,9 +1104,9 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "geo",
- "geoarrow",
+ "geoarrow 0.4.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "geozero",
- "numpy 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numpy",
  "pyo3",
  "pyo3-arrow",
  "pyo3-geoarrow",
@@ -1092,9 +1123,9 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "geo",
- "geoarrow",
+ "geoarrow 0.4.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "geozero",
- "numpy 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numpy",
  "pyo3",
  "pyo3-arrow",
  "pyo3-geoarrow",
@@ -1112,7 +1143,7 @@ dependencies = [
  "flatgeobuf",
  "futures",
  "geo",
- "geoarrow",
+ "geoarrow 0.4.0-beta.1",
  "object_store",
  "openssl",
  "parquet",
@@ -1899,20 +1930,6 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
 dependencies = [
- "libc",
- "ndarray",
- "num-complex",
- "num-integer",
- "num-traits",
- "pyo3",
- "rustc-hash 1.1.0",
-]
-
-[[package]]
-name = "numpy"
-version = "0.21.0"
-source = "git+https://github.com/stinodego/rust-numpy.git?rev=9ba9962ae57ba26e35babdce6f179edf5fe5b9c8#9ba9962ae57ba26e35babdce6f179edf5fe5b9c8"
-dependencies = [
  "half",
  "libc",
  "ndarray",
@@ -2290,8 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-arrow"
-version = "0.3.0"
-source = "git+https://github.com/kylebarron/arro3?rev=7cf67d35ec9c3e3f90f83641b456d4026ec5c7aa#7cf67d35ec9c3e3f90f83641b456d4026ec5c7aa"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e23a03fb0bc2b06103d4bc6948424292ad410ef31ed14b1af620c5937f6fac37"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2299,7 +2317,7 @@ dependencies = [
  "arrow-schema",
  "half",
  "indexmap",
- "numpy 0.21.0 (git+https://github.com/stinodego/rust-numpy.git?rev=9ba9962ae57ba26e35babdce6f179edf5fe5b9c8)",
+ "numpy",
  "pyo3",
  "thiserror",
 ]
@@ -2346,7 +2364,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "geo",
- "geoarrow",
+ "geoarrow 0.4.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "geozero",
  "indexmap",
  "pyo3",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-geoarrow"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -18,8 +18,9 @@ arrow = "53"
 arrow-array = "53"
 arrow-buffer = "53"
 arrow-schema = "53"
-# geoarrow = { path = "../", features = ["geozero"] }
-geoarrow = { version = "0.4.0-beta.1", features = ["geozero"] }
+geoarrow = { path = "../", features = ["geozero"] }
+# Uncomment when publishing
+# geoarrow = { version = "0.4.0-beta.1", features = ["geozero"] }
 geozero = "0.14"
 indexmap = "2.5.0"
 object_store = "0.11"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -18,12 +18,13 @@ arrow = "53"
 arrow-array = "53"
 arrow-buffer = "53"
 arrow-schema = "53"
-geoarrow = { path = "../", features = ["geozero"] }
+# geoarrow = { path = "../", features = ["geozero"] }
+geoarrow = { version = "0.4.0-beta.1", features = ["geozero"] }
 geozero = "0.14"
 indexmap = "2.5.0"
 object_store = "0.11"
 parquet = "53"
 pyo3 = { version = "0.21.0", features = ["hashbrown", "serde", "anyhow"] }
-pyo3-arrow = { git = "https://github.com/kylebarron/arro3", rev = "7cf67d35ec9c3e3f90f83641b456d4026ec5c7aa" }
+pyo3-arrow = "0.4"
 serde_json = "1"
 thiserror = "1"

--- a/python/pyo3-geoarrow/Cargo.toml
+++ b/python/pyo3-geoarrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-geoarrow"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2021"
 description = "GeoArrow integration for pyo3."


### PR DESCRIPTION
Set versions so we can publish to crates.io

I'm not sure how I want to version this. Should I version it separately? With the core `geoarrow` crate?