### PR TITLE
Add python constructors to docs

### DIFF
--- a/python/docs/api/core/constructors.md
+++ b/python/docs/api/core/constructors.md
@@ -1,0 +1,13 @@
+# Constructors
+
+::: geoarrow.rust.core
+    options:
+      filters:
+        - "!^_"
+      members:
+        - points
+        - linestrings
+        - polygons
+        - multipoints
+        - multilinestrings
+        - multipolygons

--- a/python/mkdocs.yml
+++ b/python/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
           - api/core/geometry/array.md
           - api/core/geometry/chunked.md
           - api/core/geometry/scalar.md
+          - api/core/constructors.md
           - api/core/functions.md
           - api/core/enums.md
           - api/core/types.md


### PR DESCRIPTION
Follow up from https://github.com/geoarrow/geoarrow-rs/pull/810