### PR TITLE
Add shapefile reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
           - "-F csv"
           - "-F flatgeobuf"
           - "-F flatgeobuf_async"
-          - "-F geozero"
           - "-F ipc_compression"
           - "-F parquet"
           - "-F parquet_async"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1274,8 @@ dependencies = [
  "bytes",
  "chrono",
  "criterion",
+ "dbase",
+ "enum-as-inner",
  "flatgeobuf",
  "futures",
  "gdal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ categories = ["science::geo"]
 rust-version = "1.80"
 
 [features]
-csv = ["dep:geozero", "geozero/with-csv"]
-flatgeobuf = ["dep:flatgeobuf", "geozero"]
+csv = ["geozero/with-csv"]
+flatgeobuf = ["dep:flatgeobuf"]
 flatgeobuf_async = [
   "flatgeobuf/http",
   "dep:async-trait",
@@ -21,14 +21,6 @@ flatgeobuf_async = [
 ]
 gdal = ["dep:gdal"]
 geos = ["dep:geos"]
-geozero = [
-  "dep:arrow-cast",
-  "dep:chrono",
-  "dep:geozero",
-  "dep:half",
-  "dep:indexmap",
-  "dep:lexical-core",
-]
 ipc_compression = ["arrow-ipc/lz4", "arrow-ipc/zstd"]
 parquet = ["dep:parquet"]
 parquet_async = [
@@ -46,7 +38,7 @@ parquet_compression = [
   "parquet/zstd",
 ]
 polylabel = ["dep:polylabel"]
-postgis = ["dep:chrono", "dep:futures", "dep:sqlx", "geozero"]
+postgis = ["dep:futures", "dep:sqlx"]
 proj = ["dep:proj"]
 rayon = ["dep:rayon"]
 
@@ -55,7 +47,7 @@ rayon = ["dep:rayon"]
 arrow = { version = "53", features = ["ffi"] }
 arrow-array = { version = "53", features = ["chrono-tz"] }
 arrow-buffer = "53"
-arrow-cast = { version = "53", optional = true }
+arrow-cast = { version = "53" }
 arrow-data = "53"
 arrow-ipc = "53"
 arrow-schema = "53"
@@ -63,7 +55,7 @@ async-stream = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 byteorder = "1"
 bytes = { version = "1.5.0", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4" }
 dbase = "0.5.0"
 enum-as-inner = "0.6.1"
 # Set default-features = false because async not working in wasm right now
@@ -73,11 +65,11 @@ gdal = { version = "0.17", optional = true }
 geo = "0.28"
 geo-index = "0.1.1"
 geos = { version = "9.0", features = ["v3_10_0", "geo"], optional = true }
-geozero = { version = "0.14", features = ["with-wkb"], optional = true }
-half = { version = "2.4.1", optional = true }
+geozero = { version = "0.14", features = ["with-wkb"] }
+half = { version = "2.4.1" }
 http-range-client = { version = "0.8", optional = true }
-indexmap = { version = "2", optional = true }
-lexical-core = { version = "0.8.5", optional = true }
+indexmap = { version = "2" }
+lexical-core = { version = "0.8.5" }
 num_enum = "0.7"
 object_store = { version = "0.11", optional = true }
 parquet = { version = "53", optional = true, default-features = false, features = [
@@ -160,12 +152,4 @@ required-features = ["parquet_compression"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
-features = [
-  "csv",
-  "flatgeobuf",
-  "geos",
-  "geozero",
-  "parquet",
-  "postgis",
-  "rayon",
-]
+features = ["csv", "flatgeobuf", "geos", "parquet", "postgis", "rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ async-trait = { version = "0.1", optional = true }
 byteorder = "1"
 bytes = { version = "1.5.0", optional = true }
 chrono = { version = "0.4", optional = true }
+dbase = "0.5.0"
+enum-as-inner = "0.6.1"
 # Set default-features = false because async not working in wasm right now
 flatgeobuf = { version = "4.4.0", optional = true, default-features = false }
 futures = { version = "0.3", optional = true }

--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -785,6 +785,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1058,8 @@ dependencies = [
  "async-stream",
  "byteorder",
  "chrono",
+ "dbase",
+ "enum-as-inner",
  "flatgeobuf",
  "futures",
  "geo",

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -27,7 +27,7 @@ data = []
 geodesy = ["dep:geodesy"]
 debug = ["console_error_panic_hook"]
 io_flatgeobuf = ["geoarrow/flatgeobuf", "table"]
-io_geojson = ["geoarrow/geozero", "table"]
+io_geojson = ["table"]
 io_http = []
 io_object_store = [
     "dep:async-trait",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -744,6 +744,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1052,8 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "dbase",
+ "enum-as-inner",
  "flatgeobuf",
  "futures",
  "geo",
@@ -1264,6 +1278,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2361,7 +2381,7 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -2983,7 +3003,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -3123,7 +3143,7 @@ checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -18,9 +18,9 @@ arrow = "53"
 arrow-array = "53"
 arrow-buffer = "53"
 arrow-schema = "53"
-geoarrow = { path = "../", features = ["geozero"] }
+geoarrow = { path = "../" }
 # Uncomment when publishing
-# geoarrow = { version = "0.4.0-beta.1", features = ["geozero"] }
+# geoarrow = { version = "0.4.0-beta.1" }
 geozero = "0.14"
 indexmap = "2.5.0"
 object_store = "0.11"

--- a/python/geoarrow-compute/Cargo.toml
+++ b/python/geoarrow-compute/Cargo.toml
@@ -30,7 +30,7 @@ pyo3 = { workspace = true }
 pyo3-arrow = { workspace = true }
 pyo3-geoarrow = { path = "../pyo3-geoarrow" }
 geo = "0.28"
-geoarrow = { workspace = true, features = ["geozero"] }
+geoarrow = { workspace = true }
 geozero = { version = "0.14", features = ["with-svg"] }
 numpy = "0.21"
 serde_json = "1"

--- a/python/geoarrow-core/Cargo.toml
+++ b/python/geoarrow-core/Cargo.toml
@@ -30,7 +30,7 @@ pyo3 = { workspace = true }
 pyo3-arrow = { workspace = true }
 pyo3-geoarrow = { path = "../pyo3-geoarrow" }
 geo = "0.28"
-geoarrow = { workspace = true, features = ["geozero"] }
+geoarrow = { workspace = true }
 geozero = { version = "0.14", features = ["with-svg"] }
 numpy = "0.21"
 serde_json = "1"

--- a/python/geoarrow-io/Cargo.toml
+++ b/python/geoarrow-io/Cargo.toml
@@ -53,7 +53,6 @@ geo = "0.28"
 geoarrow = { path = "../../", features = [
     "csv",
     "flatgeobuf",
-    "geozero",
     "ipc_compression",
     "parquet_compression",
     "parquet",

--- a/python/geoarrow-io/python/geoarrow/rust/io/_io.pyi
+++ b/python/geoarrow-io/python/geoarrow/rust/io/_io.pyi
@@ -527,6 +527,13 @@ async def read_postgis_async(connection_url: str, sql: str) -> Optional[Table]:
         Table from query.
     """
 
+def read_shapefile(
+    shp_file: Union[str, Path, BinaryIO], dbf_file: Union[str, Path, BinaryIO]
+) -> Table:
+    """
+    Read a Shapefile into an Arrow Table.
+    """
+
 def write_csv(table: ArrowStreamExportable, file: str | Path | BinaryIO) -> None:
     """
     Write a Table to a CSV file on disk.

--- a/python/geoarrow-io/src/io/mod.rs
+++ b/python/geoarrow-io/src/io/mod.rs
@@ -10,3 +10,4 @@ pub mod object_store;
 pub mod parquet;
 #[cfg(feature = "async")]
 pub mod postgis;
+pub mod shapefile;

--- a/python/geoarrow-io/src/io/shapefile.rs
+++ b/python/geoarrow-io/src/io/shapefile.rs
@@ -1,0 +1,16 @@
+use crate::error::PyGeoArrowResult;
+use crate::io::input::sync::FileReader;
+use crate::util::table_to_pytable;
+use geoarrow::io::shapefile::read_shapefile as _read_shapefile;
+use pyo3::prelude::*;
+
+#[pyfunction]
+// #[pyo3(signature = (file, *, batch_size=65536))]
+pub fn read_shapefile(
+    py: Python,
+    mut shp_file: FileReader,
+    mut dbf_file: FileReader,
+) -> PyGeoArrowResult<PyObject> {
+    let table = _read_shapefile(&mut shp_file, &mut dbf_file)?;
+    Ok(table_to_pytable(table).to_arro3(py)?)
+}

--- a/python/geoarrow-io/src/lib.rs
+++ b/python/geoarrow-io/src/lib.rs
@@ -58,6 +58,7 @@ fn _io(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         crate::io::geojson_lines::write_geojson_lines,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(crate::io::shapefile::read_shapefile, m)?)?;
 
     Ok(())
 }

--- a/python/pyo3-geoarrow/Cargo.toml
+++ b/python/pyo3-geoarrow/Cargo.toml
@@ -17,7 +17,7 @@ arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 arrow-schema = { workspace = true }
 geo = "0.28"
-geoarrow = { workspace = true, features = ["geozero"] }
+geoarrow = { workspace = true }
 geozero = { workspace = true }
 indexmap = { workspace = true }
 pyo3 = { workspace = true, features = ["chrono", "indexmap"] }

--- a/python/tests/io/test_shapefile.py
+++ b/python/tests/io/test_shapefile.py
@@ -1,0 +1,10 @@
+import geodatasets
+from geoarrow.rust.io import read_shapefile
+
+
+def test_read_shapefile():
+    shp_path = geodatasets.get_path("ny.bb")
+    dbf_path = shp_path.rstrip(".shp") + ".dbf"
+
+    table = read_shapefile(shp_path, dbf_path)
+    assert len(table) == 5

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,6 @@ pub enum GeoArrowError {
     GdalError(#[from] gdal::errors::GdalError),
 
     /// [geozero::error::GeozeroError]
-    #[cfg(feature = "geozero")]
     #[error(transparent)]
     GeozeroError(#[from] geozero::error::GeozeroError),
 

--- a/src/io/flatgeobuf/reader/sync.rs
+++ b/src/io/flatgeobuf/reader/sync.rs
@@ -89,23 +89,6 @@ pub fn read_flatgeobuf<R: Read + Seek>(
 
     match (geometry_type, has_z) {
         (GeometryType::Point, false) => {
-            let mut builder = GeoTableBuilder::<PointBuilder<2>>::new_with_options(options);
-            while let Some(feature) = selection.next()? {
-                feature.process_properties(&mut builder)?;
-                builder.properties_end()?;
-
-                let geom: Option<super::core::Geometry<'_>> = feature
-                    .geometry()
-                    .map(|g| super::core::Point::new(g, Dimension::XY))
-                    .map(|g| g.into());
-                builder.push_geometry(geom.as_ref())?;
-
-                builder.feature_end(0)?;
-            }
-            selection.process_features(&mut builder)?;
-            builder.finish()
-        }
-        (GeometryType::Point, false) => {
             impl_read!(PointBuilder<2>, super::core::Point, Dimension::XY)
         }
         (GeometryType::LineString, false) => {

--- a/src/io/flatgeobuf/reader/sync.rs
+++ b/src/io/flatgeobuf/reader/sync.rs
@@ -89,6 +89,23 @@ pub fn read_flatgeobuf<R: Read + Seek>(
 
     match (geometry_type, has_z) {
         (GeometryType::Point, false) => {
+            let mut builder = GeoTableBuilder::<PointBuilder<2>>::new_with_options(options);
+            while let Some(feature) = selection.next()? {
+                feature.process_properties(&mut builder)?;
+                builder.properties_end()?;
+
+                let geom: Option<super::core::Geometry<'_>> = feature
+                    .geometry()
+                    .map(|g| super::core::Point::new(g, Dimension::XY))
+                    .map(|g| g.into());
+                builder.push_geometry(geom.as_ref())?;
+
+                builder.feature_end(0)?;
+            }
+            selection.process_features(&mut builder)?;
+            builder.finish()
+        }
+        (GeometryType::Point, false) => {
             impl_read!(PointBuilder<2>, super::core::Point, Dimension::XY)
         }
         (GeometryType::LineString, false) => {

--- a/src/io/geozero/table/builder/mod.rs
+++ b/src/io/geozero/table/builder/mod.rs
@@ -1,5 +1,5 @@
-mod anyvalue;
-mod properties;
+pub(crate) mod anyvalue;
+pub(crate) mod properties;
 mod table;
 
 pub use table::{GeoTableBuilder, GeoTableBuilderOptions};

--- a/src/io/geozero/table/builder/properties.rs
+++ b/src/io/geozero/table/builder/properties.rs
@@ -12,7 +12,7 @@ use indexmap::IndexMap;
 /// A builder for a single RecordBatch of properties
 // TODO: store an Arc<Schema> on this struct? Especially when known or user-provided?
 // TODO: switch to ordered Vec of builders instead of a hashmap for sources like postgis
-pub struct PropertiesBatchBuilder {
+pub(crate) struct PropertiesBatchBuilder {
     /// A mapping from column name to its builder.
     ///
     /// For now, we use an IndexMap in order to maintain
@@ -23,7 +23,7 @@ pub struct PropertiesBatchBuilder {
     ///
     /// We want to track column ordering
     /// TODO: track column ordering?
-    columns: IndexMap<String, AnyBuilder>,
+    pub(crate) columns: IndexMap<String, AnyBuilder>,
 
     /// A counter for the number of rows that have been added, excluding the current row.
     ///

--- a/src/io/geozero/table/builder/table.rs
+++ b/src/io/geozero/table/builder/table.rs
@@ -156,6 +156,11 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
         &mut self.prop_builder
     }
 
+    /// Access the underlying geometry builder
+    pub(crate) fn geom_builder(&mut self) -> &mut G {
+        &mut self.geom_builder
+    }
+
     pub fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
         self.geom_builder.push_geometry(value)
     }

--- a/src/io/geozero/table/mod.rs
+++ b/src/io/geozero/table/mod.rs
@@ -1,4 +1,4 @@
-mod builder;
+pub(crate) mod builder;
 mod data_source;
 mod json_encoder;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -25,7 +25,7 @@ pub mod ipc;
 pub mod parquet;
 #[cfg(feature = "postgis")]
 pub mod postgis;
-mod shapefile;
+pub mod shapefile;
 mod stream;
 pub mod wkb;
 pub mod wkt;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -5,20 +5,16 @@
 
 #[cfg(feature = "csv")]
 pub mod csv;
-#[cfg(feature = "geozero")]
 pub mod display;
 #[cfg(feature = "flatgeobuf")]
 pub mod flatgeobuf;
 #[cfg(feature = "gdal")]
 pub mod gdal;
 pub mod geo;
-#[cfg(feature = "geozero")]
 pub mod geojson;
-#[cfg(feature = "geozero")]
 pub mod geojson_lines;
 #[cfg(feature = "geos")]
 pub mod geos;
-#[cfg(feature = "geozero")]
 pub mod geozero;
 pub mod ipc;
 #[cfg(feature = "parquet")]

--- a/src/io/shapefile/mod.rs
+++ b/src/io/shapefile/mod.rs
@@ -1,2 +1,4 @@
+mod reader;
 mod scalar;
-// mod reader;
+
+pub use reader::read_shapefile;

--- a/src/io/shapefile/reader.rs
+++ b/src/io/shapefile/reader.rs
@@ -1,43 +1,359 @@
 use std::io::{Read, Seek};
-use std::path::Path;
 use std::sync::Arc;
 
-use dbase::FieldType;
-use shapefile::{Reader, ShapeReader};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use dbase::{FieldInfo, FieldType, FieldValue, Record};
+use geozero::FeatureProcessor;
+use shapefile::{Reader, ShapeReader, ShapeType};
 
-use crate::array::PointBuilder;
+use crate::array::{MultiLineStringBuilder, MultiPointBuilder, MultiPolygonBuilder, PointBuilder};
+use crate::error::{GeoArrowError, Result};
+use crate::io::geozero::table::builder::anyvalue::AnyBuilder;
+use crate::io::geozero::table::builder::properties::PropertiesBatchBuilder;
+use crate::io::geozero::table::{GeoTableBuilder, GeoTableBuilderOptions};
 use crate::table::Table;
-use crate::trait_::NativeArray;
 
 // TODO:
 // stretch goal: return a record batch reader.
-pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) {
+pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Table> {
     let dbf_reader = dbase::Reader::new(dbf_reader).unwrap();
     let shp_reader = ShapeReader::new(shp_reader).unwrap();
 
     let header = shp_reader.header();
-    // header.shape_type
 
-    let fields = dbf_reader.fields();
-    let field = &fields[0];
-    // match field.field_type() {
-    //     FieldType::
-    // }
+    let dbf_fields = dbf_reader.fields().to_vec();
+    let schema = infer_schema(&dbf_fields);
+    let geometry_type = header.shape_type;
+
+    let features_count = dbf_reader.header().num_records as usize;
+    let features_count = if features_count > 0 {
+        Some(features_count)
+    } else {
+        None
+    };
+
+    // TODO: move to options
+    let coord_type = Default::default();
+    let batch_size = Some(65536);
+
+    // TODO: propagate CRS
+    let options = GeoTableBuilderOptions::new(
+        coord_type,
+        true,
+        batch_size,
+        Some(schema),
+        features_count,
+        Default::default(),
+    );
 
     let mut reader = Reader::new(shp_reader, dbf_reader);
-    for x in reader.iter_shapes_and_records_as::<shapefile::Point, dbase::Record>() {
-        let (geom, record) = x.unwrap();
-        // let y = Point(&geom);
-        PointBuilder::w
-        // record is a wrapper around a hash map of values
+
+    // TODO: these might work in a macro
+
+    match geometry_type {
+        ShapeType::Point => {
+            let mut builder = GeoTableBuilder::<PointBuilder<2>>::new_with_options(options);
+
+            for geom_and_record in
+                reader.iter_shapes_and_records_as::<shapefile::Point, dbase::Record>()
+            {
+                let (geom, record) = geom_and_record.unwrap();
+
+                // Process properties
+                let prop_builder = builder.properties_builder_mut();
+                prop_builder.add_record(record, &dbf_fields)?;
+
+                // Hack to advance internal row number
+                builder.properties_end()?;
+
+                let geom = super::scalar::Point::new(&geom);
+                builder.geom_builder().push_point(Some(&geom));
+
+                // Hack to advance internal row number
+                builder.feature_end(0)?;
+            }
+            builder.finish()
+        }
+        ShapeType::PointZ => {
+            let mut builder = GeoTableBuilder::<PointBuilder<3>>::new_with_options(options);
+
+            for geom_and_record in
+                reader.iter_shapes_and_records_as::<shapefile::PointZ, dbase::Record>()
+            {
+                let (geom, record) = geom_and_record.unwrap();
+
+                // Process properties
+                let prop_builder = builder.properties_builder_mut();
+                prop_builder.add_record(record, &dbf_fields)?;
+
+                // Hack to advance internal row number
+                builder.properties_end()?;
+
+                let geom = super::scalar::PointZ::new(&geom);
+                builder.geom_builder().push_point(Some(&geom));
+
+                // Hack to advance internal row number
+                builder.feature_end(0)?;
+            }
+            builder.finish()
+        }
+        ShapeType::Multipoint => {
+            let mut builder = GeoTableBuilder::<MultiPointBuilder<2>>::new_with_options(options);
+
+            for geom_and_record in
+                reader.iter_shapes_and_records_as::<shapefile::Multipoint, dbase::Record>()
+            {
+                let (geom, record) = geom_and_record.unwrap();
+
+                // Process properties
+                let prop_builder = builder.properties_builder_mut();
+                prop_builder.add_record(record, &dbf_fields)?;
+
+                // Hack to advance internal row number
+                builder.properties_end()?;
+
+                let geom = super::scalar::MultiPoint::new(&geom);
+                builder.geom_builder().push_multi_point(Some(&geom))?;
+
+                // Hack to advance internal row number
+                builder.feature_end(0)?;
+            }
+            builder.finish()
+        }
+        ShapeType::MultipointZ => {
+            let mut builder = GeoTableBuilder::<MultiPointBuilder<3>>::new_with_options(options);
+
+            for geom_and_record in
+                reader.iter_shapes_and_records_as::<shapefile::MultipointZ, dbase::Record>()
+            {
+                let (geom, record) = geom_and_record.unwrap();
+
+                // Process properties
+                let prop_builder = builder.properties_builder_mut();
+                prop_builder.add_record(record, &dbf_fields)?;
+
+                // Hack to advance internal row number
+                builder.properties_end()?;
+
+                let geom = super::scalar::MultiPointZ::new(&geom);
+                builder.geom_builder().push_multi_point(Some(&geom))?;
+
+                // Hack to advance internal row number
+                builder.feature_end(0)?;
+            }
+            builder.finish()
+        }
+        ShapeType::Polyline => {
+            let mut builder =
+                GeoTableBuilder::<MultiLineStringBuilder<2>>::new_with_options(options);
+
+            for geom_and_record in
+                reader.iter_shapes_and_records_as::<shapefile::Polyline, dbase::Record>()
+            {
+                let (geom, record) = geom_and_record.unwrap();
+
+                // Process properties
+                let prop_builder = builder.properties_builder_mut();
+                prop_builder.add_record(record, &dbf_fields)?;
+
+                // Hack to advance internal row number
+                builder.properties_end()?;
+
+                let geom = super::scalar::Polyline::new(&geom);
+                builder.geom_builder().push_multi_line_string(Some(&geom))?;
+
+                // Hack to advance internal row number
+                builder.feature_end(0)?;
+            }
+            builder.finish()
+        }
+        ShapeType::PolylineZ => {
+            let mut builder =
+                GeoTableBuilder::<MultiLineStringBuilder<3>>::new_with_options(options);
+
+            for geom_and_record in
+                reader.iter_shapes_and_records_as::<shapefile::PolylineZ, dbase::Record>()
+            {
+                let (geom, record) = geom_and_record.unwrap();
+
+                // Process properties
+                let prop_builder = builder.properties_builder_mut();
+                prop_builder.add_record(record, &dbf_fields)?;
+
+                // Hack to advance internal row number
+                builder.properties_end()?;
+
+                let geom = super::scalar::PolylineZ::new(&geom);
+                builder.geom_builder().push_multi_line_string(Some(&geom))?;
+
+                // Hack to advance internal row number
+                builder.feature_end(0)?;
+            }
+            builder.finish()
+        }
+        ShapeType::Polygon => {
+            let mut builder = GeoTableBuilder::<MultiPolygonBuilder<2>>::new_with_options(options);
+
+            for geom_and_record in
+                reader.iter_shapes_and_records_as::<shapefile::Polygon, dbase::Record>()
+            {
+                let (geom, record) = geom_and_record.unwrap();
+
+                // Process properties
+                let prop_builder = builder.properties_builder_mut();
+                prop_builder.add_record(record, &dbf_fields)?;
+
+                // Hack to advance internal row number
+                builder.properties_end()?;
+
+                let geom = super::scalar::MultiPolygon::new(geom);
+                builder.geom_builder().push_multi_polygon(Some(&geom))?;
+
+                // Hack to advance internal row number
+                builder.feature_end(0)?;
+            }
+            builder.finish()
+        }
+        ShapeType::PolygonZ => {
+            let mut builder = GeoTableBuilder::<MultiPolygonBuilder<3>>::new_with_options(options);
+
+            for geom_and_record in
+                reader.iter_shapes_and_records_as::<shapefile::PolygonZ, dbase::Record>()
+            {
+                let (geom, record) = geom_and_record.unwrap();
+
+                // Process properties
+                let prop_builder = builder.properties_builder_mut();
+                prop_builder.add_record(record, &dbf_fields)?;
+
+                // Hack to advance internal row number
+                builder.properties_end()?;
+
+                let geom = super::scalar::MultiPolygonZ::new(geom);
+                builder.geom_builder().push_multi_polygon(Some(&geom))?;
+
+                // Hack to advance internal row number
+                builder.feature_end(0)?;
+            }
+            builder.finish()
+        }
+        t => Err(GeoArrowError::General(format!(
+            "Unsupported shapefile geometry type: {}",
+            t
+        ))),
     }
 }
 
-fn read_point<T: Read + Seek, D: Read + Seek>(reader: &mut Reader<T, D>) -> GeometryArrayRef {
-    let mut builder = PointBuilder::<2>::with_capacity(reader.shape_count().unwrap());
-    for row in reader.iter_shapes_and_records_as::<shapefile::Point, dbase::Record>() {
-        let (geom, _record) = row.unwrap();
-        builder.push_point(Some(&Point(&geom)));
+impl PropertiesBatchBuilder {
+    fn add_record(&mut self, record: Record, fields: &[FieldInfo]) -> Result<()> {
+        for field_info in fields {
+            let field_name = field_info.name();
+            let builder = self
+                .columns
+                .get_mut(field_name)
+                .ok_or(GeoArrowError::General(format!(
+                    "Builder with name {} does not exist",
+                    field_name
+                )))?;
+            let field_value = record
+                .get(field_name)
+                .ok_or(GeoArrowError::General(format!(
+                    "Field value with name {} does not exist",
+                    field_name
+                )))?;
+            builder.add_field_value(field_value)?;
+        }
+
+        Ok(())
     }
-    Arc::new(builder.finish())
+}
+
+impl AnyBuilder {
+    fn add_field_value(&mut self, value: &FieldValue) -> Result<()> {
+        match value {
+            FieldValue::Character(v) => {
+                if let Some(v) = v {
+                    self.as_string_mut().unwrap().append_value(v);
+                } else {
+                    self.append_null();
+                }
+            }
+            FieldValue::Currency(v) | FieldValue::Double(v) => {
+                self.as_float64_mut().unwrap().append_value(*v);
+            }
+            FieldValue::Date(v) => {
+                if let Some(v) = v {
+                    let unix_days = v.to_unix_days();
+                    self.as_date32_mut().unwrap().append_value(unix_days);
+                } else {
+                    self.append_null();
+                }
+            }
+            FieldValue::DateTime(v) => {
+                let unix_timestamp_s = v.to_unix_timestamp();
+                // seconds to microseconds
+                let unix_timestamp_us = unix_timestamp_s * 1000 * 1000;
+                self.as_date_time_mut()
+                    .unwrap()
+                    .0
+                    .append_value(unix_timestamp_us);
+            }
+            FieldValue::Float(v) => {
+                if let Some(v) = v {
+                    self.as_float32_mut().unwrap().append_value(*v);
+                } else {
+                    self.append_null();
+                }
+            }
+            FieldValue::Integer(v) => {
+                self.as_int32_mut().unwrap().append_value(*v);
+            }
+            FieldValue::Logical(v) => {
+                if let Some(v) = v {
+                    self.as_bool_mut().unwrap().append_value(*v);
+                } else {
+                    self.append_null();
+                }
+            }
+            FieldValue::Memo(v) => {
+                self.as_string_mut().unwrap().append_value(v);
+            }
+            FieldValue::Numeric(v) => {
+                if let Some(v) = v {
+                    self.as_float64_mut().unwrap().append_value(*v);
+                } else {
+                    self.append_null();
+                }
+            }
+        };
+        Ok(())
+    }
+}
+
+fn infer_schema(fields: &[FieldInfo]) -> SchemaRef {
+    let mut out_fields = Vec::with_capacity(fields.len());
+
+    for field in fields {
+        let name = field.name().to_string();
+        let field = match field.field_type() {
+            FieldType::Numeric | FieldType::Double | FieldType::Currency => {
+                Field::new(name, DataType::Float64, true)
+            }
+            FieldType::Character | FieldType::Memo => Field::new(name, DataType::Utf8, true),
+            FieldType::Float => Field::new(name, DataType::Float32, true),
+            FieldType::Integer => Field::new(name, DataType::Int32, true),
+            FieldType::Logical => Field::new(name, DataType::Boolean, true),
+            FieldType::Date => Field::new(name, DataType::Date32, true),
+            FieldType::DateTime => Field::new(
+                name,
+                // The dbase DateTime only stores data at second precision, but we currently build
+                // millisecond arrays, because that's our existing code path
+                DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None),
+                true,
+            ),
+        };
+        out_fields.push(Arc::new(field));
+    }
+
+    Arc::new(Schema::new(out_fields))
 }

--- a/src/io/shapefile/scalar.rs
+++ b/src/io/shapefile/scalar.rs
@@ -3,7 +3,13 @@ use crate::geo_traits::{
     PointTrait, PolygonTrait,
 };
 
-struct Point<'a>(&'a shapefile::Point);
+pub(super) struct Point<'a>(&'a shapefile::Point);
+
+impl<'a> Point<'a> {
+    pub(super) fn new(geom: &'a shapefile::Point) -> Self {
+        Self(geom)
+    }
+}
 
 impl<'a> PointTrait for Point<'a> {
     type T = f64;
@@ -54,7 +60,13 @@ impl<'a> CoordTrait for Point<'a> {
 }
 
 // Note: PointZ can optionally have M values
-struct PointZ<'a>(&'a shapefile::PointZ);
+pub(super) struct PointZ<'a>(&'a shapefile::PointZ);
+
+impl<'a> PointZ<'a> {
+    pub(super) fn new(geom: &'a shapefile::PointZ) -> Self {
+        Self(geom)
+    }
+}
 
 impl<'a> PointTrait for PointZ<'a> {
     type T = f64;
@@ -106,7 +118,7 @@ impl<'a> CoordTrait for PointZ<'a> {
     }
 }
 
-struct LineString<'a>(&'a [shapefile::Point]);
+pub(super) struct LineString<'a>(&'a [shapefile::Point]);
 
 impl<'a> LineStringTrait for LineString<'a> {
     type T = f64;
@@ -125,7 +137,7 @@ impl<'a> LineStringTrait for LineString<'a> {
     }
 }
 
-struct LineStringZ<'a>(&'a [shapefile::PointZ]);
+pub(super) struct LineStringZ<'a>(&'a [shapefile::PointZ]);
 
 impl<'a> LineStringTrait for LineStringZ<'a> {
     type T = f64;
@@ -144,7 +156,7 @@ impl<'a> LineStringTrait for LineStringZ<'a> {
     }
 }
 
-struct Polygon {
+pub(super) struct Polygon {
     outer: Vec<shapefile::Point>,
     inner: Vec<Vec<shapefile::Point>>,
 }
@@ -170,7 +182,7 @@ impl<'a> PolygonTrait for &'a Polygon {
     }
 }
 
-struct PolygonZ {
+pub(super) struct PolygonZ {
     outer: Vec<shapefile::PointZ>,
     inner: Vec<Vec<shapefile::PointZ>>,
 }
@@ -196,7 +208,13 @@ impl<'a> PolygonTrait for &'a PolygonZ {
     }
 }
 
-struct MultiPoint<'a>(&'a shapefile::Multipoint);
+pub(super) struct MultiPoint<'a>(&'a shapefile::Multipoint);
+
+impl<'a> MultiPoint<'a> {
+    pub(super) fn new(geom: &'a shapefile::Multipoint) -> Self {
+        Self(geom)
+    }
+}
 
 impl<'a> MultiPointTrait for MultiPoint<'a> {
     type T = f64;
@@ -215,8 +233,13 @@ impl<'a> MultiPointTrait for MultiPoint<'a> {
     }
 }
 
-struct MultiPointZ<'a>(&'a shapefile::MultipointZ);
+pub(super) struct MultiPointZ<'a>(&'a shapefile::MultipointZ);
 
+impl<'a> MultiPointZ<'a> {
+    pub(super) fn new(geom: &'a shapefile::MultipointZ) -> Self {
+        Self(geom)
+    }
+}
 impl<'a> MultiPointTrait for MultiPointZ<'a> {
     type T = f64;
     type ItemType<'b> = PointZ<'a> where Self: 'b;
@@ -234,7 +257,13 @@ impl<'a> MultiPointTrait for MultiPointZ<'a> {
     }
 }
 
-struct Polyline<'a>(&'a shapefile::Polyline);
+pub(super) struct Polyline<'a>(&'a shapefile::Polyline);
+
+impl<'a> Polyline<'a> {
+    pub(super) fn new(geom: &'a shapefile::Polyline) -> Self {
+        Self(geom)
+    }
+}
 
 impl<'a> MultiLineStringTrait for Polyline<'a> {
     type T = f64;
@@ -253,7 +282,13 @@ impl<'a> MultiLineStringTrait for Polyline<'a> {
     }
 }
 
-struct PolylineZ<'a>(&'a shapefile::PolylineZ);
+pub(super) struct PolylineZ<'a>(&'a shapefile::PolylineZ);
+
+impl<'a> PolylineZ<'a> {
+    pub(super) fn new(geom: &'a shapefile::PolylineZ) -> Self {
+        Self(geom)
+    }
+}
 
 impl<'a> MultiLineStringTrait for PolylineZ<'a> {
     type T = f64;
@@ -272,13 +307,12 @@ impl<'a> MultiLineStringTrait for PolylineZ<'a> {
     }
 }
 
-struct MultiPolygon(Vec<Polygon>);
+pub(super) struct MultiPolygon(Vec<Polygon>);
 
 impl MultiPolygon {
     /// This is ported from the geo-types From impl
     /// https://github.com/tmontaigu/shapefile-rs/blob/a27a93ec721d954661620d7f451db53e4bf4e5e9/src/record/polygon.rs#L564
-    #[allow(dead_code)]
-    fn new(geom: shapefile::Polygon) -> Self {
+    pub(super) fn new(geom: shapefile::Polygon) -> Self {
         let mut last_poly = None;
         let mut polygons = Vec::new();
         for ring in geom.into_inner() {
@@ -332,13 +366,12 @@ impl MultiPolygonTrait for MultiPolygon {
     }
 }
 
-struct MultiPolygonZ(Vec<PolygonZ>);
+pub(super) struct MultiPolygonZ(Vec<PolygonZ>);
 
 impl MultiPolygonZ {
     /// This is ported from the geo-types From impl
     /// https://github.com/tmontaigu/shapefile-rs/blob/a27a93ec721d954661620d7f451db53e4bf4e5e9/src/record/polygon.rs#L564
-    #[allow(dead_code)]
-    fn new(geom: shapefile::PolygonZ) -> Self {
+    pub(super) fn new(geom: shapefile::PolygonZ) -> Self {
         let mut last_poly = None;
         let mut polygons = Vec::new();
         for ring in geom.into_inner() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,12 @@
 //!
 //! ```toml
 //! [dependencies]
-//! geoarrow = { version = "*", features = ["geozero"] }
+//! geoarrow = { version = "*" }
 //! ```
 //!
 //! Then:
 //!
 //! ```
-//! # #[cfg(feature = "geozero")]
 //! # {
 //! use std::{io::Cursor, fs::File};
 //!

--- a/src/table.rs
+++ b/src/table.rs
@@ -140,7 +140,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     /// use geoarrow::{array::CoordType, datatypes::{NativeType, Dimension}};
@@ -275,7 +274,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -293,7 +291,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -311,7 +308,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -329,7 +325,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -347,7 +342,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -369,7 +363,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -398,7 +391,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -441,7 +433,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -465,7 +456,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::fs::File;
     ///
@@ -483,7 +473,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::{sync::Arc, fs::File};
     /// use arrow_schema::{DataType, Field};
@@ -548,7 +537,6 @@ impl Table {
     /// # Examples
     ///
     /// ```
-    /// # #[cfg(feature = "geozero")]
     /// # {
     /// use std::{sync::Arc, fs::File};
     /// use arrow_schema::{DataType, Field};


### PR DESCRIPTION
### Change list

- Add `read_shapefile` function to Rust
- Add bare-bones `read_shapefile` function to Python, which currently makes you supply paths for both the SHP and DBF paths.
- Add `Date32` variant to `AnyBuilder`.
- Remove geozero feature flag (always include the base geozero dependency)

Todo:

- [ ] Read CRS from PRJ file
- [ ] Read encoding from CPG file
- [ ] Shapefile reader options like coord type, batch size
- [ ] Performance dive into why we're 2x slower than gdal 🥲 

Looks pretty good!!

<img width="697" alt="image" src="https://github.com/user-attachments/assets/813c8649-90d3-43fa-bae5-45c976e1d9a2">
