### PR TITLE
Fix MSRV

### DIFF
--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["webassembly", "arrow", "geospatial"]
 categories = ["wasm", "science::geo"]
-rust-version = "1.80"
+rust-version = "1.82"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "arrow", "geospatial"]
 categories = ["wasm", "science::geo"]
-rust-version = "1.80"
+rust-version = "1.82"
 
 [workspace.dependencies]
 arrow = "53"

--- a/python/pyo3-geoarrow/Cargo.toml
+++ b/python/pyo3-geoarrow/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "arrow"]
 categories = []
-rust-version = "1.75"
+rust-version = "1.82"
 
 [dependencies]
 arrow = { workspace = true, features = ["ffi", "chrono-tz"] }

--- a/rust/geoarrow/Cargo.toml
+++ b/rust/geoarrow/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/geoarrow/geoarrow-rs"
 description = "Rust implementation of GeoArrow"
 categories = ["science::geo"]
-rust-version = "1.80"
+rust-version = "1.82"
 
 [features]
 csv = ["geozero/with-csv"]


### PR DESCRIPTION
`geoarrow` now uses https://github.com/kylebarron/wkb (expected to transfer to the georust org "soon"). That requires an MSRV of 1.82.