### PR TITLE
Add `push_geometry` to `GeometryArrayBuilder`

### DIFF
--- a/src/algorithm/native/map_coords.rs
+++ b/src/algorithm/native/map_coords.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::array::mixed::builder::DEFAULT_PREFER_MULTI;
 use crate::array::*;
 use crate::chunked_array::*;
 use crate::datatypes::{Dimension, NativeType};
@@ -377,6 +378,7 @@ impl MapCoords for MixedGeometryArray<2> {
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
+            DEFAULT_PREFER_MULTI,
         );
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
@@ -402,6 +404,7 @@ impl MapCoords for GeometryCollectionArray<2> {
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
+            DEFAULT_PREFER_MULTI,
         );
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {

--- a/src/algorithm/native/take.rs
+++ b/src/algorithm/native/take.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use crate::array::mixed::builder::DEFAULT_PREFER_MULTI;
 use crate::array::*;
 use crate::chunked_array::ChunkedGeometryArray;
 use crate::datatypes::{Dimension, NativeType};
@@ -158,6 +159,7 @@ macro_rules! take_impl_fallible {
                     capacity,
                     self.coord_type(),
                     self.metadata(),
+                    DEFAULT_PREFER_MULTI,
                 );
 
                 for index in indices.iter() {
@@ -182,6 +184,7 @@ macro_rules! take_impl_fallible {
                     capacity,
                     self.coord_type(),
                     self.metadata(),
+                    DEFAULT_PREFER_MULTI,
                 );
 
                 for i in range.start..range.end {

--- a/src/array/linestring/builder.rs
+++ b/src/array/linestring/builder.rs
@@ -319,6 +319,10 @@ impl<const D: usize> GeometryArrayBuilder for LineStringBuilder<D> {
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
+    fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(value)
+    }
+
     fn finish(self) -> Arc<dyn crate::NativeArray> {
         Arc::new(self.finish())
     }

--- a/src/array/mixed/mod.rs
+++ b/src/array/mixed/mod.rs
@@ -3,5 +3,5 @@ pub use builder::MixedGeometryBuilder;
 pub use capacity::MixedCapacity;
 
 pub(crate) mod array;
-mod builder;
+pub(crate) mod builder;
 mod capacity;

--- a/src/array/multilinestring/builder.rs
+++ b/src/array/multilinestring/builder.rs
@@ -399,6 +399,10 @@ impl<const D: usize> GeometryArrayBuilder for MultiLineStringBuilder<D> {
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
+    fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(value)
+    }
+
     fn finish(self) -> Arc<dyn crate::NativeArray> {
         Arc::new(self.finish())
     }

--- a/src/array/multipoint/builder.rs
+++ b/src/array/multipoint/builder.rs
@@ -350,6 +350,10 @@ impl<const D: usize> GeometryArrayBuilder for MultiPointBuilder<D> {
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
+    fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(value)
+    }
+
     fn finish(self) -> Arc<dyn crate::NativeArray> {
         Arc::new(self.finish())
     }

--- a/src/array/multipolygon/builder.rs
+++ b/src/array/multipolygon/builder.rs
@@ -468,6 +468,10 @@ impl<const D: usize> GeometryArrayBuilder for MultiPolygonBuilder<D> {
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
+    fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(value)
+    }
+
     fn finish(self) -> Arc<dyn crate::NativeArray> {
         Arc::new(self.finish())
     }

--- a/src/array/point/builder.rs
+++ b/src/array/point/builder.rs
@@ -237,6 +237,10 @@ impl<const D: usize> GeometryArrayBuilder for PointBuilder<D> {
         self.metadata = metadata;
     }
 
+    fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(value)
+    }
+
     fn finish(self) -> Arc<dyn crate::NativeArray> {
         Arc::new(self.finish())
     }

--- a/src/array/polygon/builder.rs
+++ b/src/array/polygon/builder.rs
@@ -429,6 +429,10 @@ impl<const D: usize> GeometryArrayBuilder for PolygonBuilder<D> {
         Self::with_capacity_and_options(capacity, coord_type, metadata)
     }
 
+    fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(value)
+    }
+
     fn finish(self) -> Arc<dyn crate::NativeArray> {
         Arc::new(self.finish())
     }

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -982,9 +982,9 @@ mod test {
         assert_eq!(ml_array.data_type(), data_type);
 
         let mut builder = MixedGeometryBuilder::<2>::new();
-        builder.push_point(Some(&crate::test::point::p0()));
-        builder.push_point(Some(&crate::test::point::p1()));
-        builder.push_point(Some(&crate::test::point::p2()));
+        builder.push_point(Some(&crate::test::point::p0())).unwrap();
+        builder.push_point(Some(&crate::test::point::p1())).unwrap();
+        builder.push_point(Some(&crate::test::point::p2())).unwrap();
         builder
             .push_multi_line_string(Some(&crate::test::multilinestring::ml0()))
             .unwrap();

--- a/src/io/geozero/api/ewkb.rs
+++ b/src/io/geozero/api/ewkb.rs
@@ -61,14 +61,15 @@ impl FromEWKB for GeometryCollectionArray<2> {
     ) -> Result<Self> {
         // TODO: Add GeometryCollectionStreamBuilder and use that instead of going through geo
         let arr = arr.clone().into_inner();
-        let mut builder = GeometryCollectionBuilder::new_with_options(coord_type, metadata);
+        let mut builder =
+            GeometryCollectionBuilder::new_with_options(coord_type, metadata, prefer_multi);
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 let buf = arr.value(i);
                 let mut geo = GeoWriter::new();
                 process_ewkb_geom(&mut Cursor::new(buf), &mut geo).unwrap();
                 let geo_geom = geo.take_geometry().unwrap();
-                builder.push_geometry(Some(&geo_geom), prefer_multi)?;
+                builder.push_geometry(Some(&geo_geom))?;
             } else {
                 builder.push_null();
             }

--- a/src/io/geozero/api/wkt.rs
+++ b/src/io/geozero/api/wkt.rs
@@ -58,12 +58,13 @@ impl FromWKT for GeometryCollectionArray<2> {
         prefer_multi: bool,
     ) -> Result<Self> {
         // TODO: Add GeometryCollectionStreamBuilder and use that instead of going through geo
-        let mut builder = GeometryCollectionBuilder::new_with_options(coord_type, metadata);
+        let mut builder =
+            GeometryCollectionBuilder::new_with_options(coord_type, metadata, prefer_multi);
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 let wkt_str = geozero::wkt::Wkt(arr.value(i));
                 let geo_geom = wkt_str.to_geo()?;
-                builder.push_geometry(Some(&geo_geom), prefer_multi)?;
+                builder.push_geometry(Some(&geo_geom))?;
             } else {
                 builder.push_null();
             }

--- a/src/io/parquet/test.rs
+++ b/src/io/parquet/test.rs
@@ -42,7 +42,9 @@ fn round_trip_nybb() -> Result<()> {
 #[test]
 fn mixed_geometry_roundtrip() {
     let mut builder = MixedGeometryBuilder::<2>::new();
-    builder.push_point(Some(&geo::point!(x: -105., y: 40.)));
+    builder
+        .push_point(Some(&geo::point!(x: -105., y: 40.)))
+        .unwrap();
     let geometry = ChunkedNativeArrayDyn::from_geoarrow_chunks(&[&builder.finish()])
         .unwrap()
         .into_inner();

--- a/src/io/wkt/reader/mod.rs
+++ b/src/io/wkt/reader/mod.rs
@@ -20,7 +20,8 @@ impl<O: OffsetSizeTrait> ParseWKT for GenericStringArray<O> {
     type Output = Arc<dyn NativeArray>;
 
     fn parse_wkt(&self, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self::Output {
-        let mut builder = MixedGeometryBuilder::<2>::new_with_options(coord_type, metadata, true);
+        // TODO: switch this prefer_multi to true when we use downcasting here.
+        let mut builder = MixedGeometryBuilder::<2>::new_with_options(coord_type, metadata, false);
         for i in 0..self.len() {
             if self.is_valid(i) {
                 let w = wkt::Wkt::<f64>::from_str(self.value(i)).unwrap();

--- a/src/io/wkt/reader/mod.rs
+++ b/src/io/wkt/reader/mod.rs
@@ -20,7 +20,7 @@ impl<O: OffsetSizeTrait> ParseWKT for GenericStringArray<O> {
     type Output = Arc<dyn NativeArray>;
 
     fn parse_wkt(&self, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self::Output {
-        let mut builder = MixedGeometryBuilder::<2>::new_with_options(coord_type, metadata);
+        let mut builder = MixedGeometryBuilder::<2>::new_with_options(coord_type, metadata, true);
         for i in 0..self.len() {
             if self.is_valid(i) {
                 let w = wkt::Wkt::<f64>::from_str(self.value(i)).unwrap();

--- a/src/trait_.rs
+++ b/src/trait_.rs
@@ -3,6 +3,8 @@
 use crate::array::metadata::ArrayMetadata;
 use crate::array::{CoordBuffer, CoordType};
 use crate::datatypes::{NativeType, SerializedType};
+use crate::error::Result;
+use crate::geo_traits::GeometryTrait;
 use crate::scalar::Geometry;
 use arrow_array::{Array, ArrayRef};
 use arrow_buffer::{NullBuffer, NullBufferBuilder};
@@ -897,6 +899,9 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
             Default::default(),
         )
     }
+
+    /// Push a geometry onto this array.
+    fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()>;
 
     /// Sets this builders metadata.
     ///


### PR DESCRIPTION
### Change list

- Move `prefer_multi` from a parameter when adding a single geometry to a parameter on builder initialization. Realistically, the `prefer_multi` keyword is used when downcasting is planned, such as when using an unknown geometry source. In these cases, we'll always know on array creation whether we'll want to downcast later.
- This means that we can now add `push_geometry` onto the `GeometryArrayBuilder` trait, because we have a single signature that all builders can follow. This should make it a lot easier to manage stuff like macros because we won't need a different impl for points, geometries, and geometry collections.