### PR TITLE
Remove const generic from arrays

### DIFF
--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -93,43 +93,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "approx"
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aef0d9cf9a039bf6cd1acc451b137aca819977b0928dece52bd92811b640ba"
+checksum = "4caf25cdc4a985f91df42ed9e9308e1adbcd341a31a72605c697033fcef163e3"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03675e42d1560790f3524800e41403b40d0da1c793fe9528929fde06d8c7649a"
+checksum = "91f2dfd1a7ec0aca967dfaa616096aec49779adc8eccec005e2f5e4111b1192a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2bf348cf9f02a5975c5962c7fa6dee107a2009a7b41ac5fb1a027e12dc033f"
+checksum = "d39387ca628be747394890a6e47f138ceac1aa912eab64f02519fed24b637af8"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -189,15 +189,15 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown",
+ "hashbrown 0.14.5",
  "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3092e37715f168976012ce52273c3989b5793b0db5f06cbaa246be25e5f0924d"
+checksum = "9e51e05228852ffe3eb391ce7178a0f97d2cf80cc6ef91d3c4a6b3cb688049ec"
 dependencies = [
  "bytes",
  "half",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce1018bb710d502f9db06af026ed3561552e493e989a79d0d0f5d9cf267a785"
+checksum = "d09aea56ec9fa267f3f3f6cdab67d8a9974cbba90b3aa38c8fe9d0bb071bd8c1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -219,16 +219,16 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "half",
- "lexical-core",
+ "lexical-core 1.0.2",
  "num",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-csv"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd178575f45624d045e4ebee714e246a05d9652e41363ee3f57ec18cca97f740"
+checksum = "c07b5232be87d115fde73e32f2ca7f1b353bff1b44ac422d3c6fc6ae38f11f0d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -239,15 +239,15 @@ dependencies = [
  "csv",
  "csv-core",
  "lazy_static",
- "lexical-core",
+ "lexical-core 1.0.2",
  "regex",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ac0c4ee79150afe067dc4857154b3ee9c1cd52b5f40d59a77306d0ed18d65"
+checksum = "b98ae0af50890b494cebd7d6b04b35e896205c1d1df7b29a6272c5d0d0249ef5"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb307482348a1267f91b0912e962cd53440e5de0f7fb24c5f7b10da70b38c94a"
+checksum = "0ed91bdeaff5a1c00d28d8f73466bcb64d32bbd7093b5a30156b4b9f4dba3eee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24805ba326758effdd6f2cbdd482fcfab749544f21b134701add25b33f474e6"
+checksum = "0471f51260a5309307e5d409c9dc70aede1cd9cf1d4ff0f0a1e8e1a2dd0e0d3c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -283,7 +283,7 @@ dependencies = [
  "chrono",
  "half",
  "indexmap",
- "lexical-core",
+ "lexical-core 1.0.2",
  "num",
  "serde",
  "serde_json",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644046c479d80ae8ed02a7f1e1399072ea344ca6a7b0e293ab2d5d9ed924aa3b"
+checksum = "2883d7035e0b600fb4c30ce1e50e66e53d8656aa729f2bfa4b51d359cf3ded52"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29791f8eb13b340ce35525b723f5f0df17ecb955599e11f65c2a94ab34e2efb"
+checksum = "552907e8e587a6fde4f8843fd7a27a576a260f65dab6c065741ea79f633fc5be"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -320,18 +320,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85320a3a2facf2b2822b57aa9d6d9d55edb8aee0b6b5d3b8df158e503d10858"
+checksum = "539ada65246b949bd99ffa0881a9a15a4a529448af1a07a9838dd78617dafab1"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc7e6b582e23855fd1625ce46e51647aa440c20ea2e71b1d748e0839dd73cba"
+checksum = "6259e566b752da6dceab91766ed8b2e67bf6270eb9ad8a6e07a33c1bede2b125"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0775b6567c66e56ded19b87a954b6b1beffbdd784ef95a3a2b03f59570c1d230"
+checksum = "f3179ccbd18ebf04277a095ba7321b93fd1f774f18816bd5f6b3ce2f594edb6c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -386,24 +386,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -416,10 +416,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.3.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backon"
@@ -474,9 +480,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -501,9 +507,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder"
@@ -513,15 +519,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -550,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+checksum = "cd6dd8046d00723a59a2f8c5f295c515b9bb9a331ee4f8f3d4dd49e428acd3b6"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -561,20 +567,19 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+checksum = "e94fea34d77a245229e7746bd2beb786cd2a896f306ff491fb8cecb3074b10a7"
 dependencies = [
  "parse-zoneinfo",
- "phf",
  "phf_codegen",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -582,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d19864d6b68464c59f7162c9914a0b569ddc2926b4a2d71afe62a9738eff53"
+checksum = "34c77f67047557f62582784fd7482884697731b2932c7d37ced54bce2312e1e2"
 dependencies = [
  "clap",
  "log",
@@ -592,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -604,27 +609,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -689,9 +694,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "csv"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
 dependencies = [
  "csv-core",
  "itoa",
@@ -748,6 +753,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,9 +787,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -787,7 +803,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -827,9 +843,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "flatbuffers"
@@ -843,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -909,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -924,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -934,15 +950,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -951,38 +967,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1037,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+checksum = "b6f47c611187777bbca61ea7aba780213f5f3441fd36294ab333e96cfa791b65"
 dependencies = [
  "approx",
  "num-traits",
@@ -1070,7 +1086,7 @@ dependencies = [
  "geozero",
  "half",
  "indexmap",
- "lexical-core",
+ "lexical-core 0.8.5",
  "parquet",
  "phf",
  "rstar",
@@ -1080,7 +1096,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "wkb",
- "wkt 0.11.1",
+ "wkt 0.11.1 (git+https://github.com/georust/wkt?branch=kyle/geo-traits-writer)",
 ]
 
 [[package]]
@@ -1103,7 +1119,7 @@ dependencies = [
  "object_store",
  "parquet",
  "range-reader",
- "reqwest",
+ "reqwest 0.12.9",
  "serde",
  "serde-wasm-bindgen",
  "thiserror",
@@ -1169,7 +1185,7 @@ dependencies = [
  "scroll",
  "serde_json",
  "thiserror",
- "wkt 0.11.0",
+ "wkt 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1187,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
@@ -1202,7 +1218,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1239,6 +1274,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "heapless"
@@ -1286,21 +1327,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -1316,17 +1391,17 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1339,16 +1414,75 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
- "hyper",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.5.0",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.0",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.5.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1375,23 +1509,152 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -1402,9 +1665,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -1458,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1477,11 +1740,24 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
 dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
+ "lexical-parse-float 0.8.5",
+ "lexical-parse-integer 0.8.6",
+ "lexical-util 0.8.5",
+ "lexical-write-float 0.8.5",
+ "lexical-write-integer 0.8.5",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431c65b318a590c1de6b8fd6e72798c92291d27762d94c9e6c37ed7a73d8458"
+dependencies = [
+ "lexical-parse-float 1.0.2",
+ "lexical-parse-integer 1.0.2",
+ "lexical-util 1.0.3",
+ "lexical-write-float 1.0.2",
+ "lexical-write-integer 1.0.2",
 ]
 
 [[package]]
@@ -1490,8 +1766,19 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
 dependencies = [
- "lexical-parse-integer",
- "lexical-util",
+ "lexical-parse-integer 0.8.6",
+ "lexical-util 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb17a4bdb9b418051aa59d41d65b1c9be5affab314a872e5ad7f06231fb3b4e0"
+dependencies = [
+ "lexical-parse-integer 1.0.2",
+ "lexical-util 1.0.3",
  "static_assertions",
 ]
 
@@ -1501,7 +1788,17 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
 dependencies = [
- "lexical-util",
+ "lexical-util 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df98f4a4ab53bf8b175b363a34c7af608fe31f93cc1fb1bf07130622ca4ef61"
+dependencies = [
+ "lexical-util 1.0.3",
  "static_assertions",
 ]
 
@@ -1515,13 +1812,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-util"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85314db53332e5c192b6bca611fb10c114a80d1b831ddac0af1e9be1b9232ca0"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lexical-write-float"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
 dependencies = [
- "lexical-util",
- "lexical-write-integer",
+ "lexical-util 0.8.5",
+ "lexical-write-integer 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7c3ad4e37db81c1cbe7cf34610340adc09c322871972f74877a712abc6c809"
+dependencies = [
+ "lexical-util 1.0.3",
+ "lexical-write-integer 1.0.2",
  "static_assertions",
 ]
 
@@ -1531,21 +1848,31 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
 dependencies = [
- "lexical-util",
+ "lexical-util 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb89e9f6958b83258afa3deed90b5de9ef68eef090ad5086c791cd2345610162"
+dependencies = [
+ "lexical-util 1.0.3",
  "static_assertions",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
@@ -1562,6 +1889,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -1602,9 +1935,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71e683cd655513b99affab7d317deb690528255a0d5f717f1024093c12b169"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
 dependencies = [
  "cc",
  "walkdir",
@@ -1746,14 +2079,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
@@ -1770,7 +2103,7 @@ dependencies = [
  "futures",
  "js-sys",
  "object_store",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde-wasm-bindgen",
  "snafu 0.7.5",
@@ -1784,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
+checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1796,7 +2129,7 @@ dependencies = [
  "itertools 0.13.0",
  "parking_lot",
  "percent-encoding",
- "snafu 0.8.4",
+ "snafu 0.8.5",
  "tokio",
  "tracing",
  "url",
@@ -1805,15 +2138,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -1832,7 +2165,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1843,9 +2176,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -1887,9 +2220,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0fbf928021131daaa57d334ca8e3904fe9ae22f73c56244fc7db9b04eedc3d8"
+checksum = "dea02606ba6f5e856561d8d507dba8bac060aefca2a6c0f1aa1d361fed91ff3e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1906,7 +2239,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lz4_flex",
  "num",
  "num-bigint",
@@ -1982,7 +2315,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1996,29 +2329,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2028,9 +2361,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "powerfmt"
@@ -2049,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2091,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2111,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2123,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2134,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -2149,11 +2482,52 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.31",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.0",
+ "hyper-rustls",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2166,18 +2540,31 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 1.0.1",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
- "winreg",
+ "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2188,9 +2575,9 @@ checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
 name = "rstar"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133315eb94c7b1e8d0cb097e5a710d850263372fd028fff18969de708afc7008"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
 dependencies = [
  "heapless",
  "num-traits",
@@ -2214,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2226,12 +2613,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2251,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -2291,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2313,9 +2730,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -2333,20 +2750,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -2415,11 +2832,11 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b835cb902660db3415a672d862905e791e54d306c6e8189168c7f3d9ae1c79d"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
 dependencies = [
- "snafu-derive 0.8.4",
+ "snafu-derive 0.8.5",
 ]
 
 [[package]]
@@ -2436,14 +2853,14 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d1e02fca405f6280643174a50c942219f0bbf4dbf7d480f1dd864d6f211ae5"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2468,11 +2885,17 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f5ef1f863aca7d1d7dda7ccfc36a0a4279bd6d3c375176e5e0712e25cb4889"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
  "num-traits",
  "robust",
  "smallvec",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2493,6 +2916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2521,6 +2950,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,7 +2977,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -2542,10 +3002,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.12.0"
+name = "system-configuration-sys"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2565,22 +3035,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2623,6 +3093,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,9 +3119,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2661,7 +3141,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2671,6 +3151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -2695,9 +3186,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2729,7 +3220,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2758,36 +3249,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.24"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2797,9 +3291,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
  "wasm-bindgen",
@@ -2844,9 +3338,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2857,24 +3351,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2884,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2894,28 +3388,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.43"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9"
+checksum = "d381749acb0943d357dcbd8f0b100640679883fcdeeef04def49daf8d33a5426"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -2928,20 +3422,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.43"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
+checksum = "c97b2ef2c8d627381e51c071c2ab328eac606d3f69dd82bcbca20a9e389d95f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2952,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2997,6 +3491,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -3150,9 +3674,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -3180,9 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "wkt"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296937617013271141d1145d9c05861f5ed3b1bc4297e81c692aa3cff9270a9c"
+checksum = "54f7f1ff4ea4c18936d6cd26a6fd24f0003af37e951a8e0e8b9e9a2d0bd0a46d"
 dependencies = [
  "geo-types",
  "log",
@@ -3193,13 +3717,49 @@ dependencies = [
 [[package]]
 name = "wkt"
 version = "0.11.1"
-source = "git+https://github.com/georust/wkt?branch=kyle/geo-traits-writer#63b13243568470d6da5a44fcc9fe7b903aa53eea"
+source = "git+https://github.com/georust/wkt?branch=kyle/geo-traits-writer#f3434f5283d070f1accd64cd1bd09303f0f0547c"
 dependencies = [
  "geo-traits",
  "geo-types",
  "log",
  "num-traits",
  "thiserror",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
 ]
 
 [[package]]
@@ -3219,7 +3779,56 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/js/src/data/mod.rs
+++ b/js/src/data/mod.rs
@@ -3,6 +3,7 @@ pub mod coord;
 use arrow_array::BinaryArray;
 use arrow_buffer::Buffer;
 pub use coord::{CoordBuffer, InterleavedCoordBuffer, SeparatedCoordBuffer};
+use geoarrow::datatypes::Dimension;
 
 use crate::error::WasmResult;
 use crate::utils::vec_to_offsets;
@@ -45,42 +46,42 @@ macro_rules! impl_data {
 impl_data! {
     /// An immutable array of Point geometries in WebAssembly memory using GeoArrow's in-memory
     /// representation.
-    pub struct PointData(pub(crate) geoarrow::array::PointArray<2>);
+    pub struct PointData(pub(crate) geoarrow::array::PointArray);
 }
 impl_data! {
     /// An immutable array of LineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct LineStringData(pub(crate) geoarrow::array::LineStringArray<2>);
+    pub struct LineStringData(pub(crate) geoarrow::array::LineStringArray);
 }
 impl_data! {
     /// An immutable array of Polygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct PolygonData(pub(crate) geoarrow::array::PolygonArray<2>);
+    pub struct PolygonData(pub(crate) geoarrow::array::PolygonArray);
 }
 impl_data! {
     /// An immutable array of MultiPoint geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPointData(pub(crate) geoarrow::array::MultiPointArray<2>);
+    pub struct MultiPointData(pub(crate) geoarrow::array::MultiPointArray);
 }
 impl_data! {
     /// An immutable array of MultiLineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiLineStringData(pub(crate) geoarrow::array::MultiLineStringArray<2>);
+    pub struct MultiLineStringData(pub(crate) geoarrow::array::MultiLineStringArray);
 }
 impl_data! {
     /// An immutable array of MultiPolygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPolygonData(pub(crate) geoarrow::array::MultiPolygonArray<2>);
+    pub struct MultiPolygonData(pub(crate) geoarrow::array::MultiPolygonArray);
 }
 impl_data! {
     /// An immutable array of Geometry geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MixedGeometryData(pub(crate) geoarrow::array::MixedGeometryArray<2>);
+    pub struct MixedGeometryData(pub(crate) geoarrow::array::MixedGeometryArray);
 }
 impl_data! {
     /// An immutable array of GeometryCollection geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct GeometryCollectionData(pub(crate) geoarrow::array::GeometryCollectionArray<2>);
+    pub struct GeometryCollectionData(pub(crate) geoarrow::array::GeometryCollectionArray);
 }
 impl_data! {
     /// An immutable array of WKB-encoded geometries in WebAssembly memory using GeoArrow's
@@ -90,7 +91,7 @@ impl_data! {
 impl_data! {
     /// An immutable array of Rect geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct RectData(pub(crate) geoarrow::array::RectArray<2>);
+    pub struct RectData(pub(crate) geoarrow::array::RectArray);
 }
 
 #[wasm_bindgen]
@@ -205,7 +206,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoPointArray)]
     pub fn into_point_array(self) -> WasmResult<PointData> {
-        let arr: geoarrow::array::PointArray<2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::PointArray = (self.0, Dimension::XY).try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -217,7 +218,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoLineStringArray)]
     pub fn into_line_string_array(self) -> WasmResult<LineStringData> {
-        let arr: geoarrow::array::LineStringArray<2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::LineStringArray = (self.0, Dimension::XY).try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -229,7 +230,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoPolygonArray)]
     pub fn into_polygon_array(self) -> WasmResult<PolygonData> {
-        let arr: geoarrow::array::PolygonArray<2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::PolygonArray = (self.0, Dimension::XY).try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -241,7 +242,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiPointArray)]
     pub fn into_multi_point_array(self) -> WasmResult<MultiPointData> {
-        let arr: geoarrow::array::MultiPointArray<2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiPointArray = (self.0, Dimension::XY).try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -253,7 +254,8 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiLineStringArray)]
     pub fn into_multi_line_string_array(self) -> WasmResult<MultiLineStringData> {
-        let arr: geoarrow::array::MultiLineStringArray<2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiLineStringArray =
+            (self.0, Dimension::XY).try_into().unwrap();
         Ok(arr.into())
     }
 
@@ -265,7 +267,7 @@ impl WKBData {
     /// and the original wkb array's memory does not need to be freed manually.
     #[wasm_bindgen(js_name = intoMultiPolygonArray)]
     pub fn into_multi_polygon_array(self) -> WasmResult<MultiPolygonData> {
-        let arr: geoarrow::array::MultiPolygonArray<2> = self.0.try_into().unwrap();
+        let arr: geoarrow::array::MultiPolygonArray = (self.0, Dimension::XY).try_into().unwrap();
         Ok(arr.into())
     }
 }

--- a/js/src/scalar/linestring.rs
+++ b/js/src/scalar/linestring.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedLineString;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct LineString(pub(crate) OwnedLineString<2>);
+pub struct LineString(pub(crate) OwnedLineString);
 
-impl<'a> From<&'a LineString> for geoarrow::scalar::LineString<'a, 2> {
+impl<'a> From<&'a LineString> for geoarrow::scalar::LineString<'a> {
     fn from(value: &'a LineString) -> Self {
         (&value.0).into()
     }
 }
 
-impl From<LineString> for geoarrow::scalar::OwnedLineString<2> {
+impl From<LineString> for geoarrow::scalar::OwnedLineString {
     fn from(value: LineString) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::LineString<'a, 2>> for LineString {
-    fn from(value: geoarrow::scalar::LineString<'a, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::LineString<'a>> for LineString {
+    fn from(value: geoarrow::scalar::LineString<'a>) -> Self {
         LineString(value.into())
     }
 }

--- a/js/src/scalar/multilinestring.rs
+++ b/js/src/scalar/multilinestring.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedMultiLineString;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiLineString(pub(crate) OwnedMultiLineString<2>);
+pub struct MultiLineString(pub(crate) OwnedMultiLineString);
 
-impl<'a> From<&'a MultiLineString> for geoarrow::scalar::MultiLineString<'a, 2> {
+impl<'a> From<&'a MultiLineString> for geoarrow::scalar::MultiLineString<'a> {
     fn from(value: &'a MultiLineString) -> Self {
         (&value.0).into()
     }
 }
 
-impl From<MultiLineString> for geoarrow::scalar::OwnedMultiLineString<2> {
+impl From<MultiLineString> for geoarrow::scalar::OwnedMultiLineString {
     fn from(value: MultiLineString) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiLineString<'a, 2>> for MultiLineString {
-    fn from(value: geoarrow::scalar::MultiLineString<'a, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiLineString<'a>> for MultiLineString {
+    fn from(value: geoarrow::scalar::MultiLineString<'a>) -> Self {
         MultiLineString(value.into())
     }
 }

--- a/js/src/scalar/multipoint.rs
+++ b/js/src/scalar/multipoint.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedMultiPoint;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiPoint(pub(crate) OwnedMultiPoint<2>);
+pub struct MultiPoint(pub(crate) OwnedMultiPoint);
 
-impl<'a> From<&'a MultiPoint> for geoarrow::scalar::MultiPoint<'a, 2> {
+impl<'a> From<&'a MultiPoint> for geoarrow::scalar::MultiPoint<'a> {
     fn from(value: &'a MultiPoint) -> Self {
         (&value.0).into()
     }
 }
 
-impl From<MultiPoint> for geoarrow::scalar::OwnedMultiPoint<2> {
+impl From<MultiPoint> for geoarrow::scalar::OwnedMultiPoint {
     fn from(value: MultiPoint) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiPoint<'a, 2>> for MultiPoint {
-    fn from(value: geoarrow::scalar::MultiPoint<'a, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiPoint<'a>> for MultiPoint {
+    fn from(value: geoarrow::scalar::MultiPoint<'a>) -> Self {
         MultiPoint(value.into())
     }
 }

--- a/js/src/scalar/multipolygon.rs
+++ b/js/src/scalar/multipolygon.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedMultiPolygon;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct MultiPolygon(pub(crate) OwnedMultiPolygon<2>);
+pub struct MultiPolygon(pub(crate) OwnedMultiPolygon);
 
-impl<'a> From<&'a MultiPolygon> for geoarrow::scalar::MultiPolygon<'a, 2> {
+impl<'a> From<&'a MultiPolygon> for geoarrow::scalar::MultiPolygon<'a> {
     fn from(value: &'a MultiPolygon) -> Self {
         (&value.0).into()
     }
 }
 
-impl From<MultiPolygon> for geoarrow::scalar::OwnedMultiPolygon<2> {
+impl From<MultiPolygon> for geoarrow::scalar::OwnedMultiPolygon {
     fn from(value: MultiPolygon) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::MultiPolygon<'a, 2>> for MultiPolygon {
-    fn from(value: geoarrow::scalar::MultiPolygon<'a, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::MultiPolygon<'a>> for MultiPolygon {
+    fn from(value: geoarrow::scalar::MultiPolygon<'a>) -> Self {
         MultiPolygon(value.into())
     }
 }

--- a/js/src/scalar/point.rs
+++ b/js/src/scalar/point.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedPoint;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct Point(pub(crate) OwnedPoint<2>);
+pub struct Point(pub(crate) OwnedPoint);
 
-impl<'a> From<&'a Point> for geoarrow::scalar::Point<'a, 2> {
+impl<'a> From<&'a Point> for geoarrow::scalar::Point<'a> {
     fn from(value: &'a Point) -> Self {
         (&value.0).into()
     }
 }
 
-impl From<Point> for geoarrow::scalar::OwnedPoint<2> {
+impl From<Point> for geoarrow::scalar::OwnedPoint {
     fn from(value: Point) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::Point<'a, 2>> for Point {
-    fn from(value: geoarrow::scalar::Point<'a, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::Point<'a>> for Point {
+    fn from(value: geoarrow::scalar::Point<'a>) -> Self {
         Point(value.into())
     }
 }

--- a/js/src/scalar/polygon.rs
+++ b/js/src/scalar/polygon.rs
@@ -2,22 +2,22 @@ use geoarrow::scalar::OwnedPolygon;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct Polygon(pub(crate) OwnedPolygon<2>);
+pub struct Polygon(pub(crate) OwnedPolygon);
 
-impl<'a> From<&'a Polygon> for geoarrow::scalar::Polygon<'a, 2> {
+impl<'a> From<&'a Polygon> for geoarrow::scalar::Polygon<'a> {
     fn from(value: &'a Polygon) -> Self {
         (&value.0).into()
     }
 }
 
-impl From<Polygon> for geoarrow::scalar::OwnedPolygon<2> {
+impl From<Polygon> for geoarrow::scalar::OwnedPolygon {
     fn from(value: Polygon) -> Self {
         value.0
     }
 }
 
-impl<'a> From<geoarrow::scalar::Polygon<'a, 2>> for Polygon {
-    fn from(value: geoarrow::scalar::Polygon<'a, 2>) -> Self {
+impl<'a> From<geoarrow::scalar::Polygon<'a>> for Polygon {
+    fn from(value: geoarrow::scalar::Polygon<'a>) -> Self {
         Polygon(value.into())
     }
 }

--- a/js/src/vector/mod.rs
+++ b/js/src/vector/mod.rs
@@ -26,42 +26,42 @@ macro_rules! impl_vector {
 impl_vector! {
     /// An immutable chunked array of Point geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct PointVector(pub(crate) geoarrow::chunked_array::ChunkedPointArray<2>);
+    pub struct PointVector(pub(crate) geoarrow::chunked_array::ChunkedPointArray);
 }
 impl_vector! {
     /// An immutable chunked array of LineString geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct LineStringVector(pub(crate) geoarrow::chunked_array::ChunkedLineStringArray<2>);
+    pub struct LineStringVector(pub(crate) geoarrow::chunked_array::ChunkedLineStringArray);
 }
 impl_vector! {
     /// An immutable chunked array of Polygon geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct PolygonVector(pub(crate) geoarrow::chunked_array::ChunkedPolygonArray<2>);
+    pub struct PolygonVector(pub(crate) geoarrow::chunked_array::ChunkedPolygonArray);
 }
 impl_vector! {
     /// An immutable chunked array of MultiPoint geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct MultiPointVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPointArray<2>);
+    pub struct MultiPointVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPointArray);
 }
 impl_vector! {
     /// An immutable chunked array of MultiLineString geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MultiLineStringVector(pub(crate) geoarrow::chunked_array::ChunkedMultiLineStringArray<2>);
+    pub struct MultiLineStringVector(pub(crate) geoarrow::chunked_array::ChunkedMultiLineStringArray);
 }
 impl_vector! {
     /// An immutable chunked array of MultiPolygon geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MultiPolygonVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPolygonArray<2>);
+    pub struct MultiPolygonVector(pub(crate) geoarrow::chunked_array::ChunkedMultiPolygonArray);
 }
 impl_vector! {
     /// An immutable chunked array of Geometry geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct MixedGeometryVector(pub(crate) geoarrow::chunked_array::ChunkedMixedGeometryArray<2>);
+    pub struct MixedGeometryVector(pub(crate) geoarrow::chunked_array::ChunkedMixedGeometryArray);
 }
 impl_vector! {
     /// An immutable chunked array of GeometryCollection geometries in WebAssembly memory using
     /// GeoArrow's in-memory representation.
-    pub struct GeometryCollectionVector(pub(crate) geoarrow::chunked_array::ChunkedGeometryCollectionArray<2>);
+    pub struct GeometryCollectionVector(pub(crate) geoarrow::chunked_array::ChunkedGeometryCollectionArray);
 }
 impl_vector! {
     /// An immutable chunked array of WKB-encoded geometries in WebAssembly memory using GeoArrow's
@@ -71,5 +71,5 @@ impl_vector! {
 impl_vector! {
     /// An immutable chunked array of Rect geometries in WebAssembly memory using GeoArrow's
     /// in-memory representation.
-    pub struct RectVector(pub(crate) geoarrow::chunked_array::ChunkedRectArray<2>);
+    pub struct RectVector(pub(crate) geoarrow::chunked_array::ChunkedRectArray);
 }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "approx"
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aef0d9cf9a039bf6cd1acc451b137aca819977b0928dece52bd92811b640ba"
+checksum = "4caf25cdc4a985f91df42ed9e9308e1adbcd341a31a72605c697033fcef163e3"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03675e42d1560790f3524800e41403b40d0da1c793fe9528929fde06d8c7649a"
+checksum = "91f2dfd1a7ec0aca967dfaa616096aec49779adc8eccec005e2f5e4111b1192a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2bf348cf9f02a5975c5962c7fa6dee107a2009a7b41ac5fb1a027e12dc033f"
+checksum = "d39387ca628be747394890a6e47f138ceac1aa912eab64f02519fed24b637af8"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3092e37715f168976012ce52273c3989b5793b0db5f06cbaa246be25e5f0924d"
+checksum = "9e51e05228852ffe3eb391ce7178a0f97d2cf80cc6ef91d3c4a6b3cb688049ec"
 dependencies = [
  "bytes",
  "half",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce1018bb710d502f9db06af026ed3561552e493e989a79d0d0f5d9cf267a785"
+checksum = "d09aea56ec9fa267f3f3f6cdab67d8a9974cbba90b3aa38c8fe9d0bb071bd8c1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -170,16 +170,16 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "half",
- "lexical-core",
+ "lexical-core 1.0.2",
  "num",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-csv"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd178575f45624d045e4ebee714e246a05d9652e41363ee3f57ec18cca97f740"
+checksum = "c07b5232be87d115fde73e32f2ca7f1b353bff1b44ac422d3c6fc6ae38f11f0d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -190,15 +190,15 @@ dependencies = [
  "csv",
  "csv-core",
  "lazy_static",
- "lexical-core",
+ "lexical-core 1.0.2",
  "regex",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ac0c4ee79150afe067dc4857154b3ee9c1cd52b5f40d59a77306d0ed18d65"
+checksum = "b98ae0af50890b494cebd7d6b04b35e896205c1d1df7b29a6272c5d0d0249ef5"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb307482348a1267f91b0912e962cd53440e5de0f7fb24c5f7b10da70b38c94a"
+checksum = "0ed91bdeaff5a1c00d28d8f73466bcb64d32bbd7093b5a30156b4b9f4dba3eee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24805ba326758effdd6f2cbdd482fcfab749544f21b134701add25b33f474e6"
+checksum = "0471f51260a5309307e5d409c9dc70aede1cd9cf1d4ff0f0a1e8e1a2dd0e0d3c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -236,7 +236,7 @@ dependencies = [
  "chrono",
  "half",
  "indexmap",
- "lexical-core",
+ "lexical-core 1.0.2",
  "num",
  "serde",
  "serde_json",
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644046c479d80ae8ed02a7f1e1399072ea344ca6a7b0e293ab2d5d9ed924aa3b"
+checksum = "2883d7035e0b600fb4c30ce1e50e66e53d8656aa729f2bfa4b51d359cf3ded52"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29791f8eb13b340ce35525b723f5f0df17ecb955599e11f65c2a94ab34e2efb"
+checksum = "552907e8e587a6fde4f8843fd7a27a576a260f65dab6c065741ea79f633fc5be"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -273,18 +273,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85320a3a2facf2b2822b57aa9d6d9d55edb8aee0b6b5d3b8df158e503d10858"
+checksum = "539ada65246b949bd99ffa0881a9a15a4a529448af1a07a9838dd78617dafab1"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc7e6b582e23855fd1625ce46e51647aa440c20ea2e71b1d748e0839dd73cba"
+checksum = "6259e566b752da6dceab91766ed8b2e67bf6270eb9ad8a6e07a33c1bede2b125"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0775b6567c66e56ded19b87a954b6b1beffbdd784ef95a3a2b03f59570c1d230"
+checksum = "f3179ccbd18ebf04277a095ba7321b93fd1f774f18816bd5f6b3ce2f594edb6c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -330,7 +330,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -451,9 +451,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder"
@@ -463,15 +463,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -483,6 +483,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -501,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+checksum = "cd6dd8046d00723a59a2f8c5f295c515b9bb9a331ee4f8f3d4dd49e428acd3b6"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -512,12 +518,11 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+checksum = "e94fea34d77a245229e7746bd2beb786cd2a896f306ff491fb8cecb3074b10a7"
 dependencies = [
  "parse-zoneinfo",
- "phf",
  "phf_codegen",
 ]
 
@@ -565,9 +570,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -648,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
 dependencies = [
  "csv-core",
  "itoa",
@@ -710,6 +715,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -752,7 +768,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -796,9 +812,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "flatbuffers"
@@ -812,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -845,9 +861,9 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -886,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -901,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -911,15 +927,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -939,38 +955,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1020,7 +1036,7 @@ dependencies = [
  "bytemuck",
  "float_next_after",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
 ]
 
@@ -1035,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+checksum = "b6f47c611187777bbca61ea7aba780213f5f3441fd36294ab333e96cfa791b65"
 dependencies = [
  "approx",
  "num-traits",
@@ -1071,7 +1087,7 @@ dependencies = [
  "half",
  "http-range-client",
  "indexmap",
- "lexical-core",
+ "lexical-core 0.8.5",
  "object_store",
  "parquet",
  "phf",
@@ -1082,10 +1098,10 @@ dependencies = [
  "serde_json",
  "shapefile",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "wkb",
- "wkt 0.11.1",
+ "wkt 0.11.1 (git+https://github.com/georust/wkt?branch=kyle/geo-traits-writer)",
 ]
 
 [[package]]
@@ -1103,7 +1119,7 @@ dependencies = [
  "pyo3-arrow",
  "pyo3-geoarrow",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -1122,7 +1138,7 @@ dependencies = [
  "pyo3-arrow",
  "pyo3-geoarrow",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -1148,7 +1164,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "url",
 ]
@@ -1171,7 +1187,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1186,8 +1202,8 @@ dependencies = [
  "log",
  "scroll",
  "serde_json",
- "thiserror",
- "wkt 0.11.0",
+ "thiserror 1.0.69",
+ "wkt 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1197,15 +1213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
@@ -1258,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "hashlink"
@@ -1380,7 +1398,7 @@ dependencies = [
  "bytes",
  "read-logger",
  "reqwest",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1397,9 +1415,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1425,7 +1443,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.13",
+ "rustls 0.23.16",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -1451,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1492,13 +1510,142 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1508,7 +1655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -1525,9 +1672,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "itertools"
@@ -1564,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1586,11 +1733,24 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
 dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
+ "lexical-parse-float 0.8.5",
+ "lexical-parse-integer 0.8.6",
+ "lexical-util 0.8.5",
+ "lexical-write-float 0.8.5",
+ "lexical-write-integer 0.8.5",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431c65b318a590c1de6b8fd6e72798c92291d27762d94c9e6c37ed7a73d8458"
+dependencies = [
+ "lexical-parse-float 1.0.2",
+ "lexical-parse-integer 1.0.2",
+ "lexical-util 1.0.3",
+ "lexical-write-float 1.0.2",
+ "lexical-write-integer 1.0.2",
 ]
 
 [[package]]
@@ -1599,8 +1759,19 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
 dependencies = [
- "lexical-parse-integer",
- "lexical-util",
+ "lexical-parse-integer 0.8.6",
+ "lexical-util 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb17a4bdb9b418051aa59d41d65b1c9be5affab314a872e5ad7f06231fb3b4e0"
+dependencies = [
+ "lexical-parse-integer 1.0.2",
+ "lexical-util 1.0.3",
  "static_assertions",
 ]
 
@@ -1610,7 +1781,17 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
 dependencies = [
- "lexical-util",
+ "lexical-util 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df98f4a4ab53bf8b175b363a34c7af608fe31f93cc1fb1bf07130622ca4ef61"
+dependencies = [
+ "lexical-util 1.0.3",
  "static_assertions",
 ]
 
@@ -1624,13 +1805,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-util"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85314db53332e5c192b6bca611fb10c114a80d1b831ddac0af1e9be1b9232ca0"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lexical-write-float"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
 dependencies = [
- "lexical-util",
- "lexical-write-integer",
+ "lexical-util 0.8.5",
+ "lexical-write-integer 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7c3ad4e37db81c1cbe7cf34610340adc09c322871972f74877a712abc6c809"
+dependencies = [
+ "lexical-util 1.0.3",
+ "lexical-write-integer 1.0.2",
  "static_assertions",
 ]
 
@@ -1640,21 +1841,31 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
 dependencies = [
- "lexical-util",
+ "lexical-util 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb89e9f6958b83258afa3deed90b5de9ef68eef090ad5086c791cd2345610162"
+dependencies = [
+ "lexical-util 1.0.3",
  "static_assertions",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1672,6 +1883,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -1785,14 +2002,16 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
@@ -1921,7 +2140,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1942,18 +2161,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "object_store"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
+checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1982,18 +2201,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -2012,7 +2228,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2023,18 +2239,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.2+3.3.2"
+version = "300.4.0+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+checksum = "a709e02f2b4aca747929cca5ed248880847c650233cf8b8cdc48f40aaf4898a6"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -2077,9 +2293,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "53.0.0"
+version = "53.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0fbf928021131daaa57d334ca8e3904fe9ae22f73c56244fc7db9b04eedc3d8"
+checksum = "dea02606ba6f5e856561d8d507dba8bac060aefca2a6c0f1aa1d361fed91ff3e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2181,7 +2397,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2195,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2240,7 +2456,7 @@ checksum = "20b682daed9c6adcacc2c546410d7692babe5bf946e71a5e3b8b5c9b20d604b2"
 dependencies = [
  "geo",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2248,6 +2464,15 @@ name = "portable-atomic"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a7d5beecc52a491b54d6dd05c7a45ba1801666a5baad9fdbfc6fef8d2d206c"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -2275,18 +2500,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2319,7 +2544,7 @@ dependencies = [
  "indexmap",
  "numpy",
  "pyo3",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2337,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2347,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2370,33 +2595,33 @@ dependencies = [
  "pyo3",
  "pyo3-arrow",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2409,7 +2634,7 @@ dependencies = [
  "object_store",
  "pyo3",
  "pyo3-async-runtimes",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -2435,45 +2660,49 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
 dependencies = [
  "bytes",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.16",
  "socket2",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
+ "getrandom",
  "rand",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.16",
+ "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.3",
  "tinyvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -2566,9 +2795,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2578,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2595,9 +2824,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2622,7 +2851,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.13",
+ "rustls 0.23.16",
  "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -2687,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "rstar"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133315eb94c7b1e8d0cb097e5a710d850263372fd028fff18969de708afc7008"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
 dependencies = [
  "heapless",
  "num-traits",
@@ -2725,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2749,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "once_cell",
  "ring",
@@ -2794,9 +3023,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2836,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -2880,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2902,29 +3134,29 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -3031,7 +3263,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3139,7 +3371,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "sqlformat",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3224,7 +3456,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "whoami",
 ]
@@ -3263,7 +3495,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "whoami",
 ]
@@ -3334,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3350,6 +3582,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3381,9 +3624,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3394,22 +3637,42 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3452,6 +3715,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,9 +3741,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3490,7 +3763,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3509,7 +3782,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls 0.23.16",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3581,7 +3854,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3617,9 +3890,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -3668,9 +3941,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3682,6 +3955,18 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vcpkg"
@@ -3728,9 +4013,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3739,24 +4024,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3766,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3776,28 +4061,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3808,9 +4093,19 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4045,31 +4340,67 @@ dependencies = [
  "byteorder",
  "geo-traits",
  "num_enum",
- "thiserror",
-]
-
-[[package]]
-name = "wkt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296937617013271141d1145d9c05861f5ed3b1bc4297e81c692aa3cff9270a9c"
-dependencies = [
- "geo-types",
- "log",
- "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "wkt"
 version = "0.11.1"
-source = "git+https://github.com/georust/wkt?branch=kyle/geo-traits-writer#63b13243568470d6da5a44fcc9fe7b903aa53eea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f7f1ff4ea4c18936d6cd26a6fd24f0003af37e951a8e0e8b9e9a2d0bd0a46d"
+dependencies = [
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wkt"
+version = "0.11.1"
+source = "git+https://github.com/georust/wkt?branch=kyle/geo-traits-writer#f3434f5283d070f1accd64cd1bd09303f0f0547c"
 dependencies = [
  "geo-traits",
  "geo-types",
  "log",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
 ]
 
 [[package]]
@@ -4090,7 +4421,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
 ]
 
 [[package]]
@@ -4098,6 +4450,28 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "zstd"
@@ -4119,9 +4493,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/python/geoarrow-compute/src/algorithm/geo/convex_hull.rs
+++ b/python/geoarrow-compute/src/algorithm/geo/convex_hull.rs
@@ -12,11 +12,11 @@ use pyo3_geoarrow::PyGeoArrowResult;
 pub fn convex_hull(py: Python, input: AnyNativeInput) -> PyGeoArrowResult<PyObject> {
     match input {
         AnyNativeInput::Array(arr) => {
-            let out: PolygonArray<2> = arr.as_ref().convex_hull()?;
+            let out: PolygonArray = arr.as_ref().convex_hull()?;
             return_geometry_array(py, Arc::new(out))
         }
         AnyNativeInput::Chunked(arr) => {
-            let out: ChunkedGeometryArray<PolygonArray<2>> = arr.as_ref().convex_hull()?;
+            let out: ChunkedGeometryArray<PolygonArray> = arr.as_ref().convex_hull()?;
             return_chunked_geometry_array(py, Arc::new(out))
         }
     }

--- a/python/geoarrow-core/src/constructors.rs
+++ b/python/geoarrow-core/src/constructors.rs
@@ -22,7 +22,7 @@ fn create_array_metadata(crs: Option<CRS>) -> Arc<ArrayMetadata> {
 pub fn points(coords: PyCoordBuffer, crs: Option<CRS>) -> PyGeoArrowResult<PyNativeArray> {
     let metadata = create_array_metadata(crs);
     // TODO: remove const generic
-    let array = PointArray::<2>::new(coords.into_inner(), None, metadata);
+    let array = PointArray::new(coords.into_inner(), None, metadata);
     Ok(PyNativeArray::new(NativeArrayDyn::new(Arc::new(array))))
 }
 
@@ -35,7 +35,7 @@ pub fn linestrings(
 ) -> PyGeoArrowResult<PyNativeArray> {
     let metadata = create_array_metadata(crs);
     // TODO: remove const generic
-    let array = LineStringArray::<2>::new(
+    let array = LineStringArray::new(
         coords.into_inner(),
         geom_offsets.into_inner(),
         None,
@@ -54,7 +54,7 @@ pub fn polygons(
 ) -> PyGeoArrowResult<PyNativeArray> {
     let metadata = create_array_metadata(crs);
     // TODO: remove const generic
-    let array = PolygonArray::<2>::new(
+    let array = PolygonArray::new(
         coords.into_inner(),
         geom_offsets.into_inner(),
         ring_offsets.into_inner(),
@@ -72,7 +72,7 @@ pub fn multipoints(
     crs: Option<CRS>,
 ) -> PyGeoArrowResult<PyNativeArray> {
     let metadata = create_array_metadata(crs);
-    let array = MultiPointArray::<2>::new(
+    let array = MultiPointArray::new(
         coords.into_inner(),
         geom_offsets.into_inner(),
         None,
@@ -90,7 +90,7 @@ pub fn multilinestrings(
     crs: Option<CRS>,
 ) -> PyGeoArrowResult<PyNativeArray> {
     let metadata = create_array_metadata(crs);
-    let array = MultiLineStringArray::<2>::new(
+    let array = MultiLineStringArray::new(
         coords.into_inner(),
         geom_offsets.into_inner(),
         ring_offsets.into_inner(),
@@ -110,7 +110,7 @@ pub fn multipolygons(
     crs: Option<CRS>,
 ) -> PyGeoArrowResult<PyNativeArray> {
     let metadata = create_array_metadata(crs);
-    let array = MultiPolygonArray::<2>::new(
+    let array = MultiPolygonArray::new(
         coords.into_inner(),
         geom_offsets.into_inner(),
         polygon_offsets.into_inner(),

--- a/python/geoarrow-core/src/interop/ewkb.rs
+++ b/python/geoarrow-core/src/interop/ewkb.rs
@@ -1,5 +1,5 @@
 use geoarrow::array::{CoordType, WKBArray};
-use geoarrow::datatypes::SerializedType;
+use geoarrow::datatypes::{Dimension, SerializedType};
 use geoarrow::io::geozero::FromEWKB;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -15,11 +15,23 @@ pub fn from_ewkb(py: Python, input: PyArray) -> PyGeoArrowResult<PyObject> {
     let geo_array = match typ {
         SerializedType::WKB => {
             let wkb_arr = WKBArray::<i32>::try_from((array.as_ref(), field.as_ref()))?;
-            FromEWKB::from_ewkb(&wkb_arr, CoordType::Interleaved, Default::default(), false)?
+            FromEWKB::from_ewkb(
+                &wkb_arr,
+                CoordType::Interleaved,
+                Dimension::XY,
+                Default::default(),
+                false,
+            )?
         }
         SerializedType::LargeWKB => {
             let wkb_arr = WKBArray::<i64>::try_from((array.as_ref(), field.as_ref()))?;
-            FromEWKB::from_ewkb(&wkb_arr, CoordType::Interleaved, Default::default(), false)?
+            FromEWKB::from_ewkb(
+                &wkb_arr,
+                CoordType::Interleaved,
+                Dimension::XY,
+                Default::default(),
+                false,
+            )?
         }
         _ => return Err(PyValueError::new_err("Expected a WKB array").into()),
     };

--- a/python/geoarrow-core/src/interop/shapely/to_shapely.rs
+++ b/python/geoarrow-core/src/interop/shapely/to_shapely.rs
@@ -135,7 +135,7 @@ fn pyarray_to_shapely(py: Python, input: PyArray) -> PyGeoArrowResult<Bound<PyAn
     }
 }
 
-fn point_arr<const D: usize>(
+fn point_arr(
     py: Python,
     arr: geoarrow::array::PointArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -150,7 +150,7 @@ fn point_arr<const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn linestring_arr<const D: usize>(
+fn linestring_arr(
     py: Python,
     arr: geoarrow::array::LineStringArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -168,7 +168,7 @@ fn linestring_arr<const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn polygon_arr<const D: usize>(
+fn polygon_arr(
     py: Python,
     arr: geoarrow::array::PolygonArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -189,7 +189,7 @@ fn polygon_arr<const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn multipoint_arr<const D: usize>(
+fn multipoint_arr(
     py: Python,
     arr: geoarrow::array::MultiPointArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -207,7 +207,7 @@ fn multipoint_arr<const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn multilinestring_arr<const D: usize>(
+fn multilinestring_arr(
     py: Python,
     arr: geoarrow::array::MultiLineStringArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
@@ -228,7 +228,7 @@ fn multilinestring_arr<const D: usize>(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn multipolygon_arr<const D: usize>(
+fn multipolygon_arr(
     py: Python,
     arr: geoarrow::array::MultiPolygonArray<D>,
 ) -> PyGeoArrowResult<Bound<PyAny>> {

--- a/python/geoarrow-core/src/interop/shapely/to_shapely.rs
+++ b/python/geoarrow-core/src/interop/shapely/to_shapely.rs
@@ -6,7 +6,7 @@ use arrow_buffer::NullBuffer;
 use geoarrow::array::{
     AsNativeArray, AsSerializedArray, CoordBuffer, NativeArrayDyn, SerializedArrayDyn,
 };
-use geoarrow::datatypes::{AnyType, Dimension, NativeType, SerializedType};
+use geoarrow::datatypes::{AnyType, NativeType, SerializedType};
 use geoarrow::io::wkb::to_wkb;
 use geoarrow::NativeArray;
 use numpy::PyArrayMethods;
@@ -88,41 +88,21 @@ fn pyarray_to_shapely(py: Python, input: PyArray) -> PyGeoArrowResult<Bound<PyAn
         AnyType::Native(typ) => {
             let array = NativeArrayDyn::from_arrow_array(&array, &field)?.into_inner();
 
-            use Dimension::*;
             use NativeType::*;
             match typ {
-                Point(_, XY) => point_arr(py, array.as_ref().as_point::<2>().clone()),
-                LineString(_, XY) => {
-                    linestring_arr(py, array.as_ref().as_line_string::<2>().clone())
+                Point(_, _) => point_arr(py, array.as_ref().as_point().clone()),
+                LineString(_, _) => linestring_arr(py, array.as_ref().as_line_string().clone()),
+                Polygon(_, _) => polygon_arr(py, array.as_ref().as_polygon().clone()),
+                MultiPoint(_, _) => multipoint_arr(py, array.as_ref().as_multi_point().clone()),
+                MultiLineString(_, _) => {
+                    multilinestring_arr(py, array.as_ref().as_multi_line_string().clone())
                 }
-                Polygon(_, XY) => polygon_arr(py, array.as_ref().as_polygon::<2>().clone()),
-                MultiPoint(_, XY) => {
-                    multipoint_arr(py, array.as_ref().as_multi_point::<2>().clone())
+                MultiPolygon(_, _) => {
+                    multipolygon_arr(py, array.as_ref().as_multi_polygon().clone())
                 }
-                MultiLineString(_, XY) => {
-                    multilinestring_arr(py, array.as_ref().as_multi_line_string::<2>().clone())
-                }
-                MultiPolygon(_, XY) => {
-                    multipolygon_arr(py, array.as_ref().as_multi_polygon::<2>().clone())
-                }
-                Rect(XY) => rect_arr(py, array.as_ref().as_rect::<2>().clone()),
-                Point(_, XYZ) => point_arr(py, array.as_ref().as_point::<3>().clone()),
-                LineString(_, XYZ) => {
-                    linestring_arr(py, array.as_ref().as_line_string::<3>().clone())
-                }
-                Polygon(_, XYZ) => polygon_arr(py, array.as_ref().as_polygon::<3>().clone()),
-                MultiPoint(_, XYZ) => {
-                    multipoint_arr(py, array.as_ref().as_multi_point::<3>().clone())
-                }
-                MultiLineString(_, XYZ) => {
-                    multilinestring_arr(py, array.as_ref().as_multi_line_string::<3>().clone())
-                }
-                MultiPolygon(_, XYZ) => {
-                    multipolygon_arr(py, array.as_ref().as_multi_polygon::<3>().clone())
-                }
+                Rect(_) => rect_arr(py, array.as_ref().as_rect().clone()),
                 Mixed(_, _) => via_wkb(py, array),
                 GeometryCollection(_, _) => via_wkb(py, array),
-                t => Err(PyValueError::new_err(format!("unsupported type {:?}", t)).into()),
             }
         }
         AnyType::Serialized(typ) => {
@@ -135,10 +115,7 @@ fn pyarray_to_shapely(py: Python, input: PyArray) -> PyGeoArrowResult<Bound<PyAn
     }
 }
 
-fn point_arr(
-    py: Python,
-    arr: geoarrow::array::PointArray<D>,
-) -> PyGeoArrowResult<Bound<PyAny>> {
+fn point_arr(py: Python, arr: geoarrow::array::PointArray) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
 
@@ -152,7 +129,7 @@ fn point_arr(
 
 fn linestring_arr(
     py: Python,
-    arr: geoarrow::array::LineStringArray<D>,
+    arr: geoarrow::array::LineStringArray,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
@@ -168,10 +145,7 @@ fn linestring_arr(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn polygon_arr(
-    py: Python,
-    arr: geoarrow::array::PolygonArray<D>,
-) -> PyGeoArrowResult<Bound<PyAny>> {
+fn polygon_arr(py: Python, arr: geoarrow::array::PolygonArray) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
 
@@ -191,7 +165,7 @@ fn polygon_arr(
 
 fn multipoint_arr(
     py: Python,
-    arr: geoarrow::array::MultiPointArray<D>,
+    arr: geoarrow::array::MultiPointArray,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
@@ -209,7 +183,7 @@ fn multipoint_arr(
 
 fn multilinestring_arr(
     py: Python,
-    arr: geoarrow::array::MultiLineStringArray<D>,
+    arr: geoarrow::array::MultiLineStringArray,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
@@ -230,7 +204,7 @@ fn multilinestring_arr(
 
 fn multipolygon_arr(
     py: Python,
-    arr: geoarrow::array::MultiPolygonArray<D>,
+    arr: geoarrow::array::MultiPolygonArray,
 ) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
     let shapely_geom_type_enum = shapely_mod.getattr(intern!(py, "GeometryType"))?;
@@ -250,7 +224,7 @@ fn multipolygon_arr(
     Ok(shapely_mod.call_method1(intern!(py, "from_ragged_array"), args)?)
 }
 
-fn rect_arr(py: Python, arr: geoarrow::array::RectArray<2>) -> PyGeoArrowResult<Bound<PyAny>> {
+fn rect_arr(py: Python, arr: geoarrow::array::RectArray) -> PyGeoArrowResult<Bound<PyAny>> {
     let shapely_mod = import_shapely(py)?;
 
     let lower = arr.lower();

--- a/python/geoarrow-core/src/interop/wkb.rs
+++ b/python/geoarrow-core/src/interop/wkb.rs
@@ -1,6 +1,6 @@
 use geoarrow::array::WKBArray;
 use geoarrow::chunked_array::{ChunkedArrayBase, ChunkedWKBArray};
-use geoarrow::datatypes::SerializedType;
+use geoarrow::datatypes::{Dimension, SerializedType};
 use geoarrow::io::wkb::{to_wkb as _to_wkb, FromWKB, ToWKB};
 use geoarrow::ArrayBase;
 use pyo3::exceptions::PyValueError;
@@ -31,11 +31,11 @@ pub fn from_wkb(
             let geo_array = match typ {
                 SerializedType::WKB => {
                     let wkb_arr = WKBArray::<i32>::try_from((arr.as_ref(), field.as_ref()))?;
-                    FromWKB::from_wkb(&wkb_arr, coord_type)?
+                    FromWKB::from_wkb(&wkb_arr, coord_type, Dimension::XY)?
                 }
                 SerializedType::LargeWKB => {
                     let wkb_arr = WKBArray::<i64>::try_from((arr.as_ref(), field.as_ref()))?;
-                    FromWKB::from_wkb(&wkb_arr, coord_type)?
+                    FromWKB::from_wkb(&wkb_arr, coord_type, Dimension::XY)?
                 }
                 _ => return Err(PyValueError::new_err("Expected a WKB array").into()),
             };
@@ -50,14 +50,14 @@ pub fn from_wkb(
                         .into_iter()
                         .map(|chunk| WKBArray::<i32>::try_from((chunk.as_ref(), field.as_ref())))
                         .collect::<Result<Vec<_>, _>>()?;
-                    FromWKB::from_wkb(&ChunkedWKBArray::new(chunks), coord_type)?
+                    FromWKB::from_wkb(&ChunkedWKBArray::new(chunks), coord_type, Dimension::XY)?
                 }
                 SerializedType::LargeWKB => {
                     let chunks = chunks
                         .into_iter()
                         .map(|chunk| WKBArray::<i64>::try_from((chunk.as_ref(), field.as_ref())))
                         .collect::<Result<Vec<_>, _>>()?;
-                    FromWKB::from_wkb(&ChunkedWKBArray::new(chunks), coord_type)?
+                    FromWKB::from_wkb(&ChunkedWKBArray::new(chunks), coord_type, Dimension::XY)?
                 }
                 _ => return Err(PyValueError::new_err("Expected a WKB array").into()),
             };

--- a/python/geoarrow-core/src/interop/wkt.rs
+++ b/python/geoarrow-core/src/interop/wkt.rs
@@ -4,6 +4,7 @@ use arrow::datatypes::DataType;
 use arrow_array::cast::AsArray;
 use geoarrow::array::metadata::ArrayMetadata;
 use geoarrow::chunked_array::{ChunkedArray, ChunkedMixedGeometryArray};
+use geoarrow::datatypes::Dimension;
 use geoarrow::io::geozero::FromWKT;
 use geoarrow::io::wkt::reader::ParseWKT;
 use geoarrow::io::wkt::ToWKT;
@@ -47,7 +48,7 @@ pub fn from_wkt(
             let chunked_arr = s.into_chunked_array()?;
             let (chunks, field) = chunked_arr.into_inner();
             let metadata = Arc::new(ArrayMetadata::try_from(field.as_ref())?);
-            let geo_array: ChunkedMixedGeometryArray<2> = match field.data_type() {
+            let geo_array: ChunkedMixedGeometryArray = match field.data_type() {
                 DataType::Utf8 => {
                     let string_chunks = chunks
                         .iter()
@@ -56,6 +57,7 @@ pub fn from_wkt(
                     FromWKT::from_wkt(
                         &ChunkedArray::new(string_chunks),
                         coord_type,
+                        Dimension::XY,
                         metadata,
                         false,
                     )?
@@ -68,6 +70,7 @@ pub fn from_wkt(
                     FromWKT::from_wkt(
                         &ChunkedArray::new(string_chunks),
                         coord_type,
+                        Dimension::XY,
                         metadata,
                         false,
                     )?

--- a/python/pyo3-geoarrow/src/ffi/from_python/scalar.rs
+++ b/python/pyo3-geoarrow/src/ffi/from_python/scalar.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::array::*;
 use crate::scalar::*;
 use geoarrow::array::MixedGeometryArray;
+use geoarrow::datatypes::Dimension;
 use geoarrow::io::geozero::ToMixedArray;
 use geoarrow::scalar::GeometryScalar;
 use geozero::geojson::GeoJsonString;
@@ -25,8 +26,8 @@ impl<'a> FromPyObject<'a> for PyGeometry {
             let reader = GeoJsonString(json_string);
 
             // TODO: we need a dynamic dimensionality reader
-            let arr: MixedGeometryArray<2> = reader
-                .to_mixed_geometry_array()
+            let arr: MixedGeometryArray = reader
+                .to_mixed_geometry_array(Dimension::XY)
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
             Ok(Self(
                 GeometryScalar::try_new(Arc::new(arr))

--- a/rust/geoarrow/benches/area.rs
+++ b/rust/geoarrow/benches/area.rs
@@ -4,14 +4,14 @@ use geoarrow::array::{AsChunkedNativeArray, MultiPolygonArray};
 use geoarrow::io::flatgeobuf::read_flatgeobuf;
 use std::fs::File;
 
-fn load_file() -> MultiPolygonArray<2> {
+fn load_file() -> MultiPolygonArray {
     let mut file = File::open("fixtures/flatgeobuf/countries.fgb").unwrap();
     let table = read_flatgeobuf(&mut file, Default::default()).unwrap();
     table
         .geometry_column(None)
         .unwrap()
         .as_ref()
-        .as_multi_polygon::<2>()
+        .as_multi_polygon()
         .chunks()
         .first()
         .unwrap()

--- a/rust/geoarrow/benches/from_geo.rs
+++ b/rust/geoarrow/benches/from_geo.rs
@@ -2,6 +2,7 @@ use geo::polygon;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use geoarrow::array::{PolygonArray, PolygonBuilder};
+use geoarrow::datatypes::Dimension;
 
 fn create_data() -> Vec<geo::Polygon> {
     // An L shape
@@ -24,9 +25,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("convert Vec<geo::Polygon> to PolygonArray", |b| {
         b.iter(|| {
-            let mut_arr =
-                PolygonBuilder::<2>::from_polygons(&data, Default::default(), Default::default());
-            let _arr: PolygonArray<2> = mut_arr.into();
+            let mut_arr = PolygonBuilder::from_polygons(
+                &data,
+                Dimension::XY,
+                Default::default(),
+                Default::default(),
+            );
+            let _arr: PolygonArray = mut_arr.into();
         })
     });
 }

--- a/rust/geoarrow/benches/geos_buffer.rs
+++ b/rust/geoarrow/benches/geos_buffer.rs
@@ -3,7 +3,7 @@ use geoarrow::algorithm::geos::Buffer;
 use geoarrow::array::{CoordBuffer, InterleavedCoordBuffer, PointArray, PolygonArray};
 use geoarrow::datatypes::Dimension;
 
-fn generate_data() -> PointArray<2> {
+fn generate_data() -> PointArray {
     let coords = vec![0.0; 100_000];
     let coord_buffer =
         CoordBuffer::Interleaved(InterleavedCoordBuffer::new(coords.into(), Dimension::XY));
@@ -15,7 +15,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("buffer", |b| {
         b.iter(|| {
-            let _buffered: PolygonArray<2> = point_array.buffer(1.0, 8).unwrap();
+            let _buffered: PolygonArray = point_array.buffer(1.0, 8).unwrap();
         })
     });
 }

--- a/rust/geoarrow/benches/nybb.rs
+++ b/rust/geoarrow/benches/nybb.rs
@@ -4,9 +4,10 @@ use arrow_ipc::reader::FileReader;
 use criterion::{criterion_group, criterion_main, Criterion};
 use geoarrow::algorithm::geo::EuclideanDistance;
 use geoarrow::array::{MultiPolygonArray, PointArray};
+use geoarrow::datatypes::Dimension;
 use geoarrow::trait_::ArrayAccessor;
 
-fn load_nybb() -> MultiPolygonArray<2> {
+fn load_nybb() -> MultiPolygonArray {
     let file = File::open("fixtures/nybb.arrow").unwrap();
     let reader = FileReader::try_new(file, None).unwrap();
 
@@ -20,7 +21,7 @@ fn load_nybb() -> MultiPolygonArray<2> {
             .position(|field| field.name() == "geometry")
             .unwrap();
         let arr = record_batch.column(geom_idx);
-        let multi_poly_arr: MultiPolygonArray<2> = arr.as_ref().try_into().unwrap();
+        let multi_poly_arr: MultiPolygonArray = (arr.as_ref(), Dimension::XY).try_into().unwrap();
         arrays.push(multi_poly_arr);
     }
 
@@ -39,7 +40,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("euclidean distance to scalar point", |b| {
         b.iter(|| {
             let point = geo::Point::new(0.0f64, 0.0f64);
-            let point_array = PointArray::from(vec![point].as_slice());
+            let point_array = PointArray::from((vec![point].as_slice(), Dimension::XY));
 
             let _distances = array.euclidean_distance(&point_array.value(0));
         })

--- a/rust/geoarrow/benches/translate.rs
+++ b/rust/geoarrow/benches/translate.rs
@@ -3,8 +3,9 @@ use geo::polygon;
 use criterion::{criterion_group, criterion_main, Criterion};
 use geoarrow::algorithm::geo::Translate;
 use geoarrow::array::PolygonArray;
+use geoarrow::datatypes::Dimension;
 
-fn create_data() -> PolygonArray<2> {
+fn create_data() -> PolygonArray {
     // An L shape
     // https://github.com/georust/geo/blob/7cb7d0ffa6bf1544c5ca9922bd06100c36f815d7/README.md?plain=1#L40
     let poly = polygon![
@@ -17,7 +18,7 @@ fn create_data() -> PolygonArray<2> {
         (x: 0.0, y: 0.0),
     ];
     let v = vec![poly; 1000];
-    v.as_slice().into()
+    (v.as_slice(), Dimension::XY).into()
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/rust/geoarrow/src/algorithm/geo/affine_ops.rs
+++ b/rust/geoarrow/src/algorithm/geo/affine_ops.rs
@@ -58,7 +58,7 @@ impl AffineOps<&AffineTransform> for PointArray {
     type Output = Self;
 
     fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
-        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.buffer_lengths());
 
         self.iter_geo().for_each(|maybe_g| {
             output_array.push_point(
@@ -79,7 +79,8 @@ macro_rules! iter_geo_impl {
             type Output = Self;
 
             fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
-                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
+                let mut output_array =
+                    <$builder_type>::with_capacity(Dimension::XY, self.buffer_lengths());
 
                 self.iter_geo().for_each(|maybe_g| {
                     output_array
@@ -105,16 +106,8 @@ iter_geo_impl!(
     MultiLineStringBuilder,
     push_multi_line_string
 );
-iter_geo_impl!(
-    MultiPolygonArray,
-    MultiPolygonBuilder,
-    push_multi_polygon
-);
-iter_geo_impl!(
-    MixedGeometryArray,
-    MixedGeometryBuilder,
-    push_geometry
-);
+iter_geo_impl!(MultiPolygonArray, MultiPolygonBuilder, push_multi_polygon);
+iter_geo_impl!(MixedGeometryArray, MixedGeometryBuilder, push_geometry);
 iter_geo_impl!(
     GeometryCollectionArray,
     GeometryCollectionBuilder,
@@ -218,7 +211,7 @@ impl AffineOps<&[AffineTransform]> for PointArray {
     type Output = Self;
 
     fn affine_transform(&self, transform: &[AffineTransform]) -> Self::Output {
-        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.buffer_lengths());
 
         self.iter_geo()
             .zip(transform.iter())
@@ -241,7 +234,8 @@ macro_rules! iter_geo_impl2 {
             type Output = Self;
 
             fn affine_transform(&self, transform: &[AffineTransform]) -> Self::Output {
-                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
+                let mut output_array =
+                    <$builder_type>::with_capacity(Dimension::XY, self.buffer_lengths());
 
                 self.iter_geo()
                     .zip(transform.iter())
@@ -269,16 +263,8 @@ iter_geo_impl2!(
     MultiLineStringBuilder,
     push_multi_line_string
 );
-iter_geo_impl2!(
-    MultiPolygonArray,
-    MultiPolygonBuilder,
-    push_multi_polygon
-);
-iter_geo_impl2!(
-    MixedGeometryArray,
-    MixedGeometryBuilder,
-    push_geometry
-);
+iter_geo_impl2!(MultiPolygonArray, MultiPolygonBuilder, push_multi_polygon);
+iter_geo_impl2!(MixedGeometryArray, MixedGeometryBuilder, push_geometry);
 iter_geo_impl2!(
     GeometryCollectionArray,
     GeometryCollectionBuilder,
@@ -300,14 +286,11 @@ impl AffineOps<&[AffineTransform]> for &dyn NativeArray {
             MultiLineString(_, XY) => {
                 Arc::new(self.as_multi_line_string().affine_transform(transform))
             }
-            MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon().affine_transform(transform))
-            }
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().affine_transform(transform)),
             Mixed(_, XY) => Arc::new(self.as_mixed().affine_transform(transform)),
-            GeometryCollection(_, XY) => Arc::new(
-                self.as_geometry_collection()
-                    .affine_transform(transform),
-            ),
+            GeometryCollection(_, XY) => {
+                Arc::new(self.as_geometry_collection().affine_transform(transform))
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/rust/geoarrow/src/algorithm/geo/affine_ops.rs
+++ b/rust/geoarrow/src/algorithm/geo/affine_ops.rs
@@ -54,7 +54,7 @@ pub trait AffineOps<Rhs> {
 // └─────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl AffineOps<&AffineTransform> for PointArray<2> {
+impl AffineOps<&AffineTransform> for PointArray {
     type Output = Self;
 
     fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
@@ -97,27 +97,27 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
-iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
-iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
+iter_geo_impl!(LineStringArray, LineStringBuilder, push_line_string);
+iter_geo_impl!(PolygonArray, PolygonBuilder, push_polygon);
+iter_geo_impl!(MultiPointArray, MultiPointBuilder, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
+    MultiLineStringArray,
+    MultiLineStringBuilder,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
+    MultiPolygonArray,
+    MultiPolygonBuilder,
     push_multi_polygon
 );
 iter_geo_impl!(
-    MixedGeometryArray<2>,
-    MixedGeometryBuilder<2>,
+    MixedGeometryArray,
+    MixedGeometryBuilder,
     push_geometry
 );
 iter_geo_impl!(
-    GeometryCollectionArray<2>,
-    GeometryCollectionBuilder<2>,
+    GeometryCollectionArray,
+    GeometryCollectionBuilder,
     push_geometry_collection
 );
 
@@ -149,7 +149,7 @@ impl AffineOps<&AffineTransform> for &dyn NativeArray {
     }
 }
 
-impl AffineOps<&AffineTransform> for ChunkedPointArray<2> {
+impl AffineOps<&AffineTransform> for ChunkedPointArray {
     type Output = Self;
 
     fn affine_transform(&self, transform: &AffineTransform) -> Self::Output {
@@ -173,13 +173,13 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<2>);
-impl_chunked!(ChunkedPolygonArray<2>);
-impl_chunked!(ChunkedMultiPointArray<2>);
-impl_chunked!(ChunkedMultiLineStringArray<2>);
-impl_chunked!(ChunkedMultiPolygonArray<2>);
-impl_chunked!(ChunkedMixedGeometryArray<2>);
-impl_chunked!(ChunkedGeometryCollectionArray<2>);
+impl_chunked!(ChunkedLineStringArray);
+impl_chunked!(ChunkedPolygonArray);
+impl_chunked!(ChunkedMultiPointArray);
+impl_chunked!(ChunkedMultiLineStringArray);
+impl_chunked!(ChunkedMultiPolygonArray);
+impl_chunked!(ChunkedMixedGeometryArray);
+impl_chunked!(ChunkedGeometryCollectionArray);
 
 impl AffineOps<&AffineTransform> for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -214,7 +214,7 @@ impl AffineOps<&AffineTransform> for &dyn ChunkedNativeArray {
 // └────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl AffineOps<&[AffineTransform]> for PointArray<2> {
+impl AffineOps<&[AffineTransform]> for PointArray {
     type Output = Self;
 
     fn affine_transform(&self, transform: &[AffineTransform]) -> Self::Output {
@@ -261,27 +261,27 @@ macro_rules! iter_geo_impl2 {
     };
 }
 
-iter_geo_impl2!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
-iter_geo_impl2!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
-iter_geo_impl2!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
+iter_geo_impl2!(LineStringArray, LineStringBuilder, push_line_string);
+iter_geo_impl2!(PolygonArray, PolygonBuilder, push_polygon);
+iter_geo_impl2!(MultiPointArray, MultiPointBuilder, push_multi_point);
 iter_geo_impl2!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
+    MultiLineStringArray,
+    MultiLineStringBuilder,
     push_multi_line_string
 );
 iter_geo_impl2!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
+    MultiPolygonArray,
+    MultiPolygonBuilder,
     push_multi_polygon
 );
 iter_geo_impl2!(
-    MixedGeometryArray<2>,
-    MixedGeometryBuilder<2>,
+    MixedGeometryArray,
+    MixedGeometryBuilder,
     push_geometry
 );
 iter_geo_impl2!(
-    GeometryCollectionArray<2>,
-    GeometryCollectionBuilder<2>,
+    GeometryCollectionArray,
+    GeometryCollectionBuilder,
     push_geometry_collection
 );
 
@@ -293,19 +293,19 @@ impl AffineOps<&[AffineTransform]> for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().affine_transform(transform)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().affine_transform(transform)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().affine_transform(transform)),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().affine_transform(transform)),
+            Point(_, XY) => Arc::new(self.as_point().affine_transform(transform)),
+            LineString(_, XY) => Arc::new(self.as_line_string().affine_transform(transform)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().affine_transform(transform)),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().affine_transform(transform)),
             MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().affine_transform(transform))
+                Arc::new(self.as_multi_line_string().affine_transform(transform))
             }
             MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon::<2>().affine_transform(transform))
+                Arc::new(self.as_multi_polygon().affine_transform(transform))
             }
-            Mixed(_, XY) => Arc::new(self.as_mixed::<2>().affine_transform(transform)),
+            Mixed(_, XY) => Arc::new(self.as_mixed().affine_transform(transform)),
             GeometryCollection(_, XY) => Arc::new(
-                self.as_geometry_collection::<2>()
+                self.as_geometry_collection()
                     .affine_transform(transform),
             ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),

--- a/rust/geoarrow/src/algorithm/geo/area.rs
+++ b/rust/geoarrow/src/algorithm/geo/area.rs
@@ -18,6 +18,7 @@ use geo::prelude::Area as GeoArea;
 ///
 /// use geoarrow::algorithm::geo::Area;
 /// use geoarrow::array::PolygonArray;
+/// use geoarrow::datatypes::Dimension;
 ///
 /// let polygon = polygon![
 ///     (x: 0., y: 0.),
@@ -32,8 +33,8 @@ use geo::prelude::Area as GeoArea;
 ///     line_string.0.reverse();
 /// });
 ///
-/// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
-/// let reversed_polygon_array: PolygonArray = vec![reversed_polygon].as_slice().into();
+/// let polygon_array: PolygonArray = (vec![polygon].as_slice(), Dimension::XY).into();
+/// let reversed_polygon_array: PolygonArray = (vec![reversed_polygon].as_slice(), Dimension::XY).into();
 ///
 /// assert_eq!(polygon_array.signed_area().value(0), 30.);
 /// assert_eq!(polygon_array.unsigned_area().value(0), 30.);

--- a/rust/geoarrow/src/algorithm/geo/area.rs
+++ b/rust/geoarrow/src/algorithm/geo/area.rs
@@ -32,8 +32,8 @@ use geo::prelude::Area as GeoArea;
 ///     line_string.0.reverse();
 /// });
 ///
-/// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
-/// let reversed_polygon_array: PolygonArray<2> = vec![reversed_polygon].as_slice().into();
+/// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
+/// let reversed_polygon_array: PolygonArray = vec![reversed_polygon].as_slice().into();
 ///
 /// assert_eq!(polygon_array.signed_area().value(0), 30.);
 /// assert_eq!(polygon_array.unsigned_area().value(0), 30.);
@@ -66,10 +66,10 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(PointArray<2>);
-zero_impl!(LineStringArray<2>);
-zero_impl!(MultiPointArray<2>);
-zero_impl!(MultiLineStringArray<2>);
+zero_impl!(PointArray);
+zero_impl!(LineStringArray);
+zero_impl!(MultiPointArray);
+zero_impl!(MultiLineStringArray);
 
 macro_rules! iter_geo_impl {
     ($type:ty) => {
@@ -87,11 +87,11 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
-iter_geo_impl!(RectArray<2>);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
+iter_geo_impl!(RectArray);
 
 impl Area for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -101,15 +101,15 @@ impl Area for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().signed_area(),
-            LineString(_, XY) => self.as_line_string::<2>().signed_area(),
-            Polygon(_, XY) => self.as_polygon::<2>().signed_area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().signed_area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().signed_area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().signed_area(),
-            Mixed(_, XY) => self.as_mixed::<2>().signed_area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().signed_area(),
-            Rect(XY) => self.as_rect::<2>().signed_area(),
+            Point(_, XY) => self.as_point().signed_area(),
+            LineString(_, XY) => self.as_line_string().signed_area(),
+            Polygon(_, XY) => self.as_polygon().signed_area(),
+            MultiPoint(_, XY) => self.as_multi_point().signed_area(),
+            MultiLineString(_, XY) => self.as_multi_line_string().signed_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().signed_area(),
+            Mixed(_, XY) => self.as_mixed().signed_area(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().signed_area(),
+            Rect(XY) => self.as_rect().signed_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -120,15 +120,15 @@ impl Area for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().unsigned_area(),
-            LineString(_, XY) => self.as_line_string::<2>().unsigned_area(),
-            Polygon(_, XY) => self.as_polygon::<2>().unsigned_area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().unsigned_area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().unsigned_area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().unsigned_area(),
-            Mixed(_, XY) => self.as_mixed::<2>().unsigned_area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().unsigned_area(),
-            Rect(XY) => self.as_rect::<2>().unsigned_area(),
+            Point(_, XY) => self.as_point().unsigned_area(),
+            LineString(_, XY) => self.as_line_string().unsigned_area(),
+            Polygon(_, XY) => self.as_polygon().unsigned_area(),
+            MultiPoint(_, XY) => self.as_multi_point().unsigned_area(),
+            MultiLineString(_, XY) => self.as_multi_line_string().unsigned_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().unsigned_area(),
+            Mixed(_, XY) => self.as_mixed().unsigned_area(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().unsigned_area(),
+            Rect(XY) => self.as_rect().unsigned_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -157,15 +157,15 @@ impl Area for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().signed_area(),
-            LineString(_, XY) => self.as_line_string::<2>().signed_area(),
-            Polygon(_, XY) => self.as_polygon::<2>().signed_area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().signed_area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().signed_area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().signed_area(),
-            Mixed(_, XY) => self.as_mixed::<2>().signed_area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().signed_area(),
-            Rect(XY) => self.as_rect::<2>().signed_area(),
+            Point(_, XY) => self.as_point().signed_area(),
+            LineString(_, XY) => self.as_line_string().signed_area(),
+            Polygon(_, XY) => self.as_polygon().signed_area(),
+            MultiPoint(_, XY) => self.as_multi_point().signed_area(),
+            MultiLineString(_, XY) => self.as_multi_line_string().signed_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().signed_area(),
+            Mixed(_, XY) => self.as_mixed().signed_area(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().signed_area(),
+            Rect(XY) => self.as_rect().signed_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -175,15 +175,15 @@ impl Area for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().unsigned_area(),
-            LineString(_, XY) => self.as_line_string::<2>().unsigned_area(),
-            Polygon(_, XY) => self.as_polygon::<2>().unsigned_area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().unsigned_area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().unsigned_area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().unsigned_area(),
-            Mixed(_, XY) => self.as_mixed::<2>().unsigned_area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().unsigned_area(),
-            Rect(XY) => self.as_rect::<2>().unsigned_area(),
+            Point(_, XY) => self.as_point().unsigned_area(),
+            LineString(_, XY) => self.as_line_string().unsigned_area(),
+            Polygon(_, XY) => self.as_polygon().unsigned_area(),
+            MultiPoint(_, XY) => self.as_multi_point().unsigned_area(),
+            MultiLineString(_, XY) => self.as_multi_line_string().unsigned_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().unsigned_area(),
+            Mixed(_, XY) => self.as_mixed().unsigned_area(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().unsigned_area(),
+            Rect(XY) => self.as_rect().unsigned_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/rust/geoarrow/src/algorithm/geo/bounding_rect.rs
+++ b/rust/geoarrow/src/algorithm/geo/bounding_rect.rs
@@ -35,8 +35,8 @@ pub trait BoundingRect {
     fn bounding_rect(&self) -> Self::Output;
 }
 
-impl BoundingRect for PointArray<2> {
-    type Output = RectArray<2>;
+impl BoundingRect for PointArray {
+    type Output = RectArray;
 
     fn bounding_rect(&self) -> Self::Output {
         let output_geoms: Vec<Option<Rect>> = self
@@ -52,7 +52,7 @@ impl BoundingRect for PointArray<2> {
 macro_rules! iter_geo_impl {
     ($type:ty) => {
         impl BoundingRect for $type {
-            type Output = RectArray<2>;
+            type Output = RectArray;
 
             fn bounding_rect(&self) -> Self::Output {
                 let output_geoms: Vec<Option<Rect>> = self
@@ -66,30 +66,30 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPointArray);
+iter_geo_impl!(MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
 
 impl BoundingRect for &dyn NativeArray {
-    type Output = Result<RectArray<2>>;
+    type Output = Result<RectArray>;
 
     fn bounding_rect(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().bounding_rect(),
-            LineString(_, XY) => self.as_line_string::<2>().bounding_rect(),
-            Polygon(_, XY) => self.as_polygon::<2>().bounding_rect(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().bounding_rect(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().bounding_rect(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().bounding_rect(),
-            Mixed(_, XY) => self.as_mixed::<2>().bounding_rect(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().bounding_rect(),
+            Point(_, XY) => self.as_point().bounding_rect(),
+            LineString(_, XY) => self.as_line_string().bounding_rect(),
+            Polygon(_, XY) => self.as_polygon().bounding_rect(),
+            MultiPoint(_, XY) => self.as_multi_point().bounding_rect(),
+            MultiLineString(_, XY) => self.as_multi_line_string().bounding_rect(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().bounding_rect(),
+            Mixed(_, XY) => self.as_mixed().bounding_rect(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().bounding_rect(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -97,7 +97,7 @@ impl BoundingRect for &dyn NativeArray {
 }
 
 impl<G: NativeArray> BoundingRect for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedGeometryArray<RectArray<2>>>;
+    type Output = Result<ChunkedGeometryArray<RectArray>>;
 
     fn bounding_rect(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().bounding_rect())?
@@ -106,21 +106,21 @@ impl<G: NativeArray> BoundingRect for ChunkedGeometryArray<G> {
 }
 
 impl BoundingRect for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedGeometryArray<RectArray<2>>>;
+    type Output = Result<ChunkedGeometryArray<RectArray>>;
 
     fn bounding_rect(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().bounding_rect(),
-            LineString(_, XY) => self.as_line_string::<2>().bounding_rect(),
-            Polygon(_, XY) => self.as_polygon::<2>().bounding_rect(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().bounding_rect(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().bounding_rect(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().bounding_rect(),
-            Mixed(_, XY) => self.as_mixed::<2>().bounding_rect(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().bounding_rect(),
+            Point(_, XY) => self.as_point().bounding_rect(),
+            LineString(_, XY) => self.as_line_string().bounding_rect(),
+            Polygon(_, XY) => self.as_polygon().bounding_rect(),
+            MultiPoint(_, XY) => self.as_multi_point().bounding_rect(),
+            MultiLineString(_, XY) => self.as_multi_line_string().bounding_rect(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().bounding_rect(),
+            Mixed(_, XY) => self.as_mixed().bounding_rect(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().bounding_rect(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/rust/geoarrow/src/algorithm/geo/bounding_rect.rs
+++ b/rust/geoarrow/src/algorithm/geo/bounding_rect.rs
@@ -44,7 +44,7 @@ impl BoundingRect for PointArray {
             .map(|maybe_g| maybe_g.map(|geom| geom.bounding_rect()))
             .collect();
 
-        output_geoms.into()
+        (output_geoms, Dimension::XY).into()
     }
 }
 
@@ -60,7 +60,7 @@ macro_rules! iter_geo_impl {
                     .map(|maybe_g| maybe_g.and_then(|geom| geom.bounding_rect()))
                     .collect();
 
-                output_geoms.into()
+                (output_geoms, Dimension::XY).into()
             }
         }
     };

--- a/rust/geoarrow/src/algorithm/geo/center.rs
+++ b/rust/geoarrow/src/algorithm/geo/center.rs
@@ -30,7 +30,7 @@ macro_rules! iter_geo_impl {
             type Output = PointArray;
 
             fn center(&self) -> Self::Output {
-                let mut output_array = PointBuilder::with_capacity(self.len());
+                let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.len());
                 self.iter_geo().for_each(|maybe_g| {
                     output_array.push_coord(
                         maybe_g

--- a/rust/geoarrow/src/algorithm/geo/center.rs
+++ b/rust/geoarrow/src/algorithm/geo/center.rs
@@ -15,8 +15,8 @@ pub trait Center {
     fn center(&self) -> Self::Output;
 }
 
-impl Center for PointArray<2> {
-    type Output = PointArray<2>;
+impl Center for PointArray {
+    type Output = PointArray;
 
     fn center(&self) -> Self::Output {
         self.clone()
@@ -27,7 +27,7 @@ impl Center for PointArray<2> {
 macro_rules! iter_geo_impl {
     ($type:ty) => {
         impl Center for $type {
-            type Output = PointArray<2>;
+            type Output = PointArray;
 
             fn center(&self) -> Self::Output {
                 let mut output_array = PointBuilder::with_capacity(self.len());
@@ -44,30 +44,30 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPointArray);
+iter_geo_impl!(MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
 
 impl Center for &dyn NativeArray {
-    type Output = Result<PointArray<2>>;
+    type Output = Result<PointArray>;
 
     fn center(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().center(),
-            LineString(_, XY) => self.as_line_string::<2>().center(),
-            Polygon(_, XY) => self.as_polygon::<2>().center(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().center(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().center(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().center(),
-            Mixed(_, XY) => self.as_mixed::<2>().center(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().center(),
+            Point(_, XY) => self.as_point().center(),
+            LineString(_, XY) => self.as_line_string().center(),
+            Polygon(_, XY) => self.as_polygon().center(),
+            MultiPoint(_, XY) => self.as_multi_point().center(),
+            MultiLineString(_, XY) => self.as_multi_line_string().center(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().center(),
+            Mixed(_, XY) => self.as_mixed().center(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().center(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -75,7 +75,7 @@ impl Center for &dyn NativeArray {
 }
 
 impl<G: NativeArray> Center for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedPointArray<2>>;
+    type Output = Result<ChunkedPointArray>;
 
     fn center(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().center())?.try_into()
@@ -83,21 +83,21 @@ impl<G: NativeArray> Center for ChunkedGeometryArray<G> {
 }
 
 impl Center for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPointArray<2>>;
+    type Output = Result<ChunkedPointArray>;
 
     fn center(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().center(),
-            LineString(_, XY) => self.as_line_string::<2>().center(),
-            Polygon(_, XY) => self.as_polygon::<2>().center(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().center(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().center(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().center(),
-            Mixed(_, XY) => self.as_mixed::<2>().center(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().center(),
+            Point(_, XY) => self.as_point().center(),
+            LineString(_, XY) => self.as_line_string().center(),
+            Polygon(_, XY) => self.as_polygon().center(),
+            MultiPoint(_, XY) => self.as_multi_point().center(),
+            MultiLineString(_, XY) => self.as_multi_line_string().center(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().center(),
+            Mixed(_, XY) => self.as_mixed().center(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().center(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/rust/geoarrow/src/algorithm/geo/centroid.rs
+++ b/rust/geoarrow/src/algorithm/geo/centroid.rs
@@ -79,7 +79,7 @@ macro_rules! iter_geo_impl {
             type Output = PointArray;
 
             fn centroid(&self) -> Self::Output {
-                let mut output_array = PointBuilder::with_capacity(self.len());
+                let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.len());
                 self.iter_geo().for_each(|maybe_g| {
                     output_array.push_point(maybe_g.and_then(|g| g.centroid()).as_ref())
                 });

--- a/rust/geoarrow/src/algorithm/geo/centroid.rs
+++ b/rust/geoarrow/src/algorithm/geo/centroid.rs
@@ -30,7 +30,7 @@ use geo::algorithm::centroid::Centroid as GeoCentroid;
 ///     (x: 1., y: -1.),
 ///     (x: -2., y: 1.),
 /// ];
-/// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
+/// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
 ///
 /// assert_eq!(
 ///     Some(point!(x: 1., y: 1.)),
@@ -54,7 +54,7 @@ pub trait Centroid {
     ///     (x: 40.02f64, y: 116.34),
     ///     (x: 40.02f64, y: 118.23),
     /// ];
-    /// let line_string_array: LineStringArray<2> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray = vec![line_string].as_slice().into();
     ///
     /// assert_eq!(
     ///     Some(point!(x: 40.02, y: 117.285)),
@@ -64,8 +64,8 @@ pub trait Centroid {
     fn centroid(&self) -> Self::Output;
 }
 
-impl Centroid for PointArray<2> {
-    type Output = PointArray<2>;
+impl Centroid for PointArray {
+    type Output = PointArray;
 
     fn centroid(&self) -> Self::Output {
         self.clone()
@@ -76,7 +76,7 @@ impl Centroid for PointArray<2> {
 macro_rules! iter_geo_impl {
     ($type:ty) => {
         impl Centroid for $type {
-            type Output = PointArray<2>;
+            type Output = PointArray;
 
             fn centroid(&self) -> Self::Output {
                 let mut output_array = PointBuilder::with_capacity(self.len());
@@ -89,30 +89,30 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPointArray);
+iter_geo_impl!(MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
 
 impl Centroid for &dyn NativeArray {
-    type Output = Result<PointArray<2>>;
+    type Output = Result<PointArray>;
 
     fn centroid(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().centroid(),
-            LineString(_, XY) => self.as_line_string::<2>().centroid(),
-            Polygon(_, XY) => self.as_polygon::<2>().centroid(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().centroid(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().centroid(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().centroid(),
-            Mixed(_, XY) => self.as_mixed::<2>().centroid(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().centroid(),
+            Point(_, XY) => self.as_point().centroid(),
+            LineString(_, XY) => self.as_line_string().centroid(),
+            Polygon(_, XY) => self.as_polygon().centroid(),
+            MultiPoint(_, XY) => self.as_multi_point().centroid(),
+            MultiLineString(_, XY) => self.as_multi_line_string().centroid(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().centroid(),
+            Mixed(_, XY) => self.as_mixed().centroid(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().centroid(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -120,7 +120,7 @@ impl Centroid for &dyn NativeArray {
 }
 
 impl<G: NativeArray> Centroid for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedPointArray<2>>;
+    type Output = Result<ChunkedPointArray>;
 
     fn centroid(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().centroid())?.try_into()
@@ -128,21 +128,21 @@ impl<G: NativeArray> Centroid for ChunkedGeometryArray<G> {
 }
 
 impl Centroid for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPointArray<2>>;
+    type Output = Result<ChunkedPointArray>;
 
     fn centroid(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().centroid(),
-            LineString(_, XY) => self.as_line_string::<2>().centroid(),
-            Polygon(_, XY) => self.as_polygon::<2>().centroid(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().centroid(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().centroid(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().centroid(),
-            Mixed(_, XY) => self.as_mixed::<2>().centroid(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().centroid(),
+            Point(_, XY) => self.as_point().centroid(),
+            LineString(_, XY) => self.as_line_string().centroid(),
+            Polygon(_, XY) => self.as_polygon().centroid(),
+            MultiPoint(_, XY) => self.as_multi_point().centroid(),
+            MultiLineString(_, XY) => self.as_multi_line_string().centroid(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().centroid(),
+            Mixed(_, XY) => self.as_mixed().centroid(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().centroid(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/rust/geoarrow/src/algorithm/geo/centroid.rs
+++ b/rust/geoarrow/src/algorithm/geo/centroid.rs
@@ -20,6 +20,7 @@ use geo::algorithm::centroid::Centroid as GeoCentroid;
 /// use geoarrow::algorithm::geo::Centroid;
 /// use geoarrow::array::PolygonArray;
 /// use geoarrow::trait_::ArrayAccessor;
+/// use geoarrow::datatypes::Dimension;
 /// use geo::{point, polygon};
 ///
 /// // rhombus shaped polygon
@@ -30,7 +31,7 @@ use geo::algorithm::centroid::Centroid as GeoCentroid;
 ///     (x: 1., y: -1.),
 ///     (x: -2., y: 1.),
 /// ];
-/// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
+/// let polygon_array: PolygonArray = (vec![polygon].as_slice(), Dimension::XY).into();
 ///
 /// assert_eq!(
 ///     Some(point!(x: 1., y: 1.)),
@@ -48,13 +49,14 @@ pub trait Centroid {
     /// use geoarrow::algorithm::geo::Centroid;
     /// use geoarrow::array::LineStringArray;
     /// use geoarrow::trait_::ArrayAccessor;
+    /// use geoarrow::datatypes::Dimension;
     /// use geo::{line_string, point};
     ///
     /// let line_string = line_string![
     ///     (x: 40.02f64, y: 116.34),
     ///     (x: 40.02f64, y: 118.23),
     /// ];
-    /// let line_string_array: LineStringArray = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray = (vec![line_string].as_slice(), Dimension::XY).into();
     ///
     /// assert_eq!(
     ///     Some(point!(x: 40.02, y: 117.285)),

--- a/rust/geoarrow/src/algorithm/geo/chaikin_smoothing.rs
+++ b/rust/geoarrow/src/algorithm/geo/chaikin_smoothing.rs
@@ -46,10 +46,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, geo::LineString);
-iter_geo_impl!(PolygonArray<2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
+iter_geo_impl!(LineStringArray, geo::LineString);
+iter_geo_impl!(PolygonArray, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray, geo::MultiPolygon);
 
 impl ChaikinSmoothing for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -60,15 +60,15 @@ impl ChaikinSmoothing for &dyn NativeArray {
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
             LineString(_, XY) => {
-                Arc::new(self.as_line_string::<2>().chaikin_smoothing(n_iterations))
+                Arc::new(self.as_line_string().chaikin_smoothing(n_iterations))
             }
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().chaikin_smoothing(n_iterations)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().chaikin_smoothing(n_iterations)),
             MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string::<2>()
+                self.as_multi_line_string()
                     .chaikin_smoothing(n_iterations),
             ),
             MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon::<2>().chaikin_smoothing(n_iterations))
+                Arc::new(self.as_multi_polygon().chaikin_smoothing(n_iterations))
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -90,10 +90,10 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<2>);
-impl_chunked!(ChunkedPolygonArray<2>);
-impl_chunked!(ChunkedMultiLineStringArray<2>);
-impl_chunked!(ChunkedMultiPolygonArray<2>);
+impl_chunked!(ChunkedLineStringArray);
+impl_chunked!(ChunkedPolygonArray);
+impl_chunked!(ChunkedMultiLineStringArray);
+impl_chunked!(ChunkedMultiPolygonArray);
 
 impl ChaikinSmoothing for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -104,15 +104,15 @@ impl ChaikinSmoothing for &dyn ChunkedNativeArray {
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             LineString(_, XY) => {
-                Arc::new(self.as_line_string::<2>().chaikin_smoothing(n_iterations))
+                Arc::new(self.as_line_string().chaikin_smoothing(n_iterations))
             }
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().chaikin_smoothing(n_iterations)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().chaikin_smoothing(n_iterations)),
             MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string::<2>()
+                self.as_multi_line_string()
                     .chaikin_smoothing(n_iterations),
             ),
             MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon::<2>().chaikin_smoothing(n_iterations))
+                Arc::new(self.as_multi_polygon().chaikin_smoothing(n_iterations))
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };

--- a/rust/geoarrow/src/algorithm/geo/chaikin_smoothing.rs
+++ b/rust/geoarrow/src/algorithm/geo/chaikin_smoothing.rs
@@ -40,7 +40,7 @@ macro_rules! iter_geo_impl {
                     })
                     .collect();
 
-                output_geoms.into()
+                (output_geoms, Dimension::XY).into()
             }
         }
     };
@@ -59,14 +59,11 @@ impl ChaikinSmoothing for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            LineString(_, XY) => {
-                Arc::new(self.as_line_string().chaikin_smoothing(n_iterations))
-            }
+            LineString(_, XY) => Arc::new(self.as_line_string().chaikin_smoothing(n_iterations)),
             Polygon(_, XY) => Arc::new(self.as_polygon().chaikin_smoothing(n_iterations)),
-            MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string()
-                    .chaikin_smoothing(n_iterations),
-            ),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string().chaikin_smoothing(n_iterations))
+            }
             MultiPolygon(_, XY) => {
                 Arc::new(self.as_multi_polygon().chaikin_smoothing(n_iterations))
             }
@@ -103,14 +100,11 @@ impl ChaikinSmoothing for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
-            LineString(_, XY) => {
-                Arc::new(self.as_line_string().chaikin_smoothing(n_iterations))
-            }
+            LineString(_, XY) => Arc::new(self.as_line_string().chaikin_smoothing(n_iterations)),
             Polygon(_, XY) => Arc::new(self.as_polygon().chaikin_smoothing(n_iterations)),
-            MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string()
-                    .chaikin_smoothing(n_iterations),
-            ),
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string().chaikin_smoothing(n_iterations))
+            }
             MultiPolygon(_, XY) => {
                 Arc::new(self.as_multi_polygon().chaikin_smoothing(n_iterations))
             }

--- a/rust/geoarrow/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/rust/geoarrow/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -28,6 +28,7 @@ use geo::prelude::ChamberlainDuquetteArea as GeoChamberlainDuquetteArea;
 /// use geoarrow::array::PolygonArray;
 /// use geoarrow::NativeArray;
 /// use geoarrow::algorithm::geo::ChamberlainDuquetteArea;
+/// use geoarrow::datatypes::Dimension;
 ///
 /// // The O2 in London
 /// let mut polygon: Polygon<f64> = polygon![
@@ -47,8 +48,8 @@ use geo::prelude::ChamberlainDuquetteArea as GeoChamberlainDuquetteArea;
 ///     line_string.0.reverse();
 /// });
 ///
-/// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
-/// let reversed_polygon_array: PolygonArray = vec![reversed_polygon].as_slice().into();
+/// let polygon_array: PolygonArray = (vec![polygon].as_slice(), Dimension::XY).into();
+/// let reversed_polygon_array: PolygonArray = (vec![reversed_polygon].as_slice(), Dimension::XY).into();
 ///
 /// // 78,478 meters²
 /// assert_eq!(78_478., polygon_array.chamberlain_duquette_unsigned_area().value(0).round());
@@ -128,19 +129,13 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point().chamberlain_duquette_signed_area(),
-            LineString(_, XY) => self
-                .as_line_string()
-                .chamberlain_duquette_signed_area(),
+            LineString(_, XY) => self.as_line_string().chamberlain_duquette_signed_area(),
             Polygon(_, XY) => self.as_polygon().chamberlain_duquette_signed_area(),
-            MultiPoint(_, XY) => self
-                .as_multi_point()
-                .chamberlain_duquette_signed_area(),
+            MultiPoint(_, XY) => self.as_multi_point().chamberlain_duquette_signed_area(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string()
                 .chamberlain_duquette_signed_area(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon()
-                .chamberlain_duquette_signed_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().chamberlain_duquette_signed_area(),
             Mixed(_, XY) => self.as_mixed().chamberlain_duquette_signed_area(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection()
@@ -156,19 +151,13 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point().chamberlain_duquette_unsigned_area(),
-            LineString(_, XY) => self
-                .as_line_string()
-                .chamberlain_duquette_unsigned_area(),
+            LineString(_, XY) => self.as_line_string().chamberlain_duquette_unsigned_area(),
             Polygon(_, XY) => self.as_polygon().chamberlain_duquette_unsigned_area(),
-            MultiPoint(_, XY) => self
-                .as_multi_point()
-                .chamberlain_duquette_unsigned_area(),
+            MultiPoint(_, XY) => self.as_multi_point().chamberlain_duquette_unsigned_area(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string()
                 .chamberlain_duquette_unsigned_area(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon()
-                .chamberlain_duquette_unsigned_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().chamberlain_duquette_unsigned_area(),
             Mixed(_, XY) => self.as_mixed().chamberlain_duquette_unsigned_area(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection()
@@ -210,19 +199,13 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point().chamberlain_duquette_signed_area(),
-            LineString(_, XY) => self
-                .as_line_string()
-                .chamberlain_duquette_signed_area(),
+            LineString(_, XY) => self.as_line_string().chamberlain_duquette_signed_area(),
             Polygon(_, XY) => self.as_polygon().chamberlain_duquette_signed_area(),
-            MultiPoint(_, XY) => self
-                .as_multi_point()
-                .chamberlain_duquette_signed_area(),
+            MultiPoint(_, XY) => self.as_multi_point().chamberlain_duquette_signed_area(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string()
                 .chamberlain_duquette_signed_area(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon()
-                .chamberlain_duquette_signed_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().chamberlain_duquette_signed_area(),
             Mixed(_, XY) => self.as_mixed().chamberlain_duquette_signed_area(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection()
@@ -237,19 +220,13 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point().chamberlain_duquette_unsigned_area(),
-            LineString(_, XY) => self
-                .as_line_string()
-                .chamberlain_duquette_unsigned_area(),
+            LineString(_, XY) => self.as_line_string().chamberlain_duquette_unsigned_area(),
             Polygon(_, XY) => self.as_polygon().chamberlain_duquette_unsigned_area(),
-            MultiPoint(_, XY) => self
-                .as_multi_point()
-                .chamberlain_duquette_unsigned_area(),
+            MultiPoint(_, XY) => self.as_multi_point().chamberlain_duquette_unsigned_area(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string()
                 .chamberlain_duquette_unsigned_area(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon()
-                .chamberlain_duquette_unsigned_area(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().chamberlain_duquette_unsigned_area(),
             Mixed(_, XY) => self.as_mixed().chamberlain_duquette_unsigned_area(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection()

--- a/rust/geoarrow/src/algorithm/geo/chamberlain_duquette_area.rs
+++ b/rust/geoarrow/src/algorithm/geo/chamberlain_duquette_area.rs
@@ -47,8 +47,8 @@ use geo::prelude::ChamberlainDuquetteArea as GeoChamberlainDuquetteArea;
 ///     line_string.0.reverse();
 /// });
 ///
-/// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
-/// let reversed_polygon_array: PolygonArray<2> = vec![reversed_polygon].as_slice().into();
+/// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
+/// let reversed_polygon_array: PolygonArray = vec![reversed_polygon].as_slice().into();
 ///
 /// // 78,478 meters²
 /// assert_eq!(78_478., polygon_array.chamberlain_duquette_unsigned_area().value(0).round());
@@ -82,10 +82,10 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(PointArray<2>);
-zero_impl!(LineStringArray<2>);
-zero_impl!(MultiPointArray<2>);
-zero_impl!(MultiLineStringArray<2>);
+zero_impl!(PointArray);
+zero_impl!(LineStringArray);
+zero_impl!(MultiPointArray);
+zero_impl!(MultiLineStringArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -114,10 +114,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
 
 impl ChamberlainDuquetteArea for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -127,23 +127,23 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().chamberlain_duquette_signed_area(),
+            Point(_, XY) => self.as_point().chamberlain_duquette_signed_area(),
             LineString(_, XY) => self
-                .as_line_string::<2>()
+                .as_line_string()
                 .chamberlain_duquette_signed_area(),
-            Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_signed_area(),
+            Polygon(_, XY) => self.as_polygon().chamberlain_duquette_signed_area(),
             MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
+                .as_multi_point()
                 .chamberlain_duquette_signed_area(),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .chamberlain_duquette_signed_area(),
             MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
+                .as_multi_polygon()
                 .chamberlain_duquette_signed_area(),
-            Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_signed_area(),
+            Mixed(_, XY) => self.as_mixed().chamberlain_duquette_signed_area(),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .chamberlain_duquette_signed_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -155,23 +155,23 @@ impl ChamberlainDuquetteArea for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().chamberlain_duquette_unsigned_area(),
+            Point(_, XY) => self.as_point().chamberlain_duquette_unsigned_area(),
             LineString(_, XY) => self
-                .as_line_string::<2>()
+                .as_line_string()
                 .chamberlain_duquette_unsigned_area(),
-            Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_unsigned_area(),
+            Polygon(_, XY) => self.as_polygon().chamberlain_duquette_unsigned_area(),
             MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
+                .as_multi_point()
                 .chamberlain_duquette_unsigned_area(),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .chamberlain_duquette_unsigned_area(),
             MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
+                .as_multi_polygon()
                 .chamberlain_duquette_unsigned_area(),
-            Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_unsigned_area(),
+            Mixed(_, XY) => self.as_mixed().chamberlain_duquette_unsigned_area(),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .chamberlain_duquette_unsigned_area(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -209,23 +209,23 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().chamberlain_duquette_signed_area(),
+            Point(_, XY) => self.as_point().chamberlain_duquette_signed_area(),
             LineString(_, XY) => self
-                .as_line_string::<2>()
+                .as_line_string()
                 .chamberlain_duquette_signed_area(),
-            Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_signed_area(),
+            Polygon(_, XY) => self.as_polygon().chamberlain_duquette_signed_area(),
             MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
+                .as_multi_point()
                 .chamberlain_duquette_signed_area(),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .chamberlain_duquette_signed_area(),
             MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
+                .as_multi_polygon()
                 .chamberlain_duquette_signed_area(),
-            Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_signed_area(),
+            Mixed(_, XY) => self.as_mixed().chamberlain_duquette_signed_area(),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .chamberlain_duquette_signed_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -236,23 +236,23 @@ impl ChamberlainDuquetteArea for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().chamberlain_duquette_unsigned_area(),
+            Point(_, XY) => self.as_point().chamberlain_duquette_unsigned_area(),
             LineString(_, XY) => self
-                .as_line_string::<2>()
+                .as_line_string()
                 .chamberlain_duquette_unsigned_area(),
-            Polygon(_, XY) => self.as_polygon::<2>().chamberlain_duquette_unsigned_area(),
+            Polygon(_, XY) => self.as_polygon().chamberlain_duquette_unsigned_area(),
             MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
+                .as_multi_point()
                 .chamberlain_duquette_unsigned_area(),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .chamberlain_duquette_unsigned_area(),
             MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
+                .as_multi_polygon()
                 .chamberlain_duquette_unsigned_area(),
-            Mixed(_, XY) => self.as_mixed::<2>().chamberlain_duquette_unsigned_area(),
+            Mixed(_, XY) => self.as_mixed().chamberlain_duquette_unsigned_area(),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .chamberlain_duquette_unsigned_area(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }

--- a/rust/geoarrow/src/algorithm/geo/contains.rs
+++ b/rust/geoarrow/src/algorithm/geo/contains.rs
@@ -175,9 +175,7 @@ impl<G: PointTrait<T = f64>> ContainsPoint<G> for &dyn NativeArray {
             LineString(_, XY) => ContainsPoint::contains(self.as_line_string(), rhs),
             Polygon(_, XY) => ContainsPoint::contains(self.as_polygon(), rhs),
             MultiPoint(_, XY) => ContainsPoint::contains(self.as_multi_point(), rhs),
-            MultiLineString(_, XY) => {
-                ContainsPoint::contains(self.as_multi_line_string(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsPoint::contains(self.as_multi_line_string(), rhs),
             MultiPolygon(_, XY) => ContainsPoint::contains(self.as_multi_polygon(), rhs),
             Mixed(_, XY) => ContainsPoint::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
@@ -291,9 +289,7 @@ impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for &dyn NativeArray {
             LineString(_, XY) => ContainsPolygon::contains(self.as_line_string(), rhs),
             Polygon(_, XY) => ContainsPolygon::contains(self.as_polygon(), rhs),
             MultiPoint(_, XY) => ContainsPolygon::contains(self.as_multi_point(), rhs),
-            MultiLineString(_, XY) => {
-                ContainsPolygon::contains(self.as_multi_line_string(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsPolygon::contains(self.as_multi_line_string(), rhs),
             MultiPolygon(_, XY) => ContainsPolygon::contains(self.as_multi_polygon(), rhs),
             Mixed(_, XY) => ContainsPolygon::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
@@ -404,9 +400,7 @@ impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for &dyn Nativ
             MultiLineString(_, XY) => {
                 ContainsMultiLineString::contains(self.as_multi_line_string(), rhs)
             }
-            MultiPolygon(_, XY) => {
-                ContainsMultiLineString::contains(self.as_multi_polygon(), rhs)
-            }
+            MultiPolygon(_, XY) => ContainsMultiLineString::contains(self.as_multi_polygon(), rhs),
             Mixed(_, XY) => ContainsMultiLineString::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
                 ContainsMultiLineString::contains(self.as_geometry_collection(), rhs)
@@ -461,9 +455,7 @@ impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for &dyn NativeArray
             MultiLineString(_, XY) => {
                 ContainsMultiPolygon::contains(self.as_multi_line_string(), rhs)
             }
-            MultiPolygon(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_multi_polygon(), rhs)
-            }
+            MultiPolygon(_, XY) => ContainsMultiPolygon::contains(self.as_multi_polygon(), rhs),
             Mixed(_, XY) => ContainsMultiPolygon::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
                 ContainsMultiPolygon::contains(self.as_geometry_collection(), rhs)
@@ -515,9 +507,7 @@ impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for &dyn NativeArray {
             LineString(_, XY) => ContainsGeometry::contains(self.as_line_string(), rhs),
             Polygon(_, XY) => ContainsGeometry::contains(self.as_polygon(), rhs),
             MultiPoint(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_point(), rhs),
-            MultiLineString(_, XY) => {
-                ContainsGeometry::contains(self.as_multi_line_string(), rhs)
-            }
+            MultiLineString(_, XY) => ContainsGeometry::contains(self.as_multi_line_string(), rhs),
             MultiPolygon(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_polygon(), rhs),
             Mixed(_, XY) => ContainsGeometry::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
@@ -567,13 +557,9 @@ impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for &dyn
 
         match self.data_type() {
             Point(_, XY) => ContainsGeometryCollection::contains(self.as_point(), rhs),
-            LineString(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_line_string(), rhs)
-            }
+            LineString(_, XY) => ContainsGeometryCollection::contains(self.as_line_string(), rhs),
             Polygon(_, XY) => ContainsGeometryCollection::contains(self.as_polygon(), rhs),
-            MultiPoint(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_multi_point(), rhs)
-            }
+            MultiPoint(_, XY) => ContainsGeometryCollection::contains(self.as_multi_point(), rhs),
             MultiLineString(_, XY) => {
                 ContainsGeometryCollection::contains(self.as_multi_line_string(), rhs)
             }

--- a/rust/geoarrow/src/algorithm/geo/contains.rs
+++ b/rust/geoarrow/src/algorithm/geo/contains.rs
@@ -59,7 +59,7 @@ pub trait Contains<Rhs = Self> {
 // └────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl Contains for PointArray<2> {
+impl Contains for PointArray {
     fn contains(&self, rhs: &Self) -> BooleanArray {
         self.try_binary_boolean(rhs, |left, right| {
             Ok(left.to_geo().contains(&right.to_geo()))
@@ -83,51 +83,51 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray<2>, LineStringArray<2>);
-iter_geo_impl!(PointArray<2>, PolygonArray<2>);
-iter_geo_impl!(PointArray<2>, MultiPointArray<2>);
-iter_geo_impl!(PointArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(PointArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(PointArray, LineStringArray);
+iter_geo_impl!(PointArray, PolygonArray);
+iter_geo_impl!(PointArray, MultiPointArray);
+iter_geo_impl!(PointArray, MultiLineStringArray);
+iter_geo_impl!(PointArray, MultiPolygonArray);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<2>, PointArray<2>);
-iter_geo_impl!(LineStringArray<2>, LineStringArray<2>);
-iter_geo_impl!(LineStringArray<2>, PolygonArray<2>);
-iter_geo_impl!(LineStringArray<2>, MultiPointArray<2>);
-iter_geo_impl!(LineStringArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(LineStringArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(LineStringArray, PointArray);
+iter_geo_impl!(LineStringArray, LineStringArray);
+iter_geo_impl!(LineStringArray, PolygonArray);
+iter_geo_impl!(LineStringArray, MultiPointArray);
+iter_geo_impl!(LineStringArray, MultiLineStringArray);
+iter_geo_impl!(LineStringArray, MultiPolygonArray);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<2>, PointArray<2>);
-iter_geo_impl!(PolygonArray<2>, LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>, PolygonArray<2>);
-iter_geo_impl!(PolygonArray<2>, MultiPointArray<2>);
-iter_geo_impl!(PolygonArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(PolygonArray, PointArray);
+iter_geo_impl!(PolygonArray, LineStringArray);
+iter_geo_impl!(PolygonArray, PolygonArray);
+iter_geo_impl!(PolygonArray, MultiPointArray);
+iter_geo_impl!(PolygonArray, MultiLineStringArray);
+iter_geo_impl!(PolygonArray, MultiPolygonArray);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<2>, PointArray<2>);
-iter_geo_impl!(MultiPointArray<2>, LineStringArray<2>);
-iter_geo_impl!(MultiPointArray<2>, PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>, MultiPointArray<2>);
-iter_geo_impl!(MultiPointArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(MultiPointArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiPointArray, PointArray);
+iter_geo_impl!(MultiPointArray, LineStringArray);
+iter_geo_impl!(MultiPointArray, PolygonArray);
+iter_geo_impl!(MultiPointArray, MultiPointArray);
+iter_geo_impl!(MultiPointArray, MultiLineStringArray);
+iter_geo_impl!(MultiPointArray, MultiPolygonArray);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<2>, PointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, LineStringArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, PolygonArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiLineStringArray, PointArray);
+iter_geo_impl!(MultiLineStringArray, LineStringArray);
+iter_geo_impl!(MultiLineStringArray, PolygonArray);
+iter_geo_impl!(MultiLineStringArray, MultiPointArray);
+iter_geo_impl!(MultiLineStringArray, MultiLineStringArray);
+iter_geo_impl!(MultiLineStringArray, MultiPolygonArray);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<2>, PointArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, LineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, PolygonArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPointArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiPolygonArray, PointArray);
+iter_geo_impl!(MultiPolygonArray, LineStringArray);
+iter_geo_impl!(MultiPolygonArray, PolygonArray);
+iter_geo_impl!(MultiPolygonArray, MultiPointArray);
+iter_geo_impl!(MultiPolygonArray, MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray, MultiPolygonArray);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
@@ -137,7 +137,7 @@ pub trait ContainsPoint<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: PointTrait<T = f64>> ContainsPoint<G> for PointArray<2> {
+impl<G: PointTrait<T = f64>> ContainsPoint<G> for PointArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = point_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -157,13 +157,13 @@ macro_rules! impl_contains_point {
     };
 }
 
-impl_contains_point!(LineStringArray<2>);
-impl_contains_point!(PolygonArray<2>);
-impl_contains_point!(MultiPointArray<2>);
-impl_contains_point!(MultiLineStringArray<2>);
-impl_contains_point!(MultiPolygonArray<2>);
-impl_contains_point!(MixedGeometryArray<2>);
-impl_contains_point!(GeometryCollectionArray<2>);
+impl_contains_point!(LineStringArray);
+impl_contains_point!(PolygonArray);
+impl_contains_point!(MultiPointArray);
+impl_contains_point!(MultiLineStringArray);
+impl_contains_point!(MultiPolygonArray);
+impl_contains_point!(MixedGeometryArray);
+impl_contains_point!(GeometryCollectionArray);
 
 impl<G: PointTrait<T = f64>> ContainsPoint<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -171,17 +171,17 @@ impl<G: PointTrait<T = f64>> ContainsPoint<G> for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => ContainsPoint::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => ContainsPoint::contains(self.as_line_string::<2>(), rhs),
-            Polygon(_, XY) => ContainsPoint::contains(self.as_polygon::<2>(), rhs),
-            MultiPoint(_, XY) => ContainsPoint::contains(self.as_multi_point::<2>(), rhs),
+            Point(_, XY) => ContainsPoint::contains(self.as_point(), rhs),
+            LineString(_, XY) => ContainsPoint::contains(self.as_line_string(), rhs),
+            Polygon(_, XY) => ContainsPoint::contains(self.as_polygon(), rhs),
+            MultiPoint(_, XY) => ContainsPoint::contains(self.as_multi_point(), rhs),
             MultiLineString(_, XY) => {
-                ContainsPoint::contains(self.as_multi_line_string::<2>(), rhs)
+                ContainsPoint::contains(self.as_multi_line_string(), rhs)
             }
-            MultiPolygon(_, XY) => ContainsPoint::contains(self.as_multi_polygon::<2>(), rhs),
-            Mixed(_, XY) => ContainsPoint::contains(self.as_mixed::<2>(), rhs),
+            MultiPolygon(_, XY) => ContainsPoint::contains(self.as_multi_polygon(), rhs),
+            Mixed(_, XY) => ContainsPoint::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
-                ContainsPoint::contains(self.as_geometry_collection::<2>(), rhs)
+                ContainsPoint::contains(self.as_geometry_collection(), rhs)
             }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -192,7 +192,7 @@ pub trait ContainsLineString<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for PointArray<2> {
+impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for PointArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = line_string_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -218,13 +218,13 @@ macro_rules! impl_contains_line_string {
     };
 }
 
-impl_contains_line_string!(LineStringArray<2>);
-impl_contains_line_string!(PolygonArray<2>);
-impl_contains_line_string!(MultiPointArray<2>);
-impl_contains_line_string!(MultiLineStringArray<2>);
-impl_contains_line_string!(MultiPolygonArray<2>);
-impl_contains_line_string!(MixedGeometryArray<2>);
-impl_contains_line_string!(GeometryCollectionArray<2>);
+impl_contains_line_string!(LineStringArray);
+impl_contains_line_string!(PolygonArray);
+impl_contains_line_string!(MultiPointArray);
+impl_contains_line_string!(MultiLineStringArray);
+impl_contains_line_string!(MultiPolygonArray);
+impl_contains_line_string!(MixedGeometryArray);
+impl_contains_line_string!(GeometryCollectionArray);
 
 impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -232,17 +232,17 @@ impl<G: LineStringTrait<T = f64>> ContainsLineString<G> for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => ContainsLineString::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => ContainsLineString::contains(self.as_line_string::<2>(), rhs),
-            Polygon(_, XY) => ContainsLineString::contains(self.as_polygon::<2>(), rhs),
-            MultiPoint(_, XY) => ContainsLineString::contains(self.as_multi_point::<2>(), rhs),
+            Point(_, XY) => ContainsLineString::contains(self.as_point(), rhs),
+            LineString(_, XY) => ContainsLineString::contains(self.as_line_string(), rhs),
+            Polygon(_, XY) => ContainsLineString::contains(self.as_polygon(), rhs),
+            MultiPoint(_, XY) => ContainsLineString::contains(self.as_multi_point(), rhs),
             MultiLineString(_, XY) => {
-                ContainsLineString::contains(self.as_multi_line_string::<2>(), rhs)
+                ContainsLineString::contains(self.as_multi_line_string(), rhs)
             }
-            MultiPolygon(_, XY) => ContainsLineString::contains(self.as_multi_polygon::<2>(), rhs),
-            Mixed(_, XY) => ContainsLineString::contains(self.as_mixed::<2>(), rhs),
+            MultiPolygon(_, XY) => ContainsLineString::contains(self.as_multi_polygon(), rhs),
+            Mixed(_, XY) => ContainsLineString::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
-                ContainsLineString::contains(self.as_geometry_collection::<2>(), rhs)
+                ContainsLineString::contains(self.as_geometry_collection(), rhs)
             }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -253,7 +253,7 @@ pub trait ContainsPolygon<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for PointArray<2> {
+impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for PointArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = polygon_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -273,13 +273,13 @@ macro_rules! impl_contains_polygon {
     };
 }
 
-impl_contains_polygon!(LineStringArray<2>);
-impl_contains_polygon!(PolygonArray<2>);
-impl_contains_polygon!(MultiPointArray<2>);
-impl_contains_polygon!(MultiLineStringArray<2>);
-impl_contains_polygon!(MultiPolygonArray<2>);
-impl_contains_polygon!(MixedGeometryArray<2>);
-impl_contains_polygon!(GeometryCollectionArray<2>);
+impl_contains_polygon!(LineStringArray);
+impl_contains_polygon!(PolygonArray);
+impl_contains_polygon!(MultiPointArray);
+impl_contains_polygon!(MultiLineStringArray);
+impl_contains_polygon!(MultiPolygonArray);
+impl_contains_polygon!(MixedGeometryArray);
+impl_contains_polygon!(GeometryCollectionArray);
 
 impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -287,17 +287,17 @@ impl<G: PolygonTrait<T = f64>> ContainsPolygon<G> for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => ContainsPolygon::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => ContainsPolygon::contains(self.as_line_string::<2>(), rhs),
-            Polygon(_, XY) => ContainsPolygon::contains(self.as_polygon::<2>(), rhs),
-            MultiPoint(_, XY) => ContainsPolygon::contains(self.as_multi_point::<2>(), rhs),
+            Point(_, XY) => ContainsPolygon::contains(self.as_point(), rhs),
+            LineString(_, XY) => ContainsPolygon::contains(self.as_line_string(), rhs),
+            Polygon(_, XY) => ContainsPolygon::contains(self.as_polygon(), rhs),
+            MultiPoint(_, XY) => ContainsPolygon::contains(self.as_multi_point(), rhs),
             MultiLineString(_, XY) => {
-                ContainsPolygon::contains(self.as_multi_line_string::<2>(), rhs)
+                ContainsPolygon::contains(self.as_multi_line_string(), rhs)
             }
-            MultiPolygon(_, XY) => ContainsPolygon::contains(self.as_multi_polygon::<2>(), rhs),
-            Mixed(_, XY) => ContainsPolygon::contains(self.as_mixed::<2>(), rhs),
+            MultiPolygon(_, XY) => ContainsPolygon::contains(self.as_multi_polygon(), rhs),
+            Mixed(_, XY) => ContainsPolygon::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
-                ContainsPolygon::contains(self.as_geometry_collection::<2>(), rhs)
+                ContainsPolygon::contains(self.as_geometry_collection(), rhs)
             }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -308,7 +308,7 @@ pub trait ContainsMultiPoint<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for PointArray<2> {
+impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for PointArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_point_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -328,13 +328,13 @@ macro_rules! impl_contains_multi_point {
     };
 }
 
-impl_contains_multi_point!(LineStringArray<2>);
-impl_contains_multi_point!(PolygonArray<2>);
-impl_contains_multi_point!(MultiPointArray<2>);
-impl_contains_multi_point!(MultiLineStringArray<2>);
-impl_contains_multi_point!(MultiPolygonArray<2>);
-impl_contains_multi_point!(MixedGeometryArray<2>);
-impl_contains_multi_point!(GeometryCollectionArray<2>);
+impl_contains_multi_point!(LineStringArray);
+impl_contains_multi_point!(PolygonArray);
+impl_contains_multi_point!(MultiPointArray);
+impl_contains_multi_point!(MultiLineStringArray);
+impl_contains_multi_point!(MultiPolygonArray);
+impl_contains_multi_point!(MixedGeometryArray);
+impl_contains_multi_point!(GeometryCollectionArray);
 
 impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -342,17 +342,17 @@ impl<G: MultiPointTrait<T = f64>> ContainsMultiPoint<G> for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => ContainsMultiPoint::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => ContainsMultiPoint::contains(self.as_line_string::<2>(), rhs),
-            Polygon(_, XY) => ContainsMultiPoint::contains(self.as_polygon::<2>(), rhs),
-            MultiPoint(_, XY) => ContainsMultiPoint::contains(self.as_multi_point::<2>(), rhs),
+            Point(_, XY) => ContainsMultiPoint::contains(self.as_point(), rhs),
+            LineString(_, XY) => ContainsMultiPoint::contains(self.as_line_string(), rhs),
+            Polygon(_, XY) => ContainsMultiPoint::contains(self.as_polygon(), rhs),
+            MultiPoint(_, XY) => ContainsMultiPoint::contains(self.as_multi_point(), rhs),
             MultiLineString(_, XY) => {
-                ContainsMultiPoint::contains(self.as_multi_line_string::<2>(), rhs)
+                ContainsMultiPoint::contains(self.as_multi_line_string(), rhs)
             }
-            MultiPolygon(_, XY) => ContainsMultiPoint::contains(self.as_multi_polygon::<2>(), rhs),
-            Mixed(_, XY) => ContainsMultiPoint::contains(self.as_mixed::<2>(), rhs),
+            MultiPolygon(_, XY) => ContainsMultiPoint::contains(self.as_multi_polygon(), rhs),
+            Mixed(_, XY) => ContainsMultiPoint::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
-                ContainsMultiPoint::contains(self.as_geometry_collection::<2>(), rhs)
+                ContainsMultiPoint::contains(self.as_geometry_collection(), rhs)
             }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -363,7 +363,7 @@ pub trait ContainsMultiLineString<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for PointArray<2> {
+impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for PointArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_line_string_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -383,13 +383,13 @@ macro_rules! impl_contains_multi_line_string {
     };
 }
 
-impl_contains_multi_line_string!(LineStringArray<2>);
-impl_contains_multi_line_string!(PolygonArray<2>);
-impl_contains_multi_line_string!(MultiPointArray<2>);
-impl_contains_multi_line_string!(MultiLineStringArray<2>);
-impl_contains_multi_line_string!(MultiPolygonArray<2>);
-impl_contains_multi_line_string!(MixedGeometryArray<2>);
-impl_contains_multi_line_string!(GeometryCollectionArray<2>);
+impl_contains_multi_line_string!(LineStringArray);
+impl_contains_multi_line_string!(PolygonArray);
+impl_contains_multi_line_string!(MultiPointArray);
+impl_contains_multi_line_string!(MultiLineStringArray);
+impl_contains_multi_line_string!(MultiPolygonArray);
+impl_contains_multi_line_string!(MixedGeometryArray);
+impl_contains_multi_line_string!(GeometryCollectionArray);
 
 impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -397,19 +397,19 @@ impl<G: MultiLineStringTrait<T = f64>> ContainsMultiLineString<G> for &dyn Nativ
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => ContainsMultiLineString::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => ContainsMultiLineString::contains(self.as_line_string::<2>(), rhs),
-            Polygon(_, XY) => ContainsMultiLineString::contains(self.as_polygon::<2>(), rhs),
-            MultiPoint(_, XY) => ContainsMultiLineString::contains(self.as_multi_point::<2>(), rhs),
+            Point(_, XY) => ContainsMultiLineString::contains(self.as_point(), rhs),
+            LineString(_, XY) => ContainsMultiLineString::contains(self.as_line_string(), rhs),
+            Polygon(_, XY) => ContainsMultiLineString::contains(self.as_polygon(), rhs),
+            MultiPoint(_, XY) => ContainsMultiLineString::contains(self.as_multi_point(), rhs),
             MultiLineString(_, XY) => {
-                ContainsMultiLineString::contains(self.as_multi_line_string::<2>(), rhs)
+                ContainsMultiLineString::contains(self.as_multi_line_string(), rhs)
             }
             MultiPolygon(_, XY) => {
-                ContainsMultiLineString::contains(self.as_multi_polygon::<2>(), rhs)
+                ContainsMultiLineString::contains(self.as_multi_polygon(), rhs)
             }
-            Mixed(_, XY) => ContainsMultiLineString::contains(self.as_mixed::<2>(), rhs),
+            Mixed(_, XY) => ContainsMultiLineString::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
-                ContainsMultiLineString::contains(self.as_geometry_collection::<2>(), rhs)
+                ContainsMultiLineString::contains(self.as_geometry_collection(), rhs)
             }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -420,7 +420,7 @@ pub trait ContainsMultiPolygon<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for PointArray<2> {
+impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for PointArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = multi_polygon_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -440,13 +440,13 @@ macro_rules! impl_contains_multi_polygon {
     };
 }
 
-impl_contains_multi_polygon!(LineStringArray<2>);
-impl_contains_multi_polygon!(PolygonArray<2>);
-impl_contains_multi_polygon!(MultiPointArray<2>);
-impl_contains_multi_polygon!(MultiLineStringArray<2>);
-impl_contains_multi_polygon!(MultiPolygonArray<2>);
-impl_contains_multi_polygon!(MixedGeometryArray<2>);
-impl_contains_multi_polygon!(GeometryCollectionArray<2>);
+impl_contains_multi_polygon!(LineStringArray);
+impl_contains_multi_polygon!(PolygonArray);
+impl_contains_multi_polygon!(MultiPointArray);
+impl_contains_multi_polygon!(MultiLineStringArray);
+impl_contains_multi_polygon!(MultiPolygonArray);
+impl_contains_multi_polygon!(MixedGeometryArray);
+impl_contains_multi_polygon!(GeometryCollectionArray);
 
 impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -454,19 +454,19 @@ impl<G: MultiPolygonTrait<T = f64>> ContainsMultiPolygon<G> for &dyn NativeArray
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => ContainsMultiPolygon::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => ContainsMultiPolygon::contains(self.as_line_string::<2>(), rhs),
-            Polygon(_, XY) => ContainsMultiPolygon::contains(self.as_polygon::<2>(), rhs),
-            MultiPoint(_, XY) => ContainsMultiPolygon::contains(self.as_multi_point::<2>(), rhs),
+            Point(_, XY) => ContainsMultiPolygon::contains(self.as_point(), rhs),
+            LineString(_, XY) => ContainsMultiPolygon::contains(self.as_line_string(), rhs),
+            Polygon(_, XY) => ContainsMultiPolygon::contains(self.as_polygon(), rhs),
+            MultiPoint(_, XY) => ContainsMultiPolygon::contains(self.as_multi_point(), rhs),
             MultiLineString(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_multi_line_string::<2>(), rhs)
+                ContainsMultiPolygon::contains(self.as_multi_line_string(), rhs)
             }
             MultiPolygon(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_multi_polygon::<2>(), rhs)
+                ContainsMultiPolygon::contains(self.as_multi_polygon(), rhs)
             }
-            Mixed(_, XY) => ContainsMultiPolygon::contains(self.as_mixed::<2>(), rhs),
+            Mixed(_, XY) => ContainsMultiPolygon::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
-                ContainsMultiPolygon::contains(self.as_geometry_collection::<2>(), rhs)
+                ContainsMultiPolygon::contains(self.as_geometry_collection(), rhs)
             }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -477,7 +477,7 @@ pub trait ContainsGeometry<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for PointArray<2> {
+impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for PointArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = geometry_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -497,13 +497,13 @@ macro_rules! impl_contains_geometry {
     };
 }
 
-impl_contains_geometry!(LineStringArray<2>);
-impl_contains_geometry!(PolygonArray<2>);
-// impl_contains_geometry!(MultiPointArray<2>); // Not implemented in geo
-impl_contains_geometry!(MultiLineStringArray<2>);
-// impl_contains_geometry!(MultiPolygonArray<2>); // Not implemented in geo
-impl_contains_geometry!(MixedGeometryArray<2>);
-impl_contains_geometry!(GeometryCollectionArray<2>);
+impl_contains_geometry!(LineStringArray);
+impl_contains_geometry!(PolygonArray);
+// impl_contains_geometry!(MultiPointArray); // Not implemented in geo
+impl_contains_geometry!(MultiLineStringArray);
+// impl_contains_geometry!(MultiPolygonArray); // Not implemented in geo
+impl_contains_geometry!(MixedGeometryArray);
+impl_contains_geometry!(GeometryCollectionArray);
 
 impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -511,17 +511,17 @@ impl<G: GeometryTrait<T = f64>> ContainsGeometry<G> for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => ContainsGeometry::contains(self.as_point::<2>(), rhs),
-            LineString(_, XY) => ContainsGeometry::contains(self.as_line_string::<2>(), rhs),
-            Polygon(_, XY) => ContainsGeometry::contains(self.as_polygon::<2>(), rhs),
-            MultiPoint(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_point::<2>(), rhs),
+            Point(_, XY) => ContainsGeometry::contains(self.as_point(), rhs),
+            LineString(_, XY) => ContainsGeometry::contains(self.as_line_string(), rhs),
+            Polygon(_, XY) => ContainsGeometry::contains(self.as_polygon(), rhs),
+            MultiPoint(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_point(), rhs),
             MultiLineString(_, XY) => {
-                ContainsGeometry::contains(self.as_multi_line_string::<2>(), rhs)
+                ContainsGeometry::contains(self.as_multi_line_string(), rhs)
             }
-            MultiPolygon(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_polygon::<2>(), rhs),
-            Mixed(_, XY) => ContainsGeometry::contains(self.as_mixed::<2>(), rhs),
+            MultiPolygon(_, XY) => todo!(), // ContainsGeometry::contains(self.as_multi_polygon(), rhs),
+            Mixed(_, XY) => ContainsGeometry::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
-                ContainsGeometry::contains(self.as_geometry_collection::<2>(), rhs)
+                ContainsGeometry::contains(self.as_geometry_collection(), rhs)
             }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -532,7 +532,7 @@ pub trait ContainsGeometryCollection<Rhs> {
     fn contains(&self, rhs: &Rhs) -> BooleanArray;
 }
 
-impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for PointArray<2> {
+impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for PointArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
         let rhs = geometry_collection_to_geo(rhs);
         self.try_unary_boolean::<_, GeoArrowError>(|geom| Ok(geom.to_geo().contains(&rhs)))
@@ -552,13 +552,13 @@ macro_rules! impl_contains_geometry_collection {
     };
 }
 
-impl_contains_geometry_collection!(LineStringArray<2>);
-impl_contains_geometry_collection!(PolygonArray<2>);
-impl_contains_geometry_collection!(MultiPointArray<2>);
-impl_contains_geometry_collection!(MultiLineStringArray<2>);
-impl_contains_geometry_collection!(MultiPolygonArray<2>);
-impl_contains_geometry_collection!(MixedGeometryArray<2>);
-impl_contains_geometry_collection!(GeometryCollectionArray<2>);
+impl_contains_geometry_collection!(LineStringArray);
+impl_contains_geometry_collection!(PolygonArray);
+impl_contains_geometry_collection!(MultiPointArray);
+impl_contains_geometry_collection!(MultiLineStringArray);
+impl_contains_geometry_collection!(MultiPolygonArray);
+impl_contains_geometry_collection!(MixedGeometryArray);
+impl_contains_geometry_collection!(GeometryCollectionArray);
 
 impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for &dyn NativeArray {
     fn contains(&self, rhs: &G) -> BooleanArray {
@@ -566,23 +566,23 @@ impl<G: GeometryCollectionTrait<T = f64>> ContainsGeometryCollection<G> for &dyn
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => ContainsGeometryCollection::contains(self.as_point::<2>(), rhs),
+            Point(_, XY) => ContainsGeometryCollection::contains(self.as_point(), rhs),
             LineString(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_line_string::<2>(), rhs)
+                ContainsGeometryCollection::contains(self.as_line_string(), rhs)
             }
-            Polygon(_, XY) => ContainsGeometryCollection::contains(self.as_polygon::<2>(), rhs),
+            Polygon(_, XY) => ContainsGeometryCollection::contains(self.as_polygon(), rhs),
             MultiPoint(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_multi_point::<2>(), rhs)
+                ContainsGeometryCollection::contains(self.as_multi_point(), rhs)
             }
             MultiLineString(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_multi_line_string::<2>(), rhs)
+                ContainsGeometryCollection::contains(self.as_multi_line_string(), rhs)
             }
             MultiPolygon(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_multi_polygon::<2>(), rhs)
+                ContainsGeometryCollection::contains(self.as_multi_polygon(), rhs)
             }
-            Mixed(_, XY) => ContainsGeometryCollection::contains(self.as_mixed::<2>(), rhs),
+            Mixed(_, XY) => ContainsGeometryCollection::contains(self.as_mixed(), rhs),
             GeometryCollection(_, XY) => {
-                ContainsGeometryCollection::contains(self.as_geometry_collection::<2>(), rhs)
+                ContainsGeometryCollection::contains(self.as_geometry_collection(), rhs)
             }
             _ => panic!("incorrect type"), // _ => return Err(GeoArrowError::IncorrectType("".into())),
         }

--- a/rust/geoarrow/src/algorithm/geo/convex_hull.rs
+++ b/rust/geoarrow/src/algorithm/geo/convex_hull.rs
@@ -53,7 +53,7 @@ pub trait ConvexHull {
 macro_rules! iter_geo_impl {
     ($type:ty) => {
         impl ConvexHull for $type {
-            type Output = PolygonArray<2>;
+            type Output = PolygonArray;
 
             fn convex_hull(&self) -> Self::Output {
                 let output_geoms: Vec<Option<Polygon>> = self
@@ -67,33 +67,33 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PointArray<2>);
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
-iter_geo_impl!(RectArray<2>);
+iter_geo_impl!(PointArray);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPointArray);
+iter_geo_impl!(MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
+iter_geo_impl!(RectArray);
 
 impl ConvexHull for &dyn NativeArray {
-    type Output = Result<PolygonArray<2>>;
+    type Output = Result<PolygonArray>;
 
     fn convex_hull(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().convex_hull(),
-            LineString(_, XY) => self.as_line_string::<2>().convex_hull(),
-            Polygon(_, XY) => self.as_polygon::<2>().convex_hull(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().convex_hull(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().convex_hull(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().convex_hull(),
-            Mixed(_, XY) => self.as_mixed::<2>().convex_hull(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().convex_hull(),
-            Rect(XY) => self.as_rect::<2>().convex_hull(),
+            Point(_, XY) => self.as_point().convex_hull(),
+            LineString(_, XY) => self.as_line_string().convex_hull(),
+            Polygon(_, XY) => self.as_polygon().convex_hull(),
+            MultiPoint(_, XY) => self.as_multi_point().convex_hull(),
+            MultiLineString(_, XY) => self.as_multi_line_string().convex_hull(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().convex_hull(),
+            Mixed(_, XY) => self.as_mixed().convex_hull(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().convex_hull(),
+            Rect(XY) => self.as_rect().convex_hull(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -101,7 +101,7 @@ impl ConvexHull for &dyn NativeArray {
 }
 
 impl<G: NativeArray> ConvexHull for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedGeometryArray<PolygonArray<2>>>;
+    type Output = Result<ChunkedGeometryArray<PolygonArray>>;
 
     fn convex_hull(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().convex_hull())?
@@ -110,22 +110,22 @@ impl<G: NativeArray> ConvexHull for ChunkedGeometryArray<G> {
 }
 
 impl ConvexHull for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPolygonArray<2>>;
+    type Output = Result<ChunkedPolygonArray>;
 
     fn convex_hull(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().convex_hull(),
-            LineString(_, XY) => self.as_line_string::<2>().convex_hull(),
-            Polygon(_, XY) => self.as_polygon::<2>().convex_hull(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().convex_hull(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().convex_hull(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().convex_hull(),
-            Mixed(_, XY) => self.as_mixed::<2>().convex_hull(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().convex_hull(),
-            Rect(XY) => self.as_rect::<2>().convex_hull(),
+            Point(_, XY) => self.as_point().convex_hull(),
+            LineString(_, XY) => self.as_line_string().convex_hull(),
+            Polygon(_, XY) => self.as_polygon().convex_hull(),
+            MultiPoint(_, XY) => self.as_multi_point().convex_hull(),
+            MultiLineString(_, XY) => self.as_multi_line_string().convex_hull(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().convex_hull(),
+            Mixed(_, XY) => self.as_mixed().convex_hull(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().convex_hull(),
+            Rect(XY) => self.as_rect().convex_hull(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -154,8 +154,8 @@ mod tests {
             Point::new(0.0, 10.0),
         ]
         .into();
-        let input_array: MultiPointArray<2> = vec![input_geom].as_slice().into();
-        let result_array: PolygonArray<2> = input_array.convex_hull();
+        let input_array: MultiPointArray = vec![input_geom].as_slice().into();
+        let result_array: PolygonArray = input_array.convex_hull();
 
         let expected = polygon![
             (x:0.0, y: -10.0),
@@ -182,8 +182,8 @@ mod tests {
             (x: 0.0, y: 10.0),
         ];
 
-        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
-        let result_array: PolygonArray<2> = input_array.convex_hull();
+        let input_array: LineStringArray = vec![input_geom].as_slice().into();
+        let result_array: PolygonArray = input_array.convex_hull();
 
         let expected = polygon![
             (x: 0.0, y: -10.0),

--- a/rust/geoarrow/src/algorithm/geo/convex_hull.rs
+++ b/rust/geoarrow/src/algorithm/geo/convex_hull.rs
@@ -61,7 +61,7 @@ macro_rules! iter_geo_impl {
                     .map(|maybe_g| maybe_g.map(|geom| geom.convex_hull()))
                     .collect();
 
-                output_geoms.into()
+                (output_geoms, Dimension::XY).into()
             }
         }
     };
@@ -136,6 +136,7 @@ mod tests {
     use super::ConvexHull;
     use crate::array::polygon::PolygonArray;
     use crate::array::{LineStringArray, MultiPointArray};
+    use crate::datatypes::Dimension;
     use crate::trait_::ArrayAccessor;
     use geo::{line_string, polygon, MultiPoint, Point};
 
@@ -154,7 +155,7 @@ mod tests {
             Point::new(0.0, 10.0),
         ]
         .into();
-        let input_array: MultiPointArray = vec![input_geom].as_slice().into();
+        let input_array: MultiPointArray = (vec![input_geom].as_slice(), Dimension::XY).into();
         let result_array: PolygonArray = input_array.convex_hull();
 
         let expected = polygon![
@@ -182,7 +183,7 @@ mod tests {
             (x: 0.0, y: 10.0),
         ];
 
-        let input_array: LineStringArray = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = (vec![input_geom].as_slice(), Dimension::XY).into();
         let result_array: PolygonArray = input_array.convex_hull();
 
         let expected = polygon![

--- a/rust/geoarrow/src/algorithm/geo/densify.rs
+++ b/rust/geoarrow/src/algorithm/geo/densify.rs
@@ -42,7 +42,7 @@ macro_rules! iter_geo_impl {
                     .map(|maybe_g| maybe_g.map(|geom| geom.densify(max_distance)))
                     .collect();
 
-                output_geoms.into()
+                (output_geoms, Dimension::XY).into()
             }
         }
     };
@@ -63,9 +63,7 @@ impl Densify for &dyn NativeArray {
         let result: Arc<dyn NativeArray> = match self.data_type() {
             LineString(_, XY) => Arc::new(self.as_line_string().densify(max_distance)),
             Polygon(_, XY) => Arc::new(self.as_polygon().densify(max_distance)),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string().densify(max_distance))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().densify(max_distance)),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().densify(max_distance)),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -102,9 +100,7 @@ impl Densify for &dyn ChunkedNativeArray {
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
             LineString(_, XY) => Arc::new(self.as_line_string().densify(max_distance)),
             Polygon(_, XY) => Arc::new(self.as_polygon().densify(max_distance)),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string().densify(max_distance))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().densify(max_distance)),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().densify(max_distance)),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };

--- a/rust/geoarrow/src/algorithm/geo/densify.rs
+++ b/rust/geoarrow/src/algorithm/geo/densify.rs
@@ -48,10 +48,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, geo::LineString);
-iter_geo_impl!(PolygonArray<2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
+iter_geo_impl!(LineStringArray, geo::LineString);
+iter_geo_impl!(PolygonArray, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray, geo::MultiPolygon);
 
 impl Densify for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -61,12 +61,12 @@ impl Densify for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().densify(max_distance)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().densify(max_distance)),
+            LineString(_, XY) => Arc::new(self.as_line_string().densify(max_distance)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().densify(max_distance)),
             MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().densify(max_distance))
+                Arc::new(self.as_multi_line_string().densify(max_distance))
             }
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().densify(max_distance)),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().densify(max_distance)),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -87,10 +87,10 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<2>);
-impl_chunked!(ChunkedPolygonArray<2>);
-impl_chunked!(ChunkedMultiLineStringArray<2>);
-impl_chunked!(ChunkedMultiPolygonArray<2>);
+impl_chunked!(ChunkedLineStringArray);
+impl_chunked!(ChunkedPolygonArray);
+impl_chunked!(ChunkedMultiLineStringArray);
+impl_chunked!(ChunkedMultiPolygonArray);
 
 impl Densify for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -100,12 +100,12 @@ impl Densify for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().densify(max_distance)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().densify(max_distance)),
+            LineString(_, XY) => Arc::new(self.as_line_string().densify(max_distance)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().densify(max_distance)),
             MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().densify(max_distance))
+                Arc::new(self.as_multi_line_string().densify(max_distance))
             }
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().densify(max_distance)),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().densify(max_distance)),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/rust/geoarrow/src/algorithm/geo/dimensions.rs
+++ b/rust/geoarrow/src/algorithm/geo/dimensions.rs
@@ -51,14 +51,14 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PointArray<2>);
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
+iter_geo_impl!(PointArray);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPointArray);
+iter_geo_impl!(MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
 
 impl HasDimensions for &dyn NativeArray {
     type Output = Result<BooleanArray>;
@@ -68,16 +68,14 @@ impl HasDimensions for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => HasDimensions::is_empty(self.as_point::<2>()),
-            LineString(_, XY) => HasDimensions::is_empty(self.as_line_string::<2>()),
-            Polygon(_, XY) => HasDimensions::is_empty(self.as_polygon::<2>()),
-            MultiPoint(_, XY) => HasDimensions::is_empty(self.as_multi_point::<2>()),
-            MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string::<2>()),
-            MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon::<2>()),
-            Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed::<2>()),
-            GeometryCollection(_, XY) => {
-                HasDimensions::is_empty(self.as_geometry_collection::<2>())
-            }
+            Point(_, XY) => HasDimensions::is_empty(self.as_point()),
+            LineString(_, XY) => HasDimensions::is_empty(self.as_line_string()),
+            Polygon(_, XY) => HasDimensions::is_empty(self.as_polygon()),
+            MultiPoint(_, XY) => HasDimensions::is_empty(self.as_multi_point()),
+            MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string()),
+            MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon()),
+            Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed()),
+            GeometryCollection(_, XY) => HasDimensions::is_empty(self.as_geometry_collection()),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -101,16 +99,14 @@ impl HasDimensions for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => HasDimensions::is_empty(self.as_point::<2>()),
-            LineString(_, XY) => HasDimensions::is_empty(self.as_line_string::<2>()),
-            Polygon(_, XY) => HasDimensions::is_empty(self.as_polygon::<2>()),
-            MultiPoint(_, XY) => HasDimensions::is_empty(self.as_multi_point::<2>()),
-            MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string::<2>()),
-            MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon::<2>()),
-            Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed::<2>()),
-            GeometryCollection(_, XY) => {
-                HasDimensions::is_empty(self.as_geometry_collection::<2>())
-            }
+            Point(_, XY) => HasDimensions::is_empty(self.as_point()),
+            LineString(_, XY) => HasDimensions::is_empty(self.as_line_string()),
+            Polygon(_, XY) => HasDimensions::is_empty(self.as_polygon()),
+            MultiPoint(_, XY) => HasDimensions::is_empty(self.as_multi_point()),
+            MultiLineString(_, XY) => HasDimensions::is_empty(self.as_multi_line_string()),
+            MultiPolygon(_, XY) => HasDimensions::is_empty(self.as_multi_polygon()),
+            Mixed(_, XY) => HasDimensions::is_empty(self.as_mixed()),
+            GeometryCollection(_, XY) => HasDimensions::is_empty(self.as_geometry_collection()),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/rust/geoarrow/src/algorithm/geo/euclidean_distance.rs
+++ b/rust/geoarrow/src/algorithm/geo/euclidean_distance.rs
@@ -57,7 +57,7 @@ pub trait EuclideanDistance<Rhs> {
     ///
     /// let distance = point.euclidean_distance(&polygon);
     ///
-    /// assert_relative_eq!(distance, 2.1213203435596424);
+    /// assert_relative_eq!(distance.1213203435596424);
     /// ```
     ///
     /// `Point` to `LineString`:
@@ -186,9 +186,9 @@ iter_geo_impl!(MultiPolygonArray, PointArray);
 // └─────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl<'a> EuclideanDistance<Point<'a, 2>> for PointArray {
+impl<'a> EuclideanDistance<Point<'a>> for PointArray {
     /// Minimum distance between two Points
-    fn euclidean_distance(&self, other: &Point<'a, 2>) -> Float64Array {
+    fn euclidean_distance(&self, other: &Point<'a>) -> Float64Array {
         let mut output_array = Float64Builder::with_capacity(self.len());
 
         self.iter_geo().for_each(|maybe_point| {
@@ -220,48 +220,48 @@ macro_rules! iter_geo_impl_scalar {
 }
 
 // Implementations on PointArray
-iter_geo_impl_scalar!(PointArray, LineString<'a, 2>);
-iter_geo_impl_scalar!(PointArray, Polygon<'a, 2>);
-iter_geo_impl_scalar!(PointArray, MultiPoint<'a, 2>);
-iter_geo_impl_scalar!(PointArray, MultiLineString<'a, 2>);
-iter_geo_impl_scalar!(PointArray, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(PointArray, LineString<'a>);
+iter_geo_impl_scalar!(PointArray, Polygon<'a>);
+iter_geo_impl_scalar!(PointArray, MultiPoint<'a>);
+iter_geo_impl_scalar!(PointArray, MultiLineString<'a>);
+iter_geo_impl_scalar!(PointArray, MultiPolygon<'a>);
 
 // Implementations on LineStringArray
-iter_geo_impl_scalar!(LineStringArray, Point<'a, 2>);
-iter_geo_impl_scalar!(LineStringArray, LineString<'a, 2>);
-iter_geo_impl_scalar!(LineStringArray, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(LineStringArray, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(LineStringArray, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(LineStringArray, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(LineStringArray, Point<'a>);
+iter_geo_impl_scalar!(LineStringArray, LineString<'a>);
+iter_geo_impl_scalar!(LineStringArray, Polygon<'a>);
+// iter_geo_impl_scalar!(LineStringArray, MultiPoint<'a>);
+// iter_geo_impl_scalar!(LineStringArray, MultiLineString<'a>);
+// iter_geo_impl_scalar!(LineStringArray, MultiPolygon<'a>);
 
 // Implementations on PolygonArray
-iter_geo_impl_scalar!(PolygonArray, Point<'a, 2>);
-iter_geo_impl_scalar!(PolygonArray, LineString<'a, 2>);
-iter_geo_impl_scalar!(PolygonArray, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(PolygonArray, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(PolygonArray, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(PolygonArray, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(PolygonArray, Point<'a>);
+iter_geo_impl_scalar!(PolygonArray, LineString<'a>);
+iter_geo_impl_scalar!(PolygonArray, Polygon<'a>);
+// iter_geo_impl_scalar!(PolygonArray, MultiPoint<'a>);
+// iter_geo_impl_scalar!(PolygonArray, MultiLineString<'a>);
+// iter_geo_impl_scalar!(PolygonArray, MultiPolygon<'a>);
 
 // Implementations on MultiPointArray
-iter_geo_impl_scalar!(MultiPointArray, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray, LineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(MultiPointArray, Point<'a>);
+// iter_geo_impl_scalar!(MultiPointArray, LineString<'a>);
+// iter_geo_impl_scalar!(MultiPointArray, Polygon<'a>);
+// iter_geo_impl_scalar!(MultiPointArray, MultiPoint<'a>);
+// iter_geo_impl_scalar!(MultiPointArray, MultiLineString<'a>);
+// iter_geo_impl_scalar!(MultiPointArray, MultiPolygon<'a>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_scalar!(MultiLineStringArray, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray, LineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(MultiLineStringArray, Point<'a>);
+// iter_geo_impl_scalar!(MultiLineStringArray, LineString<'a>);
+// iter_geo_impl_scalar!(MultiLineStringArray, Polygon<'a>);
+// iter_geo_impl_scalar!(MultiLineStringArray, MultiPoint<'a>);
+// iter_geo_impl_scalar!(MultiLineStringArray, MultiLineString<'a>);
+// iter_geo_impl_scalar!(MultiLineStringArray, MultiPolygon<'a>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_scalar!(MultiPolygonArray, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray, LineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(MultiPolygonArray, Point<'a>);
+// iter_geo_impl_scalar!(MultiPolygonArray, LineString<'a>);
+// iter_geo_impl_scalar!(MultiPolygonArray, Polygon<'a>);
+// iter_geo_impl_scalar!(MultiPolygonArray, MultiPoint<'a>);
+// iter_geo_impl_scalar!(MultiPolygonArray, MultiLineString<'a>);
+// iter_geo_impl_scalar!(MultiPolygonArray, MultiPolygon<'a>);

--- a/rust/geoarrow/src/algorithm/geo/euclidean_distance.rs
+++ b/rust/geoarrow/src/algorithm/geo/euclidean_distance.rs
@@ -92,9 +92,9 @@ pub trait EuclideanDistance<Rhs> {
 // └────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl EuclideanDistance<PointArray<2>> for PointArray<2> {
+impl EuclideanDistance<PointArray> for PointArray {
     /// Minimum distance between two Points
-    fn euclidean_distance(&self, other: &PointArray<2>) -> Float64Array {
+    fn euclidean_distance(&self, other: &PointArray) -> Float64Array {
         assert_eq!(self.len(), other.len());
         let mut output_array = Float64Builder::with_capacity(self.len());
 
@@ -135,58 +135,58 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray<2>, LineStringArray<2>);
-iter_geo_impl!(PointArray<2>, PolygonArray<2>);
-iter_geo_impl!(PointArray<2>, MultiPointArray<2>);
-iter_geo_impl!(PointArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(PointArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(PointArray, LineStringArray);
+iter_geo_impl!(PointArray, PolygonArray);
+iter_geo_impl!(PointArray, MultiPointArray);
+iter_geo_impl!(PointArray, MultiLineStringArray);
+iter_geo_impl!(PointArray, MultiPolygonArray);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<2>, PointArray<2>);
-iter_geo_impl!(LineStringArray<2>, LineStringArray<2>);
-iter_geo_impl!(LineStringArray<2>, PolygonArray<2>);
-// iter_geo_impl!(LineStringArray<2>, MultiPointArray<2>);
-// iter_geo_impl!(LineStringArray<2>, MultiLineStringArray<2>);
-// iter_geo_impl!(LineStringArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(LineStringArray, PointArray);
+iter_geo_impl!(LineStringArray, LineStringArray);
+iter_geo_impl!(LineStringArray, PolygonArray);
+// iter_geo_impl!(LineStringArray, MultiPointArray);
+// iter_geo_impl!(LineStringArray, MultiLineStringArray);
+// iter_geo_impl!(LineStringArray, MultiPolygonArray);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<2>, PointArray<2>);
-iter_geo_impl!(PolygonArray<2>, LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>, PolygonArray<2>);
-// iter_geo_impl!(PolygonArray<2>, MultiPointArray<2>);
-// iter_geo_impl!(PolygonArray<2>, MultiLineStringArray<2>);
-// iter_geo_impl!(PolygonArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(PolygonArray, PointArray);
+iter_geo_impl!(PolygonArray, LineStringArray);
+iter_geo_impl!(PolygonArray, PolygonArray);
+// iter_geo_impl!(PolygonArray, MultiPointArray);
+// iter_geo_impl!(PolygonArray, MultiLineStringArray);
+// iter_geo_impl!(PolygonArray, MultiPolygonArray);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<2>, PointArray<2>);
-// iter_geo_impl!(MultiPointArray<2>, LineStringArray<2>);
-// iter_geo_impl!(MultiPointArray<2>, PolygonArray<2>);
-// iter_geo_impl!(MultiPointArray<2>, MultiPointArray<2>);
-// iter_geo_impl!(MultiPointArray<2>, MultiLineStringArray<2>);
-// iter_geo_impl!(MultiPointArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiPointArray, PointArray);
+// iter_geo_impl!(MultiPointArray, LineStringArray);
+// iter_geo_impl!(MultiPointArray, PolygonArray);
+// iter_geo_impl!(MultiPointArray, MultiPointArray);
+// iter_geo_impl!(MultiPointArray, MultiLineStringArray);
+// iter_geo_impl!(MultiPointArray, MultiPolygonArray);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<2>, PointArray<2>);
-// iter_geo_impl!(MultiLineStringArray<2>, LineStringArray<2>);
-// iter_geo_impl!(MultiLineStringArray<2>, PolygonArray<2>);
-// iter_geo_impl!(MultiLineStringArray<2>, MultiPointArray<2>);
-// iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringArray<2>);
-// iter_geo_impl!(MultiLineStringArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiLineStringArray, PointArray);
+// iter_geo_impl!(MultiLineStringArray, LineStringArray);
+// iter_geo_impl!(MultiLineStringArray, PolygonArray);
+// iter_geo_impl!(MultiLineStringArray, MultiPointArray);
+// iter_geo_impl!(MultiLineStringArray, MultiLineStringArray);
+// iter_geo_impl!(MultiLineStringArray, MultiPolygonArray);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<2>, PointArray<2>);
-// iter_geo_impl!(MultiPolygonArray<2>, LineStringArray<2>);
-// iter_geo_impl!(MultiPolygonArray<2>, PolygonArray<2>);
-// iter_geo_impl!(MultiPolygonArray<2>, MultiPointArray<2>);
-// iter_geo_impl!(MultiPolygonArray<2>, MultiLineStringArray<2>);
-// iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiPolygonArray, PointArray);
+// iter_geo_impl!(MultiPolygonArray, LineStringArray);
+// iter_geo_impl!(MultiPolygonArray, PolygonArray);
+// iter_geo_impl!(MultiPolygonArray, MultiPointArray);
+// iter_geo_impl!(MultiPolygonArray, MultiLineStringArray);
+// iter_geo_impl!(MultiPolygonArray, MultiPolygonArray);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
 // └─────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl<'a> EuclideanDistance<Point<'a, 2>> for PointArray<2> {
+impl<'a> EuclideanDistance<Point<'a, 2>> for PointArray {
     /// Minimum distance between two Points
     fn euclidean_distance(&self, other: &Point<'a, 2>) -> Float64Array {
         let mut output_array = Float64Builder::with_capacity(self.len());
@@ -220,48 +220,48 @@ macro_rules! iter_geo_impl_scalar {
 }
 
 // Implementations on PointArray
-iter_geo_impl_scalar!(PointArray<2>, LineString<'a, 2>);
-iter_geo_impl_scalar!(PointArray<2>, Polygon<'a, 2>);
-iter_geo_impl_scalar!(PointArray<2>, MultiPoint<'a, 2>);
-iter_geo_impl_scalar!(PointArray<2>, MultiLineString<'a, 2>);
-iter_geo_impl_scalar!(PointArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(PointArray, LineString<'a, 2>);
+iter_geo_impl_scalar!(PointArray, Polygon<'a, 2>);
+iter_geo_impl_scalar!(PointArray, MultiPoint<'a, 2>);
+iter_geo_impl_scalar!(PointArray, MultiLineString<'a, 2>);
+iter_geo_impl_scalar!(PointArray, MultiPolygon<'a, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl_scalar!(LineStringArray<2>, Point<'a, 2>);
-iter_geo_impl_scalar!(LineStringArray<2>, LineString<'a, 2>);
-iter_geo_impl_scalar!(LineStringArray<2>, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(LineStringArray<2>, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(LineStringArray<2>, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(LineStringArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(LineStringArray, Point<'a, 2>);
+iter_geo_impl_scalar!(LineStringArray, LineString<'a, 2>);
+iter_geo_impl_scalar!(LineStringArray, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(LineStringArray, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(LineStringArray, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(LineStringArray, MultiPolygon<'a, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl_scalar!(PolygonArray<2>, Point<'a, 2>);
-iter_geo_impl_scalar!(PolygonArray<2>, LineString<'a, 2>);
-iter_geo_impl_scalar!(PolygonArray<2>, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(PolygonArray<2>, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(PolygonArray<2>, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(PolygonArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(PolygonArray, Point<'a, 2>);
+iter_geo_impl_scalar!(PolygonArray, LineString<'a, 2>);
+iter_geo_impl_scalar!(PolygonArray, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(PolygonArray, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(PolygonArray, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(PolygonArray, MultiPolygon<'a, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl_scalar!(MultiPointArray<2>, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<2>, LineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<2>, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<2>, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<2>, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiPointArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(MultiPointArray, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray, LineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiPointArray, MultiPolygon<'a, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_scalar!(MultiLineStringArray<2>, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<2>, LineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<2>, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<2>, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<2>, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiLineStringArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(MultiLineStringArray, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray, LineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiLineStringArray, MultiPolygon<'a, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_scalar!(MultiPolygonArray<2>, Point<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<2>, LineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<2>, Polygon<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<2>, MultiPoint<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<2>, MultiLineString<'a, 2>);
-// iter_geo_impl_scalar!(MultiPolygonArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_scalar!(MultiPolygonArray, Point<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray, LineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray, Polygon<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray, MultiPoint<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray, MultiLineString<'a, 2>);
+// iter_geo_impl_scalar!(MultiPolygonArray, MultiPolygon<'a, 2>);

--- a/rust/geoarrow/src/algorithm/geo/euclidean_distance.rs
+++ b/rust/geoarrow/src/algorithm/geo/euclidean_distance.rs
@@ -57,7 +57,7 @@ pub trait EuclideanDistance<Rhs> {
     ///
     /// let distance = point.euclidean_distance(&polygon);
     ///
-    /// assert_relative_eq!(distance.1213203435596424);
+    /// assert_relative_eq!(distance, 2.1213203435596424);
     /// ```
     ///
     /// `Point` to `LineString`:

--- a/rust/geoarrow/src/algorithm/geo/euclidean_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/euclidean_length.rs
@@ -20,12 +20,13 @@ pub trait EuclideanLength {
     /// use geo::line_string;
     /// use geoarrow::array::LineStringArray;
     /// use geoarrow::algorithm::geo::EuclideanLength;
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let line_string = line_string![
     ///     (x: 40.02f64, y: 116.34),
     ///     (x: 42.02f64, y: 116.34),
     /// ];
-    /// let linestring_array: LineStringArray = vec![line_string].as_slice().into();
+    /// let linestring_array: LineStringArray = (vec![line_string].as_slice(), Dimension::XY).into();
     ///
     /// let length_array = linestring_array.euclidean_length();
     ///

--- a/rust/geoarrow/src/algorithm/geo/euclidean_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/euclidean_length.rs
@@ -166,7 +166,7 @@ mod tests {
             (x: 10., y: 1.),
             (x: 11., y: 1.)
         ];
-        let input_array: LineStringArray = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = (vec![input_geom].as_slice(), Dimension::XY).into();
         let result_array = input_array.euclidean_length();
 
         let expected = 10.0_f64;

--- a/rust/geoarrow/src/algorithm/geo/euclidean_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/euclidean_length.rs
@@ -25,7 +25,7 @@ pub trait EuclideanLength {
     ///     (x: 40.02f64, y: 116.34),
     ///     (x: 42.02f64, y: 116.34),
     /// ];
-    /// let linestring_array: LineStringArray<2> = vec![line_string].as_slice().into();
+    /// let linestring_array: LineStringArray = vec![line_string].as_slice().into();
     ///
     /// let length_array = linestring_array.euclidean_length();
     ///
@@ -50,8 +50,8 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(PointArray<2>);
-zero_impl!(MultiPointArray<2>);
+zero_impl!(PointArray);
+zero_impl!(MultiPointArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -66,8 +66,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(MultiLineStringArray);
 
 impl EuclideanLength for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -77,19 +77,19 @@ impl EuclideanLength for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().euclidean_length(),
-            LineString(_, XY) => self.as_line_string::<2>().euclidean_length(),
-            // Polygon(_, XY) => self.as_polygon::<2>().euclidean_length(),
-            // LargePolygon(_, XY) => self.as_large_polygon::<2>().euclidean_length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().euclidean_length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().euclidean_length(),
-            // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().euclidean_length(),
-            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().euclidean_length(),
-            // Mixed(_, XY) => self.as_mixed::<2>().euclidean_length(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().euclidean_length(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().euclidean_length(),
+            Point(_, XY) => self.as_point().euclidean_length(),
+            LineString(_, XY) => self.as_line_string().euclidean_length(),
+            // Polygon(_, XY) => self.as_polygon().euclidean_length(),
+            // LargePolygon(_, XY) => self.as_large_polygon().euclidean_length(),
+            MultiPoint(_, XY) => self.as_multi_point().euclidean_length(),
+            MultiLineString(_, XY) => self.as_multi_line_string().euclidean_length(),
+            // MultiPolygon(_, XY) => self.as_multi_polygon().euclidean_length(),
+            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon().euclidean_length(),
+            // Mixed(_, XY) => self.as_mixed().euclidean_length(),
+            // LargeMixed(_, XY) => self.as_large_mixed().euclidean_length(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().euclidean_length(),
             // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().euclidean_length()
+            //     self.as_large_geometry_collection().euclidean_length()
             // }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -97,7 +97,7 @@ impl EuclideanLength for &dyn NativeArray {
     }
 }
 
-impl EuclideanLength for ChunkedGeometryArray<PointArray<2>> {
+impl EuclideanLength for ChunkedGeometryArray<PointArray> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn euclidean_length(&self) -> Self::Output {
@@ -118,9 +118,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray>);
 
 impl EuclideanLength for &dyn ChunkedNativeArray {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -130,19 +130,19 @@ impl EuclideanLength for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().euclidean_length(),
-            LineString(_, XY) => self.as_line_string::<2>().euclidean_length(),
-            // Polygon(_, XY) => self.as_polygon::<2>().euclidean_length(),
-            // LargePolygon(_, XY) => self.as_large_polygon::<2>().euclidean_length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().euclidean_length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().euclidean_length(),
-            // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().euclidean_length(),
-            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon::<2>().euclidean_length(),
-            // Mixed(_, XY) => self.as_mixed::<2>().euclidean_length(),
-            // LargeMixed(_, XY) => self.as_large_mixed::<2>().euclidean_length(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().euclidean_length(),
+            Point(_, XY) => self.as_point().euclidean_length(),
+            LineString(_, XY) => self.as_line_string().euclidean_length(),
+            // Polygon(_, XY) => self.as_polygon().euclidean_length(),
+            // LargePolygon(_, XY) => self.as_large_polygon().euclidean_length(),
+            MultiPoint(_, XY) => self.as_multi_point().euclidean_length(),
+            MultiLineString(_, XY) => self.as_multi_line_string().euclidean_length(),
+            // MultiPolygon(_, XY) => self.as_multi_polygon().euclidean_length(),
+            // LargeMultiPolygon(_, XY) => self.as_large_multi_polygon().euclidean_length(),
+            // Mixed(_, XY) => self.as_mixed().euclidean_length(),
+            // LargeMixed(_, XY) => self.as_large_mixed().euclidean_length(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().euclidean_length(),
             // LargeGeometryCollection(_, XY) => {
-            //     self.as_large_geometry_collection::<2>().euclidean_length()
+            //     self.as_large_geometry_collection().euclidean_length()
             // }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -166,7 +166,7 @@ mod tests {
             (x: 10., y: 1.),
             (x: 11., y: 1.)
         ];
-        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = vec![input_geom].as_slice().into();
         let result_array = input_array.euclidean_length();
 
         let expected = 10.0_f64;

--- a/rust/geoarrow/src/algorithm/geo/frechet_distance.rs
+++ b/rust/geoarrow/src/algorithm/geo/frechet_distance.rs
@@ -26,10 +26,10 @@ pub trait FrechetDistance<Rhs = Self> {
     fn frechet_distance(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl FrechetDistance<LineStringArray<2>> for LineStringArray<2> {
+impl FrechetDistance<LineStringArray> for LineStringArray {
     type Output = Float64Array;
 
-    fn frechet_distance(&self, rhs: &LineStringArray<2>) -> Self::Output {
+    fn frechet_distance(&self, rhs: &LineStringArray) -> Self::Output {
         self.try_binary_primitive(rhs, |left, right| {
             Ok(left.to_geo().frechet_distance(&right.to_geo()))
         })
@@ -37,10 +37,10 @@ impl FrechetDistance<LineStringArray<2>> for LineStringArray<2> {
     }
 }
 
-impl FrechetDistance<ChunkedLineStringArray<2>> for ChunkedLineStringArray<2> {
+impl FrechetDistance<ChunkedLineStringArray> for ChunkedLineStringArray {
     type Output = ChunkedArray<Float64Array>;
 
-    fn frechet_distance(&self, rhs: &ChunkedLineStringArray<2>) -> Self::Output {
+    fn frechet_distance(&self, rhs: &ChunkedLineStringArray) -> Self::Output {
         ChunkedArray::new(self.binary_map(rhs.chunks(), |(left, right)| {
             FrechetDistance::frechet_distance(left, right)
         }))
@@ -56,8 +56,8 @@ impl FrechetDistance for &dyn NativeArray {
 
         let result = match (self.data_type(), rhs.data_type()) {
             (LineString(_, XY), LineString(_, XY)) => FrechetDistance::frechet_distance(
-                self.as_line_string::<2>(),
-                rhs.as_line_string::<2>(),
+                self.as_line_string(),
+                rhs.as_line_string(),
             ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -74,8 +74,8 @@ impl FrechetDistance for &dyn ChunkedNativeArray {
 
         let result = match (self.data_type(), rhs.data_type()) {
             (LineString(_, XY), LineString(_, XY)) => FrechetDistance::frechet_distance(
-                self.as_line_string::<2>(),
-                rhs.as_line_string::<2>(),
+                self.as_line_string(),
+                rhs.as_line_string(),
             ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -93,7 +93,7 @@ pub trait FrechetDistanceLineString<Rhs> {
     fn frechet_distance(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for LineStringArray<2> {
+impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for LineStringArray {
     type Output = Float64Array;
 
     fn frechet_distance(&self, rhs: &G) -> Self::Output {
@@ -106,7 +106,7 @@ impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for LineStringArr
 }
 
 impl<G: LineStringTrait<T = f64> + Sync> FrechetDistanceLineString<G>
-    for ChunkedLineStringArray<2>
+    for ChunkedLineStringArray
 {
     type Output = ChunkedArray<Float64Array>;
 
@@ -124,7 +124,7 @@ impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for &dyn NativeAr
 
         let result = match self.data_type() {
             LineString(_, XY) => {
-                FrechetDistanceLineString::frechet_distance(self.as_line_string::<2>(), rhs)
+                FrechetDistanceLineString::frechet_distance(self.as_line_string(), rhs)
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -142,7 +142,7 @@ impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for &dyn ChunkedN
         let rhs = line_string_to_geo(rhs);
         let result = match self.data_type() {
             LineString(_, XY) => {
-                FrechetDistanceLineString::frechet_distance(self.as_line_string::<2>(), &rhs)
+                FrechetDistanceLineString::frechet_distance(self.as_line_string(), &rhs)
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };

--- a/rust/geoarrow/src/algorithm/geo/frechet_distance.rs
+++ b/rust/geoarrow/src/algorithm/geo/frechet_distance.rs
@@ -55,10 +55,9 @@ impl FrechetDistance for &dyn NativeArray {
         use NativeType::*;
 
         let result = match (self.data_type(), rhs.data_type()) {
-            (LineString(_, XY), LineString(_, XY)) => FrechetDistance::frechet_distance(
-                self.as_line_string(),
-                rhs.as_line_string(),
-            ),
+            (LineString(_, XY), LineString(_, XY)) => {
+                FrechetDistance::frechet_distance(self.as_line_string(), rhs.as_line_string())
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -73,10 +72,9 @@ impl FrechetDistance for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result = match (self.data_type(), rhs.data_type()) {
-            (LineString(_, XY), LineString(_, XY)) => FrechetDistance::frechet_distance(
-                self.as_line_string(),
-                rhs.as_line_string(),
-            ),
+            (LineString(_, XY), LineString(_, XY)) => {
+                FrechetDistance::frechet_distance(self.as_line_string(), rhs.as_line_string())
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -105,9 +103,7 @@ impl<G: LineStringTrait<T = f64>> FrechetDistanceLineString<G> for LineStringArr
     }
 }
 
-impl<G: LineStringTrait<T = f64> + Sync> FrechetDistanceLineString<G>
-    for ChunkedLineStringArray
-{
+impl<G: LineStringTrait<T = f64> + Sync> FrechetDistanceLineString<G> for ChunkedLineStringArray {
     type Output = ChunkedArray<Float64Array>;
 
     fn frechet_distance(&self, rhs: &G) -> Self::Output {

--- a/rust/geoarrow/src/algorithm/geo/geodesic_area.rs
+++ b/rust/geoarrow/src/algorithm/geo/geodesic_area.rs
@@ -60,7 +60,7 @@ pub trait GeodesicArea {
     ///     (x: 0.00185608, y: 51.501770),
     ///     (x: 0.00388383, y: 51.501574),
     /// ];
-    /// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
+    /// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
     ///
     /// let area_array = polygon_array.geodesic_area_signed();
     ///
@@ -100,7 +100,7 @@ pub trait GeodesicArea {
     ///     (x: 1.0, y: 1.0),
     ///     (x: 1.0, y: 0.0),
     /// ];
-    /// let polygon_array: PolygonArray<2> = vec![polygon].as_slice().into();
+    /// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
     ///
     /// let area_array = polygon_array.geodesic_area_unsigned();
     ///
@@ -211,10 +211,10 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(PointArray<2>);
-zero_impl!(LineStringArray<2>);
-zero_impl!(MultiPointArray<2>);
-zero_impl!(MultiLineStringArray<2>);
+zero_impl!(PointArray);
+zero_impl!(LineStringArray);
+zero_impl!(MultiPointArray);
+zero_impl!(MultiLineStringArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -292,10 +292,10 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
 
 impl GeodesicArea for &dyn NativeArray {
     type OutputSingle = Result<Float64Array>;
@@ -306,14 +306,14 @@ impl GeodesicArea for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_area_signed(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_area_signed(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_area_signed(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_area_signed(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_signed(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_signed(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_signed(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_area_signed(),
+            Point(_, XY) => self.as_point().geodesic_area_signed(),
+            LineString(_, XY) => self.as_line_string().geodesic_area_signed(),
+            Polygon(_, XY) => self.as_polygon().geodesic_area_signed(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_area_signed(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_area_signed(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_area_signed(),
+            Mixed(_, XY) => self.as_mixed().geodesic_area_signed(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().geodesic_area_signed(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -324,15 +324,15 @@ impl GeodesicArea for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_area_unsigned(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_area_unsigned(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_area_unsigned(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_area_unsigned(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_unsigned(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_unsigned(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_unsigned(),
+            Point(_, XY) => self.as_point().geodesic_area_unsigned(),
+            LineString(_, XY) => self.as_line_string().geodesic_area_unsigned(),
+            Polygon(_, XY) => self.as_polygon().geodesic_area_unsigned(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_area_unsigned(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_area_unsigned(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_area_unsigned(),
+            Mixed(_, XY) => self.as_mixed().geodesic_area_unsigned(),
             GeometryCollection(_, XY) => {
-                self.as_geometry_collection::<2>().geodesic_area_unsigned()
+                self.as_geometry_collection().geodesic_area_unsigned()
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -344,14 +344,14 @@ impl GeodesicArea for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_perimeter(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter(),
+            Point(_, XY) => self.as_point().geodesic_perimeter(),
+            LineString(_, XY) => self.as_line_string().geodesic_perimeter(),
+            Polygon(_, XY) => self.as_polygon().geodesic_perimeter(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_perimeter(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_perimeter(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_perimeter(),
+            Mixed(_, XY) => self.as_mixed().geodesic_perimeter(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().geodesic_perimeter(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -362,19 +362,19 @@ impl GeodesicArea for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_signed(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_signed(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_signed(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_signed(),
+            Point(_, XY) => self.as_point().geodesic_perimeter_area_signed(),
+            LineString(_, XY) => self.as_line_string().geodesic_perimeter_area_signed(),
+            Polygon(_, XY) => self.as_polygon().geodesic_perimeter_area_signed(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_perimeter_area_signed(),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .geodesic_perimeter_area_signed(),
             MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
+                .as_multi_polygon()
                 .geodesic_perimeter_area_signed(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_signed(),
+            Mixed(_, XY) => self.as_mixed().geodesic_perimeter_area_signed(),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .geodesic_perimeter_area_signed(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -386,23 +386,23 @@ impl GeodesicArea for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_unsigned(),
+            Point(_, XY) => self.as_point().geodesic_perimeter_area_unsigned(),
             LineString(_, XY) => self
-                .as_line_string::<2>()
+                .as_line_string()
                 .geodesic_perimeter_area_unsigned(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_unsigned(),
+            Polygon(_, XY) => self.as_polygon().geodesic_perimeter_area_unsigned(),
             MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
+                .as_multi_point()
                 .geodesic_perimeter_area_unsigned(),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .geodesic_perimeter_area_unsigned(),
             MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
+                .as_multi_polygon()
                 .geodesic_perimeter_area_unsigned(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_unsigned(),
+            Mixed(_, XY) => self.as_mixed().geodesic_perimeter_area_unsigned(),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .geodesic_perimeter_area_unsigned(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -455,14 +455,14 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_area_signed(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_area_signed(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_area_signed(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_area_signed(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_signed(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_signed(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_signed(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_area_signed(),
+            Point(_, XY) => self.as_point().geodesic_area_signed(),
+            LineString(_, XY) => self.as_line_string().geodesic_area_signed(),
+            Polygon(_, XY) => self.as_polygon().geodesic_area_signed(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_area_signed(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_area_signed(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_area_signed(),
+            Mixed(_, XY) => self.as_mixed().geodesic_area_signed(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().geodesic_area_signed(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -472,15 +472,15 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_area_unsigned(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_area_unsigned(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_area_unsigned(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_area_unsigned(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_area_unsigned(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_area_unsigned(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_area_unsigned(),
+            Point(_, XY) => self.as_point().geodesic_area_unsigned(),
+            LineString(_, XY) => self.as_line_string().geodesic_area_unsigned(),
+            Polygon(_, XY) => self.as_polygon().geodesic_area_unsigned(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_area_unsigned(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_area_unsigned(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_area_unsigned(),
+            Mixed(_, XY) => self.as_mixed().geodesic_area_unsigned(),
             GeometryCollection(_, XY) => {
-                self.as_geometry_collection::<2>().geodesic_area_unsigned()
+                self.as_geometry_collection().geodesic_area_unsigned()
             }
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -491,14 +491,14 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_perimeter(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_perimeter(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_perimeter(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_perimeter(),
+            Point(_, XY) => self.as_point().geodesic_perimeter(),
+            LineString(_, XY) => self.as_line_string().geodesic_perimeter(),
+            Polygon(_, XY) => self.as_polygon().geodesic_perimeter(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_perimeter(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_perimeter(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_perimeter(),
+            Mixed(_, XY) => self.as_mixed().geodesic_perimeter(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().geodesic_perimeter(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -508,19 +508,19 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_signed(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_perimeter_area_signed(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_signed(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_perimeter_area_signed(),
+            Point(_, XY) => self.as_point().geodesic_perimeter_area_signed(),
+            LineString(_, XY) => self.as_line_string().geodesic_perimeter_area_signed(),
+            Polygon(_, XY) => self.as_polygon().geodesic_perimeter_area_signed(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_perimeter_area_signed(),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .geodesic_perimeter_area_signed(),
             MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
+                .as_multi_polygon()
                 .geodesic_perimeter_area_signed(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_signed(),
+            Mixed(_, XY) => self.as_mixed().geodesic_perimeter_area_signed(),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .geodesic_perimeter_area_signed(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
@@ -531,23 +531,23 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_perimeter_area_unsigned(),
+            Point(_, XY) => self.as_point().geodesic_perimeter_area_unsigned(),
             LineString(_, XY) => self
-                .as_line_string::<2>()
+                .as_line_string()
                 .geodesic_perimeter_area_unsigned(),
-            Polygon(_, XY) => self.as_polygon::<2>().geodesic_perimeter_area_unsigned(),
+            Polygon(_, XY) => self.as_polygon().geodesic_perimeter_area_unsigned(),
             MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
+                .as_multi_point()
                 .geodesic_perimeter_area_unsigned(),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .geodesic_perimeter_area_unsigned(),
             MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
+                .as_multi_polygon()
                 .geodesic_perimeter_area_unsigned(),
-            Mixed(_, XY) => self.as_mixed::<2>().geodesic_perimeter_area_unsigned(),
+            Mixed(_, XY) => self.as_mixed().geodesic_perimeter_area_unsigned(),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .geodesic_perimeter_area_unsigned(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }

--- a/rust/geoarrow/src/algorithm/geo/geodesic_area.rs
+++ b/rust/geoarrow/src/algorithm/geo/geodesic_area.rs
@@ -46,6 +46,7 @@ pub trait GeodesicArea {
     /// use geo::{polygon, Polygon};
     /// use geoarrow::array::PolygonArray;
     /// use geoarrow::algorithm::geo::GeodesicArea;
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// // The O2 in London
     /// let polygon: Polygon<f64> = polygon![
@@ -60,7 +61,7 @@ pub trait GeodesicArea {
     ///     (x: 0.00185608, y: 51.501770),
     ///     (x: 0.00388383, y: 51.501574),
     /// ];
-    /// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
+    /// let polygon_array: PolygonArray = (vec![polygon].as_slice(), Dimension::XY).into();
     ///
     /// let area_array = polygon_array.geodesic_area_signed();
     ///
@@ -91,6 +92,7 @@ pub trait GeodesicArea {
     /// use geo::{polygon, Polygon};
     /// use geoarrow::array::PolygonArray;
     /// use geoarrow::algorithm::geo::GeodesicArea;
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// // Describe a polygon that covers all of the earth EXCEPT this small square.
     /// // The outside of the polygon is in this square, the inside of the polygon is the rest of the earth.
@@ -100,7 +102,7 @@ pub trait GeodesicArea {
     ///     (x: 1.0, y: 1.0),
     ///     (x: 1.0, y: 0.0),
     /// ];
-    /// let polygon_array: PolygonArray = vec![polygon].as_slice().into();
+    /// let polygon_array: PolygonArray = (vec![polygon].as_slice(), Dimension::XY).into();
     ///
     /// let area_array = polygon_array.geodesic_area_unsigned();
     ///
@@ -331,9 +333,7 @@ impl GeodesicArea for &dyn NativeArray {
             MultiLineString(_, XY) => self.as_multi_line_string().geodesic_area_unsigned(),
             MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_area_unsigned(),
             Mixed(_, XY) => self.as_mixed().geodesic_area_unsigned(),
-            GeometryCollection(_, XY) => {
-                self.as_geometry_collection().geodesic_area_unsigned()
-            }
+            GeometryCollection(_, XY) => self.as_geometry_collection().geodesic_area_unsigned(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -366,12 +366,8 @@ impl GeodesicArea for &dyn NativeArray {
             LineString(_, XY) => self.as_line_string().geodesic_perimeter_area_signed(),
             Polygon(_, XY) => self.as_polygon().geodesic_perimeter_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point().geodesic_perimeter_area_signed(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string()
-                .geodesic_perimeter_area_signed(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon()
-                .geodesic_perimeter_area_signed(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_perimeter_area_signed(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_perimeter_area_signed(),
             Mixed(_, XY) => self.as_mixed().geodesic_perimeter_area_signed(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection()
@@ -387,19 +383,13 @@ impl GeodesicArea for &dyn NativeArray {
 
         let result = match self.data_type() {
             Point(_, XY) => self.as_point().geodesic_perimeter_area_unsigned(),
-            LineString(_, XY) => self
-                .as_line_string()
-                .geodesic_perimeter_area_unsigned(),
+            LineString(_, XY) => self.as_line_string().geodesic_perimeter_area_unsigned(),
             Polygon(_, XY) => self.as_polygon().geodesic_perimeter_area_unsigned(),
-            MultiPoint(_, XY) => self
-                .as_multi_point()
-                .geodesic_perimeter_area_unsigned(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_perimeter_area_unsigned(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string()
                 .geodesic_perimeter_area_unsigned(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon()
-                .geodesic_perimeter_area_unsigned(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_perimeter_area_unsigned(),
             Mixed(_, XY) => self.as_mixed().geodesic_perimeter_area_unsigned(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection()
@@ -479,9 +469,7 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
             MultiLineString(_, XY) => self.as_multi_line_string().geodesic_area_unsigned(),
             MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_area_unsigned(),
             Mixed(_, XY) => self.as_mixed().geodesic_area_unsigned(),
-            GeometryCollection(_, XY) => {
-                self.as_geometry_collection().geodesic_area_unsigned()
-            }
+            GeometryCollection(_, XY) => self.as_geometry_collection().geodesic_area_unsigned(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -512,12 +500,8 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
             LineString(_, XY) => self.as_line_string().geodesic_perimeter_area_signed(),
             Polygon(_, XY) => self.as_polygon().geodesic_perimeter_area_signed(),
             MultiPoint(_, XY) => self.as_multi_point().geodesic_perimeter_area_signed(),
-            MultiLineString(_, XY) => self
-                .as_multi_line_string()
-                .geodesic_perimeter_area_signed(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon()
-                .geodesic_perimeter_area_signed(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_perimeter_area_signed(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_perimeter_area_signed(),
             Mixed(_, XY) => self.as_mixed().geodesic_perimeter_area_signed(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection()
@@ -532,19 +516,13 @@ impl GeodesicArea for &dyn ChunkedNativeArray {
 
         match self.data_type() {
             Point(_, XY) => self.as_point().geodesic_perimeter_area_unsigned(),
-            LineString(_, XY) => self
-                .as_line_string()
-                .geodesic_perimeter_area_unsigned(),
+            LineString(_, XY) => self.as_line_string().geodesic_perimeter_area_unsigned(),
             Polygon(_, XY) => self.as_polygon().geodesic_perimeter_area_unsigned(),
-            MultiPoint(_, XY) => self
-                .as_multi_point()
-                .geodesic_perimeter_area_unsigned(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_perimeter_area_unsigned(),
             MultiLineString(_, XY) => self
                 .as_multi_line_string()
                 .geodesic_perimeter_area_unsigned(),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon()
-                .geodesic_perimeter_area_unsigned(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_perimeter_area_unsigned(),
             Mixed(_, XY) => self.as_mixed().geodesic_perimeter_area_unsigned(),
             GeometryCollection(_, XY) => self
                 .as_geometry_collection()

--- a/rust/geoarrow/src/algorithm/geo/geodesic_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/geodesic_length.rs
@@ -34,6 +34,7 @@ pub trait GeodesicLength {
     /// use geo::LineString;
     /// use geoarrow::array::LineStringArray;
     /// use geoarrow::algorithm::geo::GeodesicLength;
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let linestring = LineString::from(vec![
     ///     // New York City
@@ -43,7 +44,7 @@ pub trait GeodesicLength {
     ///     // Osaka
     ///     (135.5244559, 34.687455)
     /// ]);
-    /// let linestring_array: LineStringArray = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray = (vec![linestring].as_slice(), Dimension::XY).into();
     ///
     /// let length_array = linestring_array.geodesic_length();
     ///

--- a/rust/geoarrow/src/algorithm/geo/geodesic_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/geodesic_length.rs
@@ -174,7 +174,7 @@ mod tests {
             // Osaka
             (x: 135.5244559, y: 34.687455),
         ];
-        let input_array: LineStringArray = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = (vec![input_geom].as_slice(), Dimension::XY).into();
         let result_array = input_array.geodesic_length();
 
         // Meters

--- a/rust/geoarrow/src/algorithm/geo/geodesic_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/geodesic_length.rs
@@ -43,7 +43,7 @@ pub trait GeodesicLength {
     ///     // Osaka
     ///     (135.5244559, 34.687455)
     /// ]);
-    /// let linestring_array: LineStringArray<2> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.geodesic_length();
     ///
@@ -70,8 +70,8 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(PointArray<2>);
-zero_impl!(MultiPointArray<2>);
+zero_impl!(PointArray);
+zero_impl!(MultiPointArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -86,8 +86,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(MultiLineStringArray);
 
 impl GeodesicLength for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -97,21 +97,21 @@ impl GeodesicLength for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_length(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_length(),
-            // Polygon(_, XY) => self.as_polygon::<2>().geodesic_length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_length(),
-            // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_length(),
-            // Mixed(_, XY) => self.as_mixed::<2>().geodesic_length(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_length(),
+            Point(_, XY) => self.as_point().geodesic_length(),
+            LineString(_, XY) => self.as_line_string().geodesic_length(),
+            // Polygon(_, XY) => self.as_polygon().geodesic_length(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_length(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_length(),
+            // MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_length(),
+            // Mixed(_, XY) => self.as_mixed().geodesic_length(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().geodesic_length(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl GeodesicLength for ChunkedGeometryArray<PointArray<2>> {
+impl GeodesicLength for ChunkedGeometryArray<PointArray> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn geodesic_length(&self) -> Self::Output {
@@ -132,9 +132,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray>);
 
 impl GeodesicLength for &dyn ChunkedNativeArray {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -144,14 +144,14 @@ impl GeodesicLength for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().geodesic_length(),
-            LineString(_, XY) => self.as_line_string::<2>().geodesic_length(),
-            // Polygon(_, XY) => self.as_polygon::<2>().geodesic_length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().geodesic_length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().geodesic_length(),
-            // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().geodesic_length(),
-            // Mixed(_, XY) => self.as_mixed::<2>().geodesic_length(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().geodesic_length(),
+            Point(_, XY) => self.as_point().geodesic_length(),
+            LineString(_, XY) => self.as_line_string().geodesic_length(),
+            // Polygon(_, XY) => self.as_polygon().geodesic_length(),
+            MultiPoint(_, XY) => self.as_multi_point().geodesic_length(),
+            MultiLineString(_, XY) => self.as_multi_line_string().geodesic_length(),
+            // MultiPolygon(_, XY) => self.as_multi_polygon().geodesic_length(),
+            // Mixed(_, XY) => self.as_mixed().geodesic_length(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().geodesic_length(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -174,7 +174,7 @@ mod tests {
             // Osaka
             (x: 135.5244559, y: 34.687455),
         ];
-        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = vec![input_geom].as_slice().into();
         let result_array = input_array.geodesic_length();
 
         // Meters

--- a/rust/geoarrow/src/algorithm/geo/haversine_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/haversine_length.rs
@@ -30,6 +30,7 @@ pub trait HaversineLength {
     /// use geo::LineString;
     /// use geoarrow::array::LineStringArray;
     /// use geoarrow::algorithm::geo::HaversineLength;
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let linestring = LineString::<f64>::from(vec![
     ///     // New York City
@@ -37,7 +38,7 @@ pub trait HaversineLength {
     ///     // London
     ///     (-0.1278, 51.5074),
     /// ]);
-    /// let linestring_array: LineStringArray = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray = (vec![linestring].as_slice(), Dimension::XY).into();
     ///
     /// let length_array = linestring_array.haversine_length();
     ///

--- a/rust/geoarrow/src/algorithm/geo/haversine_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/haversine_length.rs
@@ -37,7 +37,7 @@ pub trait HaversineLength {
     ///     // London
     ///     (-0.1278, 51.5074),
     /// ]);
-    /// let linestring_array: LineStringArray<2> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.haversine_length();
     ///
@@ -64,8 +64,8 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(PointArray<2>);
-zero_impl!(MultiPointArray<2>);
+zero_impl!(PointArray);
+zero_impl!(MultiPointArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -80,8 +80,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(MultiLineStringArray);
 
 impl HaversineLength for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -91,21 +91,21 @@ impl HaversineLength for &dyn NativeArray {
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().haversine_length(),
-            LineString(_, XY) => self.as_line_string::<2>().haversine_length(),
-            // Polygon(_, XY) => self.as_polygon::<2>().haversine_length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().haversine_length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().haversine_length(),
-            // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().haversine_length(),
-            // Mixed(_, XY) => self.as_mixed::<2>().haversine_length(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().haversine_length(),
+            Point(_, XY) => self.as_point().haversine_length(),
+            LineString(_, XY) => self.as_line_string().haversine_length(),
+            // Polygon(_, XY) => self.as_polygon().haversine_length(),
+            MultiPoint(_, XY) => self.as_multi_point().haversine_length(),
+            MultiLineString(_, XY) => self.as_multi_line_string().haversine_length(),
+            // MultiPolygon(_, XY) => self.as_multi_polygon().haversine_length(),
+            // Mixed(_, XY) => self.as_mixed().haversine_length(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().haversine_length(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl HaversineLength for ChunkedGeometryArray<PointArray<2>> {
+impl HaversineLength for ChunkedGeometryArray<PointArray> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn haversine_length(&self) -> Self::Output {
@@ -126,9 +126,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray>);
 
 impl HaversineLength for &dyn ChunkedNativeArray {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -138,14 +138,14 @@ impl HaversineLength for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().haversine_length(),
-            LineString(_, XY) => self.as_line_string::<2>().haversine_length(),
-            // Polygon(_, XY) => self.as_polygon::<2>().haversine_length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().haversine_length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().haversine_length(),
-            // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().haversine_length(),
-            // Mixed(_, XY) => self.as_mixed::<2>().haversine_length(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().haversine_length(),
+            Point(_, XY) => self.as_point().haversine_length(),
+            LineString(_, XY) => self.as_line_string().haversine_length(),
+            // Polygon(_, XY) => self.as_polygon().haversine_length(),
+            MultiPoint(_, XY) => self.as_multi_point().haversine_length(),
+            MultiLineString(_, XY) => self.as_multi_line_string().haversine_length(),
+            // MultiPolygon(_, XY) => self.as_multi_polygon().haversine_length(),
+            // Mixed(_, XY) => self.as_mixed().haversine_length(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().haversine_length(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -166,7 +166,7 @@ mod tests {
             // London
             (x: -0.1278, y: 51.5074),
         ];
-        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = vec![input_geom].as_slice().into();
         let result_array = input_array.haversine_length();
 
         // Meters

--- a/rust/geoarrow/src/algorithm/geo/haversine_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/haversine_length.rs
@@ -166,7 +166,7 @@ mod tests {
             // London
             (x: -0.1278, y: 51.5074),
         ];
-        let input_array: LineStringArray = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = (vec![input_geom].as_slice(), Dimension::XY).into();
         let result_array = input_array.haversine_length();
 
         // Meters

--- a/rust/geoarrow/src/algorithm/geo/intersects.rs
+++ b/rust/geoarrow/src/algorithm/geo/intersects.rs
@@ -55,7 +55,7 @@ pub trait Intersects<Rhs = Self> {
 }
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl Intersects for IndexedPointArray<2> {
+impl Intersects for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &Self) -> Self::Output {
@@ -83,72 +83,63 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(IndexedPointArray<2>, IndexedLineStringArray<2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedPolygonArray<2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedMultiPointArray<2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedMultiLineStringArray<2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedMultiPolygonArray<2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedMixedGeometryArray<2>);
-iter_geo_impl!(IndexedPointArray<2>, IndexedGeometryCollectionArray<2>);
+iter_geo_impl!(IndexedPointArray, IndexedLineStringArray);
+iter_geo_impl!(IndexedPointArray, IndexedPolygonArray);
+iter_geo_impl!(IndexedPointArray, IndexedMultiPointArray);
+iter_geo_impl!(IndexedPointArray, IndexedMultiLineStringArray);
+iter_geo_impl!(IndexedPointArray, IndexedMultiPolygonArray);
+iter_geo_impl!(IndexedPointArray, IndexedMixedGeometryArray);
+iter_geo_impl!(IndexedPointArray, IndexedGeometryCollectionArray);
 
 // Implementations on LineStringArray
-iter_geo_impl!(IndexedLineStringArray<2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedLineStringArray<2>, IndexedLineStringArray<2>);
-iter_geo_impl!(IndexedLineStringArray<2>, IndexedPolygonArray<2>);
-iter_geo_impl!(IndexedLineStringArray<2>, IndexedMultiPointArray<2>);
-iter_geo_impl!(IndexedLineStringArray<2>, IndexedMultiLineStringArray<2>);
-iter_geo_impl!(IndexedLineStringArray<2>, IndexedMultiPolygonArray<2>);
-iter_geo_impl!(IndexedLineStringArray<2>, IndexedMixedGeometryArray<2>);
-iter_geo_impl!(IndexedLineStringArray<2>, IndexedGeometryCollectionArray<2>);
+iter_geo_impl!(IndexedLineStringArray, IndexedPointArray);
+iter_geo_impl!(IndexedLineStringArray, IndexedLineStringArray);
+iter_geo_impl!(IndexedLineStringArray, IndexedPolygonArray);
+iter_geo_impl!(IndexedLineStringArray, IndexedMultiPointArray);
+iter_geo_impl!(IndexedLineStringArray, IndexedMultiLineStringArray);
+iter_geo_impl!(IndexedLineStringArray, IndexedMultiPolygonArray);
+iter_geo_impl!(IndexedLineStringArray, IndexedMixedGeometryArray);
+iter_geo_impl!(IndexedLineStringArray, IndexedGeometryCollectionArray);
 
 // Implementations on PolygonArray
-iter_geo_impl!(IndexedPolygonArray<2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedPolygonArray<2>, IndexedLineStringArray<2>);
-iter_geo_impl!(IndexedPolygonArray<2>, IndexedPolygonArray<2>);
-iter_geo_impl!(IndexedPolygonArray<2>, IndexedMultiPointArray<2>);
-iter_geo_impl!(IndexedPolygonArray<2>, IndexedMultiLineStringArray<2>);
-iter_geo_impl!(IndexedPolygonArray<2>, IndexedMultiPolygonArray<2>);
-iter_geo_impl!(IndexedPolygonArray<2>, IndexedMixedGeometryArray<2>);
-iter_geo_impl!(IndexedPolygonArray<2>, IndexedGeometryCollectionArray<2>);
+iter_geo_impl!(IndexedPolygonArray, IndexedPointArray);
+iter_geo_impl!(IndexedPolygonArray, IndexedLineStringArray);
+iter_geo_impl!(IndexedPolygonArray, IndexedPolygonArray);
+iter_geo_impl!(IndexedPolygonArray, IndexedMultiPointArray);
+iter_geo_impl!(IndexedPolygonArray, IndexedMultiLineStringArray);
+iter_geo_impl!(IndexedPolygonArray, IndexedMultiPolygonArray);
+iter_geo_impl!(IndexedPolygonArray, IndexedMixedGeometryArray);
+iter_geo_impl!(IndexedPolygonArray, IndexedGeometryCollectionArray);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(IndexedMultiPointArray<2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedMultiPointArray<2>, IndexedLineStringArray<2>);
-iter_geo_impl!(IndexedMultiPointArray<2>, IndexedPolygonArray<2>);
-iter_geo_impl!(IndexedMultiPointArray<2>, IndexedMultiPointArray<2>);
-iter_geo_impl!(IndexedMultiPointArray<2>, IndexedMultiLineStringArray<2>);
-iter_geo_impl!(IndexedMultiPointArray<2>, IndexedMultiPolygonArray<2>);
-iter_geo_impl!(IndexedMultiPointArray<2>, IndexedMixedGeometryArray<2>);
-iter_geo_impl!(IndexedMultiPointArray<2>, IndexedGeometryCollectionArray<2>);
+iter_geo_impl!(IndexedMultiPointArray, IndexedPointArray);
+iter_geo_impl!(IndexedMultiPointArray, IndexedLineStringArray);
+iter_geo_impl!(IndexedMultiPointArray, IndexedPolygonArray);
+iter_geo_impl!(IndexedMultiPointArray, IndexedMultiPointArray);
+iter_geo_impl!(IndexedMultiPointArray, IndexedMultiLineStringArray);
+iter_geo_impl!(IndexedMultiPointArray, IndexedMultiPolygonArray);
+iter_geo_impl!(IndexedMultiPointArray, IndexedMixedGeometryArray);
+iter_geo_impl!(IndexedMultiPointArray, IndexedGeometryCollectionArray);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedLineStringArray<2>);
-iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedPolygonArray<2>);
-iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMultiPointArray<2>);
-iter_geo_impl!(
-    IndexedMultiLineStringArray<2>,
-    IndexedMultiLineStringArray<2>
-);
-iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMultiPolygonArray<2>);
-iter_geo_impl!(IndexedMultiLineStringArray<2>, IndexedMixedGeometryArray<2>);
-iter_geo_impl!(
-    IndexedMultiLineStringArray<2>,
-    IndexedGeometryCollectionArray<2>
-);
+iter_geo_impl!(IndexedMultiLineStringArray, IndexedPointArray);
+iter_geo_impl!(IndexedMultiLineStringArray, IndexedLineStringArray);
+iter_geo_impl!(IndexedMultiLineStringArray, IndexedPolygonArray);
+iter_geo_impl!(IndexedMultiLineStringArray, IndexedMultiPointArray);
+iter_geo_impl!(IndexedMultiLineStringArray, IndexedMultiLineStringArray);
+iter_geo_impl!(IndexedMultiLineStringArray, IndexedMultiPolygonArray);
+iter_geo_impl!(IndexedMultiLineStringArray, IndexedMixedGeometryArray);
+iter_geo_impl!(IndexedMultiLineStringArray, IndexedGeometryCollectionArray);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedPointArray<2>);
-iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedLineStringArray<2>);
-iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedPolygonArray<2>);
-iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiPointArray<2>);
-iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiLineStringArray<2>);
-iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMultiPolygonArray<2>);
-iter_geo_impl!(IndexedMultiPolygonArray<2>, IndexedMixedGeometryArray<2>);
-iter_geo_impl!(
-    IndexedMultiPolygonArray<2>,
-    IndexedGeometryCollectionArray<2>
-);
+iter_geo_impl!(IndexedMultiPolygonArray, IndexedPointArray);
+iter_geo_impl!(IndexedMultiPolygonArray, IndexedLineStringArray);
+iter_geo_impl!(IndexedMultiPolygonArray, IndexedPolygonArray);
+iter_geo_impl!(IndexedMultiPolygonArray, IndexedMultiPointArray);
+iter_geo_impl!(IndexedMultiPolygonArray, IndexedMultiLineStringArray);
+iter_geo_impl!(IndexedMultiPolygonArray, IndexedMultiPolygonArray);
+iter_geo_impl!(IndexedMultiPolygonArray, IndexedMixedGeometryArray);
+iter_geo_impl!(IndexedMultiPolygonArray, IndexedGeometryCollectionArray);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
@@ -160,7 +151,7 @@ pub trait IntersectsPoint<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedPointArray<2> {
+impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -182,15 +173,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<2>);
-impl_intersects!(IndexedPolygonArray<2>);
-impl_intersects!(IndexedMultiPointArray<2>);
-impl_intersects!(IndexedMultiLineStringArray<2>);
-impl_intersects!(IndexedMultiPolygonArray<2>);
-impl_intersects!(IndexedMixedGeometryArray<2>);
-impl_intersects!(IndexedGeometryCollectionArray<2>);
+impl_intersects!(IndexedLineStringArray);
+impl_intersects!(IndexedPolygonArray);
+impl_intersects!(IndexedMultiPointArray);
+impl_intersects!(IndexedMultiLineStringArray);
+impl_intersects!(IndexedMultiPolygonArray);
+impl_intersects!(IndexedMixedGeometryArray);
+impl_intersects!(IndexedGeometryCollectionArray);
 
-impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedChunkedPointArray<2> {
+impl<G: PointTrait<T = f64>> IntersectsPoint<G> for IndexedChunkedPointArray {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -216,13 +207,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<2>);
-impl_intersects!(IndexedChunkedPolygonArray<2>);
-impl_intersects!(IndexedChunkedMultiPointArray<2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
+impl_intersects!(IndexedChunkedLineStringArray);
+impl_intersects!(IndexedChunkedPolygonArray);
+impl_intersects!(IndexedChunkedMultiPointArray);
+impl_intersects!(IndexedChunkedMultiLineStringArray);
+impl_intersects!(IndexedChunkedMultiPolygonArray);
+impl_intersects!(IndexedChunkedMixedGeometryArray);
+impl_intersects!(IndexedChunkedGeometryCollectionArray);
 
 pub trait IntersectsLineString<Rhs> {
     type Output;
@@ -230,7 +221,7 @@ pub trait IntersectsLineString<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedPointArray<2> {
+impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -256,15 +247,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<2>);
-impl_intersects!(IndexedPolygonArray<2>);
-impl_intersects!(IndexedMultiPointArray<2>);
-impl_intersects!(IndexedMultiLineStringArray<2>);
-impl_intersects!(IndexedMultiPolygonArray<2>);
-impl_intersects!(IndexedMixedGeometryArray<2>);
-impl_intersects!(IndexedGeometryCollectionArray<2>);
+impl_intersects!(IndexedLineStringArray);
+impl_intersects!(IndexedPolygonArray);
+impl_intersects!(IndexedMultiPointArray);
+impl_intersects!(IndexedMultiLineStringArray);
+impl_intersects!(IndexedMultiPolygonArray);
+impl_intersects!(IndexedMixedGeometryArray);
+impl_intersects!(IndexedGeometryCollectionArray);
 
-impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedChunkedPointArray<2> {
+impl<G: LineStringTrait<T = f64>> IntersectsLineString<G> for IndexedChunkedPointArray {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -290,13 +281,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<2>);
-impl_intersects!(IndexedChunkedPolygonArray<2>);
-impl_intersects!(IndexedChunkedMultiPointArray<2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
+impl_intersects!(IndexedChunkedLineStringArray);
+impl_intersects!(IndexedChunkedPolygonArray);
+impl_intersects!(IndexedChunkedMultiPointArray);
+impl_intersects!(IndexedChunkedMultiLineStringArray);
+impl_intersects!(IndexedChunkedMultiPolygonArray);
+impl_intersects!(IndexedChunkedMixedGeometryArray);
+impl_intersects!(IndexedChunkedGeometryCollectionArray);
 
 pub trait IntersectsPolygon<Rhs> {
     type Output;
@@ -304,7 +295,7 @@ pub trait IntersectsPolygon<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedPointArray<2> {
+impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -330,15 +321,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<2>);
-impl_intersects!(IndexedPolygonArray<2>);
-impl_intersects!(IndexedMultiPointArray<2>);
-impl_intersects!(IndexedMultiLineStringArray<2>);
-impl_intersects!(IndexedMultiPolygonArray<2>);
-impl_intersects!(IndexedMixedGeometryArray<2>);
-impl_intersects!(IndexedGeometryCollectionArray<2>);
+impl_intersects!(IndexedLineStringArray);
+impl_intersects!(IndexedPolygonArray);
+impl_intersects!(IndexedMultiPointArray);
+impl_intersects!(IndexedMultiLineStringArray);
+impl_intersects!(IndexedMultiPolygonArray);
+impl_intersects!(IndexedMixedGeometryArray);
+impl_intersects!(IndexedGeometryCollectionArray);
 
-impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedChunkedPointArray<2> {
+impl<G: PolygonTrait<T = f64>> IntersectsPolygon<G> for IndexedChunkedPointArray {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -364,13 +355,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<2>);
-impl_intersects!(IndexedChunkedPolygonArray<2>);
-impl_intersects!(IndexedChunkedMultiPointArray<2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
+impl_intersects!(IndexedChunkedLineStringArray);
+impl_intersects!(IndexedChunkedPolygonArray);
+impl_intersects!(IndexedChunkedMultiPointArray);
+impl_intersects!(IndexedChunkedMultiLineStringArray);
+impl_intersects!(IndexedChunkedMultiPolygonArray);
+impl_intersects!(IndexedChunkedMixedGeometryArray);
+impl_intersects!(IndexedChunkedGeometryCollectionArray);
 
 pub trait IntersectsMultiPoint<Rhs> {
     type Output;
@@ -378,7 +369,7 @@ pub trait IntersectsMultiPoint<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedPointArray<2> {
+impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -404,15 +395,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<2>);
-impl_intersects!(IndexedPolygonArray<2>);
-impl_intersects!(IndexedMultiPointArray<2>);
-impl_intersects!(IndexedMultiLineStringArray<2>);
-impl_intersects!(IndexedMultiPolygonArray<2>);
-impl_intersects!(IndexedMixedGeometryArray<2>);
-impl_intersects!(IndexedGeometryCollectionArray<2>);
+impl_intersects!(IndexedLineStringArray);
+impl_intersects!(IndexedPolygonArray);
+impl_intersects!(IndexedMultiPointArray);
+impl_intersects!(IndexedMultiLineStringArray);
+impl_intersects!(IndexedMultiPolygonArray);
+impl_intersects!(IndexedMixedGeometryArray);
+impl_intersects!(IndexedGeometryCollectionArray);
 
-impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedChunkedPointArray<2> {
+impl<G: MultiPointTrait<T = f64>> IntersectsMultiPoint<G> for IndexedChunkedPointArray {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -438,13 +429,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<2>);
-impl_intersects!(IndexedChunkedPolygonArray<2>);
-impl_intersects!(IndexedChunkedMultiPointArray<2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
+impl_intersects!(IndexedChunkedLineStringArray);
+impl_intersects!(IndexedChunkedPolygonArray);
+impl_intersects!(IndexedChunkedMultiPointArray);
+impl_intersects!(IndexedChunkedMultiLineStringArray);
+impl_intersects!(IndexedChunkedMultiPolygonArray);
+impl_intersects!(IndexedChunkedMixedGeometryArray);
+impl_intersects!(IndexedChunkedGeometryCollectionArray);
 
 pub trait IntersectsMultiLineString<Rhs> {
     type Output;
@@ -452,7 +443,7 @@ pub trait IntersectsMultiLineString<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedPointArray<2> {
+impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -478,17 +469,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<2>);
-impl_intersects!(IndexedPolygonArray<2>);
-impl_intersects!(IndexedMultiPointArray<2>);
-impl_intersects!(IndexedMultiLineStringArray<2>);
-impl_intersects!(IndexedMultiPolygonArray<2>);
-impl_intersects!(IndexedMixedGeometryArray<2>);
-impl_intersects!(IndexedGeometryCollectionArray<2>);
+impl_intersects!(IndexedLineStringArray);
+impl_intersects!(IndexedPolygonArray);
+impl_intersects!(IndexedMultiPointArray);
+impl_intersects!(IndexedMultiLineStringArray);
+impl_intersects!(IndexedMultiPolygonArray);
+impl_intersects!(IndexedMixedGeometryArray);
+impl_intersects!(IndexedGeometryCollectionArray);
 
-impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G>
-    for IndexedChunkedPointArray<2>
-{
+impl<G: MultiLineStringTrait<T = f64>> IntersectsMultiLineString<G> for IndexedChunkedPointArray {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -514,13 +503,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<2>);
-impl_intersects!(IndexedChunkedPolygonArray<2>);
-impl_intersects!(IndexedChunkedMultiPointArray<2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
+impl_intersects!(IndexedChunkedLineStringArray);
+impl_intersects!(IndexedChunkedPolygonArray);
+impl_intersects!(IndexedChunkedMultiPointArray);
+impl_intersects!(IndexedChunkedMultiLineStringArray);
+impl_intersects!(IndexedChunkedMultiPolygonArray);
+impl_intersects!(IndexedChunkedMixedGeometryArray);
+impl_intersects!(IndexedChunkedGeometryCollectionArray);
 
 pub trait IntersectsMultiPolygon<Rhs> {
     type Output;
@@ -528,7 +517,7 @@ pub trait IntersectsMultiPolygon<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedPointArray<2> {
+impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -554,15 +543,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<2>);
-impl_intersects!(IndexedPolygonArray<2>);
-impl_intersects!(IndexedMultiPointArray<2>);
-impl_intersects!(IndexedMultiLineStringArray<2>);
-impl_intersects!(IndexedMultiPolygonArray<2>);
-impl_intersects!(IndexedMixedGeometryArray<2>);
-impl_intersects!(IndexedGeometryCollectionArray<2>);
+impl_intersects!(IndexedLineStringArray);
+impl_intersects!(IndexedPolygonArray);
+impl_intersects!(IndexedMultiPointArray);
+impl_intersects!(IndexedMultiLineStringArray);
+impl_intersects!(IndexedMultiPolygonArray);
+impl_intersects!(IndexedMixedGeometryArray);
+impl_intersects!(IndexedGeometryCollectionArray);
 
-impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedChunkedPointArray<2> {
+impl<G: MultiPolygonTrait<T = f64>> IntersectsMultiPolygon<G> for IndexedChunkedPointArray {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -588,13 +577,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<2>);
-impl_intersects!(IndexedChunkedPolygonArray<2>);
-impl_intersects!(IndexedChunkedMultiPointArray<2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
+impl_intersects!(IndexedChunkedLineStringArray);
+impl_intersects!(IndexedChunkedPolygonArray);
+impl_intersects!(IndexedChunkedMultiPointArray);
+impl_intersects!(IndexedChunkedMultiLineStringArray);
+impl_intersects!(IndexedChunkedMultiPolygonArray);
+impl_intersects!(IndexedChunkedMixedGeometryArray);
+impl_intersects!(IndexedChunkedGeometryCollectionArray);
 
 pub trait IntersectsGeometry<Rhs> {
     type Output;
@@ -602,7 +591,7 @@ pub trait IntersectsGeometry<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedPointArray<2> {
+impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -628,15 +617,15 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<2>);
-impl_intersects!(IndexedPolygonArray<2>);
-impl_intersects!(IndexedMultiPointArray<2>);
-impl_intersects!(IndexedMultiLineStringArray<2>);
-impl_intersects!(IndexedMultiPolygonArray<2>);
-impl_intersects!(IndexedMixedGeometryArray<2>);
-impl_intersects!(IndexedGeometryCollectionArray<2>);
+impl_intersects!(IndexedLineStringArray);
+impl_intersects!(IndexedPolygonArray);
+impl_intersects!(IndexedMultiPointArray);
+impl_intersects!(IndexedMultiLineStringArray);
+impl_intersects!(IndexedMultiPolygonArray);
+impl_intersects!(IndexedMixedGeometryArray);
+impl_intersects!(IndexedGeometryCollectionArray);
 
-impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedChunkedPointArray<2> {
+impl<G: GeometryTrait<T = f64>> IntersectsGeometry<G> for IndexedChunkedPointArray {
     type Output = ChunkedArray<BooleanArray>;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -662,13 +651,13 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<2>);
-impl_intersects!(IndexedChunkedPolygonArray<2>);
-impl_intersects!(IndexedChunkedMultiPointArray<2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
+impl_intersects!(IndexedChunkedLineStringArray);
+impl_intersects!(IndexedChunkedPolygonArray);
+impl_intersects!(IndexedChunkedMultiPointArray);
+impl_intersects!(IndexedChunkedMultiLineStringArray);
+impl_intersects!(IndexedChunkedMultiPolygonArray);
+impl_intersects!(IndexedChunkedMixedGeometryArray);
+impl_intersects!(IndexedChunkedGeometryCollectionArray);
 
 pub trait IntersectsGeometryCollection<Rhs> {
     type Output;
@@ -676,7 +665,7 @@ pub trait IntersectsGeometryCollection<Rhs> {
     fn intersects(&self, rhs: &Rhs) -> Self::Output;
 }
 
-impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for IndexedPointArray<2> {
+impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G> for IndexedPointArray {
     type Output = BooleanArray;
 
     fn intersects(&self, rhs: &G) -> Self::Output {
@@ -702,16 +691,16 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedLineStringArray<2>);
-impl_intersects!(IndexedPolygonArray<2>);
-impl_intersects!(IndexedMultiPointArray<2>);
-impl_intersects!(IndexedMultiLineStringArray<2>);
-impl_intersects!(IndexedMultiPolygonArray<2>);
-impl_intersects!(IndexedMixedGeometryArray<2>);
-impl_intersects!(IndexedGeometryCollectionArray<2>);
+impl_intersects!(IndexedLineStringArray);
+impl_intersects!(IndexedPolygonArray);
+impl_intersects!(IndexedMultiPointArray);
+impl_intersects!(IndexedMultiLineStringArray);
+impl_intersects!(IndexedMultiPolygonArray);
+impl_intersects!(IndexedMixedGeometryArray);
+impl_intersects!(IndexedGeometryCollectionArray);
 
 impl<G: GeometryCollectionTrait<T = f64>> IntersectsGeometryCollection<G>
-    for IndexedChunkedPointArray<2>
+    for IndexedChunkedPointArray
 {
     type Output = ChunkedArray<BooleanArray>;
 
@@ -738,10 +727,10 @@ macro_rules! impl_intersects {
     };
 }
 
-impl_intersects!(IndexedChunkedLineStringArray<2>);
-impl_intersects!(IndexedChunkedPolygonArray<2>);
-impl_intersects!(IndexedChunkedMultiPointArray<2>);
-impl_intersects!(IndexedChunkedMultiLineStringArray<2>);
-impl_intersects!(IndexedChunkedMultiPolygonArray<2>);
-impl_intersects!(IndexedChunkedMixedGeometryArray<2>);
-impl_intersects!(IndexedChunkedGeometryCollectionArray<2>);
+impl_intersects!(IndexedChunkedLineStringArray);
+impl_intersects!(IndexedChunkedPolygonArray);
+impl_intersects!(IndexedChunkedMultiPointArray);
+impl_intersects!(IndexedChunkedMultiLineStringArray);
+impl_intersects!(IndexedChunkedMultiPolygonArray);
+impl_intersects!(IndexedChunkedMixedGeometryArray);
+impl_intersects!(IndexedChunkedGeometryCollectionArray);

--- a/rust/geoarrow/src/algorithm/geo/line_interpolate_point.rs
+++ b/rust/geoarrow/src/algorithm/geo/line_interpolate_point.rs
@@ -47,7 +47,7 @@ impl LineInterpolatePoint<&Float64Array> for LineStringArray {
     type Output = PointArray;
 
     fn line_interpolate_point(&self, p: &Float64Array) -> Self::Output {
-        let mut output_array = PointBuilder::with_capacity(self.len());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.len());
 
         self.iter_geo()
             .zip(p)
@@ -108,7 +108,7 @@ impl LineInterpolatePoint<f64> for LineStringArray {
     type Output = PointArray;
 
     fn line_interpolate_point(&self, p: f64) -> Self::Output {
-        let mut output_array = PointBuilder::with_capacity(self.len());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.len());
 
         self.iter_geo().for_each(|maybe_line_string| {
             if let Some(line_string) = maybe_line_string {

--- a/rust/geoarrow/src/algorithm/geo/line_interpolate_point.rs
+++ b/rust/geoarrow/src/algorithm/geo/line_interpolate_point.rs
@@ -43,8 +43,8 @@ pub trait LineInterpolatePoint<Rhs> {
     fn line_interpolate_point(&self, fraction: Rhs) -> Self::Output;
 }
 
-impl LineInterpolatePoint<&Float64Array> for LineStringArray<2> {
-    type Output = PointArray<2>;
+impl LineInterpolatePoint<&Float64Array> for LineStringArray {
+    type Output = PointArray;
 
     fn line_interpolate_point(&self, p: &Float64Array) -> Self::Output {
         let mut output_array = PointBuilder::with_capacity(self.len());
@@ -67,21 +67,21 @@ impl LineInterpolatePoint<&Float64Array> for LineStringArray<2> {
 }
 
 impl LineInterpolatePoint<&Float64Array> for &dyn NativeArray {
-    type Output = Result<PointArray<2>>;
+    type Output = Result<PointArray>;
 
     fn line_interpolate_point(&self, fraction: &Float64Array) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            LineString(_, XY) => Ok(self.as_line_string::<2>().line_interpolate_point(fraction)),
+            LineString(_, XY) => Ok(self.as_line_string().line_interpolate_point(fraction)),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl LineInterpolatePoint<&[Float64Array]> for ChunkedLineStringArray<2> {
-    type Output = ChunkedPointArray<2>;
+impl LineInterpolatePoint<&[Float64Array]> for ChunkedLineStringArray {
+    type Output = ChunkedPointArray;
 
     fn line_interpolate_point(&self, p: &[Float64Array]) -> Self::Output {
         ChunkedPointArray::new(
@@ -91,21 +91,21 @@ impl LineInterpolatePoint<&[Float64Array]> for ChunkedLineStringArray<2> {
 }
 
 impl LineInterpolatePoint<&[Float64Array]> for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPointArray<2>>;
+    type Output = Result<ChunkedPointArray>;
 
     fn line_interpolate_point(&self, fraction: &[Float64Array]) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            LineString(_, XY) => Ok(self.as_line_string::<2>().line_interpolate_point(fraction)),
+            LineString(_, XY) => Ok(self.as_line_string().line_interpolate_point(fraction)),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl LineInterpolatePoint<f64> for LineStringArray<2> {
-    type Output = PointArray<2>;
+impl LineInterpolatePoint<f64> for LineStringArray {
+    type Output = PointArray;
 
     fn line_interpolate_point(&self, p: f64) -> Self::Output {
         let mut output_array = PointBuilder::with_capacity(self.len());
@@ -127,21 +127,21 @@ impl LineInterpolatePoint<f64> for LineStringArray<2> {
 }
 
 impl LineInterpolatePoint<f64> for &dyn NativeArray {
-    type Output = Result<PointArray<2>>;
+    type Output = Result<PointArray>;
 
     fn line_interpolate_point(&self, fraction: f64) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            LineString(_, XY) => Ok(self.as_line_string::<2>().line_interpolate_point(fraction)),
+            LineString(_, XY) => Ok(self.as_line_string().line_interpolate_point(fraction)),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl LineInterpolatePoint<f64> for ChunkedLineStringArray<2> {
-    type Output = ChunkedPointArray<2>;
+impl LineInterpolatePoint<f64> for ChunkedLineStringArray {
+    type Output = ChunkedPointArray;
 
     fn line_interpolate_point(&self, fraction: f64) -> Self::Output {
         ChunkedPointArray::new(self.map(|chunk| chunk.line_interpolate_point(fraction)))
@@ -149,14 +149,14 @@ impl LineInterpolatePoint<f64> for ChunkedLineStringArray<2> {
 }
 
 impl LineInterpolatePoint<f64> for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPointArray<2>>;
+    type Output = Result<ChunkedPointArray>;
 
     fn line_interpolate_point(&self, fraction: f64) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            LineString(_, XY) => Ok(self.as_line_string::<2>().line_interpolate_point(fraction)),
+            LineString(_, XY) => Ok(self.as_line_string().line_interpolate_point(fraction)),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/rust/geoarrow/src/algorithm/geo/line_locate_point.rs
+++ b/rust/geoarrow/src/algorithm/geo/line_locate_point.rs
@@ -25,10 +25,10 @@ pub trait LineLocatePoint<Rhs> {
     fn line_locate_point(&self, rhs: Rhs) -> Self::Output;
 }
 
-impl LineLocatePoint<&PointArray<2>> for LineStringArray<2> {
+impl LineLocatePoint<&PointArray> for LineStringArray {
     type Output = Float64Array;
 
-    fn line_locate_point(&self, rhs: &PointArray<2>) -> Float64Array {
+    fn line_locate_point(&self, rhs: &PointArray) -> Float64Array {
         let mut output_array = Float64Builder::with_capacity(self.len());
 
         self.iter_geo()
@@ -57,7 +57,7 @@ impl LineLocatePoint<&dyn NativeArray> for &dyn NativeArray {
 
         let result = match (self.data_type(), rhs.data_type()) {
             (LineString(_, XY), Point(_, XY)) => {
-                LineLocatePoint::line_locate_point(self.as_line_string::<2>(), rhs.as_point::<2>())
+                LineLocatePoint::line_locate_point(self.as_line_string(), rhs.as_point())
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -65,10 +65,10 @@ impl LineLocatePoint<&dyn NativeArray> for &dyn NativeArray {
     }
 }
 
-impl LineLocatePoint<&[PointArray<2>]> for ChunkedLineStringArray<2> {
+impl LineLocatePoint<&[PointArray]> for ChunkedLineStringArray {
     type Output = ChunkedArray<Float64Array>;
 
-    fn line_locate_point(&self, rhs: &[PointArray<2>]) -> ChunkedArray<Float64Array> {
+    fn line_locate_point(&self, rhs: &[PointArray]) -> ChunkedArray<Float64Array> {
         let chunks = self.binary_map(rhs, |(left, right)| {
             LineLocatePoint::line_locate_point(left, right)
         });
@@ -85,8 +85,8 @@ impl LineLocatePoint<&dyn ChunkedNativeArray> for &dyn ChunkedNativeArray {
 
         let result = match (self.data_type(), rhs.data_type()) {
             (LineString(_, XY), Point(_, XY)) => LineLocatePoint::line_locate_point(
-                self.as_line_string::<2>(),
-                &rhs.as_point::<2>().chunks,
+                self.as_line_string(),
+                &rhs.as_point().chunks,
             ),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -100,7 +100,7 @@ pub trait LineLocatePointScalar<Rhs> {
     fn line_locate_point(&self, rhs: Rhs) -> Self::Output;
 }
 
-impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for LineStringArray<2> {
+impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for LineStringArray {
     type Output = Float64Array;
 
     fn line_locate_point(&self, rhs: G) -> Self::Output {
@@ -131,7 +131,7 @@ impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for &dyn NativeArray {
 
         let result = match self.data_type() {
             LineString(_, XY) => {
-                LineLocatePointScalar::line_locate_point(self.as_line_string::<2>(), rhs)
+                LineLocatePointScalar::line_locate_point(self.as_line_string(), rhs)
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
@@ -139,7 +139,7 @@ impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for &dyn NativeArray {
     }
 }
 
-impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for ChunkedLineStringArray<2> {
+impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for ChunkedLineStringArray {
     type Output = ChunkedArray<Float64Array>;
 
     fn line_locate_point(&self, rhs: G) -> Self::Output {
@@ -158,7 +158,7 @@ impl<G: PointTrait<T = f64>> LineLocatePointScalar<G> for &dyn ChunkedNativeArra
 
         let result = match self.data_type() {
             LineString(_, XY) => {
-                LineLocatePointScalar::line_locate_point(self.as_line_string::<2>(), rhs)
+                LineLocatePointScalar::line_locate_point(self.as_line_string(), rhs)
             }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };

--- a/rust/geoarrow/src/algorithm/geo/line_locate_point.rs
+++ b/rust/geoarrow/src/algorithm/geo/line_locate_point.rs
@@ -84,10 +84,9 @@ impl LineLocatePoint<&dyn ChunkedNativeArray> for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result = match (self.data_type(), rhs.data_type()) {
-            (LineString(_, XY), Point(_, XY)) => LineLocatePoint::line_locate_point(
-                self.as_line_string(),
-                &rhs.as_point().chunks,
-            ),
+            (LineString(_, XY), Point(_, XY)) => {
+                LineLocatePoint::line_locate_point(self.as_line_string(), &rhs.as_point().chunks)
+            }
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/rust/geoarrow/src/algorithm/geo/minimum_rotated_rect.rs
+++ b/rust/geoarrow/src/algorithm/geo/minimum_rotated_rect.rs
@@ -55,7 +55,7 @@ macro_rules! iter_geo_impl {
 
                 let capacity = PolygonCapacity::new(coord_capacity, ring_capacity, geom_capacity);
 
-                let mut output_array = PolygonBuilder::with_capacity(capacity);
+                let mut output_array = PolygonBuilder::with_capacity(Dimension::XY, capacity);
 
                 self.iter_geo().for_each(|maybe_g| {
                     output_array

--- a/rust/geoarrow/src/algorithm/geo/minimum_rotated_rect.rs
+++ b/rust/geoarrow/src/algorithm/geo/minimum_rotated_rect.rs
@@ -41,7 +41,7 @@ pub trait MinimumRotatedRect {
 macro_rules! iter_geo_impl {
     ($type:ty) => {
         impl MinimumRotatedRect for $type {
-            type Output = PolygonArray<2>;
+            type Output = PolygonArray;
 
             fn minimum_rotated_rect(&self) -> Self::Output {
                 // The number of output geoms is the same as the input
@@ -69,31 +69,31 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(PointArray<2>);
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
-iter_geo_impl!(MixedGeometryArray<2>);
-iter_geo_impl!(GeometryCollectionArray<2>);
+iter_geo_impl!(PointArray);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPointArray);
+iter_geo_impl!(MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray);
+iter_geo_impl!(MixedGeometryArray);
+iter_geo_impl!(GeometryCollectionArray);
 
 impl MinimumRotatedRect for &dyn NativeArray {
-    type Output = Result<PolygonArray<2>>;
+    type Output = Result<PolygonArray>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         let result = match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().minimum_rotated_rect(),
-            LineString(_, XY) => self.as_line_string::<2>().minimum_rotated_rect(),
-            Polygon(_, XY) => self.as_polygon::<2>().minimum_rotated_rect(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().minimum_rotated_rect(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().minimum_rotated_rect(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().minimum_rotated_rect(),
-            Mixed(_, XY) => self.as_mixed::<2>().minimum_rotated_rect(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().minimum_rotated_rect(),
+            Point(_, XY) => self.as_point().minimum_rotated_rect(),
+            LineString(_, XY) => self.as_line_string().minimum_rotated_rect(),
+            Polygon(_, XY) => self.as_polygon().minimum_rotated_rect(),
+            MultiPoint(_, XY) => self.as_multi_point().minimum_rotated_rect(),
+            MultiLineString(_, XY) => self.as_multi_line_string().minimum_rotated_rect(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().minimum_rotated_rect(),
+            Mixed(_, XY) => self.as_mixed().minimum_rotated_rect(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().minimum_rotated_rect(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -101,7 +101,7 @@ impl MinimumRotatedRect for &dyn NativeArray {
 }
 
 impl<G: NativeArray> MinimumRotatedRect for ChunkedGeometryArray<G> {
-    type Output = Result<ChunkedGeometryArray<PolygonArray<2>>>;
+    type Output = Result<ChunkedGeometryArray<PolygonArray>>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         self.try_map(|chunk| chunk.as_ref().minimum_rotated_rect())?
@@ -110,21 +110,21 @@ impl<G: NativeArray> MinimumRotatedRect for ChunkedGeometryArray<G> {
 }
 
 impl MinimumRotatedRect for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPolygonArray<2>>;
+    type Output = Result<ChunkedPolygonArray>;
 
     fn minimum_rotated_rect(&self) -> Self::Output {
         use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().minimum_rotated_rect(),
-            LineString(_, XY) => self.as_line_string::<2>().minimum_rotated_rect(),
-            Polygon(_, XY) => self.as_polygon::<2>().minimum_rotated_rect(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().minimum_rotated_rect(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().minimum_rotated_rect(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().minimum_rotated_rect(),
-            Mixed(_, XY) => self.as_mixed::<2>().minimum_rotated_rect(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().minimum_rotated_rect(),
+            Point(_, XY) => self.as_point().minimum_rotated_rect(),
+            LineString(_, XY) => self.as_line_string().minimum_rotated_rect(),
+            Polygon(_, XY) => self.as_polygon().minimum_rotated_rect(),
+            MultiPoint(_, XY) => self.as_multi_point().minimum_rotated_rect(),
+            MultiLineString(_, XY) => self.as_multi_line_string().minimum_rotated_rect(),
+            MultiPolygon(_, XY) => self.as_multi_polygon().minimum_rotated_rect(),
+            Mixed(_, XY) => self.as_mixed().minimum_rotated_rect(),
+            GeometryCollection(_, XY) => self.as_geometry_collection().minimum_rotated_rect(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/rust/geoarrow/src/algorithm/geo/remove_repeated_points.rs
+++ b/rust/geoarrow/src/algorithm/geo/remove_repeated_points.rs
@@ -26,7 +26,7 @@ pub trait RemoveRepeatedPoints {
 }
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl RemoveRepeatedPoints for PointArray<2> {
+impl RemoveRepeatedPoints for PointArray {
     type Output = Self;
 
     fn remove_repeated_points(&self) -> Self::Output {
@@ -55,21 +55,21 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
-iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
-iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
+iter_geo_impl!(LineStringArray, LineStringBuilder, push_line_string);
+iter_geo_impl!(PolygonArray, PolygonBuilder, push_polygon);
+iter_geo_impl!(MultiPointArray, MultiPointBuilder, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
+    MultiLineStringArray,
+    MultiLineStringBuilder,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
+    MultiPolygonArray,
+    MultiPolygonBuilder,
     push_multi_polygon
 );
-// iter_geo_impl!(MixedGeometryArray<2>, MixedGeometryBuilder<2>, push_geometry);
-// iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
+// iter_geo_impl!(MixedGeometryArray, MixedGeometryBuilder, push_geometry);
+// iter_geo_impl!(GeometryCollectionArray, geo::GeometryCollection);
 
 impl RemoveRepeatedPoints for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -79,23 +79,23 @@ impl RemoveRepeatedPoints for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().remove_repeated_points()),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().remove_repeated_points()),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().remove_repeated_points()),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().remove_repeated_points()),
+            Point(_, XY) => Arc::new(self.as_point().remove_repeated_points()),
+            LineString(_, XY) => Arc::new(self.as_line_string().remove_repeated_points()),
+            Polygon(_, XY) => Arc::new(self.as_polygon().remove_repeated_points()),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().remove_repeated_points()),
             MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().remove_repeated_points())
+                Arc::new(self.as_multi_line_string().remove_repeated_points())
             }
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().remove_repeated_points()),
-            // Mixed(_, XY) => self.as_mixed::<2>().remove_repeated_points(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().remove_repeated_points(),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().remove_repeated_points()),
+            // Mixed(_, XY) => self.as_mixed().remove_repeated_points(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().remove_repeated_points(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl RemoveRepeatedPoints for ChunkedPointArray<2> {
+impl RemoveRepeatedPoints for ChunkedPointArray {
     type Output = Self;
 
     fn remove_repeated_points(&self) -> Self::Output {
@@ -117,11 +117,11 @@ macro_rules! impl_chunked {
     };
 }
 
-impl_chunked!(ChunkedLineStringArray<2>);
-impl_chunked!(ChunkedPolygonArray<2>);
-impl_chunked!(ChunkedMultiPointArray<2>);
-impl_chunked!(ChunkedMultiLineStringArray<2>);
-impl_chunked!(ChunkedMultiPolygonArray<2>);
+impl_chunked!(ChunkedLineStringArray);
+impl_chunked!(ChunkedPolygonArray);
+impl_chunked!(ChunkedMultiPointArray);
+impl_chunked!(ChunkedMultiLineStringArray);
+impl_chunked!(ChunkedMultiPolygonArray);
 
 impl RemoveRepeatedPoints for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -131,16 +131,16 @@ impl RemoveRepeatedPoints for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().remove_repeated_points()),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().remove_repeated_points()),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().remove_repeated_points()),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().remove_repeated_points()),
+            Point(_, XY) => Arc::new(self.as_point().remove_repeated_points()),
+            LineString(_, XY) => Arc::new(self.as_line_string().remove_repeated_points()),
+            Polygon(_, XY) => Arc::new(self.as_polygon().remove_repeated_points()),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().remove_repeated_points()),
             MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().remove_repeated_points())
+                Arc::new(self.as_multi_line_string().remove_repeated_points())
             }
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().remove_repeated_points()),
-            // Mixed(_, XY) => self.as_mixed::<2>().remove_repeated_points(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().remove_repeated_points(),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().remove_repeated_points()),
+            // Mixed(_, XY) => self.as_mixed().remove_repeated_points(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().remove_repeated_points(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/rust/geoarrow/src/algorithm/geo/remove_repeated_points.rs
+++ b/rust/geoarrow/src/algorithm/geo/remove_repeated_points.rs
@@ -41,7 +41,8 @@ macro_rules! iter_geo_impl {
             type Output = Self;
 
             fn remove_repeated_points(&self) -> Self::Output {
-                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
+                let mut output_array =
+                    <$builder_type>::with_capacity(Dimension::XY, self.buffer_lengths());
 
                 self.iter_geo().for_each(|maybe_g| {
                     output_array
@@ -63,11 +64,7 @@ iter_geo_impl!(
     MultiLineStringBuilder,
     push_multi_line_string
 );
-iter_geo_impl!(
-    MultiPolygonArray,
-    MultiPolygonBuilder,
-    push_multi_polygon
-);
+iter_geo_impl!(MultiPolygonArray, MultiPolygonBuilder, push_multi_polygon);
 // iter_geo_impl!(MixedGeometryArray, MixedGeometryBuilder, push_geometry);
 // iter_geo_impl!(GeometryCollectionArray, geo::GeometryCollection);
 

--- a/rust/geoarrow/src/algorithm/geo/rotate.rs
+++ b/rust/geoarrow/src/algorithm/geo/rotate.rs
@@ -98,7 +98,7 @@ pub trait Rotate<DegreesT> {
 // └────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Rotate<Float64Array> for PointArray<2> {
+impl Rotate<Float64Array> for PointArray {
     type Output = Self;
 
     fn rotate_around_centroid(&self, degrees: &Float64Array) -> Self {
@@ -169,18 +169,18 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(PolygonArray);
+iter_geo_impl!(MultiPointArray);
+iter_geo_impl!(MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray);
 
 // ┌─────────────────────────────────┐
 // │ Implementations for RHS scalars │
 // └─────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Rotate<f64> for PointArray<2> {
+impl Rotate<f64> for PointArray {
     type Output = Self;
 
     fn rotate_around_centroid(&self, degrees: &f64) -> Self {
@@ -239,11 +239,11 @@ macro_rules! iter_geo_impl_scalar {
     };
 }
 
-iter_geo_impl_scalar!(LineStringArray<2>);
-iter_geo_impl_scalar!(PolygonArray<2>);
-iter_geo_impl_scalar!(MultiPointArray<2>);
-iter_geo_impl_scalar!(MultiLineStringArray<2>);
-iter_geo_impl_scalar!(MultiPolygonArray<2>);
+iter_geo_impl_scalar!(LineStringArray);
+iter_geo_impl_scalar!(PolygonArray);
+iter_geo_impl_scalar!(MultiPointArray);
+iter_geo_impl_scalar!(MultiLineStringArray);
+iter_geo_impl_scalar!(MultiPolygonArray);
 
 impl Rotate<f64> for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;

--- a/rust/geoarrow/src/algorithm/geo/scale.rs
+++ b/rust/geoarrow/src/algorithm/geo/scale.rs
@@ -108,7 +108,7 @@ impl Scale for PointArray {
         x_factor: &BroadcastablePrimitive<Float64Type>,
         y_factor: &BroadcastablePrimitive<Float64Type>,
     ) -> Self {
-        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.buffer_lengths());
 
         self.iter_geo()
             .zip(x_factor)
@@ -130,7 +130,7 @@ impl Scale for PointArray {
         y_factor: &BroadcastablePrimitive<Float64Type>,
         origin: geo::Point,
     ) -> Self {
-        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.buffer_lengths());
 
         self.iter_geo()
             .zip(x_factor)
@@ -160,7 +160,8 @@ macro_rules! iter_geo_impl {
                 x_factor: &BroadcastablePrimitive<Float64Type>,
                 y_factor: &BroadcastablePrimitive<Float64Type>,
             ) -> Self {
-                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
+                let mut output_array =
+                    <$builder_type>::with_capacity(Dimension::XY, self.buffer_lengths());
 
                 self.iter_geo().zip(x_factor).zip(y_factor).for_each(
                     |((maybe_g, x_factor), y_factor)| {
@@ -183,7 +184,8 @@ macro_rules! iter_geo_impl {
                 y_factor: &BroadcastablePrimitive<Float64Type>,
                 origin: geo::Point,
             ) -> Self {
-                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
+                let mut output_array =
+                    <$builder_type>::with_capacity(Dimension::XY, self.buffer_lengths());
 
                 self.iter_geo().zip(x_factor).zip(y_factor).for_each(
                     |((maybe_g, x_factor), y_factor)| {
@@ -217,11 +219,7 @@ iter_geo_impl!(
     MultiLineStringBuilder,
     push_multi_line_string
 );
-iter_geo_impl!(
-    MultiPolygonArray,
-    MultiPolygonBuilder,
-    push_multi_polygon
-);
+iter_geo_impl!(MultiPolygonArray, MultiPolygonBuilder, push_multi_polygon);
 
 impl Scale for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;

--- a/rust/geoarrow/src/algorithm/geo/scale.rs
+++ b/rust/geoarrow/src/algorithm/geo/scale.rs
@@ -100,7 +100,7 @@ pub trait Scale: Sized {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Scale for PointArray<2> {
+impl Scale for PointArray {
     type Output = Self;
 
     fn scale_xy(
@@ -209,17 +209,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
-iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
-iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
+iter_geo_impl!(LineStringArray, LineStringBuilder, push_line_string);
+iter_geo_impl!(PolygonArray, PolygonBuilder, push_polygon);
+iter_geo_impl!(MultiPointArray, MultiPointBuilder, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
+    MultiLineStringArray,
+    MultiLineStringBuilder,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
+    MultiPolygonArray,
+    MultiPolygonBuilder,
     push_multi_polygon
 );
 

--- a/rust/geoarrow/src/algorithm/geo/simplify.rs
+++ b/rust/geoarrow/src/algorithm/geo/simplify.rs
@@ -30,6 +30,7 @@ pub trait Simplify {
     /// use geoarrow::array::LineStringArray;
     /// use geoarrow::trait_::ArrayAccessor;
     /// use geo::line_string;
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let line_string = line_string![
     ///     (x: 0.0, y: 0.0),
@@ -38,7 +39,7 @@ pub trait Simplify {
     ///     (x: 17.3, y: 3.2),
     ///     (x: 27.8, y: 0.1),
     /// ];
-    /// let line_string_array: LineStringArray = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray = (vec![line_string].as_slice(), Dimension::XY).into();
     ///
     /// let simplified_array = line_string_array.simplify(&1.0);
     ///

--- a/rust/geoarrow/src/algorithm/geo/simplify.rs
+++ b/rust/geoarrow/src/algorithm/geo/simplify.rs
@@ -38,7 +38,7 @@ pub trait Simplify {
     ///     (x: 17.3, y: 3.2),
     ///     (x: 27.8, y: 0.1),
     /// ];
-    /// let line_string_array: LineStringArray<2> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray = vec![line_string].as_slice().into();
     ///
     /// let simplified_array = line_string_array.simplify(&1.0);
     ///
@@ -67,8 +67,8 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(PointArray<2>);
-identity_impl!(MultiPointArray<2>);
+identity_impl!(PointArray);
+identity_impl!(MultiPointArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -88,12 +88,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, geo::LineString);
-iter_geo_impl!(PolygonArray<2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<2>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray, geo::LineString);
+iter_geo_impl!(PolygonArray, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray, geo::GeometryCollection);
 
 impl Simplify for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -103,21 +103,21 @@ impl Simplify for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().simplify(epsilon)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify(epsilon)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify(epsilon)),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify(epsilon)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify(epsilon)),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify(epsilon)),
-            // Mixed(_, XY) => self.as_mixed::<2>().simplify(epsilon),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify(),
+            Point(_, XY) => Arc::new(self.as_point().simplify(epsilon)),
+            LineString(_, XY) => Arc::new(self.as_line_string().simplify(epsilon)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().simplify(epsilon)),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify(epsilon)),
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().simplify(epsilon)),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().simplify(epsilon)),
+            // Mixed(_, XY) => self.as_mixed().simplify(epsilon),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().simplify(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl Simplify for ChunkedGeometryArray<PointArray<2>> {
+impl Simplify for ChunkedGeometryArray<PointArray> {
     type Output = Self;
 
     fn simplify(&self, epsilon: &f64) -> Self::Output {
@@ -142,11 +142,11 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray>);
 
 impl Simplify for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -156,14 +156,14 @@ impl Simplify for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().simplify(epsilon)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify(epsilon)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify(epsilon)),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify(epsilon)),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().simplify(epsilon)),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify(epsilon)),
-            // Mixed(_, XY) => self.as_mixed::<2>().simplify(epsilon),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify(),
+            Point(_, XY) => Arc::new(self.as_point().simplify(epsilon)),
+            LineString(_, XY) => Arc::new(self.as_line_string().simplify(epsilon)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().simplify(epsilon)),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify(epsilon)),
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().simplify(epsilon)),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().simplify(epsilon)),
+            // Mixed(_, XY) => self.as_mixed().simplify(epsilon),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().simplify(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -186,7 +186,7 @@ mod tests {
             (x: 17.3, y: 3.2 ),
             (x: 27.8, y: 0.1 ),
         ];
-        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = vec![input_geom].as_slice().into();
         let result_array = input_array.simplify(&1.0);
 
         let expected = line_string![
@@ -209,7 +209,7 @@ mod tests {
             (x: 10., y: 0.),
             (x: 0., y: 0.),
         ];
-        let input_array: PolygonArray<2> = vec![input_geom].as_slice().into();
+        let input_array: PolygonArray = vec![input_geom].as_slice().into();
         let result_array = input_array.simplify(&2.0);
 
         let expected = polygon![

--- a/rust/geoarrow/src/algorithm/geo/simplify.rs
+++ b/rust/geoarrow/src/algorithm/geo/simplify.rs
@@ -82,7 +82,7 @@ macro_rules! iter_geo_impl {
                     .map(|maybe_g| maybe_g.map(|geom| geom.simplify(epsilon)))
                     .collect();
 
-                output_geoms.into()
+                (output_geoms, Dimension::XY).into()
             }
         }
     };
@@ -186,7 +186,7 @@ mod tests {
             (x: 17.3, y: 3.2 ),
             (x: 27.8, y: 0.1 ),
         ];
-        let input_array: LineStringArray = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = (vec![input_geom].as_slice(), Dimension::XY).into();
         let result_array = input_array.simplify(&1.0);
 
         let expected = line_string![
@@ -209,7 +209,7 @@ mod tests {
             (x: 10., y: 0.),
             (x: 0., y: 0.),
         ];
-        let input_array: PolygonArray = vec![input_geom].as_slice().into();
+        let input_array: PolygonArray = (vec![input_geom].as_slice(), Dimension::XY).into();
         let result_array = input_array.simplify(&2.0);
 
         let expected = polygon![

--- a/rust/geoarrow/src/algorithm/geo/simplify_vw.rs
+++ b/rust/geoarrow/src/algorithm/geo/simplify_vw.rs
@@ -37,7 +37,7 @@ pub trait SimplifyVw {
     ///     (x: 7.0, y: 25.0),
     ///     (x: 10.0, y: 10.0),
     /// ];
-    /// let line_string_array: LineStringArray<2> = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray = vec![line_string].as_slice().into();
     ///
     /// let simplified_array = line_string_array.simplify_vw(&30.0);
     ///
@@ -65,8 +65,8 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(PointArray<2>);
-identity_impl!(MultiPointArray<2>);
+identity_impl!(PointArray);
+identity_impl!(MultiPointArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -86,12 +86,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, geo::LineString);
-iter_geo_impl!(PolygonArray<2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<2>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray, geo::LineString);
+iter_geo_impl!(PolygonArray, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray, geo::GeometryCollection);
 
 impl SimplifyVw for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -101,23 +101,23 @@ impl SimplifyVw for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().simplify_vw(epsilon)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw(epsilon)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw(epsilon)),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw(epsilon)),
+            Point(_, XY) => Arc::new(self.as_point().simplify_vw(epsilon)),
+            LineString(_, XY) => Arc::new(self.as_line_string().simplify_vw(epsilon)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().simplify_vw(epsilon)),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify_vw(epsilon)),
             MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon))
+                Arc::new(self.as_multi_line_string().simplify_vw(epsilon))
             }
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw(epsilon)),
-            // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw(epsilon),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw(),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().simplify_vw(epsilon)),
+            // Mixed(_, XY) => self.as_mixed().simplify_vw(epsilon),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().simplify_vw(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl SimplifyVw for ChunkedGeometryArray<PointArray<2>> {
+impl SimplifyVw for ChunkedGeometryArray<PointArray> {
     type Output = Self;
 
     fn simplify_vw(&self, epsilon: &f64) -> Self::Output {
@@ -142,11 +142,11 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray>);
 
 impl SimplifyVw for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -156,16 +156,16 @@ impl SimplifyVw for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().simplify_vw(epsilon)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw(epsilon)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw(epsilon)),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw(epsilon)),
+            Point(_, XY) => Arc::new(self.as_point().simplify_vw(epsilon)),
+            LineString(_, XY) => Arc::new(self.as_line_string().simplify_vw(epsilon)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().simplify_vw(epsilon)),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify_vw(epsilon)),
             MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().simplify_vw(epsilon))
+                Arc::new(self.as_multi_line_string().simplify_vw(epsilon))
             }
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().simplify_vw(epsilon)),
-            // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw(epsilon),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw(),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().simplify_vw(epsilon)),
+            // Mixed(_, XY) => self.as_mixed().simplify_vw(epsilon),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().simplify_vw(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/rust/geoarrow/src/algorithm/geo/simplify_vw.rs
+++ b/rust/geoarrow/src/algorithm/geo/simplify_vw.rs
@@ -80,7 +80,7 @@ macro_rules! iter_geo_impl {
                     .map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw(epsilon)))
                     .collect();
 
-                output_geoms.into()
+                (output_geoms, Dimension::XY).into()
             }
         }
     };
@@ -105,9 +105,7 @@ impl SimplifyVw for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string().simplify_vw(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon().simplify_vw(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify_vw(epsilon)),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string().simplify_vw(epsilon))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().simplify_vw(epsilon)),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().simplify_vw(epsilon)),
             // Mixed(_, XY) => self.as_mixed().simplify_vw(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection().simplify_vw(),
@@ -160,9 +158,7 @@ impl SimplifyVw for &dyn ChunkedNativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string().simplify_vw(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon().simplify_vw(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify_vw(epsilon)),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string().simplify_vw(epsilon))
-            }
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().simplify_vw(epsilon)),
             MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().simplify_vw(epsilon)),
             // Mixed(_, XY) => self.as_mixed().simplify_vw(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection().simplify_vw(),

--- a/rust/geoarrow/src/algorithm/geo/simplify_vw.rs
+++ b/rust/geoarrow/src/algorithm/geo/simplify_vw.rs
@@ -29,6 +29,7 @@ pub trait SimplifyVw {
     /// use geoarrow::array::LineStringArray;
     /// use geoarrow::trait_::ArrayAccessor;
     /// use geo::line_string;
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let line_string = line_string![
     ///     (x: 5.0, y: 2.0),
@@ -37,7 +38,7 @@ pub trait SimplifyVw {
     ///     (x: 7.0, y: 25.0),
     ///     (x: 10.0, y: 10.0),
     /// ];
-    /// let line_string_array: LineStringArray = vec![line_string].as_slice().into();
+    /// let line_string_array: LineStringArray = (vec![line_string].as_slice(), Dimension::XY).into();
     ///
     /// let simplified_array = line_string_array.simplify_vw(&30.0);
     ///

--- a/rust/geoarrow/src/algorithm/geo/simplify_vw_preserve.rs
+++ b/rust/geoarrow/src/algorithm/geo/simplify_vw_preserve.rs
@@ -59,8 +59,8 @@ macro_rules! identity_impl {
     };
 }
 
-identity_impl!(PointArray<2>);
-identity_impl!(MultiPointArray<2>);
+identity_impl!(PointArray);
+identity_impl!(MultiPointArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -80,12 +80,12 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, geo::LineString);
-iter_geo_impl!(PolygonArray<2>, geo::Polygon);
-iter_geo_impl!(MultiLineStringArray<2>, geo::MultiLineString);
-iter_geo_impl!(MultiPolygonArray<2>, geo::MultiPolygon);
-// iter_geo_impl!(MixedGeometryArray<2>, geo::Geometry);
-// iter_geo_impl!(GeometryCollectionArray<2>, geo::GeometryCollection);
+iter_geo_impl!(LineStringArray, geo::LineString);
+iter_geo_impl!(PolygonArray, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray, geo::MultiPolygon);
+// iter_geo_impl!(MixedGeometryArray, geo::Geometry);
+// iter_geo_impl!(GeometryCollectionArray, geo::GeometryCollection);
 
 impl SimplifyVwPreserve for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
@@ -95,26 +95,26 @@ impl SimplifyVwPreserve for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().simplify_vw_preserve(epsilon)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw_preserve(epsilon)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw_preserve(epsilon)),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw_preserve(epsilon)),
+            Point(_, XY) => Arc::new(self.as_point().simplify_vw_preserve(epsilon)),
+            LineString(_, XY) => Arc::new(self.as_line_string().simplify_vw_preserve(epsilon)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().simplify_vw_preserve(epsilon)),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify_vw_preserve(epsilon)),
             MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string::<2>()
+                self.as_multi_line_string()
                     .simplify_vw_preserve(epsilon),
             ),
             MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon))
+                Arc::new(self.as_multi_polygon().simplify_vw_preserve(epsilon))
             }
-            // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw_preserve(epsilon),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw_preserve(),
+            // Mixed(_, XY) => self.as_mixed().simplify_vw_preserve(epsilon),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().simplify_vw_preserve(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl SimplifyVwPreserve for ChunkedGeometryArray<PointArray<2>> {
+impl SimplifyVwPreserve for ChunkedGeometryArray<PointArray> {
     type Output = Self;
 
     fn simplify_vw_preserve(&self, epsilon: &f64) -> Self::Output {
@@ -139,11 +139,11 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray>);
 
 impl SimplifyVwPreserve for &dyn ChunkedNativeArray {
     type Output = Result<Arc<dyn ChunkedNativeArray>>;
@@ -153,19 +153,19 @@ impl SimplifyVwPreserve for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().simplify_vw_preserve(epsilon)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().simplify_vw_preserve(epsilon)),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().simplify_vw_preserve(epsilon)),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().simplify_vw_preserve(epsilon)),
+            Point(_, XY) => Arc::new(self.as_point().simplify_vw_preserve(epsilon)),
+            LineString(_, XY) => Arc::new(self.as_line_string().simplify_vw_preserve(epsilon)),
+            Polygon(_, XY) => Arc::new(self.as_polygon().simplify_vw_preserve(epsilon)),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify_vw_preserve(epsilon)),
             MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string::<2>()
+                self.as_multi_line_string()
                     .simplify_vw_preserve(epsilon),
             ),
             MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon::<2>().simplify_vw_preserve(epsilon))
+                Arc::new(self.as_multi_polygon().simplify_vw_preserve(epsilon))
             }
-            // Mixed(_, XY) => self.as_mixed::<2>().simplify_vw_preserve(epsilon),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().simplify_vw_preserve(),
+            // Mixed(_, XY) => self.as_mixed().simplify_vw_preserve(epsilon),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().simplify_vw_preserve(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/rust/geoarrow/src/algorithm/geo/simplify_vw_preserve.rs
+++ b/rust/geoarrow/src/algorithm/geo/simplify_vw_preserve.rs
@@ -74,7 +74,7 @@ macro_rules! iter_geo_impl {
                     .map(|maybe_g| maybe_g.map(|geom| geom.simplify_vw_preserve(epsilon)))
                     .collect();
 
-                output_geoms.into()
+                (output_geoms, Dimension::XY).into()
             }
         }
     };
@@ -99,13 +99,10 @@ impl SimplifyVwPreserve for &dyn NativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string().simplify_vw_preserve(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon().simplify_vw_preserve(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify_vw_preserve(epsilon)),
-            MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string()
-                    .simplify_vw_preserve(epsilon),
-            ),
-            MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon().simplify_vw_preserve(epsilon))
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string().simplify_vw_preserve(epsilon))
             }
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().simplify_vw_preserve(epsilon)),
             // Mixed(_, XY) => self.as_mixed().simplify_vw_preserve(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection().simplify_vw_preserve(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
@@ -157,13 +154,10 @@ impl SimplifyVwPreserve for &dyn ChunkedNativeArray {
             LineString(_, XY) => Arc::new(self.as_line_string().simplify_vw_preserve(epsilon)),
             Polygon(_, XY) => Arc::new(self.as_polygon().simplify_vw_preserve(epsilon)),
             MultiPoint(_, XY) => Arc::new(self.as_multi_point().simplify_vw_preserve(epsilon)),
-            MultiLineString(_, XY) => Arc::new(
-                self.as_multi_line_string()
-                    .simplify_vw_preserve(epsilon),
-            ),
-            MultiPolygon(_, XY) => {
-                Arc::new(self.as_multi_polygon().simplify_vw_preserve(epsilon))
+            MultiLineString(_, XY) => {
+                Arc::new(self.as_multi_line_string().simplify_vw_preserve(epsilon))
             }
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().simplify_vw_preserve(epsilon)),
             // Mixed(_, XY) => self.as_mixed().simplify_vw_preserve(epsilon),
             // GeometryCollection(_, XY) => self.as_geometry_collection().simplify_vw_preserve(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),

--- a/rust/geoarrow/src/algorithm/geo/skew.rs
+++ b/rust/geoarrow/src/algorithm/geo/skew.rs
@@ -134,7 +134,7 @@ impl Skew for PointArray {
         x_factor: &BroadcastablePrimitive<Float64Type>,
         y_factor: &BroadcastablePrimitive<Float64Type>,
     ) -> Self {
-        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.buffer_lengths());
 
         self.iter_geo()
             .zip(x_factor)
@@ -156,7 +156,7 @@ impl Skew for PointArray {
         y_factor: &BroadcastablePrimitive<Float64Type>,
         origin: geo::Point,
     ) -> Self {
-        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.buffer_lengths());
 
         self.iter_geo()
             .zip(x_factor)
@@ -186,7 +186,8 @@ macro_rules! iter_geo_impl {
                 x_factor: &BroadcastablePrimitive<Float64Type>,
                 y_factor: &BroadcastablePrimitive<Float64Type>,
             ) -> Self {
-                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
+                let mut output_array =
+                    <$builder_type>::with_capacity(Dimension::XY, self.buffer_lengths());
 
                 self.iter_geo().zip(x_factor).zip(y_factor).for_each(
                     |((maybe_g, x_factor), y_factor)| {
@@ -209,7 +210,8 @@ macro_rules! iter_geo_impl {
                 y_factor: &BroadcastablePrimitive<Float64Type>,
                 origin: geo::Point,
             ) -> Self {
-                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
+                let mut output_array =
+                    <$builder_type>::with_capacity(Dimension::XY, self.buffer_lengths());
 
                 self.iter_geo().zip(x_factor).zip(y_factor).for_each(
                     |((maybe_g, x_factor), y_factor)| {
@@ -243,11 +245,7 @@ iter_geo_impl!(
     MultiLineStringBuilder,
     push_multi_line_string
 );
-iter_geo_impl!(
-    MultiPolygonArray,
-    MultiPolygonBuilder,
-    push_multi_polygon
-);
+iter_geo_impl!(MultiPolygonArray, MultiPolygonBuilder, push_multi_polygon);
 
 impl Skew for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;

--- a/rust/geoarrow/src/algorithm/geo/skew.rs
+++ b/rust/geoarrow/src/algorithm/geo/skew.rs
@@ -126,7 +126,7 @@ pub trait Skew {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Skew for PointArray<2> {
+impl Skew for PointArray {
     type Output = Self;
 
     fn skew_xy(
@@ -235,17 +235,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
-iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
-iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
+iter_geo_impl!(LineStringArray, LineStringBuilder, push_line_string);
+iter_geo_impl!(PolygonArray, PolygonBuilder, push_polygon);
+iter_geo_impl!(MultiPointArray, MultiPointBuilder, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
+    MultiLineStringArray,
+    MultiLineStringBuilder,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
+    MultiPolygonArray,
+    MultiPolygonBuilder,
     push_multi_polygon
 );
 

--- a/rust/geoarrow/src/algorithm/geo/translate.rs
+++ b/rust/geoarrow/src/algorithm/geo/translate.rs
@@ -52,7 +52,7 @@ pub trait Translate {
 }
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Translate for PointArray<2> {
+impl Translate for PointArray {
     type Output = Self;
 
     fn translate(
@@ -110,17 +110,17 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
-iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
-iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
+iter_geo_impl!(LineStringArray, LineStringBuilder, push_line_string);
+iter_geo_impl!(PolygonArray, PolygonBuilder, push_polygon);
+iter_geo_impl!(MultiPointArray, MultiPointBuilder, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
+    MultiLineStringArray,
+    MultiLineStringBuilder,
     push_multi_line_string
 );
 iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
+    MultiPolygonArray,
+    MultiPolygonBuilder,
     push_multi_polygon
 );
 

--- a/rust/geoarrow/src/algorithm/geo/translate.rs
+++ b/rust/geoarrow/src/algorithm/geo/translate.rs
@@ -60,7 +60,7 @@ impl Translate for PointArray {
         x_offset: &BroadcastablePrimitive<Float64Type>,
         y_offset: &BroadcastablePrimitive<Float64Type>,
     ) -> Self {
-        let mut output_array = PointBuilder::with_capacity(self.buffer_lengths());
+        let mut output_array = PointBuilder::with_capacity(Dimension::XY, self.buffer_lengths());
 
         self.iter_geo()
             .zip(x_offset)
@@ -88,7 +88,8 @@ macro_rules! iter_geo_impl {
                 x_offset: &BroadcastablePrimitive<Float64Type>,
                 y_offset: &BroadcastablePrimitive<Float64Type>,
             ) -> Self {
-                let mut output_array = <$builder_type>::with_capacity(self.buffer_lengths());
+                let mut output_array =
+                    <$builder_type>::with_capacity(Dimension::XY, self.buffer_lengths());
 
                 self.iter_geo().zip(x_offset).zip(y_offset).for_each(
                     |((maybe_g, x_offset), y_offset)| {
@@ -118,11 +119,7 @@ iter_geo_impl!(
     MultiLineStringBuilder,
     push_multi_line_string
 );
-iter_geo_impl!(
-    MultiPolygonArray,
-    MultiPolygonBuilder,
-    push_multi_polygon
-);
+iter_geo_impl!(MultiPolygonArray, MultiPolygonBuilder, push_multi_polygon);
 
 impl Translate for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;

--- a/rust/geoarrow/src/algorithm/geo/vincenty_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/vincenty_length.rs
@@ -36,7 +36,7 @@ pub trait VincentyLength {
     ///     // Osaka
     ///     (135.5244559, 34.687455)
     /// ]);
-    /// let linestring_array: LineStringArray<2> = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray = vec![linestring].as_slice().into();
     ///
     /// let length_array = linestring_array.vincenty_length().unwrap();
     ///
@@ -63,8 +63,8 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(PointArray<2>);
-zero_impl!(MultiPointArray<2>);
+zero_impl!(PointArray);
+zero_impl!(MultiPointArray);
 
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
@@ -79,8 +79,8 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>);
+iter_geo_impl!(LineStringArray);
+iter_geo_impl!(MultiLineStringArray);
 
 impl VincentyLength for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -90,20 +90,20 @@ impl VincentyLength for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().vincenty_length(),
-            LineString(_, XY) => self.as_line_string::<2>().vincenty_length(),
-            // Polygon(_, XY) => self.as_polygon::<2>().vincenty_length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().vincenty_length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().vincenty_length(),
-            // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().vincenty_length(),
-            // Mixed(_, XY) => self.as_mixed::<2>().vincenty_length(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().vincenty_length(),
+            Point(_, XY) => self.as_point().vincenty_length(),
+            LineString(_, XY) => self.as_line_string().vincenty_length(),
+            // Polygon(_, XY) => self.as_polygon().vincenty_length(),
+            MultiPoint(_, XY) => self.as_multi_point().vincenty_length(),
+            MultiLineString(_, XY) => self.as_multi_line_string().vincenty_length(),
+            // MultiPolygon(_, XY) => self.as_multi_polygon().vincenty_length(),
+            // Mixed(_, XY) => self.as_mixed().vincenty_length(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().vincenty_length(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl VincentyLength for ChunkedGeometryArray<PointArray<2>> {
+impl VincentyLength for ChunkedGeometryArray<PointArray> {
     type Output = Result<ChunkedArray<Float64Array>>;
 
     fn vincenty_length(&self) -> Self::Output {
@@ -124,9 +124,9 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray>);
 
 impl VincentyLength for &dyn ChunkedNativeArray {
     type Output = Result<ChunkedArray<Float64Array>>;
@@ -136,14 +136,14 @@ impl VincentyLength for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().vincenty_length(),
-            LineString(_, XY) => self.as_line_string::<2>().vincenty_length(),
-            // Polygon(_, XY) => self.as_polygon::<2>().vincenty_length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().vincenty_length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().vincenty_length(),
-            // MultiPolygon(_, XY) => self.as_multi_polygon::<2>().vincenty_length(),
-            // Mixed(_, XY) => self.as_mixed::<2>().vincenty_length(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().vincenty_length(),
+            Point(_, XY) => self.as_point().vincenty_length(),
+            LineString(_, XY) => self.as_line_string().vincenty_length(),
+            // Polygon(_, XY) => self.as_polygon().vincenty_length(),
+            MultiPoint(_, XY) => self.as_multi_point().vincenty_length(),
+            MultiLineString(_, XY) => self.as_multi_line_string().vincenty_length(),
+            // MultiPolygon(_, XY) => self.as_multi_polygon().vincenty_length(),
+            // Mixed(_, XY) => self.as_mixed().vincenty_length(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection().vincenty_length(),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
@@ -164,7 +164,7 @@ mod tests {
             // London
             (x: -0.1278, y: 51.5074),
         ];
-        let input_array: LineStringArray<2> = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = vec![input_geom].as_slice().into();
         let result_array = input_array.vincenty_length().unwrap();
 
         // Meters

--- a/rust/geoarrow/src/algorithm/geo/vincenty_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/vincenty_length.rs
@@ -164,7 +164,7 @@ mod tests {
             // London
             (x: -0.1278, y: 51.5074),
         ];
-        let input_array: LineStringArray = vec![input_geom].as_slice().into();
+        let input_array: LineStringArray = (vec![input_geom].as_slice(), Dimension::XY).into();
         let result_array = input_array.vincenty_length().unwrap();
 
         // Meters

--- a/rust/geoarrow/src/algorithm/geo/vincenty_length.rs
+++ b/rust/geoarrow/src/algorithm/geo/vincenty_length.rs
@@ -27,6 +27,7 @@ pub trait VincentyLength {
     /// use geo::LineString;
     /// use geoarrow::array::LineStringArray;
     /// use geoarrow::algorithm::geo::VincentyLength;
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let linestring = LineString::<f64>::from(vec![
     ///     // New York City
@@ -36,7 +37,7 @@ pub trait VincentyLength {
     ///     // Osaka
     ///     (135.5244559, 34.687455)
     /// ]);
-    /// let linestring_array: LineStringArray = vec![linestring].as_slice().into();
+    /// let linestring_array: LineStringArray = (vec![linestring].as_slice(), Dimension::XY).into();
     ///
     /// let length_array = linestring_array.vincenty_length().unwrap();
     ///

--- a/rust/geoarrow/src/algorithm/geo/within.rs
+++ b/rust/geoarrow/src/algorithm/geo/within.rs
@@ -49,7 +49,7 @@ pub trait Within<Other = Self> {
 // └────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl Within for PointArray<2> {
+impl Within for PointArray {
     fn is_within(&self, rhs: &Self) -> BooleanArray {
         assert_eq!(self.len(), rhs.len());
 
@@ -91,58 +91,58 @@ macro_rules! iter_geo_impl {
 }
 
 // Implementations on PointArray
-iter_geo_impl!(PointArray<2>, LineStringArray<2>);
-iter_geo_impl!(PointArray<2>, PolygonArray<2>);
-iter_geo_impl!(PointArray<2>, MultiPointArray<2>);
-iter_geo_impl!(PointArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(PointArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(PointArray, LineStringArray);
+iter_geo_impl!(PointArray, PolygonArray);
+iter_geo_impl!(PointArray, MultiPointArray);
+iter_geo_impl!(PointArray, MultiLineStringArray);
+iter_geo_impl!(PointArray, MultiPolygonArray);
 
 // Implementations on LineStringArray
-iter_geo_impl!(LineStringArray<2>, PointArray<2>);
-iter_geo_impl!(LineStringArray<2>, LineStringArray<2>);
-iter_geo_impl!(LineStringArray<2>, PolygonArray<2>);
-iter_geo_impl!(LineStringArray<2>, MultiPointArray<2>);
-iter_geo_impl!(LineStringArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(LineStringArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(LineStringArray, PointArray);
+iter_geo_impl!(LineStringArray, LineStringArray);
+iter_geo_impl!(LineStringArray, PolygonArray);
+iter_geo_impl!(LineStringArray, MultiPointArray);
+iter_geo_impl!(LineStringArray, MultiLineStringArray);
+iter_geo_impl!(LineStringArray, MultiPolygonArray);
 
 // Implementations on PolygonArray
-iter_geo_impl!(PolygonArray<2>, PointArray<2>);
-iter_geo_impl!(PolygonArray<2>, LineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>, PolygonArray<2>);
-iter_geo_impl!(PolygonArray<2>, MultiPointArray<2>);
-iter_geo_impl!(PolygonArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(PolygonArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(PolygonArray, PointArray);
+iter_geo_impl!(PolygonArray, LineStringArray);
+iter_geo_impl!(PolygonArray, PolygonArray);
+iter_geo_impl!(PolygonArray, MultiPointArray);
+iter_geo_impl!(PolygonArray, MultiLineStringArray);
+iter_geo_impl!(PolygonArray, MultiPolygonArray);
 
 // Implementations on MultiPointArray
-iter_geo_impl!(MultiPointArray<2>, PointArray<2>);
-iter_geo_impl!(MultiPointArray<2>, LineStringArray<2>);
-iter_geo_impl!(MultiPointArray<2>, PolygonArray<2>);
-iter_geo_impl!(MultiPointArray<2>, MultiPointArray<2>);
-iter_geo_impl!(MultiPointArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(MultiPointArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiPointArray, PointArray);
+iter_geo_impl!(MultiPointArray, LineStringArray);
+iter_geo_impl!(MultiPointArray, PolygonArray);
+iter_geo_impl!(MultiPointArray, MultiPointArray);
+iter_geo_impl!(MultiPointArray, MultiLineStringArray);
+iter_geo_impl!(MultiPointArray, MultiPolygonArray);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl!(MultiLineStringArray<2>, PointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, LineStringArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, PolygonArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, MultiPointArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(MultiLineStringArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiLineStringArray, PointArray);
+iter_geo_impl!(MultiLineStringArray, LineStringArray);
+iter_geo_impl!(MultiLineStringArray, PolygonArray);
+iter_geo_impl!(MultiLineStringArray, MultiPointArray);
+iter_geo_impl!(MultiLineStringArray, MultiLineStringArray);
+iter_geo_impl!(MultiLineStringArray, MultiPolygonArray);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl!(MultiPolygonArray<2>, PointArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, LineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, PolygonArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPointArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, MultiLineStringArray<2>);
-iter_geo_impl!(MultiPolygonArray<2>, MultiPolygonArray<2>);
+iter_geo_impl!(MultiPolygonArray, PointArray);
+iter_geo_impl!(MultiPolygonArray, LineStringArray);
+iter_geo_impl!(MultiPolygonArray, PolygonArray);
+iter_geo_impl!(MultiPolygonArray, MultiPointArray);
+iter_geo_impl!(MultiPolygonArray, MultiLineStringArray);
+iter_geo_impl!(MultiPolygonArray, MultiPolygonArray);
 
 // ┌──────────────────────────────────────────┐
 // │ Implementations for RHS geoarrow scalars │
 // └──────────────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl<'a> Within<Point<'a, 2>> for PointArray<2> {
+impl<'a> Within<Point<'a, 2>> for PointArray {
     fn is_within(&self, rhs: &Point<'a, 2>) -> BooleanArray {
         let mut output_array = BooleanBuilder::with_capacity(self.len());
 
@@ -175,51 +175,51 @@ macro_rules! iter_geo_impl_geoarrow_scalar {
 }
 
 // Implementations on PointArray
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray, MultiPolygon<'a, 2>);
 
 // Implementations on LineStringArray
-iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiPolygon<'a, 2>);
 
 // Implementations on PolygonArray
-iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiPolygon<'a, 2>);
 
 // Implementations on MultiPointArray
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiPolygon<'a, 2>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiPolygon<'a, 2>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray<2>, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, Point<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, LineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, Polygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiPoint<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiLineString<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiPolygon<'a, 2>);
 
 // ┌─────────────────────────────────────┐
 // │ Implementations for RHS geo scalars │
@@ -243,12 +243,12 @@ macro_rules! non_generic_iter_geo_impl_geo_scalar {
 }
 
 // Implementations on PointArray
-non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::Point);
-non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::LineString);
-non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::Polygon);
-non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::MultiPoint);
-non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::MultiLineString);
-non_generic_iter_geo_impl_geo_scalar!(PointArray<2>, geo::MultiPolygon);
+non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::Point);
+non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::LineString);
+non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::Polygon);
+non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::MultiPoint);
+non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::MultiLineString);
+non_generic_iter_geo_impl_geo_scalar!(PointArray, geo::MultiPolygon);
 
 macro_rules! iter_geo_impl_geo_scalar {
     ($first:ty, $second:ty) => {
@@ -268,41 +268,41 @@ macro_rules! iter_geo_impl_geo_scalar {
 }
 
 // Implementations on LineStringArray
-iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::Point);
-iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::LineString);
-iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(LineStringArray<2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(LineStringArray, geo::Point);
+iter_geo_impl_geo_scalar!(LineStringArray, geo::LineString);
+iter_geo_impl_geo_scalar!(LineStringArray, geo::Polygon);
+iter_geo_impl_geo_scalar!(LineStringArray, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(LineStringArray, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(LineStringArray, geo::MultiPolygon);
 
 // Implementations on PolygonArray
-iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::Point);
-iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::LineString);
-iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(PolygonArray<2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(PolygonArray, geo::Point);
+iter_geo_impl_geo_scalar!(PolygonArray, geo::LineString);
+iter_geo_impl_geo_scalar!(PolygonArray, geo::Polygon);
+iter_geo_impl_geo_scalar!(PolygonArray, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(PolygonArray, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(PolygonArray, geo::MultiPolygon);
 
 // Implementations on MultiPointArray
-iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiPointArray<2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiPointArray, geo::Point);
+iter_geo_impl_geo_scalar!(MultiPointArray, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiPointArray, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiPointArray, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiPointArray, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiPointArray, geo::MultiPolygon);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiLineStringArray<2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiLineStringArray, geo::Point);
+iter_geo_impl_geo_scalar!(MultiLineStringArray, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiLineStringArray, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiLineStringArray, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiLineStringArray, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiLineStringArray, geo::MultiPolygon);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::Point);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::LineString);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::Polygon);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::MultiPoint);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::MultiLineString);
-iter_geo_impl_geo_scalar!(MultiPolygonArray<2>, geo::MultiPolygon);
+iter_geo_impl_geo_scalar!(MultiPolygonArray, geo::Point);
+iter_geo_impl_geo_scalar!(MultiPolygonArray, geo::LineString);
+iter_geo_impl_geo_scalar!(MultiPolygonArray, geo::Polygon);
+iter_geo_impl_geo_scalar!(MultiPolygonArray, geo::MultiPoint);
+iter_geo_impl_geo_scalar!(MultiPolygonArray, geo::MultiLineString);
+iter_geo_impl_geo_scalar!(MultiPolygonArray, geo::MultiPolygon);

--- a/rust/geoarrow/src/algorithm/geo/within.rs
+++ b/rust/geoarrow/src/algorithm/geo/within.rs
@@ -142,8 +142,8 @@ iter_geo_impl!(MultiPolygonArray, MultiPolygonArray);
 // └──────────────────────────────────────────┘
 
 // Note: this implementation is outside the macro because it is not generic over O
-impl<'a> Within<Point<'a, 2>> for PointArray {
-    fn is_within(&self, rhs: &Point<'a, 2>) -> BooleanArray {
+impl<'a> Within<Point<'a>> for PointArray {
+    fn is_within(&self, rhs: &Point<'a>) -> BooleanArray {
         let mut output_array = BooleanBuilder::with_capacity(self.len());
 
         self.iter_geo().for_each(|maybe_point| {
@@ -175,51 +175,51 @@ macro_rules! iter_geo_impl_geoarrow_scalar {
 }
 
 // Implementations on PointArray
-iter_geo_impl_geoarrow_scalar!(PointArray, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PointArray, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PointArray, LineString<'a>);
+iter_geo_impl_geoarrow_scalar!(PointArray, Polygon<'a>);
+iter_geo_impl_geoarrow_scalar!(PointArray, MultiPoint<'a>);
+iter_geo_impl_geoarrow_scalar!(PointArray, MultiLineString<'a>);
+iter_geo_impl_geoarrow_scalar!(PointArray, MultiPolygon<'a>);
 
 // Implementations on LineStringArray
-iter_geo_impl_geoarrow_scalar!(LineStringArray, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, Point<'a>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, LineString<'a>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, Polygon<'a>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiPoint<'a>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiLineString<'a>);
+iter_geo_impl_geoarrow_scalar!(LineStringArray, MultiPolygon<'a>);
 
 // Implementations on PolygonArray
-iter_geo_impl_geoarrow_scalar!(PolygonArray, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, Point<'a>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, LineString<'a>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, Polygon<'a>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiPoint<'a>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiLineString<'a>);
+iter_geo_impl_geoarrow_scalar!(PolygonArray, MultiPolygon<'a>);
 
 // Implementations on MultiPointArray
-iter_geo_impl_geoarrow_scalar!(MultiPointArray, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, Point<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, LineString<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, Polygon<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiPoint<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiLineString<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPointArray, MultiPolygon<'a>);
 
 // Implementations on MultiLineStringArray
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, Point<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, LineString<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, Polygon<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiPoint<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiLineString<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiLineStringArray, MultiPolygon<'a>);
 
 // Implementations on MultiPolygonArray
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, Point<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, LineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, Polygon<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiPoint<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiLineString<'a, 2>);
-iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiPolygon<'a, 2>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, Point<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, LineString<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, Polygon<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiPoint<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiLineString<'a>);
+iter_geo_impl_geoarrow_scalar!(MultiPolygonArray, MultiPolygon<'a>);
 
 // ┌─────────────────────────────────────┐
 // │ Implementations for RHS geo scalars │

--- a/rust/geoarrow/src/algorithm/geo_index/rtree.rs
+++ b/rust/geoarrow/src/algorithm/geo_index/rtree.rs
@@ -5,7 +5,7 @@ use crate::algorithm::native::bounding_rect::{
 };
 use crate::array::*;
 use crate::chunked_array::*;
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::error::Result;
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
@@ -24,7 +24,7 @@ pub trait RTree {
 
 macro_rules! impl_rtree {
     ($struct_name:ty, $bounding_rect_fn:ident) => {
-        impl<const D: usize> RTree for $struct_name {
+        impl RTree for $struct_name {
             type Output = OwnedRTree<f64>;
 
             fn create_rtree_with_node_size(&self, node_size: usize) -> Self::Output {
@@ -42,52 +42,38 @@ macro_rules! impl_rtree {
     };
 }
 
-impl_rtree!(PointArray<D>, bounding_rect_point);
-impl_rtree!(LineStringArray<D>, bounding_rect_linestring);
-impl_rtree!(PolygonArray<D>, bounding_rect_polygon);
-impl_rtree!(MultiPointArray<D>, bounding_rect_multipoint);
-impl_rtree!(MultiLineStringArray<D>, bounding_rect_multilinestring);
-impl_rtree!(MultiPolygonArray<D>, bounding_rect_multipolygon);
-impl_rtree!(MixedGeometryArray<D>, bounding_rect_geometry);
-impl_rtree!(
-    GeometryCollectionArray<D>,
-    bounding_rect_geometry_collection
-);
-impl_rtree!(RectArray<D>, bounding_rect_rect);
+impl_rtree!(PointArray, bounding_rect_point);
+impl_rtree!(LineStringArray, bounding_rect_linestring);
+impl_rtree!(PolygonArray, bounding_rect_polygon);
+impl_rtree!(MultiPointArray, bounding_rect_multipoint);
+impl_rtree!(MultiLineStringArray, bounding_rect_multilinestring);
+impl_rtree!(MultiPolygonArray, bounding_rect_multipolygon);
+impl_rtree!(MixedGeometryArray, bounding_rect_geometry);
+impl_rtree!(GeometryCollectionArray, bounding_rect_geometry_collection);
+impl_rtree!(RectArray, bounding_rect_rect);
 
 impl RTree for &dyn NativeArray {
     type Output = OwnedRTree<f64>;
 
     fn create_rtree_with_node_size(&self, node_size: usize) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         macro_rules! impl_method {
-            ($method:ident, $dim:expr) => {
-                self.$method::<$dim>()
-                    .create_rtree_with_node_size(node_size)
+            ($method:ident) => {
+                self.$method().create_rtree_with_node_size(node_size)
             };
         }
 
         match self.data_type() {
-            Point(_, XY) => impl_method!(as_point, 2),
-            LineString(_, XY) => impl_method!(as_line_string, 2),
-            Polygon(_, XY) => impl_method!(as_polygon, 2),
-            MultiPoint(_, XY) => impl_method!(as_multi_point, 2),
-            MultiLineString(_, XY) => impl_method!(as_multi_line_string, 2),
-            MultiPolygon(_, XY) => impl_method!(as_multi_polygon, 2),
-            Mixed(_, XY) => impl_method!(as_mixed, 2),
-            GeometryCollection(_, XY) => impl_method!(as_geometry_collection, 2),
-            Rect(XY) => impl_method!(as_rect, 2),
-            Point(_, XYZ) => impl_method!(as_point, 3),
-            LineString(_, XYZ) => impl_method!(as_line_string, 3),
-            Polygon(_, XYZ) => impl_method!(as_polygon, 3),
-            MultiPoint(_, XYZ) => impl_method!(as_multi_point, 3),
-            MultiLineString(_, XYZ) => impl_method!(as_multi_line_string, 3),
-            MultiPolygon(_, XYZ) => impl_method!(as_multi_polygon, 3),
-            Mixed(_, XYZ) => impl_method!(as_mixed, 3),
-            GeometryCollection(_, XYZ) => impl_method!(as_geometry_collection, 3),
-            Rect(XYZ) => impl_method!(as_rect, 3),
+            Point(_, _) => impl_method!(as_point),
+            LineString(_, _) => impl_method!(as_line_string),
+            Polygon(_, _) => impl_method!(as_polygon),
+            MultiPoint(_, _) => impl_method!(as_multi_point),
+            MultiLineString(_, _) => impl_method!(as_multi_line_string),
+            MultiPolygon(_, _) => impl_method!(as_multi_polygon),
+            Mixed(_, _) => impl_method!(as_mixed),
+            GeometryCollection(_, _) => impl_method!(as_geometry_collection),
+            Rect(_) => impl_method!(as_rect),
         }
     }
 }
@@ -104,35 +90,24 @@ impl RTree for &dyn ChunkedNativeArray {
     type Output = Result<Vec<OwnedRTree<f64>>>;
 
     fn create_rtree_with_node_size(&self, node_size: usize) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         macro_rules! impl_method {
-            ($method:ident, $dim:expr) => {
-                self.$method::<$dim>()
-                    .create_rtree_with_node_size(node_size)
+            ($method:ident) => {
+                self.$method().create_rtree_with_node_size(node_size)
             };
         }
 
         let result = match self.data_type() {
-            Point(_, XY) => impl_method!(as_point, 2),
-            LineString(_, XY) => impl_method!(as_line_string, 2),
-            Polygon(_, XY) => impl_method!(as_polygon, 2),
-            MultiPoint(_, XY) => impl_method!(as_multi_point, 2),
-            MultiLineString(_, XY) => impl_method!(as_multi_line_string, 2),
-            MultiPolygon(_, XY) => impl_method!(as_multi_polygon, 2),
-            Mixed(_, XY) => impl_method!(as_mixed, 2),
-            GeometryCollection(_, XY) => impl_method!(as_geometry_collection, 2),
-            Rect(XY) => impl_method!(as_rect, 2),
-            Point(_, XYZ) => impl_method!(as_point, 3),
-            LineString(_, XYZ) => impl_method!(as_line_string, 3),
-            Polygon(_, XYZ) => impl_method!(as_polygon, 3),
-            MultiPoint(_, XYZ) => impl_method!(as_multi_point, 3),
-            MultiLineString(_, XYZ) => impl_method!(as_multi_line_string, 3),
-            MultiPolygon(_, XYZ) => impl_method!(as_multi_polygon, 3),
-            Mixed(_, XYZ) => impl_method!(as_mixed, 3),
-            GeometryCollection(_, XYZ) => impl_method!(as_geometry_collection, 3),
-            Rect(XYZ) => impl_method!(as_rect, 3),
+            Point(_, _) => impl_method!(as_point),
+            LineString(_, _) => impl_method!(as_line_string),
+            Polygon(_, _) => impl_method!(as_polygon),
+            MultiPoint(_, _) => impl_method!(as_multi_point),
+            MultiLineString(_, _) => impl_method!(as_multi_line_string),
+            MultiPolygon(_, _) => impl_method!(as_multi_polygon),
+            Mixed(_, _) => impl_method!(as_mixed),
+            GeometryCollection(_, _) => impl_method!(as_geometry_collection),
+            Rect(_) => impl_method!(as_rect),
         };
         Ok(result)
     }

--- a/rust/geoarrow/src/algorithm/geos/area.rs
+++ b/rust/geoarrow/src/algorithm/geos/area.rs
@@ -2,7 +2,7 @@ use crate::algorithm::geo::utils::zeroes;
 use crate::algorithm::native::Unary;
 use crate::array::*;
 use crate::chunked_array::{ChunkedArray, ChunkedGeometryArray};
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::error::Result;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
@@ -19,7 +19,7 @@ pub trait Area {
 /// Implementation where the result is zero.
 macro_rules! zero_impl {
     ($type:ty) => {
-        impl<const D: usize> Area for $type {
+        impl Area for $type {
             type Output = Result<Float64Array>;
 
             fn area(&self) -> Self::Output {
@@ -29,14 +29,14 @@ macro_rules! zero_impl {
     };
 }
 
-zero_impl!(PointArray<D>);
-zero_impl!(LineStringArray<D>);
-zero_impl!(MultiPointArray<D>);
-zero_impl!(MultiLineStringArray<D>);
+zero_impl!(PointArray);
+zero_impl!(LineStringArray);
+zero_impl!(MultiPointArray);
+zero_impl!(MultiLineStringArray);
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<const D: usize> Area for $type {
+        impl Area for $type {
             type Output = Result<Float64Array>;
 
             fn area(&self) -> Self::Output {
@@ -46,38 +46,28 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(PolygonArray<D>);
-iter_geos_impl!(MultiPolygonArray<D>);
-iter_geos_impl!(MixedGeometryArray<D>);
-iter_geos_impl!(GeometryCollectionArray<D>);
-iter_geos_impl!(RectArray<D>);
+iter_geos_impl!(PolygonArray);
+iter_geos_impl!(MultiPolygonArray);
+iter_geos_impl!(MixedGeometryArray);
+iter_geos_impl!(GeometryCollectionArray);
+iter_geos_impl!(RectArray);
 
 impl Area for &dyn NativeArray {
     type Output = Result<Float64Array>;
 
     fn area(&self) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().area(),
-            LineString(_, XY) => self.as_line_string::<2>().area(),
-            Polygon(_, XY) => self.as_polygon::<2>().area(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().area(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().area(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().area(),
-            Mixed(_, XY) => self.as_mixed::<2>().area(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().area(),
-            Rect(XY) => self.as_rect::<2>().area(),
-            Point(_, XYZ) => self.as_point::<3>().area(),
-            LineString(_, XYZ) => self.as_line_string::<3>().area(),
-            Polygon(_, XYZ) => self.as_polygon::<3>().area(),
-            MultiPoint(_, XYZ) => self.as_multi_point::<3>().area(),
-            MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().area(),
-            MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().area(),
-            Mixed(_, XYZ) => self.as_mixed::<3>().area(),
-            GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().area(),
-            Rect(XYZ) => self.as_rect::<3>().area(),
+            Point(_, _) => self.as_point().area(),
+            LineString(_, _) => self.as_line_string().area(),
+            Polygon(_, _) => self.as_polygon().area(),
+            MultiPoint(_, _) => self.as_multi_point().area(),
+            MultiLineString(_, _) => self.as_multi_line_string().area(),
+            MultiPolygon(_, _) => self.as_multi_polygon().area(),
+            Mixed(_, _) => self.as_mixed().area(),
+            GeometryCollection(_, _) => self.as_geometry_collection().area(),
+            Rect(_) => self.as_rect().area(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/buffer.rs
+++ b/rust/geoarrow/src/algorithm/geos/buffer.rs
@@ -1,6 +1,7 @@
 use crate::algorithm::geos::util::try_unary_polygon;
 use crate::array::{PointArray, PolygonArray};
 use crate::error::Result;
+use crate::NativeArray;
 use geos::{BufferParams, Geom};
 
 pub trait Buffer {
@@ -15,11 +16,15 @@ impl Buffer for PointArray {
     type Output = Result<PolygonArray>;
 
     fn buffer(&self, width: f64, quadsegs: i32) -> Self::Output {
-        try_unary_polygon(self, |g| g.buffer(width, quadsegs))
+        try_unary_polygon(self, |g| g.buffer(width, quadsegs), self.dimension())
     }
 
     fn buffer_with_params(&self, width: f64, buffer_params: &BufferParams) -> Self::Output {
-        try_unary_polygon(self, |g| g.buffer_with_params(width, buffer_params))
+        try_unary_polygon(
+            self,
+            |g| g.buffer_with_params(width, buffer_params),
+            self.dimension(),
+        )
     }
 }
 

--- a/rust/geoarrow/src/algorithm/geos/buffer.rs
+++ b/rust/geoarrow/src/algorithm/geos/buffer.rs
@@ -11,8 +11,8 @@ pub trait Buffer {
     fn buffer_with_params(&self, width: f64, buffer_params: &BufferParams) -> Self::Output;
 }
 
-impl<const D: usize> Buffer for PointArray<D> {
-    type Output = Result<PolygonArray<D>>;
+impl Buffer for PointArray {
+    type Output = Result<PolygonArray>;
 
     fn buffer(&self, width: f64, quadsegs: i32) -> Self::Output {
         try_unary_polygon(self, |g| g.buffer(width, quadsegs))
@@ -31,7 +31,7 @@ mod test {
     #[test]
     fn point_buffer() {
         let arr = point_array();
-        let buffered: PolygonArray<2> = arr.buffer(1., 8).unwrap();
+        let buffered: PolygonArray = arr.buffer(1., 8).unwrap();
         dbg!(buffered);
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/is_empty.rs
+++ b/rust/geoarrow/src/algorithm/geos/is_empty.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::native::Unary;
 use crate::array::*;
 use crate::chunked_array::{ChunkedArray, ChunkedGeometryArray};
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::error::Result;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
@@ -17,7 +17,7 @@ pub trait IsEmpty {
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<const D: usize> IsEmpty for $type {
+        impl IsEmpty for $type {
             type Output = Result<BooleanArray>;
 
             fn is_empty(&self) -> Self::Output {
@@ -27,42 +27,32 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(PointArray<D>);
-iter_geos_impl!(LineStringArray<D>);
-iter_geos_impl!(MultiPointArray<D>);
-iter_geos_impl!(MultiLineStringArray<D>);
-iter_geos_impl!(PolygonArray<D>);
-iter_geos_impl!(MultiPolygonArray<D>);
-iter_geos_impl!(MixedGeometryArray<D>);
-iter_geos_impl!(GeometryCollectionArray<D>);
-iter_geos_impl!(RectArray<D>);
+iter_geos_impl!(PointArray);
+iter_geos_impl!(LineStringArray);
+iter_geos_impl!(MultiPointArray);
+iter_geos_impl!(MultiLineStringArray);
+iter_geos_impl!(PolygonArray);
+iter_geos_impl!(MultiPolygonArray);
+iter_geos_impl!(MixedGeometryArray);
+iter_geos_impl!(GeometryCollectionArray);
+iter_geos_impl!(RectArray);
 
 impl IsEmpty for &dyn NativeArray {
     type Output = Result<BooleanArray>;
 
     fn is_empty(&self) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => IsEmpty::is_empty(self.as_point::<2>()),
-            LineString(_, XY) => IsEmpty::is_empty(self.as_line_string::<2>()),
-            Polygon(_, XY) => IsEmpty::is_empty(self.as_polygon::<2>()),
-            MultiPoint(_, XY) => IsEmpty::is_empty(self.as_multi_point::<2>()),
-            MultiLineString(_, XY) => IsEmpty::is_empty(self.as_multi_line_string::<2>()),
-            MultiPolygon(_, XY) => IsEmpty::is_empty(self.as_multi_polygon::<2>()),
-            Mixed(_, XY) => IsEmpty::is_empty(self.as_mixed::<2>()),
-            GeometryCollection(_, XY) => IsEmpty::is_empty(self.as_geometry_collection::<2>()),
-            Rect(XY) => IsEmpty::is_empty(self.as_rect::<2>()),
-            Point(_, XYZ) => IsEmpty::is_empty(self.as_point::<3>()),
-            LineString(_, XYZ) => IsEmpty::is_empty(self.as_line_string::<3>()),
-            Polygon(_, XYZ) => IsEmpty::is_empty(self.as_polygon::<3>()),
-            MultiPoint(_, XYZ) => IsEmpty::is_empty(self.as_multi_point::<3>()),
-            MultiLineString(_, XYZ) => IsEmpty::is_empty(self.as_multi_line_string::<3>()),
-            MultiPolygon(_, XYZ) => IsEmpty::is_empty(self.as_multi_polygon::<3>()),
-            Mixed(_, XYZ) => IsEmpty::is_empty(self.as_mixed::<3>()),
-            GeometryCollection(_, XYZ) => IsEmpty::is_empty(self.as_geometry_collection::<3>()),
-            Rect(XYZ) => IsEmpty::is_empty(self.as_rect::<3>()),
+            Point(_, _) => IsEmpty::is_empty(self.as_point()),
+            LineString(_, _) => IsEmpty::is_empty(self.as_line_string()),
+            Polygon(_, _) => IsEmpty::is_empty(self.as_polygon()),
+            MultiPoint(_, _) => IsEmpty::is_empty(self.as_multi_point()),
+            MultiLineString(_, _) => IsEmpty::is_empty(self.as_multi_line_string()),
+            MultiPolygon(_, _) => IsEmpty::is_empty(self.as_multi_polygon()),
+            Mixed(_, _) => IsEmpty::is_empty(self.as_mixed()),
+            GeometryCollection(_, _) => IsEmpty::is_empty(self.as_geometry_collection()),
+            Rect(_) => IsEmpty::is_empty(self.as_rect()),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/is_ring.rs
+++ b/rust/geoarrow/src/algorithm/geos/is_ring.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::native::Unary;
 use crate::array::*;
 use crate::chunked_array::{ChunkedArray, ChunkedGeometryArray};
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::error::Result;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
@@ -17,7 +17,7 @@ pub trait IsRing {
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<const D: usize> IsRing for $type {
+        impl IsRing for $type {
             type Output = Result<BooleanArray>;
 
             fn is_ring(&self) -> Self::Output {
@@ -27,42 +27,32 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(PointArray<D>);
-iter_geos_impl!(LineStringArray<D>);
-iter_geos_impl!(MultiPointArray<D>);
-iter_geos_impl!(MultiLineStringArray<D>);
-iter_geos_impl!(PolygonArray<D>);
-iter_geos_impl!(MultiPolygonArray<D>);
-iter_geos_impl!(MixedGeometryArray<D>);
-iter_geos_impl!(GeometryCollectionArray<D>);
-iter_geos_impl!(RectArray<D>);
+iter_geos_impl!(PointArray);
+iter_geos_impl!(LineStringArray);
+iter_geos_impl!(MultiPointArray);
+iter_geos_impl!(MultiLineStringArray);
+iter_geos_impl!(PolygonArray);
+iter_geos_impl!(MultiPolygonArray);
+iter_geos_impl!(MixedGeometryArray);
+iter_geos_impl!(GeometryCollectionArray);
+iter_geos_impl!(RectArray);
 
 impl IsRing for &dyn NativeArray {
     type Output = Result<BooleanArray>;
 
     fn is_ring(&self) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().is_ring(),
-            LineString(_, XY) => self.as_line_string::<2>().is_ring(),
-            Polygon(_, XY) => self.as_polygon::<2>().is_ring(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().is_ring(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().is_ring(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().is_ring(),
-            Mixed(_, XY) => self.as_mixed::<2>().is_ring(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().is_ring(),
-            Rect(XY) => self.as_rect::<2>().is_ring(),
-            Point(_, XYZ) => self.as_point::<3>().is_ring(),
-            LineString(_, XYZ) => self.as_line_string::<3>().is_ring(),
-            Polygon(_, XYZ) => self.as_polygon::<3>().is_ring(),
-            MultiPoint(_, XYZ) => self.as_multi_point::<3>().is_ring(),
-            MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().is_ring(),
-            MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().is_ring(),
-            Mixed(_, XYZ) => self.as_mixed::<3>().is_ring(),
-            GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().is_ring(),
-            Rect(XYZ) => self.as_rect::<3>().is_ring(),
+            Point(_, _) => self.as_point().is_ring(),
+            LineString(_, _) => self.as_line_string().is_ring(),
+            Polygon(_, _) => self.as_polygon().is_ring(),
+            MultiPoint(_, _) => self.as_multi_point().is_ring(),
+            MultiLineString(_, _) => self.as_multi_line_string().is_ring(),
+            MultiPolygon(_, _) => self.as_multi_polygon().is_ring(),
+            Mixed(_, _) => self.as_mixed().is_ring(),
+            GeometryCollection(_, _) => self.as_geometry_collection().is_ring(),
+            Rect(_) => self.as_rect().is_ring(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/is_simple.rs
+++ b/rust/geoarrow/src/algorithm/geos/is_simple.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::native::Unary;
 use crate::array::*;
 use crate::chunked_array::{ChunkedArray, ChunkedGeometryArray};
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::error::Result;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
@@ -17,7 +17,7 @@ pub trait IsSimple {
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<const D: usize> IsSimple for $type {
+        impl IsSimple for $type {
             type Output = Result<BooleanArray>;
 
             fn is_simple(&self) -> Self::Output {
@@ -27,42 +27,32 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(PointArray<D>);
-iter_geos_impl!(LineStringArray<D>);
-iter_geos_impl!(MultiPointArray<D>);
-iter_geos_impl!(MultiLineStringArray<D>);
-iter_geos_impl!(PolygonArray<D>);
-iter_geos_impl!(MultiPolygonArray<D>);
-iter_geos_impl!(MixedGeometryArray<D>);
-iter_geos_impl!(GeometryCollectionArray<D>);
-iter_geos_impl!(RectArray<D>);
+iter_geos_impl!(PointArray);
+iter_geos_impl!(LineStringArray);
+iter_geos_impl!(MultiPointArray);
+iter_geos_impl!(MultiLineStringArray);
+iter_geos_impl!(PolygonArray);
+iter_geos_impl!(MultiPolygonArray);
+iter_geos_impl!(MixedGeometryArray);
+iter_geos_impl!(GeometryCollectionArray);
+iter_geos_impl!(RectArray);
 
 impl IsSimple for &dyn NativeArray {
     type Output = Result<BooleanArray>;
 
     fn is_simple(&self) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().is_simple(),
-            LineString(_, XY) => self.as_line_string::<2>().is_simple(),
-            Polygon(_, XY) => self.as_polygon::<2>().is_simple(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().is_simple(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().is_simple(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().is_simple(),
-            Mixed(_, XY) => self.as_mixed::<2>().is_simple(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().is_simple(),
-            Rect(XY) => self.as_rect::<2>().is_simple(),
-            Point(_, XYZ) => self.as_point::<3>().is_simple(),
-            LineString(_, XYZ) => self.as_line_string::<3>().is_simple(),
-            Polygon(_, XYZ) => self.as_polygon::<3>().is_simple(),
-            MultiPoint(_, XYZ) => self.as_multi_point::<3>().is_simple(),
-            MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().is_simple(),
-            MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().is_simple(),
-            Mixed(_, XYZ) => self.as_mixed::<3>().is_simple(),
-            GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().is_simple(),
-            Rect(XYZ) => self.as_rect::<3>().is_simple(),
+            Point(_, _) => self.as_point().is_simple(),
+            LineString(_, _) => self.as_line_string().is_simple(),
+            Polygon(_, _) => self.as_polygon().is_simple(),
+            MultiPoint(_, _) => self.as_multi_point().is_simple(),
+            MultiLineString(_, _) => self.as_multi_line_string().is_simple(),
+            MultiPolygon(_, _) => self.as_multi_polygon().is_simple(),
+            Mixed(_, _) => self.as_mixed().is_simple(),
+            GeometryCollection(_, _) => self.as_geometry_collection().is_simple(),
+            Rect(_) => self.as_rect().is_simple(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/is_valid.rs
+++ b/rust/geoarrow/src/algorithm/geos/is_valid.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::native::Unary;
 use crate::array::*;
 use crate::chunked_array::{ChunkedArray, ChunkedGeometryArray};
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::error::Result;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
@@ -17,7 +17,7 @@ pub trait IsValid {
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<const D: usize> IsValid for $type {
+        impl IsValid for $type {
             type Output = Result<BooleanArray>;
 
             fn is_valid(&self) -> Self::Output {
@@ -28,42 +28,32 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(PointArray<D>);
-iter_geos_impl!(LineStringArray<D>);
-iter_geos_impl!(MultiPointArray<D>);
-iter_geos_impl!(MultiLineStringArray<D>);
-iter_geos_impl!(PolygonArray<D>);
-iter_geos_impl!(MultiPolygonArray<D>);
-iter_geos_impl!(MixedGeometryArray<D>);
-iter_geos_impl!(GeometryCollectionArray<D>);
-iter_geos_impl!(RectArray<D>);
+iter_geos_impl!(PointArray);
+iter_geos_impl!(LineStringArray);
+iter_geos_impl!(MultiPointArray);
+iter_geos_impl!(MultiLineStringArray);
+iter_geos_impl!(PolygonArray);
+iter_geos_impl!(MultiPolygonArray);
+iter_geos_impl!(MixedGeometryArray);
+iter_geos_impl!(GeometryCollectionArray);
+iter_geos_impl!(RectArray);
 
 impl IsValid for &dyn NativeArray {
     type Output = Result<BooleanArray>;
 
     fn is_valid(&self) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => IsValid::is_valid(self.as_point::<2>()),
-            LineString(_, XY) => IsValid::is_valid(self.as_line_string::<2>()),
-            Polygon(_, XY) => IsValid::is_valid(self.as_polygon::<2>()),
-            MultiPoint(_, XY) => IsValid::is_valid(self.as_multi_point::<2>()),
-            MultiLineString(_, XY) => IsValid::is_valid(self.as_multi_line_string::<2>()),
-            MultiPolygon(_, XY) => IsValid::is_valid(self.as_multi_polygon::<2>()),
-            Mixed(_, XY) => IsValid::is_valid(self.as_mixed::<2>()),
-            GeometryCollection(_, XY) => IsValid::is_valid(self.as_geometry_collection::<2>()),
-            Rect(XY) => IsValid::is_valid(self.as_rect::<2>()),
-            Point(_, XYZ) => IsValid::is_valid(self.as_point::<3>()),
-            LineString(_, XYZ) => IsValid::is_valid(self.as_line_string::<3>()),
-            Polygon(_, XYZ) => IsValid::is_valid(self.as_polygon::<3>()),
-            MultiPoint(_, XYZ) => IsValid::is_valid(self.as_multi_point::<3>()),
-            MultiLineString(_, XYZ) => IsValid::is_valid(self.as_multi_line_string::<3>()),
-            MultiPolygon(_, XYZ) => IsValid::is_valid(self.as_multi_polygon::<3>()),
-            Mixed(_, XYZ) => IsValid::is_valid(self.as_mixed::<3>()),
-            GeometryCollection(_, XYZ) => IsValid::is_valid(self.as_geometry_collection::<3>()),
-            Rect(XYZ) => IsValid::is_valid(self.as_rect::<3>()),
+            Point(_, _) => IsValid::is_valid(self.as_point()),
+            LineString(_, _) => IsValid::is_valid(self.as_line_string()),
+            Polygon(_, _) => IsValid::is_valid(self.as_polygon()),
+            MultiPoint(_, _) => IsValid::is_valid(self.as_multi_point()),
+            MultiLineString(_, _) => IsValid::is_valid(self.as_multi_line_string()),
+            MultiPolygon(_, _) => IsValid::is_valid(self.as_multi_polygon()),
+            Mixed(_, _) => IsValid::is_valid(self.as_mixed()),
+            GeometryCollection(_, _) => IsValid::is_valid(self.as_geometry_collection()),
+            Rect(_) => IsValid::is_valid(self.as_rect()),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/length.rs
+++ b/rust/geoarrow/src/algorithm/geos/length.rs
@@ -2,7 +2,7 @@ use crate::algorithm::geo::utils::zeroes;
 use crate::algorithm::native::Unary;
 use crate::array::*;
 use crate::chunked_array::{ChunkedArray, ChunkedGeometryArray};
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::error::Result;
 use crate::trait_::NativeScalar;
 use crate::NativeArray;
@@ -16,7 +16,7 @@ pub trait Length {
     fn length(&self) -> Self::Output;
 }
 
-impl<const D: usize> Length for PointArray<D> {
+impl Length for PointArray {
     type Output = Result<Float64Array>;
 
     fn length(&self) -> Self::Output {
@@ -26,7 +26,7 @@ impl<const D: usize> Length for PointArray<D> {
 
 macro_rules! iter_geos_impl {
     ($type:ty) => {
-        impl<const D: usize> Length for $type {
+        impl Length for $type {
             type Output = Result<Float64Array>;
 
             fn length(&self) -> Self::Output {
@@ -36,41 +36,31 @@ macro_rules! iter_geos_impl {
     };
 }
 
-iter_geos_impl!(LineStringArray<D>);
-iter_geos_impl!(MultiPointArray<D>);
-iter_geos_impl!(MultiLineStringArray<D>);
-iter_geos_impl!(PolygonArray<D>);
-iter_geos_impl!(MultiPolygonArray<D>);
-iter_geos_impl!(MixedGeometryArray<D>);
-iter_geos_impl!(GeometryCollectionArray<D>);
-iter_geos_impl!(RectArray<D>);
+iter_geos_impl!(LineStringArray);
+iter_geos_impl!(MultiPointArray);
+iter_geos_impl!(MultiLineStringArray);
+iter_geos_impl!(PolygonArray);
+iter_geos_impl!(MultiPolygonArray);
+iter_geos_impl!(MixedGeometryArray);
+iter_geos_impl!(GeometryCollectionArray);
+iter_geos_impl!(RectArray);
 
 impl Length for &dyn NativeArray {
     type Output = Result<Float64Array>;
 
     fn length(&self) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().length(),
-            LineString(_, XY) => self.as_line_string::<2>().length(),
-            Polygon(_, XY) => self.as_polygon::<2>().length(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().length(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().length(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().length(),
-            Mixed(_, XY) => self.as_mixed::<2>().length(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().length(),
-            Rect(XY) => self.as_rect::<2>().length(),
-            Point(_, XYZ) => self.as_point::<3>().length(),
-            LineString(_, XYZ) => self.as_line_string::<3>().length(),
-            Polygon(_, XYZ) => self.as_polygon::<3>().length(),
-            MultiPoint(_, XYZ) => self.as_multi_point::<3>().length(),
-            MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().length(),
-            MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().length(),
-            Mixed(_, XYZ) => self.as_mixed::<3>().length(),
-            GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().length(),
-            Rect(XYZ) => self.as_rect::<3>().length(),
+            Point(_, _) => self.as_point().length(),
+            LineString(_, _) => self.as_line_string().length(),
+            Polygon(_, _) => self.as_polygon().length(),
+            MultiPoint(_, _) => self.as_multi_point().length(),
+            MultiLineString(_, _) => self.as_multi_line_string().length(),
+            MultiPolygon(_, _) => self.as_multi_polygon().length(),
+            Mixed(_, _) => self.as_mixed().length(),
+            GeometryCollection(_, _) => self.as_geometry_collection().length(),
+            Rect(_) => self.as_rect().length(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/util.rs
+++ b/rust/geoarrow/src/algorithm/geos/util.rs
@@ -39,10 +39,10 @@ where
     Ok(PrimitiveArray::new(values, nulls))
 }
 
-pub(super) fn try_unary_polygon<'a, const D: usize, F>(
+pub(super) fn try_unary_polygon<'a, F>(
     array: &'a dyn NativeGEOSGeometryAccessor<'a>,
     op: F,
-) -> std::result::Result<PolygonArray<D>, GeoArrowError>
+) -> std::result::Result<PolygonArray, GeoArrowError>
 where
     F: Fn(geos::Geometry) -> std::result::Result<geos::Geometry, geos::Error>,
 {

--- a/rust/geoarrow/src/algorithm/geos/util.rs
+++ b/rust/geoarrow/src/algorithm/geos/util.rs
@@ -2,6 +2,7 @@ use arrow_array::{ArrowPrimitiveType, PrimitiveArray};
 use arrow_buffer::BufferBuilder;
 
 use crate::array::PolygonArray;
+use crate::datatypes::Dimension;
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSPolygon;
 use crate::trait_::NativeGEOSGeometryAccessor;
@@ -42,6 +43,7 @@ where
 pub(super) fn try_unary_polygon<'a, F>(
     array: &'a dyn NativeGEOSGeometryAccessor<'a>,
     op: F,
+    output_dim: Dimension,
 ) -> std::result::Result<PolygonArray, GeoArrowError>
 where
     F: Fn(geos::Geometry) -> std::result::Result<geos::Geometry, geos::Error>,
@@ -65,5 +67,5 @@ where
         None => (0..len).try_for_each(f)?,
     }
 
-    Ok(PolygonArray::from(buffer))
+    Ok(PolygonArray::from((buffer, output_dim)))
 }

--- a/rust/geoarrow/src/algorithm/native/binary.rs
+++ b/rust/geoarrow/src/algorithm/native/binary.rs
@@ -118,90 +118,90 @@ pub trait Binary<'a, Rhs: ArrayAccessor<'a> = Self>: ArrayAccessor<'a> {
     }
 }
 
-// Implementations on PointArray<2>
-impl<'a> Binary<'a, PointArray<2>> for PointArray<2> {}
-impl<'a> Binary<'a, PointArray<2>> for RectArray<2> {}
-impl<'a> Binary<'a, PointArray<2>> for LineStringArray<2> {}
-impl<'a> Binary<'a, PointArray<2>> for PolygonArray<2> {}
-impl<'a> Binary<'a, PointArray<2>> for MultiPointArray<2> {}
-impl<'a> Binary<'a, PointArray<2>> for MultiLineStringArray<2> {}
-impl<'a> Binary<'a, PointArray<2>> for MultiPolygonArray<2> {}
-impl<'a> Binary<'a, PointArray<2>> for MixedGeometryArray<2> {}
-impl<'a> Binary<'a, PointArray<2>> for GeometryCollectionArray<2> {}
+// Implementations on PointArray
+impl<'a> Binary<'a, PointArray> for PointArray {}
+impl<'a> Binary<'a, PointArray> for RectArray {}
+impl<'a> Binary<'a, PointArray> for LineStringArray {}
+impl<'a> Binary<'a, PointArray> for PolygonArray {}
+impl<'a> Binary<'a, PointArray> for MultiPointArray {}
+impl<'a> Binary<'a, PointArray> for MultiLineStringArray {}
+impl<'a> Binary<'a, PointArray> for MultiPolygonArray {}
+impl<'a> Binary<'a, PointArray> for MixedGeometryArray {}
+impl<'a> Binary<'a, PointArray> for GeometryCollectionArray {}
 
 // Implementations on LineStringArray
-impl<'a> Binary<'a, LineStringArray<2>> for PointArray<2> {}
-impl<'a> Binary<'a, LineStringArray<2>> for RectArray<2> {}
-impl<'a> Binary<'a, LineStringArray<2>> for LineStringArray<2> {}
-impl<'a> Binary<'a, LineStringArray<2>> for PolygonArray<2> {}
-impl<'a> Binary<'a, LineStringArray<2>> for MultiPointArray<2> {}
-impl<'a> Binary<'a, LineStringArray<2>> for MultiLineStringArray<2> {}
-impl<'a> Binary<'a, LineStringArray<2>> for MultiPolygonArray<2> {}
-impl<'a> Binary<'a, LineStringArray<2>> for MixedGeometryArray<2> {}
-impl<'a> Binary<'a, LineStringArray<2>> for GeometryCollectionArray<2> {}
+impl<'a> Binary<'a, LineStringArray> for PointArray {}
+impl<'a> Binary<'a, LineStringArray> for RectArray {}
+impl<'a> Binary<'a, LineStringArray> for LineStringArray {}
+impl<'a> Binary<'a, LineStringArray> for PolygonArray {}
+impl<'a> Binary<'a, LineStringArray> for MultiPointArray {}
+impl<'a> Binary<'a, LineStringArray> for MultiLineStringArray {}
+impl<'a> Binary<'a, LineStringArray> for MultiPolygonArray {}
+impl<'a> Binary<'a, LineStringArray> for MixedGeometryArray {}
+impl<'a> Binary<'a, LineStringArray> for GeometryCollectionArray {}
 
 // Implementations on PolygonArray
-impl<'a> Binary<'a, PolygonArray<2>> for PointArray<2> {}
-impl<'a> Binary<'a, PolygonArray<2>> for RectArray<2> {}
-impl<'a> Binary<'a, PolygonArray<2>> for LineStringArray<2> {}
-impl<'a> Binary<'a, PolygonArray<2>> for PolygonArray<2> {}
-impl<'a> Binary<'a, PolygonArray<2>> for MultiPointArray<2> {}
-impl<'a> Binary<'a, PolygonArray<2>> for MultiLineStringArray<2> {}
-impl<'a> Binary<'a, PolygonArray<2>> for MultiPolygonArray<2> {}
-impl<'a> Binary<'a, PolygonArray<2>> for MixedGeometryArray<2> {}
-impl<'a> Binary<'a, PolygonArray<2>> for GeometryCollectionArray<2> {}
+impl<'a> Binary<'a, PolygonArray> for PointArray {}
+impl<'a> Binary<'a, PolygonArray> for RectArray {}
+impl<'a> Binary<'a, PolygonArray> for LineStringArray {}
+impl<'a> Binary<'a, PolygonArray> for PolygonArray {}
+impl<'a> Binary<'a, PolygonArray> for MultiPointArray {}
+impl<'a> Binary<'a, PolygonArray> for MultiLineStringArray {}
+impl<'a> Binary<'a, PolygonArray> for MultiPolygonArray {}
+impl<'a> Binary<'a, PolygonArray> for MixedGeometryArray {}
+impl<'a> Binary<'a, PolygonArray> for GeometryCollectionArray {}
 
 // Implementations on MultiPointArray
-impl<'a> Binary<'a, MultiPointArray<2>> for PointArray<2> {}
-impl<'a> Binary<'a, MultiPointArray<2>> for RectArray<2> {}
-impl<'a> Binary<'a, MultiPointArray<2>> for LineStringArray<2> {}
-impl<'a> Binary<'a, MultiPointArray<2>> for PolygonArray<2> {}
-impl<'a> Binary<'a, MultiPointArray<2>> for MultiPointArray<2> {}
-impl<'a> Binary<'a, MultiPointArray<2>> for MultiLineStringArray<2> {}
-impl<'a> Binary<'a, MultiPointArray<2>> for MultiPolygonArray<2> {}
-impl<'a> Binary<'a, MultiPointArray<2>> for MixedGeometryArray<2> {}
-impl<'a> Binary<'a, MultiPointArray<2>> for GeometryCollectionArray<2> {}
+impl<'a> Binary<'a, MultiPointArray> for PointArray {}
+impl<'a> Binary<'a, MultiPointArray> for RectArray {}
+impl<'a> Binary<'a, MultiPointArray> for LineStringArray {}
+impl<'a> Binary<'a, MultiPointArray> for PolygonArray {}
+impl<'a> Binary<'a, MultiPointArray> for MultiPointArray {}
+impl<'a> Binary<'a, MultiPointArray> for MultiLineStringArray {}
+impl<'a> Binary<'a, MultiPointArray> for MultiPolygonArray {}
+impl<'a> Binary<'a, MultiPointArray> for MixedGeometryArray {}
+impl<'a> Binary<'a, MultiPointArray> for GeometryCollectionArray {}
 
 // Implementations on MultiLineStringArray
-impl<'a> Binary<'a, MultiLineStringArray<2>> for PointArray<2> {}
-impl<'a> Binary<'a, MultiLineStringArray<2>> for RectArray<2> {}
-impl<'a> Binary<'a, MultiLineStringArray<2>> for LineStringArray<2> {}
-impl<'a> Binary<'a, MultiLineStringArray<2>> for PolygonArray<2> {}
-impl<'a> Binary<'a, MultiLineStringArray<2>> for MultiPointArray<2> {}
-impl<'a> Binary<'a, MultiLineStringArray<2>> for MultiLineStringArray<2> {}
-impl<'a> Binary<'a, MultiLineStringArray<2>> for MultiPolygonArray<2> {}
-impl<'a> Binary<'a, MultiLineStringArray<2>> for MixedGeometryArray<2> {}
-impl<'a> Binary<'a, MultiLineStringArray<2>> for GeometryCollectionArray<2> {}
+impl<'a> Binary<'a, MultiLineStringArray> for PointArray {}
+impl<'a> Binary<'a, MultiLineStringArray> for RectArray {}
+impl<'a> Binary<'a, MultiLineStringArray> for LineStringArray {}
+impl<'a> Binary<'a, MultiLineStringArray> for PolygonArray {}
+impl<'a> Binary<'a, MultiLineStringArray> for MultiPointArray {}
+impl<'a> Binary<'a, MultiLineStringArray> for MultiLineStringArray {}
+impl<'a> Binary<'a, MultiLineStringArray> for MultiPolygonArray {}
+impl<'a> Binary<'a, MultiLineStringArray> for MixedGeometryArray {}
+impl<'a> Binary<'a, MultiLineStringArray> for GeometryCollectionArray {}
 
 // Implementations on MultiPolygonArray
-impl<'a> Binary<'a, MultiPolygonArray<2>> for PointArray<2> {}
-impl<'a> Binary<'a, MultiPolygonArray<2>> for RectArray<2> {}
-impl<'a> Binary<'a, MultiPolygonArray<2>> for LineStringArray<2> {}
-impl<'a> Binary<'a, MultiPolygonArray<2>> for PolygonArray<2> {}
-impl<'a> Binary<'a, MultiPolygonArray<2>> for MultiPointArray<2> {}
-impl<'a> Binary<'a, MultiPolygonArray<2>> for MultiLineStringArray<2> {}
-impl<'a> Binary<'a, MultiPolygonArray<2>> for MultiPolygonArray<2> {}
-impl<'a> Binary<'a, MultiPolygonArray<2>> for MixedGeometryArray<2> {}
-impl<'a> Binary<'a, MultiPolygonArray<2>> for GeometryCollectionArray<2> {}
+impl<'a> Binary<'a, MultiPolygonArray> for PointArray {}
+impl<'a> Binary<'a, MultiPolygonArray> for RectArray {}
+impl<'a> Binary<'a, MultiPolygonArray> for LineStringArray {}
+impl<'a> Binary<'a, MultiPolygonArray> for PolygonArray {}
+impl<'a> Binary<'a, MultiPolygonArray> for MultiPointArray {}
+impl<'a> Binary<'a, MultiPolygonArray> for MultiLineStringArray {}
+impl<'a> Binary<'a, MultiPolygonArray> for MultiPolygonArray {}
+impl<'a> Binary<'a, MultiPolygonArray> for MixedGeometryArray {}
+impl<'a> Binary<'a, MultiPolygonArray> for GeometryCollectionArray {}
 
 // Implementations on MixedGeometryArray
-impl<'a> Binary<'a, MixedGeometryArray<2>> for PointArray<2> {}
-impl<'a> Binary<'a, MixedGeometryArray<2>> for RectArray<2> {}
-impl<'a> Binary<'a, MixedGeometryArray<2>> for LineStringArray<2> {}
-impl<'a> Binary<'a, MixedGeometryArray<2>> for PolygonArray<2> {}
-impl<'a> Binary<'a, MixedGeometryArray<2>> for MultiPointArray<2> {}
-impl<'a> Binary<'a, MixedGeometryArray<2>> for MultiLineStringArray<2> {}
-impl<'a> Binary<'a, MixedGeometryArray<2>> for MultiPolygonArray<2> {}
-impl<'a> Binary<'a, MixedGeometryArray<2>> for MixedGeometryArray<2> {}
-impl<'a> Binary<'a, MixedGeometryArray<2>> for GeometryCollectionArray<2> {}
+impl<'a> Binary<'a, MixedGeometryArray> for PointArray {}
+impl<'a> Binary<'a, MixedGeometryArray> for RectArray {}
+impl<'a> Binary<'a, MixedGeometryArray> for LineStringArray {}
+impl<'a> Binary<'a, MixedGeometryArray> for PolygonArray {}
+impl<'a> Binary<'a, MixedGeometryArray> for MultiPointArray {}
+impl<'a> Binary<'a, MixedGeometryArray> for MultiLineStringArray {}
+impl<'a> Binary<'a, MixedGeometryArray> for MultiPolygonArray {}
+impl<'a> Binary<'a, MixedGeometryArray> for MixedGeometryArray {}
+impl<'a> Binary<'a, MixedGeometryArray> for GeometryCollectionArray {}
 
 // Implementations on GeometryCollectionArray
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for PointArray<2> {}
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for RectArray<2> {}
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for LineStringArray<2> {}
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for PolygonArray<2> {}
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for MultiPointArray<2> {}
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for MultiLineStringArray<2> {}
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for MultiPolygonArray<2> {}
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for MixedGeometryArray<2> {}
-impl<'a> Binary<'a, GeometryCollectionArray<2>> for GeometryCollectionArray<2> {}
+impl<'a> Binary<'a, GeometryCollectionArray> for PointArray {}
+impl<'a> Binary<'a, GeometryCollectionArray> for RectArray {}
+impl<'a> Binary<'a, GeometryCollectionArray> for LineStringArray {}
+impl<'a> Binary<'a, GeometryCollectionArray> for PolygonArray {}
+impl<'a> Binary<'a, GeometryCollectionArray> for MultiPointArray {}
+impl<'a> Binary<'a, GeometryCollectionArray> for MultiLineStringArray {}
+impl<'a> Binary<'a, GeometryCollectionArray> for MultiPolygonArray {}
+impl<'a> Binary<'a, GeometryCollectionArray> for MixedGeometryArray {}
+impl<'a> Binary<'a, GeometryCollectionArray> for GeometryCollectionArray {}

--- a/rust/geoarrow/src/algorithm/native/cast.rs
+++ b/rust/geoarrow/src/algorithm/native/cast.rs
@@ -228,26 +228,17 @@ impl Cast for &dyn NativeArray {
         //     return Ok(Arc::new(self.to_owned()));
         // }
 
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_ref().as_point().cast(to_type),
-            LineString(_, XY) => self.as_ref().as_line_string().cast(to_type),
-            Polygon(_, XY) => self.as_ref().as_polygon().cast(to_type),
-            MultiPoint(_, XY) => self.as_ref().as_multi_point().cast(to_type),
-            MultiLineString(_, XY) => self.as_ref().as_multi_line_string().cast(to_type),
-            MultiPolygon(_, XY) => self.as_ref().as_multi_polygon().cast(to_type),
-            Mixed(_, XY) => self.as_ref().as_mixed().cast(to_type),
-            GeometryCollection(_, XY) => self.as_ref().as_geometry_collection().cast(to_type),
-            Point(_, XYZ) => self.as_ref().as_point().cast(to_type),
-            LineString(_, XYZ) => self.as_ref().as_line_string().cast(to_type),
-            Polygon(_, XYZ) => self.as_ref().as_polygon().cast(to_type),
-            MultiPoint(_, XYZ) => self.as_ref().as_multi_point().cast(to_type),
-            MultiLineString(_, XYZ) => self.as_ref().as_multi_line_string().cast(to_type),
-            MultiPolygon(_, XYZ) => self.as_ref().as_multi_polygon().cast(to_type),
-            Mixed(_, XYZ) => self.as_ref().as_mixed().cast(to_type),
-            GeometryCollection(_, XYZ) => self.as_ref().as_geometry_collection().cast(to_type),
+            Point(_, _) => self.as_ref().as_point().cast(to_type),
+            LineString(_, _) => self.as_ref().as_line_string().cast(to_type),
+            Polygon(_, _) => self.as_ref().as_polygon().cast(to_type),
+            MultiPoint(_, _) => self.as_ref().as_multi_point().cast(to_type),
+            MultiLineString(_, _) => self.as_ref().as_multi_line_string().cast(to_type),
+            MultiPolygon(_, _) => self.as_ref().as_multi_polygon().cast(to_type),
+            Mixed(_, _) => self.as_ref().as_mixed().cast(to_type),
+            GeometryCollection(_, _) => self.as_ref().as_geometry_collection().cast(to_type),
             _ => todo!(),
         }
     }
@@ -270,45 +261,20 @@ macro_rules! impl_chunked_cast_non_generic {
                                 .collect::<Result<Vec<_>>>()?,
                         ))
                     };
-                    ($method:ident, $dim:expr) => {
-                        Arc::new(ChunkedGeometryArray::new(
-                            self.geometry_chunks()
-                                .iter()
-                                .map(|chunk| {
-                                    Ok(chunk
-                                        .as_ref()
-                                        .cast(to_type)?
-                                        .as_ref()
-                                        .$method::<$dim>()
-                                        .clone())
-                                })
-                                .collect::<Result<Vec<_>>>()?,
-                        ))
-                    };
                 }
 
-                use Dimension::*;
                 use NativeType::*;
 
                 let result: Arc<dyn ChunkedNativeArray> = match to_type {
-                    Point(_, XY) => impl_cast!(as_point, 2),
-                    LineString(_, XY) => impl_cast!(as_line_string, 2),
-                    Polygon(_, XY) => impl_cast!(as_polygon, 2),
-                    MultiPoint(_, XY) => impl_cast!(as_multi_point, 2),
-                    MultiLineString(_, XY) => impl_cast!(as_multi_line_string, 2),
-                    MultiPolygon(_, XY) => impl_cast!(as_multi_polygon, 2),
-                    Mixed(_, XY) => impl_cast!(as_mixed, 2),
-                    GeometryCollection(_, XY) => impl_cast!(as_geometry_collection, 2),
-                    Point(_, XYZ) => impl_cast!(as_point, 3),
-                    LineString(_, XYZ) => impl_cast!(as_line_string, 3),
-                    Polygon(_, XYZ) => impl_cast!(as_polygon, 3),
-                    MultiPoint(_, XYZ) => impl_cast!(as_multi_point, 3),
-                    MultiLineString(_, XYZ) => impl_cast!(as_multi_line_string, 3),
-                    MultiPolygon(_, XYZ) => impl_cast!(as_multi_polygon, 3),
-                    Mixed(_, XYZ) => impl_cast!(as_mixed, 3),
-                    GeometryCollection(_, XYZ) => impl_cast!(as_geometry_collection, 3),
-                    Rect(XY) => impl_cast!(as_rect, 2),
-                    Rect(XYZ) => impl_cast!(as_rect, 3),
+                    Point(_, _) => impl_cast!(as_point),
+                    LineString(_, _) => impl_cast!(as_line_string),
+                    Polygon(_, _) => impl_cast!(as_polygon),
+                    MultiPoint(_, _) => impl_cast!(as_multi_point),
+                    MultiLineString(_, _) => impl_cast!(as_multi_line_string),
+                    MultiPolygon(_, _) => impl_cast!(as_multi_polygon),
+                    Mixed(_, _) => impl_cast!(as_mixed),
+                    GeometryCollection(_, _) => impl_cast!(as_geometry_collection),
+                    Rect(_) => impl_cast!(as_rect),
                 };
                 Ok(result)
             }
@@ -333,45 +299,20 @@ macro_rules! impl_chunked_cast_generic {
                                 .collect::<Result<Vec<_>>>()?,
                         ))
                     };
-                    ($method:ident, $dim:expr) => {
-                        Arc::new(ChunkedGeometryArray::new(
-                            self.geometry_chunks()
-                                .iter()
-                                .map(|chunk| {
-                                    Ok(chunk
-                                        .as_ref()
-                                        .cast(to_type)?
-                                        .as_ref()
-                                        .$method::<$dim>()
-                                        .clone())
-                                })
-                                .collect::<Result<Vec<_>>>()?,
-                        ))
-                    };
                 }
 
-                use Dimension::*;
                 use NativeType::*;
 
                 let result: Arc<dyn ChunkedNativeArray> = match to_type {
-                    Point(_, XY) => impl_cast!(as_point, 2),
-                    LineString(_, XY) => impl_cast!(as_line_string, 2),
-                    Polygon(_, XY) => impl_cast!(as_polygon, 2),
-                    MultiPoint(_, XY) => impl_cast!(as_multi_point, 2),
-                    MultiLineString(_, XY) => impl_cast!(as_multi_line_string, 2),
-                    MultiPolygon(_, XY) => impl_cast!(as_multi_polygon, 2),
-                    Mixed(_, XY) => impl_cast!(as_mixed, 2),
-                    GeometryCollection(_, XY) => impl_cast!(as_geometry_collection, 2),
-                    Point(_, XYZ) => impl_cast!(as_point, 3),
-                    LineString(_, XYZ) => impl_cast!(as_line_string, 3),
-                    Polygon(_, XYZ) => impl_cast!(as_polygon, 3),
-                    MultiPoint(_, XYZ) => impl_cast!(as_multi_point, 3),
-                    MultiLineString(_, XYZ) => impl_cast!(as_multi_line_string, 3),
-                    MultiPolygon(_, XYZ) => impl_cast!(as_multi_polygon, 3),
-                    Mixed(_, XYZ) => impl_cast!(as_mixed, 3),
-                    GeometryCollection(_, XYZ) => impl_cast!(as_geometry_collection, 3),
-                    Rect(XY) => impl_cast!(as_rect, 2),
-                    Rect(XYZ) => impl_cast!(as_rect, 3),
+                    Point(_, _) => impl_cast!(as_point),
+                    LineString(_, _) => impl_cast!(as_line_string),
+                    Polygon(_, _) => impl_cast!(as_polygon),
+                    MultiPoint(_, _) => impl_cast!(as_multi_point),
+                    MultiLineString(_, _) => impl_cast!(as_multi_line_string),
+                    MultiPolygon(_, _) => impl_cast!(as_multi_polygon),
+                    Mixed(_, _) => impl_cast!(as_mixed),
+                    GeometryCollection(_, _) => impl_cast!(as_geometry_collection),
+                    Rect(_) => impl_cast!(as_rect),
                 };
                 Ok(result)
             }
@@ -382,15 +323,6 @@ macro_rules! impl_chunked_cast_generic {
 impl_chunked_cast_non_generic!(ChunkedPointArray);
 impl_chunked_cast_non_generic!(ChunkedRectArray);
 impl_chunked_cast_non_generic!(&dyn ChunkedNativeArray);
-impl_chunked_cast_generic!(ChunkedLineStringArray);
-impl_chunked_cast_generic!(ChunkedPolygonArray);
-impl_chunked_cast_generic!(ChunkedMultiPointArray);
-impl_chunked_cast_generic!(ChunkedMultiLineStringArray);
-impl_chunked_cast_generic!(ChunkedMultiPolygonArray);
-impl_chunked_cast_generic!(ChunkedMixedGeometryArray);
-impl_chunked_cast_generic!(ChunkedGeometryCollectionArray);
-impl_chunked_cast_non_generic!(ChunkedPointArray);
-impl_chunked_cast_non_generic!(ChunkedRectArray);
 impl_chunked_cast_generic!(ChunkedLineStringArray);
 impl_chunked_cast_generic!(ChunkedPolygonArray);
 impl_chunked_cast_generic!(ChunkedMultiPointArray);

--- a/rust/geoarrow/src/algorithm/native/cast.rs
+++ b/rust/geoarrow/src/algorithm/native/cast.rs
@@ -54,7 +54,7 @@ pub trait Cast {
     fn cast(&self, to_type: &NativeType) -> Self::Output;
 }
 
-impl<const D: usize> Cast for PointArray<D> {
+impl Cast for PointArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -63,9 +63,9 @@ impl<const D: usize> Cast for PointArray<D> {
         let array = self.to_coord_type(to_type.coord_type());
         match to_type {
             Point(_, _) => Ok(Arc::new(array)),
-            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<D>::from(array))),
-            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
-            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::from(array))),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::from(array))),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
             ))),
@@ -73,7 +73,7 @@ impl<const D: usize> Cast for PointArray<D> {
     }
 }
 
-impl<const D: usize> Cast for LineStringArray<D> {
+impl Cast for LineStringArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -83,9 +83,9 @@ impl<const D: usize> Cast for LineStringArray<D> {
 
         match to_type {
             LineString(_, _) => Ok(Arc::new(array)),
-            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::<D>::from(array))),
-            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
-            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::from(array))),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::from(array))),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
             ))),
@@ -93,7 +93,7 @@ impl<const D: usize> Cast for LineStringArray<D> {
     }
 }
 
-impl<const D: usize> Cast for PolygonArray<D> {
+impl Cast for PolygonArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -103,9 +103,9 @@ impl<const D: usize> Cast for PolygonArray<D> {
 
         match to_type {
             Polygon(_, _) => Ok(Arc::new(array)),
-            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::from(array))),
-            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
-            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::from(array))),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::from(array))),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
             ))),
@@ -113,7 +113,7 @@ impl<const D: usize> Cast for PolygonArray<D> {
     }
 }
 
-impl<const D: usize> Cast for MultiPointArray<D> {
+impl Cast for MultiPointArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -122,10 +122,10 @@ impl<const D: usize> Cast for MultiPointArray<D> {
         let array = self.to_coord_type(to_type.coord_type());
 
         match to_type {
-            Point(_, _) => Ok(Arc::new(PointArray::<D>::try_from(array)?)),
+            Point(_, _) => Ok(Arc::new(PointArray::try_from(array)?)),
             MultiPoint(_, _) => Ok(Arc::new(array)),
-            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
-            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::from(array))),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
             ))),
@@ -133,7 +133,7 @@ impl<const D: usize> Cast for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> Cast for MultiLineStringArray<D> {
+impl Cast for MultiLineStringArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -142,9 +142,9 @@ impl<const D: usize> Cast for MultiLineStringArray<D> {
         let array = self.to_coord_type(to_type.coord_type());
 
         match to_type {
-            LineString(_, _) => Ok(Arc::new(LineStringArray::<D>::try_from(array)?)),
-            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
-            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            LineString(_, _) => Ok(Arc::new(LineStringArray::try_from(array)?)),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::from(array))),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
             ))),
@@ -152,7 +152,7 @@ impl<const D: usize> Cast for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> Cast for MultiPolygonArray<D> {
+impl Cast for MultiPolygonArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -161,9 +161,9 @@ impl<const D: usize> Cast for MultiPolygonArray<D> {
         let array = self.to_coord_type(to_type.coord_type());
 
         match to_type {
-            Polygon(_, _) => Ok(Arc::new(PolygonArray::<D>::try_from(array)?)),
-            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::from(array))),
-            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            Polygon(_, _) => Ok(Arc::new(PolygonArray::try_from(array)?)),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::from(array))),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
             ))),
@@ -171,7 +171,7 @@ impl<const D: usize> Cast for MultiPolygonArray<D> {
     }
 }
 
-impl<const D: usize> Cast for MixedGeometryArray<D> {
+impl Cast for MixedGeometryArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -181,13 +181,13 @@ impl<const D: usize> Cast for MixedGeometryArray<D> {
 
         match to_type {
             Point(_, _) => Ok(Arc::new(PointArray::try_from(array)?)),
-            LineString(_, _) => Ok(Arc::new(LineStringArray::<D>::try_from(array)?)),
-            Polygon(_, _) => Ok(Arc::new(PolygonArray::<D>::try_from(array)?)),
-            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<D>::try_from(array)?)),
-            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::<D>::try_from(array)?)),
-            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::try_from(array)?)),
+            LineString(_, _) => Ok(Arc::new(LineStringArray::try_from(array)?)),
+            Polygon(_, _) => Ok(Arc::new(PolygonArray::try_from(array)?)),
+            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::try_from(array)?)),
+            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::try_from(array)?)),
+            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::try_from(array)?)),
             Mixed(_, _) => Ok(Arc::new(array)),
-            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::<D>::from(array))),
+            GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::from(array))),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
             ))),
@@ -195,7 +195,7 @@ impl<const D: usize> Cast for MixedGeometryArray<D> {
     }
 }
 
-impl<const D: usize> Cast for GeometryCollectionArray<D> {
+impl Cast for GeometryCollectionArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
     fn cast(&self, to_type: &NativeType) -> Self::Output {
@@ -205,12 +205,12 @@ impl<const D: usize> Cast for GeometryCollectionArray<D> {
 
         match to_type {
             Point(_, _) => Ok(Arc::new(PointArray::try_from(array)?)),
-            LineString(_, _) => Ok(Arc::new(LineStringArray::<D>::try_from(array)?)),
-            Polygon(_, _) => Ok(Arc::new(PolygonArray::<D>::try_from(array)?)),
-            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::<D>::try_from(array)?)),
-            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::<D>::try_from(array)?)),
-            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::<D>::try_from(array)?)),
-            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::<D>::try_from(array)?)),
+            LineString(_, _) => Ok(Arc::new(LineStringArray::try_from(array)?)),
+            Polygon(_, _) => Ok(Arc::new(PolygonArray::try_from(array)?)),
+            MultiPoint(_, _) => Ok(Arc::new(MultiPointArray::try_from(array)?)),
+            MultiLineString(_, _) => Ok(Arc::new(MultiLineStringArray::try_from(array)?)),
+            MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::try_from(array)?)),
+            Mixed(_, _) => Ok(Arc::new(MixedGeometryArray::try_from(array)?)),
             GeometryCollection(_, _) => Ok(Arc::new(array)),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
@@ -232,22 +232,22 @@ impl Cast for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_ref().as_point::<2>().cast(to_type),
-            LineString(_, XY) => self.as_ref().as_line_string::<2>().cast(to_type),
-            Polygon(_, XY) => self.as_ref().as_polygon::<2>().cast(to_type),
-            MultiPoint(_, XY) => self.as_ref().as_multi_point::<2>().cast(to_type),
-            MultiLineString(_, XY) => self.as_ref().as_multi_line_string::<2>().cast(to_type),
-            MultiPolygon(_, XY) => self.as_ref().as_multi_polygon::<2>().cast(to_type),
-            Mixed(_, XY) => self.as_ref().as_mixed::<2>().cast(to_type),
-            GeometryCollection(_, XY) => self.as_ref().as_geometry_collection::<2>().cast(to_type),
-            Point(_, XYZ) => self.as_ref().as_point::<3>().cast(to_type),
-            LineString(_, XYZ) => self.as_ref().as_line_string::<3>().cast(to_type),
-            Polygon(_, XYZ) => self.as_ref().as_polygon::<3>().cast(to_type),
-            MultiPoint(_, XYZ) => self.as_ref().as_multi_point::<3>().cast(to_type),
-            MultiLineString(_, XYZ) => self.as_ref().as_multi_line_string::<3>().cast(to_type),
-            MultiPolygon(_, XYZ) => self.as_ref().as_multi_polygon::<3>().cast(to_type),
-            Mixed(_, XYZ) => self.as_ref().as_mixed::<3>().cast(to_type),
-            GeometryCollection(_, XYZ) => self.as_ref().as_geometry_collection::<3>().cast(to_type),
+            Point(_, XY) => self.as_ref().as_point().cast(to_type),
+            LineString(_, XY) => self.as_ref().as_line_string().cast(to_type),
+            Polygon(_, XY) => self.as_ref().as_polygon().cast(to_type),
+            MultiPoint(_, XY) => self.as_ref().as_multi_point().cast(to_type),
+            MultiLineString(_, XY) => self.as_ref().as_multi_line_string().cast(to_type),
+            MultiPolygon(_, XY) => self.as_ref().as_multi_polygon().cast(to_type),
+            Mixed(_, XY) => self.as_ref().as_mixed().cast(to_type),
+            GeometryCollection(_, XY) => self.as_ref().as_geometry_collection().cast(to_type),
+            Point(_, XYZ) => self.as_ref().as_point().cast(to_type),
+            LineString(_, XYZ) => self.as_ref().as_line_string().cast(to_type),
+            Polygon(_, XYZ) => self.as_ref().as_polygon().cast(to_type),
+            MultiPoint(_, XYZ) => self.as_ref().as_multi_point().cast(to_type),
+            MultiLineString(_, XYZ) => self.as_ref().as_multi_line_string().cast(to_type),
+            MultiPolygon(_, XYZ) => self.as_ref().as_multi_polygon().cast(to_type),
+            Mixed(_, XYZ) => self.as_ref().as_mixed().cast(to_type),
+            GeometryCollection(_, XYZ) => self.as_ref().as_geometry_collection().cast(to_type),
             _ => todo!(),
         }
     }
@@ -379,22 +379,22 @@ macro_rules! impl_chunked_cast_generic {
     };
 }
 
-impl_chunked_cast_non_generic!(ChunkedPointArray<2>);
-impl_chunked_cast_non_generic!(ChunkedRectArray<2>);
+impl_chunked_cast_non_generic!(ChunkedPointArray);
+impl_chunked_cast_non_generic!(ChunkedRectArray);
 impl_chunked_cast_non_generic!(&dyn ChunkedNativeArray);
-impl_chunked_cast_generic!(ChunkedLineStringArray<2>);
-impl_chunked_cast_generic!(ChunkedPolygonArray<2>);
-impl_chunked_cast_generic!(ChunkedMultiPointArray<2>);
-impl_chunked_cast_generic!(ChunkedMultiLineStringArray<2>);
-impl_chunked_cast_generic!(ChunkedMultiPolygonArray<2>);
-impl_chunked_cast_generic!(ChunkedMixedGeometryArray<2>);
-impl_chunked_cast_generic!(ChunkedGeometryCollectionArray<2>);
-impl_chunked_cast_non_generic!(ChunkedPointArray<3>);
-impl_chunked_cast_non_generic!(ChunkedRectArray<3>);
-impl_chunked_cast_generic!(ChunkedLineStringArray<3>);
-impl_chunked_cast_generic!(ChunkedPolygonArray<3>);
-impl_chunked_cast_generic!(ChunkedMultiPointArray<3>);
-impl_chunked_cast_generic!(ChunkedMultiLineStringArray<3>);
-impl_chunked_cast_generic!(ChunkedMultiPolygonArray<3>);
-impl_chunked_cast_generic!(ChunkedMixedGeometryArray<3>);
-impl_chunked_cast_generic!(ChunkedGeometryCollectionArray<3>);
+impl_chunked_cast_generic!(ChunkedLineStringArray);
+impl_chunked_cast_generic!(ChunkedPolygonArray);
+impl_chunked_cast_generic!(ChunkedMultiPointArray);
+impl_chunked_cast_generic!(ChunkedMultiLineStringArray);
+impl_chunked_cast_generic!(ChunkedMultiPolygonArray);
+impl_chunked_cast_generic!(ChunkedMixedGeometryArray);
+impl_chunked_cast_generic!(ChunkedGeometryCollectionArray);
+impl_chunked_cast_non_generic!(ChunkedPointArray);
+impl_chunked_cast_non_generic!(ChunkedRectArray);
+impl_chunked_cast_generic!(ChunkedLineStringArray);
+impl_chunked_cast_generic!(ChunkedPolygonArray);
+impl_chunked_cast_generic!(ChunkedMultiPointArray);
+impl_chunked_cast_generic!(ChunkedMultiLineStringArray);
+impl_chunked_cast_generic!(ChunkedMultiPolygonArray);
+impl_chunked_cast_generic!(ChunkedMixedGeometryArray);
+impl_chunked_cast_generic!(ChunkedGeometryCollectionArray);

--- a/rust/geoarrow/src/algorithm/native/concatenate.rs
+++ b/rust/geoarrow/src/algorithm/native/concatenate.rs
@@ -9,8 +9,8 @@ pub trait Concatenate: Sized {
     fn concatenate(&self) -> Self::Output;
 }
 
-impl Concatenate for &[PointArray<2>] {
-    type Output = Result<PointArray<2>>;
+impl Concatenate for &[PointArray] {
+    type Output = Result<PointArray>;
 
     fn concatenate(&self) -> Self::Output {
         let output_capacity = self.iter().fold(0, |sum, val| sum + val.buffer_lengths());
@@ -43,50 +43,45 @@ macro_rules! impl_concatenate {
 }
 
 impl_concatenate!(
-    LineStringArray<2>,
+    LineStringArray,
     LineStringCapacity,
-    LineStringBuilder<2>,
+    LineStringBuilder,
     push_line_string
 );
+impl_concatenate!(PolygonArray, PolygonCapacity, PolygonBuilder, push_polygon);
 impl_concatenate!(
-    PolygonArray<2>,
-    PolygonCapacity,
-    PolygonBuilder<2>,
-    push_polygon
-);
-impl_concatenate!(
-    MultiPointArray<2>,
+    MultiPointArray,
     MultiPointCapacity,
-    MultiPointBuilder<2>,
+    MultiPointBuilder,
     push_multi_point
 );
 impl_concatenate!(
-    MultiLineStringArray<2>,
+    MultiLineStringArray,
     MultiLineStringCapacity,
-    MultiLineStringBuilder<2>,
+    MultiLineStringBuilder,
     push_multi_line_string
 );
 impl_concatenate!(
-    MultiPolygonArray<2>,
+    MultiPolygonArray,
     MultiPolygonCapacity,
-    MultiPolygonBuilder<2>,
+    MultiPolygonBuilder,
     push_multi_polygon
 );
 impl_concatenate!(
-    MixedGeometryArray<2>,
+    MixedGeometryArray,
     MixedCapacity,
-    MixedGeometryBuilder<2>,
+    MixedGeometryBuilder,
     push_geometry
 );
 impl_concatenate!(
-    GeometryCollectionArray<2>,
+    GeometryCollectionArray,
     GeometryCollectionCapacity,
-    GeometryCollectionBuilder<2>,
+    GeometryCollectionBuilder,
     push_geometry_collection
 );
 
-impl Concatenate for ChunkedPointArray<2> {
-    type Output = Result<PointArray<2>>;
+impl Concatenate for ChunkedPointArray {
+    type Output = Result<PointArray>;
 
     fn concatenate(&self) -> Self::Output {
         self.chunks.as_slice().concatenate()
@@ -105,13 +100,10 @@ macro_rules! impl_chunked_concatenate {
     };
 }
 
-impl_chunked_concatenate!(ChunkedLineStringArray<2>, LineStringArray<2>);
-impl_chunked_concatenate!(ChunkedPolygonArray<2>, PolygonArray<2>);
-impl_chunked_concatenate!(ChunkedMultiPointArray<2>, MultiPointArray<2>);
-impl_chunked_concatenate!(ChunkedMultiLineStringArray<2>, MultiLineStringArray<2>);
-impl_chunked_concatenate!(ChunkedMultiPolygonArray<2>, MultiPolygonArray<2>);
-impl_chunked_concatenate!(ChunkedMixedGeometryArray<2>, MixedGeometryArray<2>);
-impl_chunked_concatenate!(
-    ChunkedGeometryCollectionArray<2>,
-    GeometryCollectionArray<2>
-);
+impl_chunked_concatenate!(ChunkedLineStringArray, LineStringArray);
+impl_chunked_concatenate!(ChunkedPolygonArray, PolygonArray);
+impl_chunked_concatenate!(ChunkedMultiPointArray, MultiPointArray);
+impl_chunked_concatenate!(ChunkedMultiLineStringArray, MultiLineStringArray);
+impl_chunked_concatenate!(ChunkedMultiPolygonArray, MultiPolygonArray);
+impl_chunked_concatenate!(ChunkedMixedGeometryArray, MixedGeometryArray);
+impl_chunked_concatenate!(ChunkedGeometryCollectionArray, GeometryCollectionArray);

--- a/rust/geoarrow/src/algorithm/native/downcast.rs
+++ b/rust/geoarrow/src/algorithm/native/downcast.rs
@@ -38,7 +38,7 @@ pub trait Downcast {
     fn downcast(&self, small_offsets: bool) -> Self::Output;
 }
 
-impl Downcast for PointArray<2> {
+impl Downcast for PointArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -90,7 +90,7 @@ pub(crate) fn can_downcast_multi<O: OffsetSizeTrait>(buffer: &OffsetBuffer<O>) -
         .all(|slice| *slice.get(1).unwrap() - *slice.first().unwrap() <= O::one())
 }
 
-impl Downcast for LineStringArray<2> {
+impl Downcast for LineStringArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -111,7 +111,7 @@ impl Downcast for LineStringArray<2> {
     }
 }
 
-impl Downcast for PolygonArray<2> {
+impl Downcast for PolygonArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -126,7 +126,7 @@ impl Downcast for PolygonArray<2> {
     }
 }
 
-impl Downcast for MultiPointArray<2> {
+impl Downcast for MultiPointArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -144,7 +144,7 @@ impl Downcast for MultiPointArray<2> {
     fn downcast(&self, small_offsets: bool) -> Self::Output {
         // Note: this won't allow a downcast for empty MultiPoints
         if *self.geom_offsets.last() as usize == self.len() {
-            return Arc::new(PointArray::<2>::new(
+            return Arc::new(PointArray::new(
                 self.coords.clone(),
                 self.validity.clone(),
                 self.metadata(),
@@ -155,7 +155,7 @@ impl Downcast for MultiPointArray<2> {
     }
 }
 
-impl Downcast for MultiLineStringArray<2> {
+impl Downcast for MultiLineStringArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -173,7 +173,7 @@ impl Downcast for MultiLineStringArray<2> {
 
     fn downcast(&self, small_offsets: bool) -> Self::Output {
         if *self.geom_offsets.last() as usize == self.len() {
-            return Arc::new(LineStringArray::<2>::new(
+            return Arc::new(LineStringArray::new(
                 self.coords.clone(),
                 self.ring_offsets.clone(),
                 self.validity.clone(),
@@ -185,7 +185,7 @@ impl Downcast for MultiLineStringArray<2> {
     }
 }
 
-impl Downcast for MultiPolygonArray<2> {
+impl Downcast for MultiPolygonArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -203,7 +203,7 @@ impl Downcast for MultiPolygonArray<2> {
 
     fn downcast(&self, small_offsets: bool) -> Self::Output {
         if *self.geom_offsets.last() as usize == self.len() {
-            return Arc::new(PolygonArray::<2>::new(
+            return Arc::new(PolygonArray::new(
                 self.coords.clone(),
                 self.polygon_offsets.clone(),
                 self.ring_offsets.clone(),
@@ -216,7 +216,7 @@ impl Downcast for MultiPolygonArray<2> {
     }
 }
 
-impl Downcast for MixedGeometryArray<2> {
+impl Downcast for MixedGeometryArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -351,7 +351,7 @@ impl Downcast for MixedGeometryArray<2> {
     }
 }
 
-impl Downcast for GeometryCollectionArray<2> {
+impl Downcast for GeometryCollectionArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -368,7 +368,7 @@ impl Downcast for GeometryCollectionArray<2> {
     }
 }
 
-impl Downcast for RectArray<2> {
+impl Downcast for RectArray {
     type Output = Arc<dyn NativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -387,25 +387,19 @@ impl Downcast for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().downcasted_data_type(small_offsets),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .downcasted_data_type(small_offsets),
-            Polygon(_, XY) => self.as_polygon::<2>().downcasted_data_type(small_offsets),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .downcasted_data_type(small_offsets),
+            Point(_, XY) => self.as_point().downcasted_data_type(small_offsets),
+            LineString(_, XY) => self.as_line_string().downcasted_data_type(small_offsets),
+            Polygon(_, XY) => self.as_polygon().downcasted_data_type(small_offsets),
+            MultiPoint(_, XY) => self.as_multi_point().downcasted_data_type(small_offsets),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .downcasted_data_type(small_offsets),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .downcasted_data_type(small_offsets),
-            Mixed(_, XY) => self.as_mixed::<2>().downcasted_data_type(small_offsets),
+            MultiPolygon(_, XY) => self.as_multi_polygon().downcasted_data_type(small_offsets),
+            Mixed(_, XY) => self.as_mixed().downcasted_data_type(small_offsets),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .downcasted_data_type(small_offsets),
-            Rect(XY) => self.as_rect::<2>().downcasted_data_type(small_offsets),
+            Rect(XY) => self.as_rect().downcasted_data_type(small_offsets),
             _ => todo!("3d support"),
         }
     }
@@ -415,15 +409,15 @@ impl Downcast for &dyn NativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().downcast(small_offsets),
-            LineString(_, XY) => self.as_line_string::<2>().downcast(small_offsets),
-            Polygon(_, XY) => self.as_polygon::<2>().downcast(small_offsets),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().downcast(small_offsets),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().downcast(small_offsets),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().downcast(small_offsets),
-            Mixed(_, XY) => self.as_mixed::<2>().downcast(small_offsets),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().downcast(small_offsets),
-            Rect(XY) => self.as_rect::<2>().downcast(small_offsets),
+            Point(_, XY) => self.as_point().downcast(small_offsets),
+            LineString(_, XY) => self.as_line_string().downcast(small_offsets),
+            Polygon(_, XY) => self.as_polygon().downcast(small_offsets),
+            MultiPoint(_, XY) => self.as_multi_point().downcast(small_offsets),
+            MultiLineString(_, XY) => self.as_multi_line_string().downcast(small_offsets),
+            MultiPolygon(_, XY) => self.as_multi_polygon().downcast(small_offsets),
+            Mixed(_, XY) => self.as_mixed().downcast(small_offsets),
+            GeometryCollection(_, XY) => self.as_geometry_collection().downcast(small_offsets),
+            Rect(XY) => self.as_rect().downcast(small_offsets),
             _ => todo!("3d support"),
         }
     }
@@ -463,7 +457,7 @@ fn resolve_types(types: &HashSet<NativeType>) -> NativeType {
     }
 }
 
-impl Downcast for ChunkedPointArray<2> {
+impl Downcast for ChunkedPointArray {
     type Output = Arc<dyn ChunkedNativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -499,15 +493,15 @@ macro_rules! impl_chunked_downcast {
     };
 }
 
-impl_chunked_downcast!(ChunkedLineStringArray<2>);
-impl_chunked_downcast!(ChunkedPolygonArray<2>);
-impl_chunked_downcast!(ChunkedMultiPointArray<2>);
-impl_chunked_downcast!(ChunkedMultiLineStringArray<2>);
-impl_chunked_downcast!(ChunkedMultiPolygonArray<2>);
-impl_chunked_downcast!(ChunkedMixedGeometryArray<2>);
-impl_chunked_downcast!(ChunkedGeometryCollectionArray<2>);
+impl_chunked_downcast!(ChunkedLineStringArray);
+impl_chunked_downcast!(ChunkedPolygonArray);
+impl_chunked_downcast!(ChunkedMultiPointArray);
+impl_chunked_downcast!(ChunkedMultiLineStringArray);
+impl_chunked_downcast!(ChunkedMultiPolygonArray);
+impl_chunked_downcast!(ChunkedMixedGeometryArray);
+impl_chunked_downcast!(ChunkedGeometryCollectionArray);
 
-impl Downcast for ChunkedRectArray<2> {
+impl Downcast for ChunkedRectArray {
     type Output = Arc<dyn ChunkedNativeArray>;
 
     fn downcasted_data_type(&self, small_offsets: bool) -> NativeType {
@@ -526,25 +520,19 @@ impl Downcast for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().downcasted_data_type(small_offsets),
-            LineString(_, XY) => self
-                .as_line_string::<2>()
-                .downcasted_data_type(small_offsets),
-            Polygon(_, XY) => self.as_polygon::<2>().downcasted_data_type(small_offsets),
-            MultiPoint(_, XY) => self
-                .as_multi_point::<2>()
-                .downcasted_data_type(small_offsets),
+            Point(_, XY) => self.as_point().downcasted_data_type(small_offsets),
+            LineString(_, XY) => self.as_line_string().downcasted_data_type(small_offsets),
+            Polygon(_, XY) => self.as_polygon().downcasted_data_type(small_offsets),
+            MultiPoint(_, XY) => self.as_multi_point().downcasted_data_type(small_offsets),
             MultiLineString(_, XY) => self
-                .as_multi_line_string::<2>()
+                .as_multi_line_string()
                 .downcasted_data_type(small_offsets),
-            MultiPolygon(_, XY) => self
-                .as_multi_polygon::<2>()
-                .downcasted_data_type(small_offsets),
-            Mixed(_, XY) => self.as_mixed::<2>().downcasted_data_type(small_offsets),
+            MultiPolygon(_, XY) => self.as_multi_polygon().downcasted_data_type(small_offsets),
+            Mixed(_, XY) => self.as_mixed().downcasted_data_type(small_offsets),
             GeometryCollection(_, XY) => self
-                .as_geometry_collection::<2>()
+                .as_geometry_collection()
                 .downcasted_data_type(small_offsets),
-            Rect(XY) => self.as_rect::<2>().downcasted_data_type(small_offsets),
+            Rect(XY) => self.as_rect().downcasted_data_type(small_offsets),
             _ => todo!("3d support"),
         }
     }
@@ -554,15 +542,15 @@ impl Downcast for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().downcast(small_offsets),
-            LineString(_, XY) => self.as_line_string::<2>().downcast(small_offsets),
-            Polygon(_, XY) => self.as_polygon::<2>().downcast(small_offsets),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().downcast(small_offsets),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().downcast(small_offsets),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().downcast(small_offsets),
-            Mixed(_, XY) => self.as_mixed::<2>().downcast(small_offsets),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().downcast(small_offsets),
-            Rect(XY) => self.as_rect::<2>().downcast(small_offsets),
+            Point(_, XY) => self.as_point().downcast(small_offsets),
+            LineString(_, XY) => self.as_line_string().downcast(small_offsets),
+            Polygon(_, XY) => self.as_polygon().downcast(small_offsets),
+            MultiPoint(_, XY) => self.as_multi_point().downcast(small_offsets),
+            MultiLineString(_, XY) => self.as_multi_line_string().downcast(small_offsets),
+            MultiPolygon(_, XY) => self.as_multi_polygon().downcast(small_offsets),
+            Mixed(_, XY) => self.as_mixed().downcast(small_offsets),
+            GeometryCollection(_, XY) => self.as_geometry_collection().downcast(small_offsets),
+            Rect(XY) => self.as_rect().downcast(small_offsets),
             _ => todo!("3d support"),
         }
     }
@@ -611,7 +599,7 @@ impl DowncastTable for Table {
     }
 }
 
-// impl Downcast for ChunkedMultiPointArray<2> {
+// impl Downcast for ChunkedMultiPointArray {
 //     type Output = Arc<dyn ChunkedNativeArray>;
 
 //     fn downcast(&self) -> Self::Output {

--- a/rust/geoarrow/src/algorithm/native/explode.rs
+++ b/rust/geoarrow/src/algorithm/native/explode.rs
@@ -22,7 +22,7 @@ pub trait Explode {
     fn explode(&self) -> Self::Output;
 }
 
-impl Explode for PointArray<2> {
+impl Explode for PointArray {
     type Output = (Self, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
@@ -30,7 +30,7 @@ impl Explode for PointArray<2> {
     }
 }
 
-impl Explode for LineStringArray<2> {
+impl Explode for LineStringArray {
     type Output = (Self, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
@@ -38,7 +38,7 @@ impl Explode for LineStringArray<2> {
     }
 }
 
-impl Explode for PolygonArray<2> {
+impl Explode for PolygonArray {
     type Output = (Self, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
@@ -67,8 +67,8 @@ fn explode_offsets(offsets: &OffsetBuffer<i32>) -> Int32Array {
     Int32Array::new(take_indices.into(), None)
 }
 
-impl Explode for MultiPointArray<2> {
-    type Output = (PointArray<2>, Option<Int32Array>);
+impl Explode for MultiPointArray {
+    type Output = (PointArray, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
         assert_eq!(
@@ -83,8 +83,8 @@ impl Explode for MultiPointArray<2> {
     }
 }
 
-impl Explode for MultiLineStringArray<2> {
-    type Output = (LineStringArray<2>, Option<Int32Array>);
+impl Explode for MultiLineStringArray {
+    type Output = (LineStringArray, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
         assert_eq!(
@@ -104,8 +104,8 @@ impl Explode for MultiLineStringArray<2> {
     }
 }
 
-impl Explode for MultiPolygonArray<2> {
-    type Output = (PolygonArray<2>, Option<Int32Array>);
+impl Explode for MultiPolygonArray {
+    type Output = (PolygonArray, Option<Int32Array>);
 
     fn explode(&self) -> Self::Output {
         assert_eq!(
@@ -147,8 +147,8 @@ impl Explode for &dyn NativeArray {
             MultiPoint(_, XY) => call_explode!(as_multi_point),
             MultiLineString(_, XY) => call_explode!(as_multi_line_string),
             MultiPolygon(_, XY) => call_explode!(as_multi_polygon),
-            // Mixed(_, XY) => self.as_mixed::<2>().explode(),
-            // GeometryCollection(_, XY) => self.as_geometry_collection::<2>().explode(),
+            // Mixed(_, XY) => self.as_mixed::().explode(),
+            // GeometryCollection(_, XY) => self.as_geometry_collection::().explode(),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -192,15 +192,15 @@ impl Explode for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().explode(),
-            LineString(_, XY) => self.as_line_string::<2>().explode(),
-            Polygon(_, XY) => self.as_polygon::<2>().explode(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().explode(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().explode(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().explode(),
-            Mixed(_, XY) => self.as_mixed::<2>().explode(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().explode(),
-            Rect(XY) => self.as_rect::<2>().explode(),
+            Point(_, XY) => self.as_point::().explode(),
+            LineString(_, XY) => self.as_line_string::().explode(),
+            Polygon(_, XY) => self.as_polygon::().explode(),
+            MultiPoint(_, XY) => self.as_multi_point::().explode(),
+            MultiLineString(_, XY) => self.as_multi_line_string::().explode(),
+            MultiPolygon(_, XY) => self.as_multi_polygon::().explode(),
+            Mixed(_, XY) => self.as_mixed::().explode(),
+            GeometryCollection(_, XY) => self.as_geometry_collection::().explode(),
+            Rect(XY) => self.as_rect::().explode(),
             _ => todo!(),
         }
     }

--- a/rust/geoarrow/src/algorithm/native/explode.rs
+++ b/rust/geoarrow/src/algorithm/native/explode.rs
@@ -188,20 +188,18 @@ impl Explode for &dyn ChunkedNativeArray {
     )>;
 
     fn explode(&self) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::().explode(),
-            LineString(_, XY) => self.as_line_string::().explode(),
-            Polygon(_, XY) => self.as_polygon::().explode(),
-            MultiPoint(_, XY) => self.as_multi_point::().explode(),
-            MultiLineString(_, XY) => self.as_multi_line_string::().explode(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::().explode(),
-            Mixed(_, XY) => self.as_mixed::().explode(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::().explode(),
-            Rect(XY) => self.as_rect::().explode(),
-            _ => todo!(),
+            Point(_, _) => self.as_point().explode(),
+            LineString(_, _) => self.as_line_string().explode(),
+            Polygon(_, _) => self.as_polygon().explode(),
+            MultiPoint(_, _) => self.as_multi_point().explode(),
+            MultiLineString(_, _) => self.as_multi_line_string().explode(),
+            MultiPolygon(_, _) => self.as_multi_polygon().explode(),
+            Mixed(_, _) => self.as_mixed().explode(),
+            GeometryCollection(_, _) => self.as_geometry_collection().explode(),
+            Rect(_) => self.as_rect().explode(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/native/map_coords.rs
+++ b/rust/geoarrow/src/algorithm/native/map_coords.rs
@@ -43,7 +43,7 @@ impl MapCoords for Coord<'_> {
     }
 }
 
-impl MapCoords for Point<'_, 2> {
+impl MapCoords for Point<'_> {
     type Output = geo::Point;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -55,7 +55,7 @@ impl MapCoords for Point<'_, 2> {
     }
 }
 
-impl MapCoords for LineString<'_, 2> {
+impl MapCoords for LineString<'_> {
     type Output = geo::LineString;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -71,7 +71,7 @@ impl MapCoords for LineString<'_, 2> {
     }
 }
 
-impl MapCoords for Polygon<'_, 2> {
+impl MapCoords for Polygon<'_> {
     type Output = geo::Polygon;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -93,7 +93,7 @@ impl MapCoords for Polygon<'_, 2> {
     }
 }
 
-impl MapCoords for MultiPoint<'_, 2> {
+impl MapCoords for MultiPoint<'_> {
     type Output = geo::MultiPoint;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -109,7 +109,7 @@ impl MapCoords for MultiPoint<'_, 2> {
     }
 }
 
-impl MapCoords for MultiLineString<'_, 2> {
+impl MapCoords for MultiLineString<'_> {
     type Output = geo::MultiLineString;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -125,7 +125,7 @@ impl MapCoords for MultiLineString<'_, 2> {
     }
 }
 
-impl MapCoords for MultiPolygon<'_, 2> {
+impl MapCoords for MultiPolygon<'_> {
     // TODO: support empty polygons within a multi polygon
     type Output = geo::MultiPolygon;
 
@@ -142,7 +142,7 @@ impl MapCoords for MultiPolygon<'_, 2> {
     }
 }
 
-impl MapCoords for Geometry<'_, 2> {
+impl MapCoords for Geometry<'_> {
     type Output = geo::Geometry;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -170,7 +170,7 @@ impl MapCoords for Geometry<'_, 2> {
     }
 }
 
-impl MapCoords for GeometryCollection<'_, 2> {
+impl MapCoords for GeometryCollection<'_> {
     type Output = geo::GeometryCollection;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -186,7 +186,7 @@ impl MapCoords for GeometryCollection<'_, 2> {
     }
 }
 
-impl MapCoords for Rect<'_, 2> {
+impl MapCoords for Rect<'_> {
     type Output = geo::Rect;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
@@ -212,8 +212,8 @@ impl MapCoords for Rect<'_, 2> {
     }
 }
 
-impl MapCoords for PointArray<2> {
-    type Output = PointArray<2>;
+impl MapCoords for PointArray {
+    type Output = PointArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -237,8 +237,8 @@ impl MapCoords for PointArray<2> {
     }
 }
 
-impl MapCoords for LineStringArray<2> {
-    type Output = LineStringArray<2>;
+impl MapCoords for LineStringArray {
+    type Output = LineStringArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -262,8 +262,8 @@ impl MapCoords for LineStringArray<2> {
     }
 }
 
-impl MapCoords for PolygonArray<2> {
-    type Output = PolygonArray<2>;
+impl MapCoords for PolygonArray {
+    type Output = PolygonArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -287,8 +287,8 @@ impl MapCoords for PolygonArray<2> {
     }
 }
 
-impl MapCoords for MultiPointArray<2> {
-    type Output = MultiPointArray<2>;
+impl MapCoords for MultiPointArray {
+    type Output = MultiPointArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -312,8 +312,8 @@ impl MapCoords for MultiPointArray<2> {
     }
 }
 
-impl MapCoords for MultiLineStringArray<2> {
-    type Output = MultiLineStringArray<2>;
+impl MapCoords for MultiLineStringArray {
+    type Output = MultiLineStringArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -337,8 +337,8 @@ impl MapCoords for MultiLineStringArray<2> {
     }
 }
 
-impl MapCoords for MultiPolygonArray<2> {
-    type Output = MultiPolygonArray<2>;
+impl MapCoords for MultiPolygonArray {
+    type Output = MultiPolygonArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -362,8 +362,8 @@ impl MapCoords for MultiPolygonArray<2> {
     }
 }
 
-impl MapCoords for MixedGeometryArray<2> {
-    type Output = MixedGeometryArray<2>;
+impl MapCoords for MixedGeometryArray {
+    type Output = MixedGeometryArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -388,8 +388,8 @@ impl MapCoords for MixedGeometryArray<2> {
     }
 }
 
-impl MapCoords for GeometryCollectionArray<2> {
-    type Output = GeometryCollectionArray<2>;
+impl MapCoords for GeometryCollectionArray {
+    type Output = GeometryCollectionArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -414,8 +414,8 @@ impl MapCoords for GeometryCollectionArray<2> {
     }
 }
 
-impl MapCoords for RectArray<2> {
-    type Output = RectArray<2>;
+impl MapCoords for RectArray {
+    type Output = RectArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -447,27 +447,25 @@ impl MapCoords for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().try_map_coords(map_op)?),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().try_map_coords(map_op)?),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().try_map_coords(map_op)?),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().try_map_coords(map_op)?),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().try_map_coords(map_op)?)
-            }
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().try_map_coords(map_op)?),
-            Mixed(_, XY) => Arc::new(self.as_mixed::<2>().try_map_coords(map_op)?),
+            Point(_, XY) => Arc::new(self.as_point().try_map_coords(map_op)?),
+            LineString(_, XY) => Arc::new(self.as_line_string().try_map_coords(map_op)?),
+            Polygon(_, XY) => Arc::new(self.as_polygon().try_map_coords(map_op)?),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().try_map_coords(map_op)?),
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().try_map_coords(map_op)?),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().try_map_coords(map_op)?),
+            Mixed(_, XY) => Arc::new(self.as_mixed().try_map_coords(map_op)?),
             GeometryCollection(_, XY) => {
-                Arc::new(self.as_geometry_collection::<2>().try_map_coords(map_op)?)
+                Arc::new(self.as_geometry_collection().try_map_coords(map_op)?)
             }
-            Rect(XY) => Arc::new(self.as_rect::<2>().try_map_coords(map_op)?),
+            Rect(XY) => Arc::new(self.as_rect().try_map_coords(map_op)?),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl MapCoords for ChunkedPointArray<2> {
-    type Output = ChunkedPointArray<2>;
+impl MapCoords for ChunkedPointArray {
+    type Output = ChunkedPointArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -480,8 +478,8 @@ impl MapCoords for ChunkedPointArray<2> {
     }
 }
 
-impl MapCoords for ChunkedLineStringArray<2> {
-    type Output = ChunkedLineStringArray<2>;
+impl MapCoords for ChunkedLineStringArray {
+    type Output = ChunkedLineStringArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -494,8 +492,8 @@ impl MapCoords for ChunkedLineStringArray<2> {
     }
 }
 
-impl MapCoords for ChunkedPolygonArray<2> {
-    type Output = ChunkedPolygonArray<2>;
+impl MapCoords for ChunkedPolygonArray {
+    type Output = ChunkedPolygonArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -508,8 +506,8 @@ impl MapCoords for ChunkedPolygonArray<2> {
     }
 }
 
-impl MapCoords for ChunkedMultiPointArray<2> {
-    type Output = ChunkedMultiPointArray<2>;
+impl MapCoords for ChunkedMultiPointArray {
+    type Output = ChunkedMultiPointArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -522,8 +520,8 @@ impl MapCoords for ChunkedMultiPointArray<2> {
     }
 }
 
-impl MapCoords for ChunkedMultiLineStringArray<2> {
-    type Output = ChunkedMultiLineStringArray<2>;
+impl MapCoords for ChunkedMultiLineStringArray {
+    type Output = ChunkedMultiLineStringArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -536,8 +534,8 @@ impl MapCoords for ChunkedMultiLineStringArray<2> {
     }
 }
 
-impl MapCoords for ChunkedMultiPolygonArray<2> {
-    type Output = ChunkedMultiPolygonArray<2>;
+impl MapCoords for ChunkedMultiPolygonArray {
+    type Output = ChunkedMultiPolygonArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -550,8 +548,8 @@ impl MapCoords for ChunkedMultiPolygonArray<2> {
     }
 }
 
-impl MapCoords for ChunkedMixedGeometryArray<2> {
-    type Output = ChunkedMixedGeometryArray<2>;
+impl MapCoords for ChunkedMixedGeometryArray {
+    type Output = ChunkedMixedGeometryArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -564,8 +562,8 @@ impl MapCoords for ChunkedMixedGeometryArray<2> {
     }
 }
 
-impl MapCoords for ChunkedGeometryCollectionArray<2> {
-    type Output = ChunkedGeometryCollectionArray<2>;
+impl MapCoords for ChunkedGeometryCollectionArray {
+    type Output = ChunkedGeometryCollectionArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -578,8 +576,8 @@ impl MapCoords for ChunkedGeometryCollectionArray<2> {
     }
 }
 
-impl MapCoords for ChunkedRectArray<2> {
-    type Output = ChunkedRectArray<2>;
+impl MapCoords for ChunkedRectArray {
+    type Output = ChunkedRectArray;
 
     fn try_map_coords<F, E>(&self, map_op: F) -> Result<Self::Output>
     where
@@ -604,19 +602,17 @@ impl MapCoords for &dyn ChunkedNativeArray {
         use NativeType::*;
 
         let result: Arc<dyn ChunkedNativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().try_map_coords(map_op)?),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().try_map_coords(map_op)?),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().try_map_coords(map_op)?),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().try_map_coords(map_op)?),
-            MultiLineString(_, XY) => {
-                Arc::new(self.as_multi_line_string::<2>().try_map_coords(map_op)?)
-            }
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().try_map_coords(map_op)?),
-            Mixed(_, XY) => Arc::new(self.as_mixed::<2>().try_map_coords(map_op)?),
+            Point(_, XY) => Arc::new(self.as_point().try_map_coords(map_op)?),
+            LineString(_, XY) => Arc::new(self.as_line_string().try_map_coords(map_op)?),
+            Polygon(_, XY) => Arc::new(self.as_polygon().try_map_coords(map_op)?),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().try_map_coords(map_op)?),
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().try_map_coords(map_op)?),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().try_map_coords(map_op)?),
+            Mixed(_, XY) => Arc::new(self.as_mixed().try_map_coords(map_op)?),
             GeometryCollection(_, XY) => {
-                Arc::new(self.as_geometry_collection::<2>().try_map_coords(map_op)?)
+                Arc::new(self.as_geometry_collection().try_map_coords(map_op)?)
             }
-            Rect(XY) => Arc::new(self.as_rect::<2>().try_map_coords(map_op)?),
+            Rect(XY) => Arc::new(self.as_rect().try_map_coords(map_op)?),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)

--- a/rust/geoarrow/src/algorithm/native/map_coords.rs
+++ b/rust/geoarrow/src/algorithm/native/map_coords.rs
@@ -13,6 +13,7 @@ use geo_traits::{
     MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait,
 };
 
+/// Note: this will currently always create a _two-dimensional_ output array because it returns a [`geo::Coord`].
 pub trait MapCoords {
     type Output;
 
@@ -221,6 +222,7 @@ impl MapCoords for PointArray {
         GeoArrowError: From<E>,
     {
         let mut builder = PointBuilder::with_capacity_and_options(
+            Dimension::XY,
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
@@ -246,6 +248,7 @@ impl MapCoords for LineStringArray {
         GeoArrowError: From<E>,
     {
         let mut builder = LineStringBuilder::with_capacity_and_options(
+            Dimension::XY,
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
@@ -271,6 +274,7 @@ impl MapCoords for PolygonArray {
         GeoArrowError: From<E>,
     {
         let mut builder = PolygonBuilder::with_capacity_and_options(
+            Dimension::XY,
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
@@ -296,6 +300,7 @@ impl MapCoords for MultiPointArray {
         GeoArrowError: From<E>,
     {
         let mut builder = MultiPointBuilder::with_capacity_and_options(
+            Dimension::XY,
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
@@ -321,6 +326,7 @@ impl MapCoords for MultiLineStringArray {
         GeoArrowError: From<E>,
     {
         let mut builder = MultiLineStringBuilder::with_capacity_and_options(
+            Dimension::XY,
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
@@ -346,6 +352,7 @@ impl MapCoords for MultiPolygonArray {
         GeoArrowError: From<E>,
     {
         let mut builder = MultiPolygonBuilder::with_capacity_and_options(
+            Dimension::XY,
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
@@ -371,6 +378,7 @@ impl MapCoords for MixedGeometryArray {
         GeoArrowError: From<E>,
     {
         let mut builder = MixedGeometryBuilder::with_capacity_and_options(
+            Dimension::XY,
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
@@ -397,6 +405,7 @@ impl MapCoords for GeometryCollectionArray {
         GeoArrowError: From<E>,
     {
         let mut builder = GeometryCollectionBuilder::with_capacity_and_options(
+            Dimension::XY,
             self.buffer_lengths(),
             self.coord_type(),
             self.metadata(),
@@ -422,7 +431,8 @@ impl MapCoords for RectArray {
         F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        let mut builder = RectBuilder::with_capacity_and_options(self.len(), self.metadata());
+        let mut builder =
+            RectBuilder::with_capacity_and_options(Dimension::XY, self.len(), self.metadata());
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
                 let result = geom.try_map_coords(&map_op)?;

--- a/rust/geoarrow/src/algorithm/native/rechunk.rs
+++ b/rust/geoarrow/src/algorithm/native/rechunk.rs
@@ -16,8 +16,8 @@ pub trait Rechunk {
     // }
 }
 
-impl Rechunk for PointArray<2> {
-    type Output = ChunkedGeometryArray<PointArray<2>>;
+impl Rechunk for PointArray {
+    type Output = ChunkedGeometryArray<PointArray>;
 
     fn rechunk(&self, ranges: &[Range<usize>]) -> Self::Output {
         let mut output_arrays = Vec::with_capacity(ranges.len());
@@ -56,15 +56,15 @@ macro_rules! rechunk_impl {
     };
 }
 
-rechunk_impl!(LineStringArray<2>);
-rechunk_impl!(PolygonArray<2>);
-rechunk_impl!(MultiPointArray<2>);
-rechunk_impl!(MultiLineStringArray<2>);
-rechunk_impl!(MultiPolygonArray<2>);
-rechunk_impl!(MixedGeometryArray<2>);
-rechunk_impl!(GeometryCollectionArray<2>);
+rechunk_impl!(LineStringArray);
+rechunk_impl!(PolygonArray);
+rechunk_impl!(MultiPointArray);
+rechunk_impl!(MultiLineStringArray);
+rechunk_impl!(MultiPolygonArray);
+rechunk_impl!(MixedGeometryArray);
+rechunk_impl!(GeometryCollectionArray);
 
-// impl<O: OffsetSizeTrait> Rechunk for LineStringArray<2> {
+// impl<O: OffsetSizeTrait> Rechunk for LineStringArray {
 //     type Output = Result<ChunkedGeometryArray<Self>>;
 
 //     fn rechunk(&self, ranges: &[Range<usize>]) -> Self::Output {

--- a/rust/geoarrow/src/algorithm/native/take.rs
+++ b/rust/geoarrow/src/algorithm/native/take.rs
@@ -25,6 +25,7 @@ impl Take for PointArray {
 
     fn take(&self, indices: &UInt32Array) -> Self::Output {
         let mut builder = PointBuilder::with_capacity_and_options(
+            self.dimension(),
             indices.len(),
             self.coord_type(),
             self.metadata(),
@@ -42,6 +43,7 @@ impl Take for PointArray {
 
     fn take_range(&self, range: &Range<usize>) -> Self::Output {
         let mut builder = PointBuilder::with_capacity_and_options(
+            self.dimension(),
             range.end - range.start,
             self.coord_type(),
             self.metadata(),
@@ -68,6 +70,7 @@ macro_rules! take_impl {
                 }
 
                 let mut builder = <$builder_type>::with_capacity_and_options(
+                    self.dimension(),
                     capacity,
                     self.coord_type(),
                     self.metadata(),
@@ -92,6 +95,7 @@ macro_rules! take_impl {
                 }
 
                 let mut builder = <$builder_type>::with_capacity_and_options(
+                    self.dimension(),
                     capacity,
                     self.coord_type(),
                     self.metadata(),
@@ -156,6 +160,7 @@ macro_rules! take_impl_fallible {
                 }
 
                 let mut builder = <$builder_type>::with_capacity_and_options(
+                    self.dimension(),
                     capacity,
                     self.coord_type(),
                     self.metadata(),
@@ -181,6 +186,7 @@ macro_rules! take_impl_fallible {
                 }
 
                 let mut builder = <$builder_type>::with_capacity_and_options(
+                    self.dimension(),
                     capacity,
                     self.coord_type(),
                     self.metadata(),

--- a/rust/geoarrow/src/algorithm/native/take.rs
+++ b/rust/geoarrow/src/algorithm/native/take.rs
@@ -20,7 +20,7 @@ pub trait Take {
     fn take_range(&self, range: &Range<usize>) -> Self::Output;
 }
 
-impl Take for PointArray<2> {
+impl Take for PointArray {
     type Output = Self;
 
     fn take(&self, indices: &UInt32Array) -> Self::Output {
@@ -108,37 +108,37 @@ macro_rules! take_impl {
 }
 
 take_impl!(
-    LineStringArray<2>,
+    LineStringArray,
     LineStringCapacity,
-    LineStringBuilder<2>,
+    LineStringBuilder,
     add_line_string,
     push_line_string
 );
 take_impl!(
-    PolygonArray<2>,
+    PolygonArray,
     PolygonCapacity,
-    PolygonBuilder<2>,
+    PolygonBuilder,
     add_polygon,
     push_polygon
 );
 take_impl!(
-    MultiPointArray<2>,
+    MultiPointArray,
     MultiPointCapacity,
-    MultiPointBuilder<2>,
+    MultiPointBuilder,
     add_multi_point,
     push_multi_point
 );
 take_impl!(
-    MultiLineStringArray<2>,
+    MultiLineStringArray,
     MultiLineStringCapacity,
-    MultiLineStringBuilder<2>,
+    MultiLineStringBuilder,
     add_multi_line_string,
     push_multi_line_string
 );
 take_impl!(
-    MultiPolygonArray<2>,
+    MultiPolygonArray,
     MultiPolygonCapacity,
-    MultiPolygonBuilder<2>,
+    MultiPolygonBuilder,
     add_multi_polygon,
     push_multi_polygon
 );
@@ -198,16 +198,16 @@ macro_rules! take_impl_fallible {
 }
 
 take_impl_fallible!(
-    MixedGeometryArray<2>,
+    MixedGeometryArray,
     MixedCapacity,
-    MixedGeometryBuilder<2>,
+    MixedGeometryBuilder,
     add_geometry,
     push_geometry
 );
 take_impl_fallible!(
-    GeometryCollectionArray<2>,
+    GeometryCollectionArray,
     GeometryCollectionCapacity,
-    GeometryCollectionBuilder<2>,
+    GeometryCollectionBuilder,
     add_geometry_collection,
     push_geometry_collection
 );
@@ -220,16 +220,14 @@ impl Take for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().take(indices)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().take(indices)?),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().take(indices)?),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().take(indices)?),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().take(indices)?),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().take(indices)?),
-            Mixed(_, XY) => Arc::new(self.as_mixed::<2>().take(indices)?),
-            GeometryCollection(_, XY) => {
-                Arc::new(self.as_geometry_collection::<2>().take(indices)?)
-            }
+            Point(_, XY) => Arc::new(self.as_point().take(indices)),
+            LineString(_, XY) => Arc::new(self.as_line_string().take(indices)?),
+            Polygon(_, XY) => Arc::new(self.as_polygon().take(indices)?),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().take(indices)?),
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().take(indices)?),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().take(indices)?),
+            Mixed(_, XY) => Arc::new(self.as_mixed().take(indices)?),
+            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection().take(indices)?),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
@@ -240,24 +238,22 @@ impl Take for &dyn NativeArray {
         use NativeType::*;
 
         let result: Arc<dyn NativeArray> = match self.data_type() {
-            Point(_, XY) => Arc::new(self.as_point::<2>().take_range(range)),
-            LineString(_, XY) => Arc::new(self.as_line_string::<2>().take_range(range)?),
-            Polygon(_, XY) => Arc::new(self.as_polygon::<2>().take_range(range)?),
-            MultiPoint(_, XY) => Arc::new(self.as_multi_point::<2>().take_range(range)?),
-            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string::<2>().take_range(range)?),
-            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon::<2>().take_range(range)?),
-            Mixed(_, XY) => Arc::new(self.as_mixed::<2>().take_range(range)?),
-            GeometryCollection(_, XY) => {
-                Arc::new(self.as_geometry_collection::<2>().take_range(range)?)
-            }
+            Point(_, XY) => Arc::new(self.as_point().take_range(range)),
+            LineString(_, XY) => Arc::new(self.as_line_string().take_range(range)?),
+            Polygon(_, XY) => Arc::new(self.as_polygon().take_range(range)?),
+            MultiPoint(_, XY) => Arc::new(self.as_multi_point().take_range(range)?),
+            MultiLineString(_, XY) => Arc::new(self.as_multi_line_string().take_range(range)?),
+            MultiPolygon(_, XY) => Arc::new(self.as_multi_polygon().take_range(range)?),
+            Mixed(_, XY) => Arc::new(self.as_mixed().take_range(range)?),
+            GeometryCollection(_, XY) => Arc::new(self.as_geometry_collection().take_range(range)?),
             _ => return Err(GeoArrowError::IncorrectType("".into())),
         };
         Ok(result)
     }
 }
 
-impl Take for ChunkedGeometryArray<PointArray<2>> {
-    type Output = Result<ChunkedGeometryArray<PointArray<2>>>;
+impl Take for ChunkedGeometryArray<PointArray> {
+    type Output = Result<ChunkedGeometryArray<PointArray>>;
 
     fn take(&self, indices: &UInt32Array) -> Self::Output {
         let mut output_chunks = Vec::with_capacity(self.chunks.len());
@@ -305,10 +301,10 @@ macro_rules! chunked_impl {
     };
 }
 
-chunked_impl!(ChunkedGeometryArray<LineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<PolygonArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPointArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiLineStringArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MultiPolygonArray<2>>);
-chunked_impl!(ChunkedGeometryArray<MixedGeometryArray<2>>);
-chunked_impl!(ChunkedGeometryArray<GeometryCollectionArray<2>>);
+chunked_impl!(ChunkedGeometryArray<LineStringArray>);
+chunked_impl!(ChunkedGeometryArray<PolygonArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPointArray>);
+chunked_impl!(ChunkedGeometryArray<MultiLineStringArray>);
+chunked_impl!(ChunkedGeometryArray<MultiPolygonArray>);
+chunked_impl!(ChunkedGeometryArray<MixedGeometryArray>);
+chunked_impl!(ChunkedGeometryArray<GeometryCollectionArray>);

--- a/rust/geoarrow/src/algorithm/native/total_bounds.rs
+++ b/rust/geoarrow/src/algorithm/native/total_bounds.rs
@@ -10,7 +10,7 @@ pub trait TotalBounds {
     fn total_bounds(&self) -> BoundingRect;
 }
 
-impl<const D: usize> TotalBounds for PointArray<D> {
+impl TotalBounds for PointArray {
     fn total_bounds(&self) -> BoundingRect {
         let mut bounds = BoundingRect::new();
         for geom in self.iter().flatten() {
@@ -20,7 +20,7 @@ impl<const D: usize> TotalBounds for PointArray<D> {
     }
 }
 
-impl<const D: usize> TotalBounds for RectArray<D> {
+impl TotalBounds for RectArray {
     fn total_bounds(&self) -> BoundingRect {
         let mut bounds = BoundingRect::new();
         for geom in self.iter().flatten() {
@@ -32,7 +32,7 @@ impl<const D: usize> TotalBounds for RectArray<D> {
 
 macro_rules! impl_array {
     ($type:ty, $func:ident) => {
-        impl<const D: usize> TotalBounds for $type {
+        impl TotalBounds for $type {
             fn total_bounds(&self) -> BoundingRect {
                 let mut bounds = BoundingRect::new();
                 for geom in self.iter().flatten() {
@@ -44,13 +44,13 @@ macro_rules! impl_array {
     };
 }
 
-impl_array!(LineStringArray<D>, add_line_string);
-impl_array!(PolygonArray<D>, add_polygon);
-impl_array!(MultiPointArray<D>, add_multi_point);
-impl_array!(MultiLineStringArray<D>, add_multi_line_string);
-impl_array!(MultiPolygonArray<D>, add_multi_polygon);
-impl_array!(MixedGeometryArray<D>, add_geometry);
-impl_array!(GeometryCollectionArray<D>, add_geometry_collection);
+impl_array!(LineStringArray, add_line_string);
+impl_array!(PolygonArray, add_polygon);
+impl_array!(MultiPointArray, add_multi_point);
+impl_array!(MultiLineStringArray, add_multi_line_string);
+impl_array!(MultiPolygonArray, add_multi_polygon);
+impl_array!(MixedGeometryArray, add_geometry);
+impl_array!(GeometryCollectionArray, add_geometry_collection);
 
 // impl<O: OffsetSizeTrait> TotalBounds for WKBArray<O> {
 //     fn total_bounds(&self) -> BoundingRect {

--- a/rust/geoarrow/src/algorithm/native/total_bounds.rs
+++ b/rust/geoarrow/src/algorithm/native/total_bounds.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::native::bounding_rect::BoundingRect;
 use crate::array::*;
 use crate::chunked_array::*;
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
 
@@ -64,28 +64,18 @@ impl_array!(GeometryCollectionArray, add_geometry_collection);
 
 impl TotalBounds for &dyn NativeArray {
     fn total_bounds(&self) -> BoundingRect {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().total_bounds(),
-            LineString(_, XY) => self.as_line_string::<2>().total_bounds(),
-            Polygon(_, XY) => self.as_polygon::<2>().total_bounds(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().total_bounds(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().total_bounds(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().total_bounds(),
-            Mixed(_, XY) => self.as_mixed::<2>().total_bounds(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().total_bounds(),
-            Rect(XY) => self.as_rect::<2>().total_bounds(),
-            Point(_, XYZ) => self.as_point::<3>().total_bounds(),
-            LineString(_, XYZ) => self.as_line_string::<3>().total_bounds(),
-            Polygon(_, XYZ) => self.as_polygon::<3>().total_bounds(),
-            MultiPoint(_, XYZ) => self.as_multi_point::<3>().total_bounds(),
-            MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().total_bounds(),
-            MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().total_bounds(),
-            Mixed(_, XYZ) => self.as_mixed::<3>().total_bounds(),
-            GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().total_bounds(),
-            Rect(XYZ) => self.as_rect::<3>().total_bounds(),
+            Point(_, _) => self.as_point().total_bounds(),
+            LineString(_, _) => self.as_line_string().total_bounds(),
+            Polygon(_, _) => self.as_polygon().total_bounds(),
+            MultiPoint(_, _) => self.as_multi_point().total_bounds(),
+            MultiLineString(_, _) => self.as_multi_line_string().total_bounds(),
+            MultiPolygon(_, _) => self.as_multi_polygon().total_bounds(),
+            Mixed(_, _) => self.as_mixed().total_bounds(),
+            GeometryCollection(_, _) => self.as_geometry_collection().total_bounds(),
+            Rect(_) => self.as_rect().total_bounds(),
             // WKB => self.as_wkb().total_bounds(),
             // LargeWKB => self.as_large_wkb().total_bounds(),
         }
@@ -103,29 +93,18 @@ impl<G: NativeArray> TotalBounds for ChunkedGeometryArray<G> {
 
 impl TotalBounds for &dyn ChunkedNativeArray {
     fn total_bounds(&self) -> BoundingRect {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point::<2>().total_bounds(),
-            LineString(_, XY) => self.as_line_string::<2>().total_bounds(),
-            Polygon(_, XY) => self.as_polygon::<2>().total_bounds(),
-            MultiPoint(_, XY) => self.as_multi_point::<2>().total_bounds(),
-            MultiLineString(_, XY) => self.as_multi_line_string::<2>().total_bounds(),
-            MultiPolygon(_, XY) => self.as_multi_polygon::<2>().total_bounds(),
-            Mixed(_, XY) => self.as_mixed::<2>().total_bounds(),
-            GeometryCollection(_, XY) => self.as_geometry_collection::<2>().total_bounds(),
-            Rect(XY) => self.as_rect::<2>().total_bounds(),
-
-            Point(_, XYZ) => self.as_point::<3>().total_bounds(),
-            LineString(_, XYZ) => self.as_line_string::<3>().total_bounds(),
-            Polygon(_, XYZ) => self.as_polygon::<3>().total_bounds(),
-            MultiPoint(_, XYZ) => self.as_multi_point::<3>().total_bounds(),
-            MultiLineString(_, XYZ) => self.as_multi_line_string::<3>().total_bounds(),
-            MultiPolygon(_, XYZ) => self.as_multi_polygon::<3>().total_bounds(),
-            Mixed(_, XYZ) => self.as_mixed::<3>().total_bounds(),
-            GeometryCollection(_, XYZ) => self.as_geometry_collection::<3>().total_bounds(),
-            Rect(XYZ) => self.as_rect::<3>().total_bounds(),
+            Point(_, _) => self.as_point().total_bounds(),
+            LineString(_, _) => self.as_line_string().total_bounds(),
+            Polygon(_, _) => self.as_polygon().total_bounds(),
+            MultiPoint(_, _) => self.as_multi_point().total_bounds(),
+            MultiLineString(_, _) => self.as_multi_line_string().total_bounds(),
+            MultiPolygon(_, _) => self.as_multi_polygon().total_bounds(),
+            Mixed(_, _) => self.as_mixed().total_bounds(),
+            GeometryCollection(_, _) => self.as_geometry_collection().total_bounds(),
+            Rect(_) => self.as_rect().total_bounds(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/native/type_id.rs
+++ b/rust/geoarrow/src/algorithm/native/type_id.rs
@@ -37,7 +37,7 @@ pub trait TypeIds {
     fn get_unique_type_ids(&self) -> HashSet<i16>;
 }
 
-impl TypeIds for PointArray<2> {
+impl TypeIds for PointArray {
     fn get_type_ids(&self) -> Int16Array {
         let values = vec![0i16; self.len()];
         Int16Array::new(values.into(), self.nulls().cloned())
@@ -67,13 +67,13 @@ macro_rules! constant_impl {
     };
 }
 
-constant_impl!(LineStringArray<2>, 1);
-constant_impl!(PolygonArray<2>, 3);
-constant_impl!(MultiPointArray<2>, 4);
-constant_impl!(MultiLineStringArray<2>, 5);
-constant_impl!(MultiPolygonArray<2>, 6);
+constant_impl!(LineStringArray, 1);
+constant_impl!(PolygonArray, 3);
+constant_impl!(MultiPointArray, 4);
+constant_impl!(MultiLineStringArray, 5);
+constant_impl!(MultiPolygonArray, 6);
 
-impl TypeIds for MixedGeometryArray<2> {
+impl TypeIds for MixedGeometryArray {
     fn get_type_ids(&self) -> Int16Array {
         use crate::scalar::Geometry::*;
 

--- a/rust/geoarrow/src/algorithm/native/unary.rs
+++ b/rust/geoarrow/src/algorithm/native/unary.rs
@@ -86,20 +86,20 @@ pub trait Unary<'a>: ArrayAccessor<'a> {
     }
 }
 
-impl<'a, const D: usize> Unary<'a> for PointArray<D> {}
-impl<'a, const D: usize> Unary<'a> for LineStringArray<D> {}
-impl<'a, const D: usize> Unary<'a> for PolygonArray<D> {}
-impl<'a, const D: usize> Unary<'a> for MultiPointArray<D> {}
-impl<'a, const D: usize> Unary<'a> for MultiLineStringArray<D> {}
-impl<'a, const D: usize> Unary<'a> for MultiPolygonArray<D> {}
-impl<'a, const D: usize> Unary<'a> for MixedGeometryArray<D> {}
-impl<'a, const D: usize> Unary<'a> for GeometryCollectionArray<D> {}
-impl<'a, const D: usize> Unary<'a> for RectArray<D> {}
+impl<'a> Unary<'a> for PointArray {}
+impl<'a> Unary<'a> for LineStringArray {}
+impl<'a> Unary<'a> for PolygonArray {}
+impl<'a> Unary<'a> for MultiPointArray {}
+impl<'a> Unary<'a> for MultiLineStringArray {}
+impl<'a> Unary<'a> for MultiPolygonArray {}
+impl<'a> Unary<'a> for MixedGeometryArray {}
+impl<'a> Unary<'a> for GeometryCollectionArray {}
+impl<'a> Unary<'a> for RectArray {}
 impl<'a, O: OffsetSizeTrait> Unary<'a> for WKBArray<O> {}
 
 #[allow(dead_code)]
 pub trait UnaryPoint<'a>: ArrayAccessor<'a> + NativeArray {
-    fn unary_point<F, G>(&'a self, op: F) -> PointArray<2>
+    fn unary_point<F, G>(&'a self, op: F) -> PointArray
     where
         G: PointTrait<T = f64> + 'a,
         F: Fn(Self::Item) -> &'a G,
@@ -113,7 +113,7 @@ pub trait UnaryPoint<'a>: ArrayAccessor<'a> + NativeArray {
         result
     }
 
-    fn try_unary_point<F, G, E>(&'a self, op: F) -> std::result::Result<PointArray<2>, E>
+    fn try_unary_point<F, G, E>(&'a self, op: F) -> std::result::Result<PointArray, E>
     where
         G: PointTrait<T = f64> + 'a,
         F: Fn(Self::Item) -> std::result::Result<G, E>,
@@ -133,12 +133,12 @@ pub trait UnaryPoint<'a>: ArrayAccessor<'a> + NativeArray {
     }
 }
 
-impl<'a> UnaryPoint<'a> for PointArray<2> {}
-impl<'a> UnaryPoint<'a> for LineStringArray<2> {}
-impl<'a> UnaryPoint<'a> for PolygonArray<2> {}
-impl<'a> UnaryPoint<'a> for MultiPointArray<2> {}
-impl<'a> UnaryPoint<'a> for MultiLineStringArray<2> {}
-impl<'a> UnaryPoint<'a> for MultiPolygonArray<2> {}
-impl<'a> UnaryPoint<'a> for MixedGeometryArray<2> {}
-impl<'a> UnaryPoint<'a> for GeometryCollectionArray<2> {}
-impl<'a> UnaryPoint<'a> for RectArray<2> {}
+impl<'a> UnaryPoint<'a> for PointArray {}
+impl<'a> UnaryPoint<'a> for LineStringArray {}
+impl<'a> UnaryPoint<'a> for PolygonArray {}
+impl<'a> UnaryPoint<'a> for MultiPointArray {}
+impl<'a> UnaryPoint<'a> for MultiLineStringArray {}
+impl<'a> UnaryPoint<'a> for MultiPolygonArray {}
+impl<'a> UnaryPoint<'a> for MixedGeometryArray {}
+impl<'a> UnaryPoint<'a> for GeometryCollectionArray {}
+impl<'a> UnaryPoint<'a> for RectArray {}

--- a/rust/geoarrow/src/algorithm/polylabel.rs
+++ b/rust/geoarrow/src/algorithm/polylabel.rs
@@ -25,8 +25,8 @@ pub trait Polylabel {
     fn polylabel(&self, tolerance: f64) -> Self::Output;
 }
 
-impl Polylabel for PolygonArray<2> {
-    type Output = Result<PointArray<2>>;
+impl Polylabel for PolygonArray {
+    type Output = Result<PointArray>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         Ok(self.try_unary_point(|geom| polylabel(&geom.to_geo(), &tolerance))?)
@@ -34,18 +34,18 @@ impl Polylabel for PolygonArray<2> {
 }
 
 impl Polylabel for &dyn NativeArray {
-    type Output = Result<PointArray<2>>;
+    type Output = Result<PointArray>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         match self.data_type() {
-            NativeType::Polygon(_, Dimension::XY) => self.as_polygon::<2>().polylabel(tolerance),
+            NativeType::Polygon(_, Dimension::XY) => self.as_polygon().polylabel(tolerance),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }
 }
 
-impl Polylabel for ChunkedPolygonArray<2> {
-    type Output = Result<ChunkedPointArray<2>>;
+impl Polylabel for ChunkedPolygonArray {
+    type Output = Result<ChunkedPointArray>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         let chunks = self.try_map(|chunk| chunk.polylabel(tolerance))?;
@@ -54,11 +54,11 @@ impl Polylabel for ChunkedPolygonArray<2> {
 }
 
 impl Polylabel for &dyn ChunkedNativeArray {
-    type Output = Result<ChunkedPointArray<2>>;
+    type Output = Result<ChunkedPointArray>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
         match self.data_type() {
-            NativeType::Polygon(_, Dimension::XY) => self.as_polygon::<2>().polylabel(tolerance),
+            NativeType::Polygon(_, Dimension::XY) => self.as_polygon().polylabel(tolerance),
             _ => Err(GeoArrowError::IncorrectType("".into())),
         }
     }

--- a/rust/geoarrow/src/algorithm/polylabel.rs
+++ b/rust/geoarrow/src/algorithm/polylabel.rs
@@ -29,7 +29,7 @@ impl Polylabel for PolygonArray {
     type Output = Result<PointArray>;
 
     fn polylabel(&self, tolerance: f64) -> Self::Output {
-        Ok(self.try_unary_point(|geom| polylabel(&geom.to_geo(), &tolerance))?)
+        Ok(self.try_unary_point(|geom| polylabel(&geom.to_geo(), &tolerance), Dimension::XY)?)
     }
 }
 

--- a/rust/geoarrow/src/algorithm/proj.rs
+++ b/rust/geoarrow/src/algorithm/proj.rs
@@ -12,7 +12,7 @@ pub trait Reproject {
         Self: Sized;
 }
 
-impl Reproject for PointArray<2> {
+impl Reproject for PointArray {
     fn reproject(&self, proj: &Proj) -> Result<Self> {
         let mut output_array = PointBuilder::with_capacity(self.len());
 
@@ -50,19 +50,15 @@ macro_rules! iter_geo_impl {
     };
 }
 
-iter_geo_impl!(LineStringArray<2>, LineStringBuilder<2>, push_line_string);
-iter_geo_impl!(PolygonArray<2>, PolygonBuilder<2>, push_polygon);
-iter_geo_impl!(MultiPointArray<2>, MultiPointBuilder<2>, push_multi_point);
+iter_geo_impl!(LineStringArray, LineStringBuilder, push_line_string);
+iter_geo_impl!(PolygonArray, PolygonBuilder, push_polygon);
+iter_geo_impl!(MultiPointArray, MultiPointBuilder, push_multi_point);
 iter_geo_impl!(
-    MultiLineStringArray<2>,
-    MultiLineStringBuilder<2>,
+    MultiLineStringArray,
+    MultiLineStringBuilder,
     push_multi_line_string
 );
-iter_geo_impl!(
-    MultiPolygonArray<2>,
-    MultiPolygonBuilder<2>,
-    push_multi_polygon
-);
+iter_geo_impl!(MultiPolygonArray, MultiPolygonBuilder, push_multi_polygon);
 
 #[cfg(test)]
 mod test {
@@ -74,7 +70,7 @@ mod test {
 
     #[test]
     fn point_round_trip() {
-        let point_array: PointArray<2> = vec![Some(p0()), Some(p1()), Some(p2())].into();
+        let point_array: PointArray = vec![Some(p0()), Some(p1()), Some(p2())].into();
         let proj = Proj::new_known_crs("EPSG:4326", "EPSG:3857", None).unwrap();
 
         // You can verify this with PROJ on the command line:

--- a/rust/geoarrow/src/algorithm/rstar.rs
+++ b/rust/geoarrow/src/algorithm/rstar.rs
@@ -13,8 +13,8 @@ pub trait RTree<'a> {
     fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject>;
 }
 
-impl<'a> RTree<'a> for PointArray<2> {
-    type RTreeObject = crate::scalar::Point<'a, 2>;
+impl<'a> RTree<'a> for PointArray {
+    type RTreeObject = crate::scalar::Point<'a>;
 
     fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject> {
         // Note: for points we don't memoize with CachedEnvelope
@@ -22,8 +22,8 @@ impl<'a> RTree<'a> for PointArray<2> {
     }
 }
 
-impl<'a> RTree<'a> for RectArray<2> {
-    type RTreeObject = crate::scalar::Rect<'a, 2>;
+impl<'a> RTree<'a> for RectArray {
+    type RTreeObject = crate::scalar::Rect<'a>;
 
     fn rstar_tree(&'a self) -> rstar::RTree<Self::RTreeObject> {
         // Note: for rects we don't memoize with CachedEnvelope
@@ -43,16 +43,13 @@ macro_rules! iter_cached_impl {
     };
 }
 
-iter_cached_impl!(LineStringArray<2>, crate::scalar::LineString<'a, 2>);
-iter_cached_impl!(PolygonArray<2>, crate::scalar::Polygon<'a, 2>);
-iter_cached_impl!(MultiPointArray<2>, crate::scalar::MultiPoint<'a, 2>);
+iter_cached_impl!(LineStringArray, crate::scalar::LineString<'a>);
+iter_cached_impl!(PolygonArray, crate::scalar::Polygon<'a>);
+iter_cached_impl!(MultiPointArray, crate::scalar::MultiPoint<'a>);
+iter_cached_impl!(MultiLineStringArray, crate::scalar::MultiLineString<'a>);
+iter_cached_impl!(MultiPolygonArray, crate::scalar::MultiPolygon<'a>);
+iter_cached_impl!(MixedGeometryArray, crate::scalar::Geometry<'a>);
 iter_cached_impl!(
-    MultiLineStringArray<2>,
-    crate::scalar::MultiLineString<'a, 2>
-);
-iter_cached_impl!(MultiPolygonArray<2>, crate::scalar::MultiPolygon<'a, 2>);
-iter_cached_impl!(MixedGeometryArray<2>, crate::scalar::Geometry<'a, 2>);
-iter_cached_impl!(
-    GeometryCollectionArray<2>,
-    crate::scalar::GeometryCollection<'a, 2>
+    GeometryCollectionArray,
+    crate::scalar::GeometryCollection<'a>
 );

--- a/rust/geoarrow/src/array/cast.rs
+++ b/rust/geoarrow/src/array/cast.rs
@@ -4,135 +4,135 @@ use crate::chunked_array::*;
 /// Helpers for downcasting a [`NativeArray`] to a concrete implementation.
 pub trait AsNativeArray {
     /// Downcast this to a [`PointArray`] returning `None` if not possible
-    fn as_point_opt<const D: usize>(&self) -> Option<&PointArray<D>>;
+    fn as_point_opt(&self) -> Option<&PointArray>;
 
     /// Downcast this to a [`PointArray`] panicking if not possible
     #[inline]
-    fn as_point<const D: usize>(&self) -> &PointArray<D> {
-        self.as_point_opt::<D>().unwrap()
+    fn as_point(&self) -> &PointArray {
+        self.as_point_opt().unwrap()
     }
 
     /// Downcast this to a [`LineStringArray`] with `i32` offsets returning `None` if not possible
-    fn as_line_string_opt<const D: usize>(&self) -> Option<&LineStringArray<D>>;
+    fn as_line_string_opt(&self) -> Option<&LineStringArray>;
 
     /// Downcast this to a [`LineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_line_string<const D: usize>(&self) -> &LineStringArray<D> {
-        self.as_line_string_opt::<D>().unwrap()
+    fn as_line_string(&self) -> &LineStringArray {
+        self.as_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`PolygonArray`] with `i32` offsets returning `None` if not possible
-    fn as_polygon_opt<const D: usize>(&self) -> Option<&PolygonArray<D>>;
+    fn as_polygon_opt(&self) -> Option<&PolygonArray>;
 
     /// Downcast this to a [`PolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_polygon<const D: usize>(&self) -> &PolygonArray<D> {
-        self.as_polygon_opt::<D>().unwrap()
+    fn as_polygon(&self) -> &PolygonArray {
+        self.as_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiPointArray`] with `i32` offsets returning `None` if not possible
-    fn as_multi_point_opt<const D: usize>(&self) -> Option<&MultiPointArray<D>>;
+    fn as_multi_point_opt(&self) -> Option<&MultiPointArray>;
 
     /// Downcast this to a [`MultiPointArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_point<const D: usize>(&self) -> &MultiPointArray<D> {
-        self.as_multi_point_opt::<D>().unwrap()
+    fn as_multi_point(&self) -> &MultiPointArray {
+        self.as_multi_point_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiLineStringArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&MultiLineStringArray<D>>;
+    fn as_multi_line_string_opt(&self) -> Option<&MultiLineStringArray>;
 
     /// Downcast this to a [`MultiLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_line_string<const D: usize>(&self) -> &MultiLineStringArray<D> {
-        self.as_multi_line_string_opt::<D>().unwrap()
+    fn as_multi_line_string(&self) -> &MultiLineStringArray {
+        self.as_multi_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`MultiPolygonArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&MultiPolygonArray<D>>;
+    fn as_multi_polygon_opt(&self) -> Option<&MultiPolygonArray>;
 
     /// Downcast this to a [`MultiPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_polygon<const D: usize>(&self) -> &MultiPolygonArray<D> {
-        self.as_multi_polygon_opt::<D>().unwrap()
+    fn as_multi_polygon(&self) -> &MultiPolygonArray {
+        self.as_multi_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`MixedGeometryArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_mixed_opt<const D: usize>(&self) -> Option<&MixedGeometryArray<D>>;
+    fn as_mixed_opt(&self) -> Option<&MixedGeometryArray>;
 
     /// Downcast this to a [`MixedGeometryArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_mixed<const D: usize>(&self) -> &MixedGeometryArray<D> {
-        self.as_mixed_opt::<D>().unwrap()
+    fn as_mixed(&self) -> &MixedGeometryArray {
+        self.as_mixed_opt().unwrap()
     }
 
     /// Downcast this to a [`GeometryCollectionArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_geometry_collection_opt<const D: usize>(&self) -> Option<&GeometryCollectionArray<D>>;
+    fn as_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray>;
 
     /// Downcast this to a [`GeometryCollectionArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_geometry_collection<const D: usize>(&self) -> &GeometryCollectionArray<D> {
-        self.as_geometry_collection_opt::<D>().unwrap()
+    fn as_geometry_collection(&self) -> &GeometryCollectionArray {
+        self.as_geometry_collection_opt().unwrap()
     }
 
     /// Downcast this to a [`RectArray`] returning `None` if not possible
-    fn as_rect_opt<const D: usize>(&self) -> Option<&RectArray<D>>;
+    fn as_rect_opt(&self) -> Option<&RectArray>;
 
     /// Downcast this to a [`RectArray`] panicking if not possible
     #[inline]
-    fn as_rect<const D: usize>(&self) -> &RectArray<D> {
-        self.as_rect_opt::<D>().unwrap()
+    fn as_rect(&self) -> &RectArray {
+        self.as_rect_opt().unwrap()
     }
 }
 
 impl AsNativeArray for &dyn NativeArray {
     #[inline]
-    fn as_point_opt<const D: usize>(&self) -> Option<&PointArray<D>> {
-        self.as_any().downcast_ref::<PointArray<D>>()
+    fn as_point_opt(&self) -> Option<&PointArray> {
+        self.as_any().downcast_ref::<PointArray>()
     }
 
     #[inline]
-    fn as_line_string_opt<const D: usize>(&self) -> Option<&LineStringArray<D>> {
-        self.as_any().downcast_ref::<LineStringArray<D>>()
+    fn as_line_string_opt(&self) -> Option<&LineStringArray> {
+        self.as_any().downcast_ref::<LineStringArray>()
     }
 
     #[inline]
-    fn as_polygon_opt<const D: usize>(&self) -> Option<&PolygonArray<D>> {
-        self.as_any().downcast_ref::<PolygonArray<D>>()
+    fn as_polygon_opt(&self) -> Option<&PolygonArray> {
+        self.as_any().downcast_ref::<PolygonArray>()
     }
 
     #[inline]
-    fn as_multi_point_opt<const D: usize>(&self) -> Option<&MultiPointArray<D>> {
-        self.as_any().downcast_ref::<MultiPointArray<D>>()
+    fn as_multi_point_opt(&self) -> Option<&MultiPointArray> {
+        self.as_any().downcast_ref::<MultiPointArray>()
     }
 
     #[inline]
-    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&MultiLineStringArray<D>> {
-        self.as_any().downcast_ref::<MultiLineStringArray<D>>()
+    fn as_multi_line_string_opt(&self) -> Option<&MultiLineStringArray> {
+        self.as_any().downcast_ref::<MultiLineStringArray>()
     }
 
     #[inline]
-    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&MultiPolygonArray<D>> {
-        self.as_any().downcast_ref::<MultiPolygonArray<D>>()
+    fn as_multi_polygon_opt(&self) -> Option<&MultiPolygonArray> {
+        self.as_any().downcast_ref::<MultiPolygonArray>()
     }
 
     #[inline]
-    fn as_mixed_opt<const D: usize>(&self) -> Option<&MixedGeometryArray<D>> {
-        self.as_any().downcast_ref::<MixedGeometryArray<D>>()
+    fn as_mixed_opt(&self) -> Option<&MixedGeometryArray> {
+        self.as_any().downcast_ref::<MixedGeometryArray>()
     }
 
     #[inline]
-    fn as_geometry_collection_opt<const D: usize>(&self) -> Option<&GeometryCollectionArray<D>> {
-        self.as_any().downcast_ref::<GeometryCollectionArray<D>>()
+    fn as_geometry_collection_opt(&self) -> Option<&GeometryCollectionArray> {
+        self.as_any().downcast_ref::<GeometryCollectionArray>()
     }
 
     #[inline]
-    fn as_rect_opt<const D: usize>(&self) -> Option<&RectArray<D>> {
-        self.as_any().downcast_ref::<RectArray<D>>()
+    fn as_rect_opt(&self) -> Option<&RectArray> {
+        self.as_any().downcast_ref::<RectArray>()
     }
 }
 
@@ -171,141 +171,136 @@ impl AsSerializedArray for &dyn SerializedArray {
 /// Helpers for downcasting a [`ChunkedNativeArray`] to a concrete implementation.
 pub trait AsChunkedNativeArray {
     /// Downcast this to a [`ChunkedPointArray`] returning `None` if not possible
-    fn as_point_opt<const D: usize>(&self) -> Option<&ChunkedPointArray<D>>;
+    fn as_point_opt(&self) -> Option<&ChunkedPointArray>;
 
     /// Downcast this to a [`ChunkedPointArray`] panicking if not possible
     #[inline]
-    fn as_point<const D: usize>(&self) -> &ChunkedPointArray<D> {
-        self.as_point_opt::<D>().unwrap()
+    fn as_point(&self) -> &ChunkedPointArray {
+        self.as_point_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedLineStringArray`] with `i32` offsets returning `None` if not possible
-    fn as_line_string_opt<const D: usize>(&self) -> Option<&ChunkedLineStringArray<D>>;
+    fn as_line_string_opt(&self) -> Option<&ChunkedLineStringArray>;
 
     /// Downcast this to a [`ChunkedLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_line_string<const D: usize>(&self) -> &ChunkedLineStringArray<D> {
-        self.as_line_string_opt::<D>().unwrap()
+    fn as_line_string(&self) -> &ChunkedLineStringArray {
+        self.as_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedPolygonArray`] with `i32` offsets returning `None` if not possible
-    fn as_polygon_opt<const D: usize>(&self) -> Option<&ChunkedPolygonArray<D>>;
+    fn as_polygon_opt(&self) -> Option<&ChunkedPolygonArray>;
 
     /// Downcast this to a [`ChunkedPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_polygon<const D: usize>(&self) -> &ChunkedPolygonArray<D> {
-        self.as_polygon_opt::<D>().unwrap()
+    fn as_polygon(&self) -> &ChunkedPolygonArray {
+        self.as_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiPointArray`] with `i32` offsets returning `None` if not possible
-    fn as_multi_point_opt<const D: usize>(&self) -> Option<&ChunkedMultiPointArray<D>>;
+    fn as_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray>;
 
     /// Downcast this to a [`ChunkedMultiPointArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_point<const D: usize>(&self) -> &ChunkedMultiPointArray<D> {
-        self.as_multi_point_opt::<D>().unwrap()
+    fn as_multi_point(&self) -> &ChunkedMultiPointArray {
+        self.as_multi_point_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&ChunkedMultiLineStringArray<D>>;
+    fn as_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray>;
 
     /// Downcast this to a [`ChunkedMultiLineStringArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_line_string<const D: usize>(&self) -> &ChunkedMultiLineStringArray<D> {
-        self.as_multi_line_string_opt::<D>().unwrap()
+    fn as_multi_line_string(&self) -> &ChunkedMultiLineStringArray {
+        self.as_multi_line_string_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&ChunkedMultiPolygonArray<D>>;
+    fn as_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray>;
 
     /// Downcast this to a [`ChunkedMultiPolygonArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_multi_polygon<const D: usize>(&self) -> &ChunkedMultiPolygonArray<D> {
-        self.as_multi_polygon_opt::<D>().unwrap()
+    fn as_multi_polygon(&self) -> &ChunkedMultiPolygonArray {
+        self.as_multi_polygon_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_mixed_opt<const D: usize>(&self) -> Option<&ChunkedMixedGeometryArray<D>>;
+    fn as_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray>;
 
     /// Downcast this to a [`ChunkedMixedGeometryArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_mixed<const D: usize>(&self) -> &ChunkedMixedGeometryArray<D> {
-        self.as_mixed_opt::<D>().unwrap()
+    fn as_mixed(&self) -> &ChunkedMixedGeometryArray {
+        self.as_mixed_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i32` offsets returning `None` if not
     /// possible
-    fn as_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedGeometryCollectionArray<D>>;
+    fn as_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray>;
 
     /// Downcast this to a [`ChunkedGeometryCollectionArray`] with `i32` offsets panicking if not possible
     #[inline]
-    fn as_geometry_collection<const D: usize>(&self) -> &ChunkedGeometryCollectionArray<D> {
-        self.as_geometry_collection_opt::<D>().unwrap()
+    fn as_geometry_collection(&self) -> &ChunkedGeometryCollectionArray {
+        self.as_geometry_collection_opt().unwrap()
     }
 
     /// Downcast this to a [`ChunkedRectArray`] returning `None` if not possible
-    fn as_rect_opt<const D: usize>(&self) -> Option<&ChunkedRectArray<D>>;
+    fn as_rect_opt(&self) -> Option<&ChunkedRectArray>;
 
     /// Downcast this to a [`ChunkedRectArray`] panicking if not possible
     #[inline]
-    fn as_rect<const D: usize>(&self) -> &ChunkedRectArray<D> {
-        self.as_rect_opt::<D>().unwrap()
+    fn as_rect(&self) -> &ChunkedRectArray {
+        self.as_rect_opt().unwrap()
     }
 }
 
 impl AsChunkedNativeArray for &dyn ChunkedNativeArray {
     #[inline]
-    fn as_point_opt<const D: usize>(&self) -> Option<&ChunkedPointArray<D>> {
-        self.as_any().downcast_ref::<ChunkedPointArray<D>>()
+    fn as_point_opt(&self) -> Option<&ChunkedPointArray> {
+        self.as_any().downcast_ref::<ChunkedPointArray>()
     }
 
     #[inline]
-    fn as_line_string_opt<const D: usize>(&self) -> Option<&ChunkedLineStringArray<D>> {
-        self.as_any().downcast_ref::<ChunkedLineStringArray<D>>()
+    fn as_line_string_opt(&self) -> Option<&ChunkedLineStringArray> {
+        self.as_any().downcast_ref::<ChunkedLineStringArray>()
     }
 
     #[inline]
-    fn as_polygon_opt<const D: usize>(&self) -> Option<&ChunkedPolygonArray<D>> {
-        self.as_any().downcast_ref::<ChunkedPolygonArray<D>>()
+    fn as_polygon_opt(&self) -> Option<&ChunkedPolygonArray> {
+        self.as_any().downcast_ref::<ChunkedPolygonArray>()
     }
 
     #[inline]
-    fn as_multi_point_opt<const D: usize>(&self) -> Option<&ChunkedMultiPointArray<D>> {
-        self.as_any().downcast_ref::<ChunkedMultiPointArray<D>>()
+    fn as_multi_point_opt(&self) -> Option<&ChunkedMultiPointArray> {
+        self.as_any().downcast_ref::<ChunkedMultiPointArray>()
     }
 
     #[inline]
-    fn as_multi_line_string_opt<const D: usize>(&self) -> Option<&ChunkedMultiLineStringArray<D>> {
+    fn as_multi_line_string_opt(&self) -> Option<&ChunkedMultiLineStringArray> {
+        self.as_any().downcast_ref::<ChunkedMultiLineStringArray>()
+    }
+
+    #[inline]
+    fn as_multi_polygon_opt(&self) -> Option<&ChunkedMultiPolygonArray> {
+        self.as_any().downcast_ref::<ChunkedMultiPolygonArray>()
+    }
+
+    #[inline]
+    fn as_mixed_opt(&self) -> Option<&ChunkedMixedGeometryArray> {
+        self.as_any().downcast_ref::<ChunkedMixedGeometryArray>()
+    }
+
+    #[inline]
+    fn as_geometry_collection_opt(&self) -> Option<&ChunkedGeometryCollectionArray> {
         self.as_any()
-            .downcast_ref::<ChunkedMultiLineStringArray<D>>()
+            .downcast_ref::<ChunkedGeometryCollectionArray>()
     }
 
     #[inline]
-    fn as_multi_polygon_opt<const D: usize>(&self) -> Option<&ChunkedMultiPolygonArray<D>> {
-        self.as_any().downcast_ref::<ChunkedMultiPolygonArray<D>>()
-    }
-
-    #[inline]
-    fn as_mixed_opt<const D: usize>(&self) -> Option<&ChunkedMixedGeometryArray<D>> {
-        self.as_any().downcast_ref::<ChunkedMixedGeometryArray<D>>()
-    }
-
-    #[inline]
-    fn as_geometry_collection_opt<const D: usize>(
-        &self,
-    ) -> Option<&ChunkedGeometryCollectionArray<D>> {
-        self.as_any()
-            .downcast_ref::<ChunkedGeometryCollectionArray<D>>()
-    }
-
-    #[inline]
-    fn as_rect_opt<const D: usize>(&self) -> Option<&ChunkedRectArray<D>> {
-        self.as_any().downcast_ref::<ChunkedRectArray<D>>()
+    fn as_rect_opt(&self) -> Option<&ChunkedRectArray> {
+        self.as_any().downcast_ref::<ChunkedRectArray>()
     }
 }
 

--- a/rust/geoarrow/src/array/dynamic.rs
+++ b/rust/geoarrow/src/array/dynamic.rs
@@ -33,39 +33,39 @@ impl NativeArrayDyn {
         use NativeType::*;
         let geo_arr: Arc<dyn NativeArray> = match data_type {
             Point(_, dim) => match dim {
-                XY => Arc::new(PointArray::<2>::try_from((array, field))?),
+                XY => Arc::new(PointArray::try_from((array, field))?),
                 XYZ => Arc::new(PointArray::<3>::try_from((array, field))?),
             },
             LineString(_, dim) => match dim {
-                XY => Arc::new(LineStringArray::<2>::try_from((array, field))?),
+                XY => Arc::new(LineStringArray::try_from((array, field))?),
                 XYZ => Arc::new(LineStringArray::<3>::try_from((array, field))?),
             },
             Polygon(_, dim) => match dim {
-                XY => Arc::new(PolygonArray::<2>::try_from((array, field))?),
+                XY => Arc::new(PolygonArray::try_from((array, field))?),
                 XYZ => Arc::new(PolygonArray::<3>::try_from((array, field))?),
             },
             MultiPoint(_, dim) => match dim {
-                XY => Arc::new(MultiPointArray::<2>::try_from((array, field))?),
+                XY => Arc::new(MultiPointArray::try_from((array, field))?),
                 XYZ => Arc::new(MultiPointArray::<3>::try_from((array, field))?),
             },
             MultiLineString(_, dim) => match dim {
-                XY => Arc::new(MultiLineStringArray::<2>::try_from((array, field))?),
+                XY => Arc::new(MultiLineStringArray::try_from((array, field))?),
                 XYZ => Arc::new(MultiLineStringArray::<3>::try_from((array, field))?),
             },
             MultiPolygon(_, dim) => match dim {
-                XY => Arc::new(MultiPolygonArray::<2>::try_from((array, field))?),
+                XY => Arc::new(MultiPolygonArray::try_from((array, field))?),
                 XYZ => Arc::new(MultiPolygonArray::<3>::try_from((array, field))?),
             },
             Mixed(_, dim) => match dim {
-                XY => Arc::new(MixedGeometryArray::<2>::try_from((array, field))?),
+                XY => Arc::new(MixedGeometryArray::try_from((array, field))?),
                 XYZ => Arc::new(MixedGeometryArray::<3>::try_from((array, field))?),
             },
             GeometryCollection(_, dim) => match dim {
-                XY => Arc::new(GeometryCollectionArray::<2>::try_from((array, field))?),
+                XY => Arc::new(GeometryCollectionArray::try_from((array, field))?),
                 XYZ => Arc::new(GeometryCollectionArray::<3>::try_from((array, field))?),
             },
             Rect(dim) => match dim {
-                XY => Arc::new(RectArray::<2>::try_from((array, field))?),
+                XY => Arc::new(RectArray::try_from((array, field))?),
                 XYZ => Arc::new(RectArray::<3>::try_from((array, field))?),
             },
         };

--- a/rust/geoarrow/src/array/dynamic.rs
+++ b/rust/geoarrow/src/array/dynamic.rs
@@ -11,7 +11,7 @@ use crate::array::metadata::ArrayMetadata;
 use crate::array::wkt::WKTArray;
 use crate::array::CoordType;
 use crate::array::*;
-use crate::datatypes::{Dimension, NativeType, SerializedType};
+use crate::datatypes::{NativeType, SerializedType};
 use crate::error::Result;
 use crate::trait_::{NativeArrayRef, SerializedArray, SerializedArrayRef};
 use crate::{ArrayBase, NativeArray};
@@ -29,45 +29,19 @@ impl NativeArrayDyn {
     pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Self> {
         let data_type = NativeType::try_from(field)?;
 
-        use Dimension::*;
         use NativeType::*;
         let geo_arr: Arc<dyn NativeArray> = match data_type {
-            Point(_, dim) => match dim {
-                XY => Arc::new(PointArray::try_from((array, field))?),
-                XYZ => Arc::new(PointArray::<3>::try_from((array, field))?),
-            },
-            LineString(_, dim) => match dim {
-                XY => Arc::new(LineStringArray::try_from((array, field))?),
-                XYZ => Arc::new(LineStringArray::<3>::try_from((array, field))?),
-            },
-            Polygon(_, dim) => match dim {
-                XY => Arc::new(PolygonArray::try_from((array, field))?),
-                XYZ => Arc::new(PolygonArray::<3>::try_from((array, field))?),
-            },
-            MultiPoint(_, dim) => match dim {
-                XY => Arc::new(MultiPointArray::try_from((array, field))?),
-                XYZ => Arc::new(MultiPointArray::<3>::try_from((array, field))?),
-            },
-            MultiLineString(_, dim) => match dim {
-                XY => Arc::new(MultiLineStringArray::try_from((array, field))?),
-                XYZ => Arc::new(MultiLineStringArray::<3>::try_from((array, field))?),
-            },
-            MultiPolygon(_, dim) => match dim {
-                XY => Arc::new(MultiPolygonArray::try_from((array, field))?),
-                XYZ => Arc::new(MultiPolygonArray::<3>::try_from((array, field))?),
-            },
-            Mixed(_, dim) => match dim {
-                XY => Arc::new(MixedGeometryArray::try_from((array, field))?),
-                XYZ => Arc::new(MixedGeometryArray::<3>::try_from((array, field))?),
-            },
-            GeometryCollection(_, dim) => match dim {
-                XY => Arc::new(GeometryCollectionArray::try_from((array, field))?),
-                XYZ => Arc::new(GeometryCollectionArray::<3>::try_from((array, field))?),
-            },
-            Rect(dim) => match dim {
-                XY => Arc::new(RectArray::try_from((array, field))?),
-                XYZ => Arc::new(RectArray::<3>::try_from((array, field))?),
-            },
+            Point(_, _) => Arc::new(PointArray::try_from((array, field))?),
+            LineString(_, _) => Arc::new(LineStringArray::try_from((array, field))?),
+            Polygon(_, _) => Arc::new(PolygonArray::try_from((array, field))?),
+            MultiPoint(_, _) => Arc::new(MultiPointArray::try_from((array, field))?),
+            MultiLineString(_, _) => Arc::new(MultiLineStringArray::try_from((array, field))?),
+            MultiPolygon(_, _) => Arc::new(MultiPolygonArray::try_from((array, field))?),
+            Mixed(_, _) => Arc::new(MixedGeometryArray::try_from((array, field))?),
+            GeometryCollection(_, _) => {
+                Arc::new(GeometryCollectionArray::try_from((array, field))?)
+            }
+            Rect(_) => Arc::new(RectArray::try_from((array, field))?),
         };
 
         Ok(Self(geo_arr))

--- a/rust/geoarrow/src/array/geometry/array.rs
+++ b/rust/geoarrow/src/array/geometry/array.rs
@@ -15,7 +15,7 @@ use crate::array::{
 use crate::datatypes::NativeType;
 use crate::error::GeoArrowError;
 use crate::scalar::Geometry;
-use crate::trait_::{GeometryArraySelfMethods, IntoArrow, ArrayAccessor};
+use crate::trait_::{ArrayAccessor, GeometryArraySelfMethods, IntoArrow};
 use crate::NativeArray;
 
 /// A GeometryArray is an enum over the various underlying _zero copy_ GeoArrow array types.
@@ -173,7 +173,7 @@ impl<O: OffsetSizeTrait> NativeArray for GeometryArray<O> {
 }
 
 impl<O: OffsetSizeTrait> GeometryArraySelfMethods for GeometryArray<O> {
-    fn with_coords(self, coords: crate::array::CoordBuffer<2>) -> Self {
+    fn with_coords(self, coords: crate::array::CoordBuffer) -> Self {
         match self {
             GeometryArray::Point(arr) => GeometryArray::Point(arr.with_coords(coords)),
             GeometryArray::LineString(arr) => GeometryArray::LineString(arr.with_coords(coords)),

--- a/rust/geoarrow/src/array/geometrycollection/array.rs
+++ b/rust/geoarrow/src/array/geometrycollection/array.rs
@@ -13,7 +13,7 @@ use crate::array::{
     CoordBuffer, CoordType, LineStringArray, MixedGeometryArray, MultiLineStringArray,
     MultiPointArray, MultiPolygonArray, PointArray, PolygonArray, WKBArray,
 };
-use crate::datatypes::NativeType;
+use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::{Geometry, GeometryCollection};
 use crate::trait_::{ArrayAccessor, GeometryArraySelfMethods, IntoArrow, NativeGeometryAccessor};
@@ -326,24 +326,26 @@ impl TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray {
     }
 }
 
-impl<G: GeometryCollectionTrait<T = f64>> From<&[G]> for GeometryCollectionArray {
-    fn from(other: &[G]) -> Self {
+impl<G: GeometryCollectionTrait<T = f64>> From<(&[G], Dimension)> for GeometryCollectionArray {
+    fn from(other: (&[G], Dimension)) -> Self {
         let mut_arr: GeometryCollectionBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: GeometryCollectionTrait<T = f64>> From<Vec<Option<G>>> for GeometryCollectionArray {
-    fn from(other: Vec<Option<G>>) -> Self {
+impl<G: GeometryCollectionTrait<T = f64>> From<(Vec<Option<G>>, Dimension)>
+    for GeometryCollectionArray
+{
+    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
         let mut_arr: GeometryCollectionBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for GeometryCollectionArray {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for GeometryCollectionArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKBArray<O>) -> Result<Self> {
+    fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
         let mut_arr: GeometryCollectionBuilder = value.try_into()?;
         Ok(mut_arr.into())
     }

--- a/rust/geoarrow/src/array/geometrycollection/array.rs
+++ b/rust/geoarrow/src/array/geometrycollection/array.rs
@@ -53,7 +53,7 @@ impl GeometryCollectionArray {
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let coord_type = array.coord_type();
-        let data_type = NativeType::GeometryCollection(coord_type, array.dim());
+        let data_type = NativeType::GeometryCollection(coord_type, array.dimension());
         Self {
             data_type,
             array,

--- a/rust/geoarrow/src/array/linestring/array.rs
+++ b/rust/geoarrow/src/array/linestring/array.rs
@@ -411,15 +411,15 @@ impl TryFrom<(&dyn Array, &Field)> for LineStringArray {
     }
 }
 
-impl<G: LineStringTrait<T = f64>> From<Vec<Option<G>>> for LineStringArray {
-    fn from(other: Vec<Option<G>>) -> Self {
+impl<G: LineStringTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for LineStringArray {
+    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
         let mut_arr: LineStringBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: LineStringTrait<T = f64>> From<&[G]> for LineStringArray {
-    fn from(other: &[G]) -> Self {
+impl<G: LineStringTrait<T = f64>> From<(&[G], Dimension)> for LineStringArray {
+    fn from(other: (&[G], Dimension)) -> Self {
         let mut_arr: LineStringBuilder = other.into();
         mut_arr.into()
     }
@@ -515,6 +515,7 @@ impl TryFrom<MixedGeometryArray> for LineStringArray {
         capacity.geom_capacity += buffer_lengths.ring_capacity;
 
         let mut builder = LineStringBuilder::with_capacity_and_options(
+            value.dim(),
             capacity,
             value.coord_type(),
             value.metadata(),

--- a/rust/geoarrow/src/array/linestring/array.rs
+++ b/rust/geoarrow/src/array/linestring/array.rs
@@ -438,10 +438,10 @@ impl From<LineStringArray> for MultiPointArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringArray {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for LineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKBArray<O>) -> Result<Self> {
+    fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
         let mut_arr: LineStringBuilder = value.try_into()?;
         Ok(mut_arr.into())
     }
@@ -546,14 +546,14 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: LineStringArray = vec![ls0(), ls1()].as_slice().into();
+        let arr: LineStringArray = (vec![ls0(), ls1()].as_slice(), Dimension::XY).into();
         assert_eq!(arr.value_as_geo(0), ls0());
         assert_eq!(arr.value_as_geo(1), ls1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: LineStringArray = vec![Some(ls0()), Some(ls1()), None].into();
+        let arr: LineStringArray = (vec![Some(ls0()), Some(ls1()), None], Dimension::XY).into();
         assert_eq!(arr.get_as_geo(0), Some(ls0()));
         assert_eq!(arr.get_as_geo(1), Some(ls1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -561,7 +561,7 @@ mod test {
 
     // #[test]
     // fn rstar_integration() {
-    //     let arr: LineStringArray = vec![ls0(), ls1()].as_slice().into();
+    //     let arr: LineStringArray = (vec![ls0(), ls1()].as_slice(), Dimension::XY).into();
     //     let tree = arr.rstar_tree();
 
     //     let search_box = AABB::from_corners([3.5, 5.5], [4.5, 6.5]);
@@ -577,7 +577,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: LineStringArray = vec![ls0(), ls1()].as_slice().into();
+        let arr: LineStringArray = (vec![ls0(), ls1()].as_slice(), Dimension::XY).into();
         let sliced = arr.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(ls1()));
@@ -585,7 +585,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: LineStringArray = vec![ls0(), ls1()].as_slice().into();
+        let arr: LineStringArray = (vec![ls0(), ls1()].as_slice(), Dimension::XY).into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -602,7 +602,7 @@ mod test {
         let linestring_arr = example_linestring_interleaved();
 
         let wkb_arr = example_linestring_wkb();
-        let parsed_linestring_arr: LineStringArray = wkb_arr.try_into().unwrap();
+        let parsed_linestring_arr: LineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(linestring_arr, parsed_linestring_arr);
     }
@@ -612,7 +612,7 @@ mod test {
         let linestring_arr = example_linestring_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_linestring_wkb();
-        let parsed_linestring_arr: LineStringArray = wkb_arr.try_into().unwrap();
+        let parsed_linestring_arr: LineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(linestring_arr, parsed_linestring_arr);
     }

--- a/rust/geoarrow/src/array/linestring/array.rs
+++ b/rust/geoarrow/src/array/linestring/array.rs
@@ -515,7 +515,7 @@ impl TryFrom<MixedGeometryArray> for LineStringArray {
         capacity.geom_capacity += buffer_lengths.ring_capacity;
 
         let mut builder = LineStringBuilder::with_capacity_and_options(
-            value.dim(),
+            value.dimension(),
             capacity,
             value.coord_type(),
             value.metadata(),

--- a/rust/geoarrow/src/array/linestring/builder.rs
+++ b/rust/geoarrow/src/array/linestring/builder.rs
@@ -301,8 +301,8 @@ impl LineStringBuilder {
     }
 
     pub fn from_nullable_geometries(
-        dim: Dimension,
         geoms: &[Option<impl GeometryTrait<T = f64>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
@@ -318,8 +318,8 @@ impl LineStringBuilder {
     }
 
     pub(crate) fn from_wkb<W: OffsetSizeTrait>(
-        dim: Dimension,
         wkb_objects: &[Option<WKB<'_, W>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
@@ -327,7 +327,7 @@ impl LineStringBuilder {
             .iter()
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(dim, &wkb_objects2, coord_type, metadata)
+        Self::from_nullable_geometries(&wkb_objects2, dim, coord_type, metadata)
     }
 }
 
@@ -424,13 +424,13 @@ impl<G: LineStringTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for LineStri
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for LineStringBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for LineStringBuilder {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKBArray<O>) -> Result<Self> {
+    fn try_from((value, dim): (WKBArray<O>, Dimension)) -> Result<Self> {
         let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, Default::default(), metadata)
+        Self::from_wkb(&wkb_objects, dim, Default::default(), metadata)
     }
 }
 

--- a/rust/geoarrow/src/array/mixed/array.rs
+++ b/rust/geoarrow/src/array/mixed/array.rs
@@ -286,10 +286,6 @@ impl MixedGeometryArray {
             && self.has_multi_polygons()
     }
 
-    pub fn dim(&self) -> Dimension {
-        todo!()
-    }
-
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
         self.buffer_lengths().num_bytes()

--- a/rust/geoarrow/src/array/mixed/array.rs
+++ b/rust/geoarrow/src/array/mixed/array.rs
@@ -659,12 +659,12 @@ impl TryFrom<&UnionArray> for MixedGeometryArray {
         Ok(Self::new(
             type_ids,
             offsets,
-            points.get(0).cloned().unwrap_or_default(),
-            line_strings.get(0).cloned().unwrap_or_default(),
-            polygons.get(0).cloned().unwrap_or_default(),
-            multi_points.get(0).cloned().unwrap_or_default(),
-            multi_line_strings.get(0).cloned().unwrap_or_default(),
-            multi_polygons.get(0).cloned().unwrap_or_default(),
+            points.first().cloned().unwrap_or_default(),
+            line_strings.first().cloned().unwrap_or_default(),
+            polygons.first().cloned().unwrap_or_default(),
+            multi_points.first().cloned().unwrap_or_default(),
+            multi_line_strings.first().cloned().unwrap_or_default(),
+            multi_polygons.first().cloned().unwrap_or_default(),
             Default::default(),
         ))
     }

--- a/rust/geoarrow/src/array/multilinestring/array.rs
+++ b/rust/geoarrow/src/array/multilinestring/array.rs
@@ -464,15 +464,15 @@ impl TryFrom<(&dyn Array, &Field)> for MultiLineStringArray {
     }
 }
 
-impl<G: MultiLineStringTrait<T = f64>> From<Vec<Option<G>>> for MultiLineStringArray {
-    fn from(other: Vec<Option<G>>) -> Self {
+impl<G: MultiLineStringTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for MultiLineStringArray {
+    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
         let mut_arr: MultiLineStringBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: MultiLineStringTrait<T = f64>> From<&[G]> for MultiLineStringArray {
-    fn from(other: &[G]) -> Self {
+impl<G: MultiLineStringTrait<T = f64>> From<(&[G], Dimension)> for MultiLineStringArray {
+    fn from(other: (&[G], Dimension)) -> Self {
         let mut_arr: MultiLineStringBuilder = other.into();
         mut_arr.into()
     }

--- a/rust/geoarrow/src/array/multilinestring/array.rs
+++ b/rust/geoarrow/src/array/multilinestring/array.rs
@@ -492,10 +492,10 @@ impl From<MultiLineStringArray> for PolygonArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringArray {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MultiLineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKBArray<O>) -> Result<Self> {
+    fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
         let mut_arr: MultiLineStringBuilder = value.try_into()?;
         Ok(mut_arr.into())
     }
@@ -596,14 +596,15 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: MultiLineStringArray = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray = (vec![ml0(), ml1()].as_slice(), Dimension::XY).into();
         assert_eq!(arr.value_as_geo(0), ml0());
         assert_eq!(arr.value_as_geo(1), ml1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: MultiLineStringArray = vec![Some(ml0()), Some(ml1()), None].into();
+        let arr: MultiLineStringArray =
+            (vec![Some(ml0()), Some(ml1()), None], Dimension::XY).into();
         assert_eq!(arr.get_as_geo(0), Some(ml0()));
         assert_eq!(arr.get_as_geo(1), Some(ml1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -611,7 +612,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiLineStringArray = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray = (vec![ml0(), ml1()].as_slice(), Dimension::XY).into();
         let sliced = arr.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(ml1()));
@@ -619,7 +620,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: MultiLineStringArray = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray = (vec![ml0(), ml1()].as_slice(), Dimension::XY).into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -640,7 +641,7 @@ mod test {
         let geom_arr = example_multilinestring_interleaved();
 
         let wkb_arr = example_multilinestring_wkb();
-        let parsed_geom_arr: MultiLineStringArray = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiLineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }
@@ -650,7 +651,7 @@ mod test {
         let geom_arr = example_multilinestring_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_multilinestring_wkb();
-        let parsed_geom_arr: MultiLineStringArray = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiLineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }

--- a/rust/geoarrow/src/array/multilinestring/array.rs
+++ b/rust/geoarrow/src/array/multilinestring/array.rs
@@ -564,7 +564,7 @@ impl TryFrom<MixedGeometryArray> for MultiLineStringArray {
         capacity += value.line_strings.buffer_lengths();
 
         let mut builder = MultiLineStringBuilder::with_capacity_and_options(
-            value.dim(),
+            value.dimension(),
             capacity,
             value.coord_type(),
             value.metadata(),

--- a/rust/geoarrow/src/array/multilinestring/array.rs
+++ b/rust/geoarrow/src/array/multilinestring/array.rs
@@ -27,7 +27,7 @@ use super::MultiLineStringBuilder;
 /// This is semantically equivalent to `Vec<Option<MultiLineString>>` due to the internal validity
 /// bitmap.
 #[derive(Debug, Clone)]
-pub struct MultiLineStringArray<const D: usize> {
+pub struct MultiLineStringArray {
     // Always NativeType::MultiLineString or NativeType::LargeMultiLineString
     data_type: NativeType,
 
@@ -72,7 +72,7 @@ pub(super) fn check(
     Ok(())
 }
 
-impl<const D: usize> MultiLineStringArray<D> {
+impl MultiLineStringArray {
     /// Create a new MultiLineStringArray from parts
     ///
     /// # Implementation
@@ -118,10 +118,7 @@ impl<const D: usize> MultiLineStringArray<D> {
             &ring_offsets,
             validity.as_ref().map(|v| v.len()),
         )?;
-
-        let coord_type = coords.coord_type();
-        let data_type = NativeType::MultiLineString(coord_type, D.try_into()?);
-
+        let data_type = NativeType::MultiLineString(coords.coord_type(), coords.dim());
         Ok(Self {
             data_type,
             coords,
@@ -240,7 +237,7 @@ impl<const D: usize> MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> ArrayBase for MultiLineStringArray<D> {
+impl ArrayBase for MultiLineStringArray {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -284,7 +281,7 @@ impl<const D: usize> ArrayBase for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> NativeArray for MultiLineStringArray<D> {
+impl NativeArray for MultiLineStringArray {
     fn data_type(&self) -> NativeType {
         self.data_type
     }
@@ -316,7 +313,7 @@ impl<const D: usize> NativeArray for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> GeometryArraySelfMethods<D> for MultiLineStringArray<D> {
+impl GeometryArraySelfMethods for MultiLineStringArray {
     fn with_coords(self, coords: CoordBuffer) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(
@@ -339,8 +336,8 @@ impl<const D: usize> GeometryArraySelfMethods<D> for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> NativeGeometryAccessor<D> for MultiLineStringArray<D> {
-    unsafe fn value_as_geometry_unchecked(&self, index: usize) -> crate::scalar::Geometry<D> {
+impl NativeGeometryAccessor for MultiLineStringArray {
+    unsafe fn value_as_geometry_unchecked(&self, index: usize) -> crate::scalar::Geometry {
         Geometry::MultiLineString(MultiLineString::new(
             &self.coords,
             &self.geom_offsets,
@@ -351,19 +348,19 @@ impl<const D: usize> NativeGeometryAccessor<D> for MultiLineStringArray<D> {
 }
 
 #[cfg(feature = "geos")]
-impl<'a, const D: usize> crate::trait_::NativeGEOSGeometryAccessor<'a> for MultiLineStringArray<D> {
+impl<'a> crate::trait_::NativeGEOSGeometryAccessor<'a> for MultiLineStringArray {
     unsafe fn value_as_geometry_unchecked(
         &'a self,
         index: usize,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         let geom =
-            MultiLineString::<D>::new(&self.coords, &self.geom_offsets, &self.ring_offsets, index);
+            MultiLineString::new(&self.coords, &self.geom_offsets, &self.ring_offsets, index);
         (&geom).try_into()
     }
 }
 
-impl<'a, const D: usize> ArrayAccessor<'a> for MultiLineStringArray<D> {
-    type Item = MultiLineString<'a, D>;
+impl<'a> ArrayAccessor<'a> for MultiLineStringArray {
+    type Item = MultiLineString<'a>;
     type ItemGeo = geo::MultiLineString;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -371,7 +368,7 @@ impl<'a, const D: usize> ArrayAccessor<'a> for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> IntoArrow for MultiLineStringArray<D> {
+impl IntoArrow for MultiLineStringArray {
     type ArrowArray = GenericListArray<i32>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -389,7 +386,7 @@ impl<const D: usize> IntoArrow for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<&GenericListArray<i32>> for MultiLineStringArray<D> {
+impl TryFrom<&GenericListArray<i32>> for MultiLineStringArray {
     type Error = GeoArrowError;
 
     fn try_from(geom_array: &GenericListArray<i32>) -> Result<Self> {
@@ -412,7 +409,7 @@ impl<const D: usize> TryFrom<&GenericListArray<i32>> for MultiLineStringArray<D>
     }
 }
 
-impl<const D: usize> TryFrom<&GenericListArray<i64>> for MultiLineStringArray<D> {
+impl TryFrom<&GenericListArray<i64>> for MultiLineStringArray {
     type Error = GeoArrowError;
 
     fn try_from(geom_array: &GenericListArray<i64>) -> Result<Self> {
@@ -435,7 +432,7 @@ impl<const D: usize> TryFrom<&GenericListArray<i64>> for MultiLineStringArray<D>
     }
 }
 
-impl<const D: usize> TryFrom<&dyn Array> for MultiLineStringArray<D> {
+impl TryFrom<&dyn Array> for MultiLineStringArray {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
@@ -456,7 +453,7 @@ impl<const D: usize> TryFrom<&dyn Array> for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiLineStringArray<D> {
+impl TryFrom<(&dyn Array, &Field)> for MultiLineStringArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -467,25 +464,25 @@ impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiLineStringArray<D> {
 }
 
 impl<G: MultiLineStringTrait<T = f64>, const D: usize> From<Vec<Option<G>>>
-    for MultiLineStringArray<D>
+    for MultiLineStringArray
 {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: MultiLineStringBuilder<D> = other.into();
+        let mut_arr: MultiLineStringBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: MultiLineStringTrait<T = f64>, const D: usize> From<&[G]> for MultiLineStringArray<D> {
+impl<G: MultiLineStringTrait<T = f64>, const D: usize> From<&[G]> for MultiLineStringArray {
     fn from(other: &[G]) -> Self {
-        let mut_arr: MultiLineStringBuilder<D> = other.into();
+        let mut_arr: MultiLineStringBuilder = other.into();
         mut_arr.into()
     }
 }
 
 /// Polygon and MultiLineString have the same layout, so enable conversions between the two to
 /// change the semantic type
-impl<const D: usize> From<MultiLineStringArray<D>> for PolygonArray<D> {
-    fn from(value: MultiLineStringArray<D>) -> Self {
+impl From<MultiLineStringArray> for PolygonArray {
+    fn from(value: MultiLineStringArray) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -496,17 +493,17 @@ impl<const D: usize> From<MultiLineStringArray<D>> for PolygonArray<D> {
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiLineStringArray<D> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiLineStringArray {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
-        let mut_arr: MultiLineStringBuilder<D> = value.try_into()?;
+        let mut_arr: MultiLineStringBuilder = value.try_into()?;
         Ok(mut_arr.into())
     }
 }
 
-impl<const D: usize> From<LineStringArray<D>> for MultiLineStringArray<D> {
-    fn from(value: LineStringArray<D>) -> Self {
+impl From<LineStringArray> for MultiLineStringArray {
+    fn from(value: LineStringArray) -> Self {
         let coords = value.coords;
         let geom_offsets = OffsetBuffer::from_lengths(vec![1; coords.len()]);
         let ring_offsets = value.geom_offsets;
@@ -516,13 +513,13 @@ impl<const D: usize> From<LineStringArray<D>> for MultiLineStringArray<D> {
 }
 
 /// Default to an empty array
-impl<const D: usize> Default for MultiLineStringArray<D> {
+impl Default for MultiLineStringArray {
     fn default() -> Self {
         MultiLineStringBuilder::default().into()
     }
 }
 
-impl<const D: usize> PartialEq for MultiLineStringArray<D> {
+impl PartialEq for MultiLineStringArray {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;
@@ -544,10 +541,10 @@ impl<const D: usize> PartialEq for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<MixedGeometryArray<D>> for MultiLineStringArray<D> {
+impl TryFrom<MixedGeometryArray> for MultiLineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: MixedGeometryArray<D>) -> Result<Self> {
+    fn try_from(value: MixedGeometryArray) -> Result<Self> {
         if value.has_points()
             || value.has_polygons()
             || value.has_multi_points()
@@ -567,7 +564,7 @@ impl<const D: usize> TryFrom<MixedGeometryArray<D>> for MultiLineStringArray<D> 
         let mut capacity = value.multi_line_strings.buffer_lengths();
         capacity += value.line_strings.buffer_lengths();
 
-        let mut builder = MultiLineStringBuilder::<D>::with_capacity_and_options(
+        let mut builder = MultiLineStringBuilder::with_capacity_and_options(
             capacity,
             value.coord_type(),
             value.metadata(),
@@ -579,10 +576,10 @@ impl<const D: usize> TryFrom<MixedGeometryArray<D>> for MultiLineStringArray<D> 
     }
 }
 
-impl<const D: usize> TryFrom<GeometryCollectionArray<D>> for MultiLineStringArray<D> {
+impl TryFrom<GeometryCollectionArray> for MultiLineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: GeometryCollectionArray<D>) -> Result<Self> {
+    fn try_from(value: GeometryCollectionArray) -> Result<Self> {
         MixedGeometryArray::try_from(value)?.try_into()
     }
 }
@@ -599,14 +596,14 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray = vec![ml0(), ml1()].as_slice().into();
         assert_eq!(arr.value_as_geo(0), ml0());
         assert_eq!(arr.value_as_geo(1), ml1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: MultiLineStringArray<2> = vec![Some(ml0()), Some(ml1()), None].into();
+        let arr: MultiLineStringArray = vec![Some(ml0()), Some(ml1()), None].into();
         assert_eq!(arr.get_as_geo(0), Some(ml0()));
         assert_eq!(arr.get_as_geo(1), Some(ml1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -614,7 +611,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray = vec![ml0(), ml1()].as_slice().into();
         let sliced = arr.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(ml1()));
@@ -622,7 +619,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
+        let arr: MultiLineStringArray = vec![ml0(), ml1()].as_slice().into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -643,7 +640,7 @@ mod test {
         let geom_arr = example_multilinestring_interleaved();
 
         let wkb_arr = example_multilinestring_wkb();
-        let parsed_geom_arr: MultiLineStringArray<2> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiLineStringArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }
@@ -653,7 +650,7 @@ mod test {
         let geom_arr = example_multilinestring_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_multilinestring_wkb();
-        let parsed_geom_arr: MultiLineStringArray<2> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiLineStringArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }

--- a/rust/geoarrow/src/array/multilinestring/builder.rs
+++ b/rust/geoarrow/src/array/multilinestring/builder.rs
@@ -405,6 +405,7 @@ impl MultiLineStringBuilder {
 
     pub(crate) fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
@@ -412,7 +413,7 @@ impl MultiLineStringBuilder {
             .iter()
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata)
+        Self::from_nullable_geometries(&wkb_objects2, dim, coord_type, metadata)
     }
 }
 
@@ -510,13 +511,13 @@ impl<G: MultiLineStringTrait<T = f64>> From<(Vec<Option<G>>, Dimension)>
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiLineStringBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MultiLineStringBuilder {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKBArray<O>) -> Result<Self> {
+    fn try_from((value, dim): (WKBArray<O>, Dimension)) -> Result<Self> {
         let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, Default::default(), metadata)
+        Self::from_wkb(&wkb_objects, dim, Default::default(), metadata)
     }
 }
 

--- a/rust/geoarrow/src/array/multipoint/array.rs
+++ b/rust/geoarrow/src/array/multipoint/array.rs
@@ -9,7 +9,7 @@ use crate::array::{
     CoordBuffer, CoordType, GeometryCollectionArray, LineStringArray, MixedGeometryArray,
     PointArray, WKBArray,
 };
-use crate::datatypes::NativeType;
+use crate::datatypes::{Dimension, NativeType};
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::{Geometry, MultiPoint};
 use crate::trait_::{ArrayAccessor, GeometryArraySelfMethods, IntoArrow, NativeGeometryAccessor};
@@ -333,11 +333,11 @@ impl IntoArrow for MultiPointArray {
     }
 }
 
-impl TryFrom<&GenericListArray<i32>> for MultiPointArray {
+impl TryFrom<(&GenericListArray<i32>, Dimension)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: &GenericListArray<i32>) -> Result<Self> {
-        let coords = CoordBuffer::from_arrow(value.values().as_ref(), D.try_into()?)?;
+    fn try_from((value, dim): (&GenericListArray<i32>, Dimension)) -> Result<Self> {
+        let coords = CoordBuffer::from_arrow(value.values().as_ref(), dim)?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
@@ -350,11 +350,11 @@ impl TryFrom<&GenericListArray<i32>> for MultiPointArray {
     }
 }
 
-impl TryFrom<&GenericListArray<i64>> for MultiPointArray {
+impl TryFrom<(&GenericListArray<i64>, Dimension)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: &GenericListArray<i64>) -> Result<Self> {
-        let coords = CoordBuffer::from_arrow(value.values().as_ref(), D.try_into()?)?;
+    fn try_from((value, dim): (&GenericListArray<i64>, Dimension)) -> Result<Self> {
+        let coords = CoordBuffer::from_arrow(value.values().as_ref(), dim)?;
         let geom_offsets = offsets_buffer_i64_to_i32(value.offsets())?;
         let validity = value.nulls();
 
@@ -367,18 +367,18 @@ impl TryFrom<&GenericListArray<i64>> for MultiPointArray {
     }
 }
 
-impl TryFrom<&dyn Array> for MultiPointArray {
+impl TryFrom<(&dyn Array, Dimension)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: &dyn Array) -> Result<Self> {
+    fn try_from((value, dim): (&dyn Array, Dimension)) -> Result<Self> {
         match value.data_type() {
             DataType::List(_) => {
                 let downcasted = value.as_list::<i32>();
-                downcasted.try_into()
+                (downcasted, dim).try_into()
             }
             DataType::LargeList(_) => {
                 let downcasted = value.as_list::<i64>();
-                downcasted.try_into()
+                (downcasted, dim).try_into()
             }
             _ => Err(GeoArrowError::General(format!(
                 "Unexpected type: {:?}",
@@ -392,27 +392,28 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPointArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let mut arr: Self = arr.try_into()?;
+        let geom_type = NativeType::try_from(field)?;
+        let mut arr: Self = (arr, geom_type.dimension()).try_into()?;
         arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
         Ok(arr)
     }
 }
 
-impl<G: MultiPointTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiPointArray {
+impl<G: MultiPointTrait<T = f64>> From<Vec<Option<G>>> for MultiPointArray {
     fn from(other: Vec<Option<G>>) -> Self {
         let mut_arr: MultiPointBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: MultiPointTrait<T = f64>, const D: usize> From<&[G]> for MultiPointArray {
+impl<G: MultiPointTrait<T = f64>> From<&[G]> for MultiPointArray {
     fn from(other: &[G]) -> Self {
         let mut_arr: MultiPointBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointArray {
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for MultiPointArray {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {

--- a/rust/geoarrow/src/array/multipoint/array.rs
+++ b/rust/geoarrow/src/array/multipoint/array.rs
@@ -26,7 +26,7 @@ use geo_traits::MultiPointTrait;
 /// This is semantically equivalent to `Vec<Option<MultiPoint>>` due to the internal validity
 /// bitmap.
 #[derive(Debug, Clone)]
-pub struct MultiPointArray<const D: usize> {
+pub struct MultiPointArray {
     // Always NativeType::MultiPoint or NativeType::LargeMultiPoint
     data_type: NativeType,
 
@@ -61,7 +61,7 @@ pub(super) fn check(
     Ok(())
 }
 
-impl<const D: usize> MultiPointArray<D> {
+impl MultiPointArray {
     /// Create a new MultiPointArray from parts
     ///
     /// # Implementation
@@ -98,10 +98,7 @@ impl<const D: usize> MultiPointArray<D> {
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         check(&coords, validity.as_ref().map(|v| v.len()), &geom_offsets)?;
-
-        let coord_type = coords.coord_type();
-        let data_type = NativeType::MultiPoint(coord_type, D.try_into()?);
-
+        let data_type = NativeType::MultiPoint(coords.coord_type(), coords.dim());
         Ok(Self {
             data_type,
             coords,
@@ -207,7 +204,7 @@ impl<const D: usize> MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> ArrayBase for MultiPointArray<D> {
+impl ArrayBase for MultiPointArray {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -251,7 +248,7 @@ impl<const D: usize> ArrayBase for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> NativeArray for MultiPointArray<D> {
+impl NativeArray for MultiPointArray {
     fn data_type(&self) -> NativeType {
         self.data_type
     }
@@ -283,7 +280,7 @@ impl<const D: usize> NativeArray for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> GeometryArraySelfMethods<D> for MultiPointArray<D> {
+impl GeometryArraySelfMethods for MultiPointArray {
     fn with_coords(self, coords: CoordBuffer) -> Self {
         assert_eq!(coords.len(), self.coords.len());
         Self::new(coords, self.geom_offsets, self.validity, self.metadata)
@@ -299,25 +296,25 @@ impl<const D: usize> GeometryArraySelfMethods<D> for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> NativeGeometryAccessor<D> for MultiPointArray<D> {
-    unsafe fn value_as_geometry_unchecked(&self, index: usize) -> crate::scalar::Geometry<D> {
+impl NativeGeometryAccessor for MultiPointArray {
+    unsafe fn value_as_geometry_unchecked(&self, index: usize) -> crate::scalar::Geometry {
         Geometry::MultiPoint(MultiPoint::new(&self.coords, &self.geom_offsets, index))
     }
 }
 
 #[cfg(feature = "geos")]
-impl<'a, const D: usize> crate::trait_::NativeGEOSGeometryAccessor<'a> for MultiPointArray<D> {
+impl<'a> crate::trait_::NativeGEOSGeometryAccessor<'a> for MultiPointArray {
     unsafe fn value_as_geometry_unchecked(
         &'a self,
         index: usize,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
-        let geom = MultiPoint::<D>::new(&self.coords, &self.geom_offsets, index);
+        let geom = MultiPoint::new(&self.coords, &self.geom_offsets, index);
         (&geom).try_into()
     }
 }
 
-impl<'a, const D: usize> ArrayAccessor<'a> for MultiPointArray<D> {
-    type Item = MultiPoint<'a, D>;
+impl<'a> ArrayAccessor<'a> for MultiPointArray {
+    type Item = MultiPoint<'a>;
     type ItemGeo = geo::MultiPoint;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -325,7 +322,7 @@ impl<'a, const D: usize> ArrayAccessor<'a> for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> IntoArrow for MultiPointArray<D> {
+impl IntoArrow for MultiPointArray {
     type ArrowArray = GenericListArray<i32>;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -336,7 +333,7 @@ impl<const D: usize> IntoArrow for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<&GenericListArray<i32>> for MultiPointArray<D> {
+impl TryFrom<&GenericListArray<i32>> for MultiPointArray {
     type Error = GeoArrowError;
 
     fn try_from(value: &GenericListArray<i32>) -> Result<Self> {
@@ -353,7 +350,7 @@ impl<const D: usize> TryFrom<&GenericListArray<i32>> for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<&GenericListArray<i64>> for MultiPointArray<D> {
+impl TryFrom<&GenericListArray<i64>> for MultiPointArray {
     type Error = GeoArrowError;
 
     fn try_from(value: &GenericListArray<i64>) -> Result<Self> {
@@ -370,7 +367,7 @@ impl<const D: usize> TryFrom<&GenericListArray<i64>> for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<&dyn Array> for MultiPointArray<D> {
+impl TryFrom<&dyn Array> for MultiPointArray {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self> {
@@ -391,7 +388,7 @@ impl<const D: usize> TryFrom<&dyn Array> for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiPointArray<D> {
+impl TryFrom<(&dyn Array, &Field)> for MultiPointArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -401,33 +398,33 @@ impl<const D: usize> TryFrom<(&dyn Array, &Field)> for MultiPointArray<D> {
     }
 }
 
-impl<G: MultiPointTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiPointArray<D> {
+impl<G: MultiPointTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiPointArray {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: MultiPointBuilder<D> = other.into();
+        let mut_arr: MultiPointBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: MultiPointTrait<T = f64>, const D: usize> From<&[G]> for MultiPointArray<D> {
+impl<G: MultiPointTrait<T = f64>, const D: usize> From<&[G]> for MultiPointArray {
     fn from(other: &[G]) -> Self {
-        let mut_arr: MultiPointBuilder<D> = other.into();
+        let mut_arr: MultiPointBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointArray<D> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointArray {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
-        let mut_arr: MultiPointBuilder<D> = value.try_into()?;
+        let mut_arr: MultiPointBuilder = value.try_into()?;
         Ok(mut_arr.into())
     }
 }
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<const D: usize> From<MultiPointArray<D>> for LineStringArray<D> {
-    fn from(value: MultiPointArray<D>) -> Self {
+impl From<MultiPointArray> for LineStringArray {
+    fn from(value: MultiPointArray) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -437,8 +434,8 @@ impl<const D: usize> From<MultiPointArray<D>> for LineStringArray<D> {
     }
 }
 
-impl<const D: usize> From<PointArray<D>> for MultiPointArray<D> {
-    fn from(value: PointArray<D>) -> Self {
+impl From<PointArray> for MultiPointArray {
+    fn from(value: PointArray) -> Self {
         let coords = value.coords;
         let geom_offsets = OffsetBuffer::from_lengths(vec![1; coords.len()]);
         let validity = value.validity;
@@ -447,13 +444,13 @@ impl<const D: usize> From<PointArray<D>> for MultiPointArray<D> {
 }
 
 /// Default to an empty array
-impl<const D: usize> Default for MultiPointArray<D> {
+impl Default for MultiPointArray {
     fn default() -> Self {
         MultiPointBuilder::default().into()
     }
 }
 
-impl<const D: usize> PartialEq for MultiPointArray<D> {
+impl PartialEq for MultiPointArray {
     fn eq(&self, other: &Self) -> bool {
         if self.validity != other.validity {
             return false;
@@ -471,10 +468,10 @@ impl<const D: usize> PartialEq for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<MixedGeometryArray<D>> for MultiPointArray<D> {
+impl TryFrom<MixedGeometryArray> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: MixedGeometryArray<D>) -> Result<Self> {
+    fn try_from(value: MixedGeometryArray) -> Result<Self> {
         if value.has_line_strings()
             || value.has_polygons()
             || value.has_multi_line_strings()
@@ -496,7 +493,7 @@ impl<const D: usize> TryFrom<MixedGeometryArray<D>> for MultiPointArray<D> {
         capacity.coord_capacity += value.points.buffer_lengths();
         capacity.geom_capacity += value.points.buffer_lengths();
 
-        let mut builder = MultiPointBuilder::<D>::with_capacity_and_options(
+        let mut builder = MultiPointBuilder::with_capacity_and_options(
             capacity,
             value.coord_type(),
             value.metadata(),
@@ -508,10 +505,10 @@ impl<const D: usize> TryFrom<MixedGeometryArray<D>> for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<GeometryCollectionArray<D>> for MultiPointArray<D> {
+impl TryFrom<GeometryCollectionArray> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: GeometryCollectionArray<D>) -> Result<Self> {
+    fn try_from(value: GeometryCollectionArray) -> Result<Self> {
         MixedGeometryArray::try_from(value)?.try_into()
     }
 }
@@ -526,14 +523,14 @@ mod test {
 
     #[test]
     fn geo_roundtrip_accurate() {
-        let arr: MultiPointArray<2> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPointArray = vec![mp0(), mp1()].as_slice().into();
         assert_eq!(arr.value_as_geo(0), mp0());
         assert_eq!(arr.value_as_geo(1), mp1());
     }
 
     #[test]
     fn geo_roundtrip_accurate_option_vec() {
-        let arr: MultiPointArray<2> = vec![Some(mp0()), Some(mp1()), None].into();
+        let arr: MultiPointArray = vec![Some(mp0()), Some(mp1()), None].into();
         assert_eq!(arr.get_as_geo(0), Some(mp0()));
         assert_eq!(arr.get_as_geo(1), Some(mp1()));
         assert_eq!(arr.get_as_geo(2), None);
@@ -541,7 +538,7 @@ mod test {
 
     #[test]
     fn slice() {
-        let arr: MultiPointArray<2> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPointArray = vec![mp0(), mp1()].as_slice().into();
         let sliced = arr.slice(1, 1);
         assert_eq!(sliced.len(), 1);
         assert_eq!(sliced.get_as_geo(0), Some(mp1()));
@@ -549,7 +546,7 @@ mod test {
 
     #[test]
     fn owned_slice() {
-        let arr: MultiPointArray<2> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPointArray = vec![mp0(), mp1()].as_slice().into();
         let sliced = arr.owned_slice(1, 1);
 
         // assert!(
@@ -566,7 +563,7 @@ mod test {
         let geom_arr = example_multipoint_interleaved();
 
         let wkb_arr = example_multipoint_wkb();
-        let parsed_geom_arr: MultiPointArray<2> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiPointArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }
@@ -577,7 +574,7 @@ mod test {
         let geom_arr = example_multipoint_separated().into_coord_type(CoordType::Interleaved);
 
         let wkb_arr = example_multipoint_wkb();
-        let parsed_geom_arr: MultiPointArray<2> = wkb_arr.try_into().unwrap();
+        let parsed_geom_arr: MultiPointArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(geom_arr, parsed_geom_arr);
     }

--- a/rust/geoarrow/src/array/multipoint/builder.rs
+++ b/rust/geoarrow/src/array/multipoint/builder.rs
@@ -19,7 +19,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, Point
 ///
 /// Converting an [`MultiPointBuilder`] into a [`MultiPointArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct MultiPointBuilder<const D: usize> {
+pub struct MultiPointBuilder {
     metadata: Arc<ArrayMetadata>,
 
     coords: CoordBufferBuilder,
@@ -30,7 +30,7 @@ pub struct MultiPointBuilder<const D: usize> {
     validity: NullBufferBuilder,
 }
 
-impl<const D: usize> MultiPointBuilder<D> {
+impl MultiPointBuilder {
     /// Creates a new empty [`MultiPointBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -140,7 +140,7 @@ impl<const D: usize> MultiPointBuilder<D> {
         Arc::new(self.into_arrow())
     }
 
-    pub fn finish(self) -> MultiPointArray<D> {
+    pub fn finish(self) -> MultiPointArray {
         self.into()
     }
 
@@ -340,13 +340,13 @@ impl<const D: usize> MultiPointBuilder<D> {
     }
 }
 
-impl<const D: usize> Default for MultiPointBuilder<D> {
+impl Default for MultiPointBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const D: usize> GeometryArrayBuilder for MultiPointBuilder<D> {
+impl GeometryArrayBuilder for MultiPointBuilder {
     fn new() -> Self {
         Self::new()
     }
@@ -393,17 +393,17 @@ impl<const D: usize> GeometryArrayBuilder for MultiPointBuilder<D> {
     }
 }
 
-impl<const D: usize> IntoArrow for MultiPointBuilder<D> {
+impl IntoArrow for MultiPointBuilder {
     type ArrowArray = GenericListArray<i32>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let arr: MultiPointArray<D> = self.into();
+        let arr: MultiPointArray = self.into();
         arr.into_arrow()
     }
 }
 
-impl<const D: usize> From<MultiPointBuilder<D>> for MultiPointArray<D> {
-    fn from(mut other: MultiPointBuilder<D>) -> Self {
+impl From<MultiPointBuilder> for MultiPointArray {
+    fn from(mut other: MultiPointBuilder) -> Self {
         let validity = other.validity.finish();
 
         // TODO: impl shrink_to_fit for all mutable -> * impls
@@ -419,25 +419,25 @@ impl<const D: usize> From<MultiPointBuilder<D>> for MultiPointArray<D> {
     }
 }
 
-impl<const D: usize> From<MultiPointBuilder<D>> for GenericListArray<i32> {
-    fn from(arr: MultiPointBuilder<D>) -> Self {
+impl From<MultiPointBuilder> for GenericListArray<i32> {
+    fn from(arr: MultiPointBuilder) -> Self {
         arr.into_arrow()
     }
 }
 
-impl<G: MultiPointTrait<T = f64>, const D: usize> From<&[G]> for MultiPointBuilder<D> {
+impl<G: MultiPointTrait<T = f64>, const D: usize> From<&[G]> for MultiPointBuilder {
     fn from(geoms: &[G]) -> Self {
         Self::from_multi_points(geoms, Default::default(), Default::default())
     }
 }
 
-impl<G: MultiPointTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiPointBuilder<D> {
+impl<G: MultiPointTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiPointBuilder {
     fn from(geoms: Vec<Option<G>>) -> Self {
         Self::from_nullable_multi_points(&geoms, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointBuilder<D> {
+impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointBuilder {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {
@@ -449,8 +449,8 @@ impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointBuil
 
 /// LineString and MultiPoint have the same layout, so enable conversions between the two to change
 /// the semantic type
-impl<const D: usize> From<MultiPointBuilder<D>> for LineStringBuilder<D> {
-    fn from(value: MultiPointBuilder<D>) -> Self {
+impl From<MultiPointBuilder> for LineStringBuilder {
+    fn from(value: MultiPointBuilder) -> Self {
         Self::try_new(
             value.coords,
             value.geom_offsets,

--- a/rust/geoarrow/src/array/multipoint/builder.rs
+++ b/rust/geoarrow/src/array/multipoint/builder.rs
@@ -8,6 +8,7 @@ use crate::array::{
     CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, LineStringBuilder,
     MultiPointArray, SeparatedCoordBufferBuilder, WKBArray,
 };
+use crate::datatypes::Dimension;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::WKB;
 use crate::trait_::{ArrayAccessor, GeometryArrayBuilder, IntoArrow};
@@ -32,38 +33,37 @@ pub struct MultiPointBuilder {
 
 impl MultiPointBuilder {
     /// Creates a new empty [`MultiPointBuilder`].
-    pub fn new() -> Self {
-        Self::new_with_options(Default::default(), Default::default())
+    pub fn new(dim: Dimension) -> Self {
+        Self::new_with_options(dim, Default::default(), Default::default())
     }
 
     /// Creates a new [`MultiPointBuilder`] with a specified [`CoordType`]
-    pub fn new_with_options(coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
-        Self::with_capacity_and_options(Default::default(), coord_type, metadata)
+    pub fn new_with_options(
+        dim: Dimension,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        Self::with_capacity_and_options(dim, Default::default(), coord_type, metadata)
     }
     /// Creates a new [`MultiPointBuilder`] with a capacity.
-    pub fn with_capacity(capacity: MultiPointCapacity) -> Self {
-        Self::with_capacity_and_options(capacity, Default::default(), Default::default())
+    pub fn with_capacity(dim: Dimension, capacity: MultiPointCapacity) -> Self {
+        Self::with_capacity_and_options(dim, capacity, Default::default(), Default::default())
     }
 
     // with capacity and options enables us to write with_capacity based on this method
     pub fn with_capacity_and_options(
+        dim: Dimension,
         capacity: MultiPointCapacity,
         coord_type: CoordType,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let coords = match coord_type {
-            CoordType::Interleaved => {
-                CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(
-                    capacity.coord_capacity,
-                    D.try_into().unwrap(),
-                ))
-            }
-            CoordType::Separated => {
-                CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(
-                    capacity.coord_capacity,
-                    D.try_into().unwrap(),
-                ))
-            }
+            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
+                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
+            ),
+            CoordType::Separated => CoordBufferBuilder::Separated(
+                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
+            ),
         };
         Self {
             coords,
@@ -146,17 +146,24 @@ impl MultiPointBuilder {
 
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+        dim: Dimension,
     ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
+        Self::with_capacity_and_options_from_iter(
+            geoms,
+            dim,
+            Default::default(),
+            Default::default(),
+        )
     }
 
     pub fn with_capacity_and_options_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
+        dim: Dimension,
         coord_type: CoordType,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let counter = MultiPointCapacity::from_multi_points(geoms);
-        Self::with_capacity_and_options(counter, coord_type, metadata)
+        Self::with_capacity_and_options(dim, counter, coord_type, metadata)
     }
 
     pub fn reserve_from_iter<'a>(
@@ -290,11 +297,13 @@ impl MultiPointBuilder {
 
     pub fn from_multi_points(
         geoms: &[impl MultiPointTrait<T = f64>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(Some),
+            dim,
             coord_type.unwrap_or_default(),
             metadata,
         );
@@ -304,11 +313,13 @@ impl MultiPointBuilder {
 
     pub fn from_nullable_multi_points(
         geoms: &[Option<impl MultiPointTrait<T = f64>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(|x| x.as_ref()),
+            dim,
             coord_type.unwrap_or_default(),
             metadata,
         );
@@ -318,17 +329,23 @@ impl MultiPointBuilder {
 
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         let capacity = MultiPointCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
-        let mut array =
-            Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default(), metadata);
+        let mut array = Self::with_capacity_and_options(
+            dim,
+            capacity,
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
         array.extend_from_geometry_iter(geoms.iter().map(|x| x.as_ref()))?;
         Ok(array)
     }
     pub(crate) fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
@@ -336,28 +353,29 @@ impl MultiPointBuilder {
             .iter()
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata)
+        Self::from_nullable_geometries(&wkb_objects2, dim, coord_type, metadata)
     }
 }
 
 impl Default for MultiPointBuilder {
     fn default() -> Self {
-        Self::new()
+        Self::new(Dimension::XY)
     }
 }
 
 impl GeometryArrayBuilder for MultiPointBuilder {
-    fn new() -> Self {
-        Self::new()
+    fn new(dim: Dimension) -> Self {
+        Self::new(dim)
     }
 
     fn with_geom_capacity_and_options(
+        dim: Dimension,
         geom_capacity: usize,
         coord_type: CoordType,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let capacity = MultiPointCapacity::new(0, geom_capacity);
-        Self::with_capacity_and_options(capacity, coord_type, metadata)
+        Self::with_capacity_and_options(dim, capacity, coord_type, metadata)
     }
 
     fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
@@ -425,25 +443,25 @@ impl From<MultiPointBuilder> for GenericListArray<i32> {
     }
 }
 
-impl<G: MultiPointTrait<T = f64>, const D: usize> From<&[G]> for MultiPointBuilder {
-    fn from(geoms: &[G]) -> Self {
-        Self::from_multi_points(geoms, Default::default(), Default::default())
+impl<G: MultiPointTrait<T = f64>> From<(&[G], Dimension)> for MultiPointBuilder {
+    fn from((geoms, dim): (&[G], Dimension)) -> Self {
+        Self::from_multi_points(geoms, dim, Default::default(), Default::default())
     }
 }
 
-impl<G: MultiPointTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for MultiPointBuilder {
-    fn from(geoms: Vec<Option<G>>) -> Self {
-        Self::from_nullable_multi_points(&geoms, Default::default(), Default::default())
+impl<G: MultiPointTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for MultiPointBuilder {
+    fn from((geoms, dim): (Vec<Option<G>>, Dimension)) -> Self {
+        Self::from_nullable_multi_points(&geoms, dim, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for MultiPointBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MultiPointBuilder {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKBArray<O>) -> Result<Self> {
+    fn try_from((value, dim): (WKBArray<O>, Dimension)) -> Result<Self> {
         let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, Default::default(), metadata)
+        Self::from_wkb(&wkb_objects, dim, Default::default(), metadata)
     }
 }
 

--- a/rust/geoarrow/src/array/point/builder.rs
+++ b/rust/geoarrow/src/array/point/builder.rs
@@ -18,13 +18,13 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, Point
 ///
 /// Converting an [`PointBuilder`] into a [`PointArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct PointBuilder<const D: usize> {
+pub struct PointBuilder {
     metadata: Arc<ArrayMetadata>,
     pub coords: CoordBufferBuilder,
     pub validity: NullBufferBuilder,
 }
 
-impl<const D: usize> PointBuilder<D> {
+impl PointBuilder {
     /// Creates a new empty [`PointBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default())
@@ -114,7 +114,7 @@ impl<const D: usize> PointBuilder<D> {
         (self.coords, self.validity)
     }
 
-    pub fn finish(self) -> PointArray<D> {
+    pub fn finish(self) -> PointArray {
         self.into()
     }
 
@@ -272,7 +272,7 @@ impl<const D: usize> PointBuilder<D> {
     }
 }
 
-impl<const D: usize> GeometryArrayBuilder for PointBuilder<D> {
+impl GeometryArrayBuilder for PointBuilder {
     fn new() -> Self {
         Self::new()
     }
@@ -318,41 +318,41 @@ impl<const D: usize> GeometryArrayBuilder for PointBuilder<D> {
     }
 }
 
-impl<const D: usize> Default for PointBuilder<D> {
+impl Default for PointBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const D: usize> IntoArrow for PointBuilder<D> {
+impl IntoArrow for PointBuilder {
     type ArrowArray = Arc<dyn Array>;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let point_array: PointArray<D> = self.into();
+        let point_array: PointArray = self.into();
         point_array.into_arrow()
     }
 }
 
-impl<const D: usize> From<PointBuilder<D>> for PointArray<D> {
-    fn from(mut other: PointBuilder<D>) -> Self {
+impl From<PointBuilder> for PointArray {
+    fn from(mut other: PointBuilder) -> Self {
         let validity = other.validity.finish();
         Self::new(other.coords.into(), validity, other.metadata)
     }
 }
 
-impl<const D: usize> From<PointBuilder<D>> for Arc<dyn Array> {
-    fn from(arr: PointBuilder<D>) -> Self {
+impl From<PointBuilder> for Arc<dyn Array> {
+    fn from(arr: PointBuilder) -> Self {
         arr.into_array_ref()
     }
 }
 
-impl<const D: usize, G: PointTrait<T = f64>> From<&[G]> for PointBuilder<D> {
+impl<const D: usize, G: PointTrait<T = f64>> From<&[G]> for PointBuilder {
     fn from(value: &[G]) -> Self {
         PointBuilder::from_points(value.iter(), Default::default(), Default::default())
     }
 }
 
-impl<const D: usize, G: PointTrait<T = f64>> From<Vec<Option<G>>> for PointBuilder<D> {
+impl<const D: usize, G: PointTrait<T = f64>> From<Vec<Option<G>>> for PointBuilder {
     fn from(geoms: Vec<Option<G>>) -> Self {
         PointBuilder::from_nullable_points(
             geoms.iter().map(|x| x.as_ref()),
@@ -362,7 +362,7 @@ impl<const D: usize, G: PointTrait<T = f64>> From<Vec<Option<G>>> for PointBuild
     }
 }
 
-impl<const D: usize, O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PointBuilder<D> {
+impl<const D: usize, O: OffsetSizeTrait> TryFrom<WKBArray<O>> for PointBuilder {
     type Error = GeoArrowError;
 
     fn try_from(value: WKBArray<O>) -> Result<Self> {

--- a/rust/geoarrow/src/array/polygon/array.rs
+++ b/rust/geoarrow/src/array/polygon/array.rs
@@ -581,7 +581,7 @@ impl TryFrom<MixedGeometryArray> for PolygonArray {
     type Error = GeoArrowError;
 
     fn try_from(value: MixedGeometryArray) -> Result<Self> {
-        let dim = value.dim();
+        let dim = value.dimension();
 
         if value.has_points()
             || value.has_line_strings()

--- a/rust/geoarrow/src/array/polygon/builder.rs
+++ b/rust/geoarrow/src/array/polygon/builder.rs
@@ -8,6 +8,7 @@ use crate::array::{
     CoordBufferBuilder, CoordType, InterleavedCoordBufferBuilder, MultiLineStringBuilder,
     PolygonArray, SeparatedCoordBufferBuilder, WKBArray,
 };
+use crate::datatypes::Dimension;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::WKB;
 use crate::trait_::{ArrayAccessor, GeometryArrayBuilder, IntoArrow};
@@ -46,37 +47,36 @@ pub struct PolygonBuilder {
 
 impl PolygonBuilder {
     /// Creates a new empty [`PolygonBuilder`].
-    pub fn new() -> Self {
-        Self::new_with_options(Default::default(), Default::default())
+    pub fn new(dim: Dimension) -> Self {
+        Self::new_with_options(dim, Default::default(), Default::default())
     }
 
-    pub fn new_with_options(coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self {
-        Self::with_capacity_and_options(Default::default(), coord_type, metadata)
+    pub fn new_with_options(
+        dim: Dimension,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        Self::with_capacity_and_options(dim, Default::default(), coord_type, metadata)
     }
 
     /// Creates a new [`PolygonBuilder`] with given capacity and no validity.
-    pub fn with_capacity(capacity: PolygonCapacity) -> Self {
-        Self::with_capacity_and_options(capacity, Default::default(), Default::default())
+    pub fn with_capacity(dim: Dimension, capacity: PolygonCapacity) -> Self {
+        Self::with_capacity_and_options(dim, capacity, Default::default(), Default::default())
     }
 
     pub fn with_capacity_and_options(
+        dim: Dimension,
         capacity: PolygonCapacity,
         coord_type: CoordType,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let coords = match coord_type {
-            CoordType::Interleaved => {
-                CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(
-                    capacity.coord_capacity,
-                    D.try_into().unwrap(),
-                ))
-            }
-            CoordType::Separated => {
-                CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(
-                    capacity.coord_capacity,
-                    D.try_into().unwrap(),
-                ))
-            }
+            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
+                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
+            ),
+            CoordType::Separated => CoordBufferBuilder::Separated(
+                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
+            ),
         };
         Self {
             coords,
@@ -210,17 +210,24 @@ impl PolygonBuilder {
 
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
+        dim: Dimension,
     ) -> Self {
-        Self::with_capacity_and_options_from_iter(geoms, Default::default(), Default::default())
+        Self::with_capacity_and_options_from_iter(
+            geoms,
+            dim,
+            Default::default(),
+            Default::default(),
+        )
     }
 
     pub fn with_capacity_and_options_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
+        dim: Dimension,
         coord_type: CoordType,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let counter = PolygonCapacity::from_polygons(geoms);
-        Self::with_capacity_and_options(counter, coord_type, metadata)
+        Self::with_capacity_and_options(dim, counter, coord_type, metadata)
     }
 
     /// Add a new Polygon to the end of this array.
@@ -375,11 +382,13 @@ impl PolygonBuilder {
 
     pub fn from_polygons(
         geoms: &[impl PolygonTrait<T = f64>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(Some),
+            dim,
             coord_type.unwrap_or_default(),
             metadata,
         );
@@ -389,11 +398,13 @@ impl PolygonBuilder {
 
     pub fn from_nullable_polygons(
         geoms: &[Option<impl PolygonTrait<T = f64>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let mut array = Self::with_capacity_and_options_from_iter(
             geoms.iter().map(|x| x.as_ref()),
+            dim,
             coord_type.unwrap_or_default(),
             metadata,
         );
@@ -403,18 +414,24 @@ impl PolygonBuilder {
 
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
         let capacity = PolygonCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
-        let mut array =
-            Self::with_capacity_and_options(capacity, coord_type.unwrap_or_default(), metadata);
+        let mut array = Self::with_capacity_and_options(
+            dim,
+            capacity,
+            coord_type.unwrap_or_default(),
+            metadata,
+        );
         array.extend_from_geometry_iter(geoms.iter().map(|x| x.as_ref()))?;
         Ok(array)
     }
 
     pub(crate) fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
+        dim: Dimension,
         coord_type: Option<CoordType>,
         metadata: Arc<ArrayMetadata>,
     ) -> Result<Self> {
@@ -422,28 +439,29 @@ impl PolygonBuilder {
             .iter()
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata)
+        Self::from_nullable_geometries(&wkb_objects2, dim, coord_type, metadata)
     }
 }
 
 impl Default for PolygonBuilder {
     fn default() -> Self {
-        Self::new()
+        Self::new(Dimension::XY)
     }
 }
 
 impl GeometryArrayBuilder for PolygonBuilder {
-    fn new() -> Self {
-        Self::new()
+    fn new(dim: Dimension) -> Self {
+        Self::new(dim)
     }
 
     fn with_geom_capacity_and_options(
+        dim: Dimension,
         geom_capacity: usize,
         coord_type: CoordType,
         metadata: Arc<ArrayMetadata>,
     ) -> Self {
         let capacity = PolygonCapacity::new(0, 0, geom_capacity);
-        Self::with_capacity_and_options(capacity, coord_type, metadata)
+        Self::with_capacity_and_options(dim, capacity, coord_type, metadata)
     }
 
     fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
@@ -505,25 +523,25 @@ impl From<PolygonBuilder> for PolygonArray {
     }
 }
 
-impl<G: PolygonTrait<T = f64>, const D: usize> From<&[G]> for PolygonBuilder {
-    fn from(geoms: &[G]) -> Self {
-        Self::from_polygons(geoms, Default::default(), Default::default())
+impl<G: PolygonTrait<T = f64>> From<(&[G], Dimension)> for PolygonBuilder {
+    fn from((geoms, dim): (&[G], Dimension)) -> Self {
+        Self::from_polygons(geoms, dim, Default::default(), Default::default())
     }
 }
 
-impl<G: PolygonTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for PolygonBuilder {
-    fn from(geoms: Vec<Option<G>>) -> Self {
-        Self::from_nullable_polygons(&geoms, Default::default(), Default::default())
+impl<G: PolygonTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for PolygonBuilder {
+    fn from((geoms, dim): (Vec<Option<G>>, Dimension)) -> Self {
+        Self::from_nullable_polygons(&geoms, dim, Default::default(), Default::default())
     }
 }
 
-impl<O: OffsetSizeTrait, const D: usize> TryFrom<WKBArray<O>> for PolygonBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for PolygonBuilder {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKBArray<O>) -> Result<Self> {
+    fn try_from((value, dim): (WKBArray<O>, Dimension)) -> Result<Self> {
         let metadata = value.metadata.clone();
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, Default::default(), metadata)
+        Self::from_wkb(&wkb_objects, dim, Default::default(), metadata)
     }
 }
 

--- a/rust/geoarrow/src/array/rect/array.rs
+++ b/rust/geoarrow/src/array/rect/array.rs
@@ -25,7 +25,7 @@ use geo_traits::RectTrait;
 ///
 /// Internally this is implemented as a FixedSizeList, laid out as minx, miny, maxx, maxy.
 #[derive(Debug, Clone, PartialEq)]
-pub struct RectArray<const D: usize> {
+pub struct RectArray {
     // Always NativeType::Rect
     data_type: NativeType,
 
@@ -40,7 +40,7 @@ pub struct RectArray<const D: usize> {
     validity: Option<NullBuffer>,
 }
 
-impl<const D: usize> RectArray<D> {
+impl RectArray {
     pub fn new(
         lower: SeparatedCoordBuffer,
         upper: SeparatedCoordBuffer,
@@ -92,7 +92,7 @@ impl<const D: usize> RectArray<D> {
     }
 }
 
-impl<const D: usize> ArrayBase for RectArray<D> {
+impl ArrayBase for RectArray {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -136,7 +136,7 @@ impl<const D: usize> ArrayBase for RectArray<D> {
     }
 }
 
-impl<const D: usize> NativeArray for RectArray<D> {
+impl NativeArray for RectArray {
     fn data_type(&self) -> NativeType {
         self.data_type
     }
@@ -168,7 +168,7 @@ impl<const D: usize> NativeArray for RectArray<D> {
     }
 }
 
-impl<const D: usize> GeometryArraySelfMethods<D> for RectArray<D> {
+impl GeometryArraySelfMethods for RectArray {
     fn with_coords(self, _coords: CoordBuffer) -> Self {
         unimplemented!()
     }
@@ -178,8 +178,8 @@ impl<const D: usize> GeometryArraySelfMethods<D> for RectArray<D> {
     }
 }
 
-impl<'a, const D: usize> ArrayAccessor<'a> for RectArray<D> {
-    type Item = Rect<'a, D>;
+impl<'a> ArrayAccessor<'a> for RectArray {
+    type Item = Rect<'a>;
     type ItemGeo = geo::Rect;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
@@ -187,7 +187,7 @@ impl<'a, const D: usize> ArrayAccessor<'a> for RectArray<D> {
     }
 }
 
-impl<const D: usize> IntoArrow for RectArray<D> {
+impl IntoArrow for RectArray {
     type ArrowArray = StructArray;
 
     fn into_arrow(self) -> Self::ArrowArray {
@@ -205,7 +205,7 @@ impl<const D: usize> IntoArrow for RectArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<&StructArray> for RectArray<D> {
+impl TryFrom<&StructArray> for RectArray {
     type Error = GeoArrowError;
 
     fn try_from(value: &StructArray) -> Result<Self, Self::Error> {
@@ -241,7 +241,7 @@ impl<const D: usize> TryFrom<&StructArray> for RectArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<&dyn Array> for RectArray<D> {
+impl TryFrom<&dyn Array> for RectArray {
     type Error = GeoArrowError;
 
     fn try_from(value: &dyn Array) -> Result<Self, Self::Error> {
@@ -257,7 +257,7 @@ impl<const D: usize> TryFrom<&dyn Array> for RectArray<D> {
     }
 }
 
-impl<const D: usize> TryFrom<(&dyn Array, &Field)> for RectArray<D> {
+impl TryFrom<(&dyn Array, &Field)> for RectArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self, Self::Error> {
@@ -267,16 +267,16 @@ impl<const D: usize> TryFrom<(&dyn Array, &Field)> for RectArray<D> {
     }
 }
 
-impl<G: RectTrait<T = f64>, const D: usize> From<&[G]> for RectArray<D> {
+impl<G: RectTrait<T = f64>, const D: usize> From<&[G]> for RectArray {
     fn from(other: &[G]) -> Self {
-        let mut_arr: RectBuilder<D> = other.into();
+        let mut_arr: RectBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: RectTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for RectArray<D> {
+impl<G: RectTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for RectArray {
     fn from(other: Vec<Option<G>>) -> Self {
-        let mut_arr: RectBuilder<D> = other.into();
+        let mut_arr: RectBuilder = other.into();
         mut_arr.into()
     }
 }

--- a/rust/geoarrow/src/array/rect/array.rs
+++ b/rust/geoarrow/src/array/rect/array.rs
@@ -267,15 +267,15 @@ impl TryFrom<(&dyn Array, &Field)> for RectArray {
     }
 }
 
-impl<G: RectTrait<T = f64>> From<&[G]> for RectArray {
-    fn from(other: &[G]) -> Self {
+impl<G: RectTrait<T = f64>> From<(&[G], Dimension)> for RectArray {
+    fn from(other: (&[G], Dimension)) -> Self {
         let mut_arr: RectBuilder = other.into();
         mut_arr.into()
     }
 }
 
-impl<G: RectTrait<T = f64>> From<Vec<Option<G>>> for RectArray {
-    fn from(other: Vec<Option<G>>) -> Self {
+impl<G: RectTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for RectArray {
+    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
         let mut_arr: RectBuilder = other.into();
         mut_arr.into()
     }

--- a/rust/geoarrow/src/array/rect/builder.rs
+++ b/rust/geoarrow/src/array/rect/builder.rs
@@ -12,14 +12,14 @@ use std::sync::Arc;
 ///
 /// Converting an [`RectBuilder`] into a [`RectArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct RectBuilder<const D: usize> {
+pub struct RectBuilder {
     pub metadata: Arc<ArrayMetadata>,
     pub lower: SeparatedCoordBufferBuilder,
     pub upper: SeparatedCoordBufferBuilder,
     pub validity: NullBufferBuilder,
 }
 
-impl<const D: usize> RectBuilder<D> {
+impl RectBuilder {
     /// Creates a new empty [`RectBuilder`].
     pub fn new() -> Self {
         Self::new_with_options(Default::default())
@@ -116,7 +116,7 @@ impl<const D: usize> RectBuilder<D> {
         Arc::new(self.into_arrow())
     }
 
-    pub fn finish(self) -> RectArray<D> {
+    pub fn finish(self) -> RectArray {
         self.into()
     }
 
@@ -141,7 +141,7 @@ impl<const D: usize> RectBuilder<D> {
     /// Add a new null value to the end of this builder.
     #[inline]
     pub fn push_null(&mut self) {
-        self.push_rect(None::<&Rect<D>>);
+        self.push_rect(None::<&Rect>);
     }
 
     /// Create this builder from a iterator of Rects.
@@ -169,23 +169,23 @@ impl<const D: usize> RectBuilder<D> {
     }
 }
 
-impl<const D: usize> Default for RectBuilder<D> {
+impl Default for RectBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<const D: usize> IntoArrow for RectBuilder<D> {
+impl IntoArrow for RectBuilder {
     type ArrowArray = StructArray;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let rect_array: RectArray<D> = self.into();
+        let rect_array: RectArray = self.into();
         rect_array.into_arrow()
     }
 }
 
-impl<const D: usize> From<RectBuilder<D>> for RectArray<D> {
-    fn from(mut other: RectBuilder<D>) -> Self {
+impl From<RectBuilder> for RectArray {
+    fn from(mut other: RectBuilder) -> Self {
         RectArray::new(
             other.lower.into(),
             other.upper.into(),
@@ -195,13 +195,13 @@ impl<const D: usize> From<RectBuilder<D>> for RectArray<D> {
     }
 }
 
-impl<G: RectTrait<T = f64>, const D: usize> From<&[G]> for RectBuilder<D> {
+impl<G: RectTrait<T = f64>, const D: usize> From<&[G]> for RectBuilder {
     fn from(geoms: &[G]) -> Self {
         RectBuilder::from_rects(geoms.iter(), Default::default())
     }
 }
 
-impl<G: RectTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for RectBuilder<D> {
+impl<G: RectTrait<T = f64>, const D: usize> From<Vec<Option<G>>> for RectBuilder {
     fn from(geoms: Vec<Option<G>>) -> Self {
         RectBuilder::from_nullable_rects(geoms.iter().map(|x| x.as_ref()), Default::default())
     }

--- a/rust/geoarrow/src/chunked_array/dynamic.rs
+++ b/rust/geoarrow/src/chunked_array/dynamic.rs
@@ -28,9 +28,10 @@ impl ChunkedNativeArrayDyn {
     /// ```
     /// use geoarrow::{ArrayBase, NativeArray, array::PointArray};
     /// use geoarrow::chunked_array::ChunkedNativeArrayDyn;
+    /// use geoarrow::datatypes::Dimension;
     /// use std::sync::Arc;
     ///
-    /// let array: PointArray = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
+    /// let array: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
     /// let field = array.extension_field();
     /// let array = array.into_array_ref();
     /// let chunks = vec![array.as_ref()];
@@ -79,9 +80,10 @@ impl ChunkedNativeArrayDyn {
     /// ```
     /// use geoarrow::{NativeArray, array::PointArray};
     /// use geoarrow::chunked_array::ChunkedNativeArrayDyn;
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunks = vec![array_0.as_ref(), array_1.as_ref()];
     /// let chunked_array = ChunkedNativeArrayDyn::from_geoarrow_chunks(chunks.as_slice()).unwrap();
     /// ```

--- a/rust/geoarrow/src/chunked_array/mod.rs
+++ b/rust/geoarrow/src/chunked_array/mod.rs
@@ -568,25 +568,25 @@ impl<G: ArrayBase> TryFrom<Vec<G>> for ChunkedGeometryArray<G> {
 }
 
 /// A chunked point array.
-pub type ChunkedPointArray<const D: usize> = ChunkedGeometryArray<PointArray<D>>;
+pub type ChunkedPointArray = ChunkedGeometryArray<PointArray<D>>;
 /// A chunked line string array.
-pub type ChunkedLineStringArray<const D: usize> = ChunkedGeometryArray<LineStringArray<D>>;
+pub type ChunkedLineStringArray = ChunkedGeometryArray<LineStringArray<D>>;
 /// A chunked polygon array.
-pub type ChunkedPolygonArray<const D: usize> = ChunkedGeometryArray<PolygonArray<D>>;
+pub type ChunkedPolygonArray = ChunkedGeometryArray<PolygonArray<D>>;
 /// A chunked multi-point array.
-pub type ChunkedMultiPointArray<const D: usize> = ChunkedGeometryArray<MultiPointArray<D>>;
+pub type ChunkedMultiPointArray = ChunkedGeometryArray<MultiPointArray<D>>;
 /// A chunked mutli-line string array.
-pub type ChunkedMultiLineStringArray<const D: usize> =
+pub type ChunkedMultiLineStringArray =
     ChunkedGeometryArray<MultiLineStringArray<D>>;
 /// A chunked multi-polygon array.
-pub type ChunkedMultiPolygonArray<const D: usize> = ChunkedGeometryArray<MultiPolygonArray<D>>;
+pub type ChunkedMultiPolygonArray = ChunkedGeometryArray<MultiPolygonArray<D>>;
 /// A chunked mixed geometry array.
-pub type ChunkedMixedGeometryArray<const D: usize> = ChunkedGeometryArray<MixedGeometryArray<D>>;
+pub type ChunkedMixedGeometryArray = ChunkedGeometryArray<MixedGeometryArray<D>>;
 /// A chunked geometry collection array.
-pub type ChunkedGeometryCollectionArray<const D: usize> =
+pub type ChunkedGeometryCollectionArray =
     ChunkedGeometryArray<GeometryCollectionArray<D>>;
 /// A chunked rect array.
-pub type ChunkedRectArray<const D: usize> = ChunkedGeometryArray<RectArray<D>>;
+pub type ChunkedRectArray = ChunkedGeometryArray<RectArray<D>>;
 /// A chunked unknown geometry array.
 #[allow(dead_code)]
 pub type ChunkedUnknownGeometryArray = ChunkedGeometryArray<Arc<dyn NativeArray>>;
@@ -797,7 +797,7 @@ pub trait ChunkedNativeArray: ChunkedArrayBase {
     }
 }
 
-impl<const D: usize> ChunkedArrayBase for ChunkedPointArray<D> {
+impl ChunkedArrayBase for ChunkedPointArray<D> {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -823,7 +823,7 @@ impl<const D: usize> ChunkedArrayBase for ChunkedPointArray<D> {
     }
 }
 
-impl<const D: usize> ChunkedNativeArray for ChunkedPointArray<D> {
+impl ChunkedNativeArray for ChunkedPointArray<D> {
     fn data_type(&self) -> NativeType {
         self.chunks.first().unwrap().data_type()
     }
@@ -884,7 +884,7 @@ impl<O: OffsetSizeTrait> ChunkedArrayBase for ChunkedWKBArray<O> {
 
 macro_rules! impl_trait {
     ($chunked_array:ty) => {
-        impl<const D: usize> ChunkedArrayBase for $chunked_array {
+        impl ChunkedArrayBase for $chunked_array {
             fn as_any(&self) -> &dyn Any {
                 self
             }
@@ -911,7 +911,7 @@ macro_rules! impl_trait {
             }
         }
 
-        impl<const D: usize> ChunkedNativeArray for $chunked_array {
+        impl ChunkedNativeArray for $chunked_array {
             fn data_type(&self) -> NativeType {
                 self.chunks.first().unwrap().data_type()
             }
@@ -938,7 +938,7 @@ impl_trait!(ChunkedMultiPolygonArray<D>);
 impl_trait!(ChunkedMixedGeometryArray<D>);
 impl_trait!(ChunkedGeometryCollectionArray<D>);
 
-impl<const D: usize> ChunkedArrayBase for ChunkedRectArray<D> {
+impl ChunkedArrayBase for ChunkedRectArray<D> {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -965,7 +965,7 @@ impl<const D: usize> ChunkedArrayBase for ChunkedRectArray<D> {
     }
 }
 
-impl<const D: usize> ChunkedNativeArray for ChunkedRectArray<D> {
+impl ChunkedNativeArray for ChunkedRectArray<D> {
     fn data_type(&self) -> NativeType {
         self.chunks.first().unwrap().data_type()
     }

--- a/rust/geoarrow/src/chunked_array/mod.rs
+++ b/rust/geoarrow/src/chunked_array/mod.rs
@@ -568,25 +568,23 @@ impl<G: ArrayBase> TryFrom<Vec<G>> for ChunkedGeometryArray<G> {
 }
 
 /// A chunked point array.
-pub type ChunkedPointArray = ChunkedGeometryArray<PointArray<D>>;
+pub type ChunkedPointArray = ChunkedGeometryArray<PointArray>;
 /// A chunked line string array.
-pub type ChunkedLineStringArray = ChunkedGeometryArray<LineStringArray<D>>;
+pub type ChunkedLineStringArray = ChunkedGeometryArray<LineStringArray>;
 /// A chunked polygon array.
-pub type ChunkedPolygonArray = ChunkedGeometryArray<PolygonArray<D>>;
+pub type ChunkedPolygonArray = ChunkedGeometryArray<PolygonArray>;
 /// A chunked multi-point array.
-pub type ChunkedMultiPointArray = ChunkedGeometryArray<MultiPointArray<D>>;
+pub type ChunkedMultiPointArray = ChunkedGeometryArray<MultiPointArray>;
 /// A chunked mutli-line string array.
-pub type ChunkedMultiLineStringArray =
-    ChunkedGeometryArray<MultiLineStringArray<D>>;
+pub type ChunkedMultiLineStringArray = ChunkedGeometryArray<MultiLineStringArray>;
 /// A chunked multi-polygon array.
-pub type ChunkedMultiPolygonArray = ChunkedGeometryArray<MultiPolygonArray<D>>;
+pub type ChunkedMultiPolygonArray = ChunkedGeometryArray<MultiPolygonArray>;
 /// A chunked mixed geometry array.
-pub type ChunkedMixedGeometryArray = ChunkedGeometryArray<MixedGeometryArray<D>>;
+pub type ChunkedMixedGeometryArray = ChunkedGeometryArray<MixedGeometryArray>;
 /// A chunked geometry collection array.
-pub type ChunkedGeometryCollectionArray =
-    ChunkedGeometryArray<GeometryCollectionArray<D>>;
+pub type ChunkedGeometryCollectionArray = ChunkedGeometryArray<GeometryCollectionArray>;
 /// A chunked rect array.
-pub type ChunkedRectArray = ChunkedGeometryArray<RectArray<D>>;
+pub type ChunkedRectArray = ChunkedGeometryArray<RectArray>;
 /// A chunked unknown geometry array.
 #[allow(dead_code)]
 pub type ChunkedUnknownGeometryArray = ChunkedGeometryArray<Arc<dyn NativeArray>>;
@@ -797,7 +795,7 @@ pub trait ChunkedNativeArray: ChunkedArrayBase {
     }
 }
 
-impl ChunkedArrayBase for ChunkedPointArray<D> {
+impl ChunkedArrayBase for ChunkedPointArray {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -823,7 +821,7 @@ impl ChunkedArrayBase for ChunkedPointArray<D> {
     }
 }
 
-impl ChunkedNativeArray for ChunkedPointArray<D> {
+impl ChunkedNativeArray for ChunkedPointArray {
     fn data_type(&self) -> NativeType {
         self.chunks.first().unwrap().data_type()
     }
@@ -930,15 +928,15 @@ macro_rules! impl_trait {
     };
 }
 
-impl_trait!(ChunkedLineStringArray<D>);
-impl_trait!(ChunkedPolygonArray<D>);
-impl_trait!(ChunkedMultiPointArray<D>);
-impl_trait!(ChunkedMultiLineStringArray<D>);
-impl_trait!(ChunkedMultiPolygonArray<D>);
-impl_trait!(ChunkedMixedGeometryArray<D>);
-impl_trait!(ChunkedGeometryCollectionArray<D>);
+impl_trait!(ChunkedLineStringArray);
+impl_trait!(ChunkedPolygonArray);
+impl_trait!(ChunkedMultiPointArray);
+impl_trait!(ChunkedMultiLineStringArray);
+impl_trait!(ChunkedMultiPolygonArray);
+impl_trait!(ChunkedMixedGeometryArray);
+impl_trait!(ChunkedGeometryCollectionArray);
 
-impl ChunkedArrayBase for ChunkedRectArray<D> {
+impl ChunkedArrayBase for ChunkedRectArray {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -965,7 +963,7 @@ impl ChunkedArrayBase for ChunkedRectArray<D> {
     }
 }
 
-impl ChunkedNativeArray for ChunkedRectArray<D> {
+impl ChunkedNativeArray for ChunkedRectArray {
     fn data_type(&self) -> NativeType {
         self.chunks.first().unwrap().data_type()
     }

--- a/rust/geoarrow/src/chunked_array/mod.rs
+++ b/rust/geoarrow/src/chunked_array/mod.rs
@@ -280,9 +280,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// ```
     pub fn new(chunks: Vec<G>) -> Self {
@@ -301,9 +302,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let field = chunked_array.extension_field();
     /// assert_eq!(field.name(), "geometry");
@@ -318,9 +320,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let chunks = chunked_array.into_inner();
     /// assert_eq!(chunks.len(), 2);
@@ -335,9 +338,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.), &geo::point!(x: 5., y: 6.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.), &geo::point!(x: 5., y: 6.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// assert_eq!(chunked_array.len(), 3);
     /// ```
@@ -351,9 +355,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// assert!(!chunked_array.is_empty());
     /// ```
@@ -367,9 +372,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let chunks = chunked_array.chunks();
     /// ```
@@ -388,9 +394,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///     trait_::ArrayBase,
     ///     datatypes::NativeType,
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let lengths = chunked_array.into_map(|chunk| chunk.len()); // chunked_array is consumed
     /// assert_eq!(lengths, vec![1, 1]);
@@ -423,9 +430,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///     trait_::ArrayBase,
     ///     datatypes::NativeType,
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let lengths = chunked_array.map(|chunk| chunk.len());
     /// assert_eq!(lengths, vec![1, 1]);
@@ -458,9 +466,10 @@ impl<G: ArrayBase> ChunkedGeometryArray<G> {
     ///     trait_::ArrayBase,
     ///     datatypes::NativeType,
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let lengths = chunked_array.try_map(|chunk| Ok(chunk.len())).unwrap();
     /// assert_eq!(lengths, vec![1, 1]);
@@ -488,9 +497,10 @@ impl<G: NativeArray> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray, datatypes::NativeType};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// assert!(matches!(chunked_array.data_type(), NativeType::Point(_, _)));
     /// ```
@@ -506,11 +516,12 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
-    /// let value = chunked_array.value(1); // geoarrow::scalar::Point<2>
+    /// let value = chunked_array.value(1); // geoarrow::scalar::Point
     /// ```
     ///
     /// # Panics
@@ -535,11 +546,12 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> ChunkedGeometryArray<G> {
     ///
     /// ```
     /// use geoarrow::{chunked_array::ChunkedGeometryArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
-    /// let value = chunked_array.get(1).unwrap(); // geoarrow::scalar::Point<2>
+    /// let value = chunked_array.get(1).unwrap(); // geoarrow::scalar::Point
     /// ```
     ///
     /// # Panics
@@ -606,9 +618,10 @@ pub trait ChunkedArrayBase: std::fmt::Debug + Send + Sync {
     ///     chunked_array::{ChunkedGeometryArray, ChunkedNativeArray, ChunkedArrayBase},
     ///     array::PointArray
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let any = chunked_array.as_any();
     /// ```
@@ -626,9 +639,10 @@ pub trait ChunkedArrayBase: std::fmt::Debug + Send + Sync {
     ///     chunked_array::{ChunkedGeometryArray, ChunkedNativeArray},
     ///     array::PointArray
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let field = chunked_array.extension_field();
     /// assert_eq!(field.metadata()["ARROW:extension:name"], "geoarrow.point");
@@ -641,9 +655,10 @@ pub trait ChunkedArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, NativeArray, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert_eq!(point_array.len(), 1);
     /// ```
     fn len(&self) -> usize;
@@ -654,9 +669,10 @@ pub trait ChunkedArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(!point_array.is_empty());
     /// ```
     fn is_empty(&self) -> bool {
@@ -672,9 +688,10 @@ pub trait ChunkedArrayBase: std::fmt::Debug + Send + Sync {
     ///     chunked_array::{ChunkedGeometryArray, ChunkedArrayBase},
     ///     array::PointArray
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// assert_eq!(chunked_array.num_chunks(), 2);
     /// ```
@@ -689,9 +706,10 @@ pub trait ChunkedArrayBase: std::fmt::Debug + Send + Sync {
     ///     chunked_array::{ChunkedGeometryArray, ChunkedArrayBase},
     ///     array::PointArray
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let arrays = chunked_array.array_refs();
     /// ```
@@ -714,9 +732,10 @@ pub trait ChunkedNativeArray: ChunkedArrayBase {
     ///     chunked_array::{ChunkedGeometryArray, ChunkedNativeArray},
     ///     array::PointArray
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let data_type = chunked_array.data_type();
     /// ```
@@ -731,9 +750,10 @@ pub trait ChunkedNativeArray: ChunkedArrayBase {
     ///     chunked_array::{ChunkedGeometryArray, ChunkedNativeArray},
     ///     array::PointArray
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let chunks = chunked_array.geometry_chunks();
     /// assert_eq!(chunks.len(), 2);
@@ -749,9 +769,10 @@ pub trait ChunkedNativeArray: ChunkedArrayBase {
     ///     chunked_array::{ChunkedGeometryArray, ChunkedNativeArray},
     ///     array::PointArray
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
-    /// let array_0: PointArray<2> = vec![&geo::point!(x: 1., y: 2.)].as_slice().into();
-    /// let array_1: PointArray<2> = vec![&geo::point!(x: 3., y: 4.)].as_slice().into();
+    /// let array_0: PointArray = (vec![&geo::point!(x: 1., y: 2.)].as_slice(), Dimension::XY).into();
+    /// let array_1: PointArray = (vec![&geo::point!(x: 3., y: 4.)].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array_0, array_1]);
     /// let array_ref = chunked_array.as_ref();
     /// ```

--- a/rust/geoarrow/src/datatypes.rs
+++ b/rust/geoarrow/src/datatypes.rs
@@ -990,7 +990,7 @@ mod test {
         let data_type: NativeType = field.as_ref().try_into().unwrap();
         assert_eq!(ml_array.data_type(), data_type);
 
-        let mut builder = MixedGeometryBuilder::new();
+        let mut builder = MixedGeometryBuilder::new(Dimension::XY);
         builder.push_point(Some(&crate::test::point::p0())).unwrap();
         builder.push_point(Some(&crate::test::point::p1())).unwrap();
         builder.push_point(Some(&crate::test::point::p2())).unwrap();

--- a/rust/geoarrow/src/datatypes.rs
+++ b/rust/geoarrow/src/datatypes.rs
@@ -990,7 +990,7 @@ mod test {
         let data_type: NativeType = field.as_ref().try_into().unwrap();
         assert_eq!(ml_array.data_type(), data_type);
 
-        let mut builder = MixedGeometryBuilder::<2>::new();
+        let mut builder = MixedGeometryBuilder::new();
         builder.push_point(Some(&crate::test::point::p0())).unwrap();
         builder.push_point(Some(&crate::test::point::p1())).unwrap();
         builder.push_point(Some(&crate::test::point::p2())).unwrap();

--- a/rust/geoarrow/src/indexed/array.rs
+++ b/rust/geoarrow/src/indexed/array.rs
@@ -125,20 +125,18 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
     }
 }
 
-pub type IndexedPointArray = IndexedGeometryArray<PointArray<D>>;
-pub type IndexedLineStringArray = IndexedGeometryArray<LineStringArray<D>>;
-pub type IndexedPolygonArray = IndexedGeometryArray<PolygonArray<D>>;
-pub type IndexedMultiPointArray = IndexedGeometryArray<MultiPointArray<D>>;
-pub type IndexedMultiLineStringArray =
-    IndexedGeometryArray<MultiLineStringArray<D>>;
-pub type IndexedMultiPolygonArray = IndexedGeometryArray<MultiPolygonArray<D>>;
-pub type IndexedMixedGeometryArray = IndexedGeometryArray<MixedGeometryArray<D>>;
-pub type IndexedGeometryCollectionArray =
-    IndexedGeometryArray<GeometryCollectionArray<D>>;
+pub type IndexedPointArray = IndexedGeometryArray<PointArray>;
+pub type IndexedLineStringArray = IndexedGeometryArray<LineStringArray>;
+pub type IndexedPolygonArray = IndexedGeometryArray<PolygonArray>;
+pub type IndexedMultiPointArray = IndexedGeometryArray<MultiPointArray>;
+pub type IndexedMultiLineStringArray = IndexedGeometryArray<MultiLineStringArray>;
+pub type IndexedMultiPolygonArray = IndexedGeometryArray<MultiPolygonArray>;
+pub type IndexedMixedGeometryArray = IndexedGeometryArray<MixedGeometryArray>;
+pub type IndexedGeometryCollectionArray = IndexedGeometryArray<GeometryCollectionArray>;
 #[allow(dead_code)]
 pub type IndexedWKBArray<O> = IndexedGeometryArray<WKBArray<O>>;
 #[allow(dead_code)]
-pub type IndexedRectArray = IndexedGeometryArray<RectArray<D>>;
+pub type IndexedRectArray = IndexedGeometryArray<RectArray>;
 #[allow(dead_code)]
 pub type IndexedUnknownGeometryArray = IndexedGeometryArray<Arc<dyn NativeArray>>;
 

--- a/rust/geoarrow/src/indexed/array.rs
+++ b/rust/geoarrow/src/indexed/array.rs
@@ -125,20 +125,20 @@ impl<'a, G: NativeArray + ArrayAccessor<'a>> IndexedGeometryArray<G> {
     }
 }
 
-pub type IndexedPointArray<const D: usize> = IndexedGeometryArray<PointArray<D>>;
-pub type IndexedLineStringArray<const D: usize> = IndexedGeometryArray<LineStringArray<D>>;
-pub type IndexedPolygonArray<const D: usize> = IndexedGeometryArray<PolygonArray<D>>;
-pub type IndexedMultiPointArray<const D: usize> = IndexedGeometryArray<MultiPointArray<D>>;
-pub type IndexedMultiLineStringArray<const D: usize> =
+pub type IndexedPointArray = IndexedGeometryArray<PointArray<D>>;
+pub type IndexedLineStringArray = IndexedGeometryArray<LineStringArray<D>>;
+pub type IndexedPolygonArray = IndexedGeometryArray<PolygonArray<D>>;
+pub type IndexedMultiPointArray = IndexedGeometryArray<MultiPointArray<D>>;
+pub type IndexedMultiLineStringArray =
     IndexedGeometryArray<MultiLineStringArray<D>>;
-pub type IndexedMultiPolygonArray<const D: usize> = IndexedGeometryArray<MultiPolygonArray<D>>;
-pub type IndexedMixedGeometryArray<const D: usize> = IndexedGeometryArray<MixedGeometryArray<D>>;
-pub type IndexedGeometryCollectionArray<const D: usize> =
+pub type IndexedMultiPolygonArray = IndexedGeometryArray<MultiPolygonArray<D>>;
+pub type IndexedMixedGeometryArray = IndexedGeometryArray<MixedGeometryArray<D>>;
+pub type IndexedGeometryCollectionArray =
     IndexedGeometryArray<GeometryCollectionArray<D>>;
 #[allow(dead_code)]
 pub type IndexedWKBArray<O> = IndexedGeometryArray<WKBArray<O>>;
 #[allow(dead_code)]
-pub type IndexedRectArray<const D: usize> = IndexedGeometryArray<RectArray<D>>;
+pub type IndexedRectArray = IndexedGeometryArray<RectArray<D>>;
 #[allow(dead_code)]
 pub type IndexedUnknownGeometryArray = IndexedGeometryArray<Arc<dyn NativeArray>>;
 

--- a/rust/geoarrow/src/indexed/chunked.rs
+++ b/rust/geoarrow/src/indexed/chunked.rs
@@ -42,24 +42,19 @@ impl<G: NativeArray> IndexedChunkedGeometryArray<G> {
     }
 }
 
-pub type IndexedChunkedPointArray = IndexedChunkedGeometryArray<PointArray<D>>;
-pub type IndexedChunkedLineStringArray =
-    IndexedChunkedGeometryArray<LineStringArray<D>>;
-pub type IndexedChunkedPolygonArray = IndexedChunkedGeometryArray<PolygonArray<D>>;
-pub type IndexedChunkedMultiPointArray =
-    IndexedChunkedGeometryArray<MultiPointArray<D>>;
-pub type IndexedChunkedMultiLineStringArray =
-    IndexedChunkedGeometryArray<MultiLineStringArray<D>>;
-pub type IndexedChunkedMultiPolygonArray =
-    IndexedChunkedGeometryArray<MultiPolygonArray<D>>;
-pub type IndexedChunkedMixedGeometryArray =
-    IndexedChunkedGeometryArray<MixedGeometryArray<D>>;
+pub type IndexedChunkedPointArray = IndexedChunkedGeometryArray<PointArray>;
+pub type IndexedChunkedLineStringArray = IndexedChunkedGeometryArray<LineStringArray>;
+pub type IndexedChunkedPolygonArray = IndexedChunkedGeometryArray<PolygonArray>;
+pub type IndexedChunkedMultiPointArray = IndexedChunkedGeometryArray<MultiPointArray>;
+pub type IndexedChunkedMultiLineStringArray = IndexedChunkedGeometryArray<MultiLineStringArray>;
+pub type IndexedChunkedMultiPolygonArray = IndexedChunkedGeometryArray<MultiPolygonArray>;
+pub type IndexedChunkedMixedGeometryArray = IndexedChunkedGeometryArray<MixedGeometryArray>;
 pub type IndexedChunkedGeometryCollectionArray =
-    IndexedChunkedGeometryArray<GeometryCollectionArray<D>>;
+    IndexedChunkedGeometryArray<GeometryCollectionArray>;
 #[allow(dead_code)]
 pub type IndexedChunkedWKBArray<O> = IndexedChunkedGeometryArray<WKBArray<O>>;
 #[allow(dead_code)]
-pub type IndexedChunkedRectArray = IndexedChunkedGeometryArray<RectArray<D>>;
+pub type IndexedChunkedRectArray = IndexedChunkedGeometryArray<RectArray>;
 #[allow(dead_code)]
 pub type IndexedChunkedUnknownGeometryArray =
     IndexedChunkedGeometryArray<Arc<dyn ChunkedNativeArray>>;

--- a/rust/geoarrow/src/indexed/chunked.rs
+++ b/rust/geoarrow/src/indexed/chunked.rs
@@ -42,24 +42,24 @@ impl<G: NativeArray> IndexedChunkedGeometryArray<G> {
     }
 }
 
-pub type IndexedChunkedPointArray<const D: usize> = IndexedChunkedGeometryArray<PointArray<D>>;
-pub type IndexedChunkedLineStringArray<const D: usize> =
+pub type IndexedChunkedPointArray = IndexedChunkedGeometryArray<PointArray<D>>;
+pub type IndexedChunkedLineStringArray =
     IndexedChunkedGeometryArray<LineStringArray<D>>;
-pub type IndexedChunkedPolygonArray<const D: usize> = IndexedChunkedGeometryArray<PolygonArray<D>>;
-pub type IndexedChunkedMultiPointArray<const D: usize> =
+pub type IndexedChunkedPolygonArray = IndexedChunkedGeometryArray<PolygonArray<D>>;
+pub type IndexedChunkedMultiPointArray =
     IndexedChunkedGeometryArray<MultiPointArray<D>>;
-pub type IndexedChunkedMultiLineStringArray<const D: usize> =
+pub type IndexedChunkedMultiLineStringArray =
     IndexedChunkedGeometryArray<MultiLineStringArray<D>>;
-pub type IndexedChunkedMultiPolygonArray<const D: usize> =
+pub type IndexedChunkedMultiPolygonArray =
     IndexedChunkedGeometryArray<MultiPolygonArray<D>>;
-pub type IndexedChunkedMixedGeometryArray<const D: usize> =
+pub type IndexedChunkedMixedGeometryArray =
     IndexedChunkedGeometryArray<MixedGeometryArray<D>>;
-pub type IndexedChunkedGeometryCollectionArray<const D: usize> =
+pub type IndexedChunkedGeometryCollectionArray =
     IndexedChunkedGeometryArray<GeometryCollectionArray<D>>;
 #[allow(dead_code)]
 pub type IndexedChunkedWKBArray<O> = IndexedChunkedGeometryArray<WKBArray<O>>;
 #[allow(dead_code)]
-pub type IndexedChunkedRectArray<const D: usize> = IndexedChunkedGeometryArray<RectArray<D>>;
+pub type IndexedChunkedRectArray = IndexedChunkedGeometryArray<RectArray<D>>;
 #[allow(dead_code)]
 pub type IndexedChunkedUnknownGeometryArray =
     IndexedChunkedGeometryArray<Arc<dyn ChunkedNativeArray>>;

--- a/rust/geoarrow/src/io/csv/reader.rs
+++ b/rust/geoarrow/src/io/csv/reader.rs
@@ -3,6 +3,7 @@ use geozero::GeozeroDatasource;
 use std::io::Read;
 
 use crate::array::CoordType;
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::io::geozero::table::{GeoTableBuilder, GeoTableBuilderOptions};
@@ -47,8 +48,10 @@ pub fn read_csv<R: Read>(
         None,
         Default::default(),
     );
-    let mut geo_table =
-        GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(table_builder_options);
+    let mut geo_table = GeoTableBuilder::<MixedGeometryStreamBuilder>::new_with_options(
+        Dimension::XY,
+        table_builder_options,
+    );
     csv.process(&mut geo_table)?;
     geo_table.finish()
 }

--- a/rust/geoarrow/src/io/display/array.rs
+++ b/rust/geoarrow/src/io/display/array.rs
@@ -78,8 +78,8 @@ macro_rules! impl_fmt_non_generic {
     };
 }
 
-impl_fmt_non_generic!(PointArray<2>, "PointArray");
-impl_fmt_non_generic!(RectArray<2>, "RectArray");
+impl_fmt_non_generic!(PointArray, "PointArray");
+impl_fmt_non_generic!(RectArray, "RectArray");
 
 macro_rules! impl_fmt_generic {
     ($struct_name:ty, $str_literal:tt) => {
@@ -122,22 +122,22 @@ macro_rules! impl_fmt_generic {
     };
 }
 
-impl_fmt_generic!(LineStringArray<2>, "LineStringArray");
-impl_fmt_generic!(PolygonArray<2>, "PolygonArray");
-impl_fmt_generic!(MultiPointArray<2>, "MultiPointArray");
-impl_fmt_generic!(MultiLineStringArray<2>, "MultiLineStringArray");
-impl_fmt_generic!(MultiPolygonArray<2>, "MultiPolygonArray");
-impl_fmt_generic!(MixedGeometryArray<2>, "MixedGeometryArray");
-impl_fmt_generic!(GeometryCollectionArray<2>, "GeometryCollectionArray");
+impl_fmt_generic!(LineStringArray, "LineStringArray");
+impl_fmt_generic!(PolygonArray, "PolygonArray");
+impl_fmt_generic!(MultiPointArray, "MultiPointArray");
+impl_fmt_generic!(MultiLineStringArray, "MultiLineStringArray");
+impl_fmt_generic!(MultiPolygonArray, "MultiPolygonArray");
+impl_fmt_generic!(MixedGeometryArray, "MixedGeometryArray");
+impl_fmt_generic!(GeometryCollectionArray, "GeometryCollectionArray");
 // impl_fmt_generic!(WKBArray<O>, "WKBArray");
 
-impl fmt::Display for PointArray<2> {
+impl fmt::Display for PointArray {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.write(f, 0)
     }
 }
 
-impl fmt::Display for RectArray<2> {
+impl fmt::Display for RectArray {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.write(f, 0)
     }
@@ -153,13 +153,13 @@ macro_rules! impl_fmt {
     };
 }
 
-impl_fmt!(LineStringArray<2>, "LineStringArray");
-impl_fmt!(PolygonArray<2>, "PolygonArray");
-impl_fmt!(MultiPointArray<2>, "MultiPointArray");
-impl_fmt!(MultiLineStringArray<2>, "MultiLineStringArray");
-impl_fmt!(MultiPolygonArray<2>, "MultiPolygonArray");
-impl_fmt!(MixedGeometryArray<2>, "MixedGeometryArray");
-impl_fmt!(GeometryCollectionArray<2>, "GeometryCollectionArray");
+impl_fmt!(LineStringArray, "LineStringArray");
+impl_fmt!(PolygonArray, "PolygonArray");
+impl_fmt!(MultiPointArray, "MultiPointArray");
+impl_fmt!(MultiLineStringArray, "MultiLineStringArray");
+impl_fmt!(MultiPolygonArray, "MultiPolygonArray");
+impl_fmt!(MixedGeometryArray, "MixedGeometryArray");
+impl_fmt!(GeometryCollectionArray, "GeometryCollectionArray");
 // impl_fmt!(WKBArray<O>, "WKBArray");
 
 #[cfg(test)]

--- a/rust/geoarrow/src/io/display/array.rs
+++ b/rust/geoarrow/src/io/display/array.rs
@@ -180,7 +180,7 @@ mod test {
 
     #[test]
     fn test_display_ls_array() {
-        let array = linestring::large_ls_array();
+        let array = linestring::ls_array();
         let result = array.to_string();
         let expected = "LineStringArray([
     <LINESTRING(0 1,1 2)>,

--- a/rust/geoarrow/src/io/display/chunked_array.rs
+++ b/rust/geoarrow/src/io/display/chunked_array.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::chunked_array::*;
 use crate::io::display::array::{write_indented_ellipsis, WriteArray};
 
-impl fmt::Display for ChunkedPointArray<2> {
+impl fmt::Display for ChunkedPointArray {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("ChunkedPointArray")?;
         writeln!(f, "([")?;
@@ -29,7 +29,7 @@ impl fmt::Display for ChunkedPointArray<2> {
     }
 }
 
-impl fmt::Display for ChunkedRectArray<2> {
+impl fmt::Display for ChunkedRectArray {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("ChunkedRectArray")?;
         writeln!(f, "([")?;
@@ -85,17 +85,14 @@ macro_rules! impl_fmt_generic {
     };
 }
 
-impl_fmt_generic!(ChunkedLineStringArray<2>, "ChunkedLineStringArray");
-impl_fmt_generic!(ChunkedPolygonArray<2>, "ChunkedPolygonArray");
-impl_fmt_generic!(ChunkedMultiPointArray<2>, "ChunkedMultiPointArray");
+impl_fmt_generic!(ChunkedLineStringArray, "ChunkedLineStringArray");
+impl_fmt_generic!(ChunkedPolygonArray, "ChunkedPolygonArray");
+impl_fmt_generic!(ChunkedMultiPointArray, "ChunkedMultiPointArray");
+impl_fmt_generic!(ChunkedMultiLineStringArray, "ChunkedMultiLineStringArray");
+impl_fmt_generic!(ChunkedMultiPolygonArray, "ChunkedMultiPolygonArray");
+impl_fmt_generic!(ChunkedMixedGeometryArray, "ChunkedMixedGeometryArray");
 impl_fmt_generic!(
-    ChunkedMultiLineStringArray<2>,
-    "ChunkedMultiLineStringArray"
-);
-impl_fmt_generic!(ChunkedMultiPolygonArray<2>, "ChunkedMultiPolygonArray");
-impl_fmt_generic!(ChunkedMixedGeometryArray<2>, "ChunkedMixedGeometryArray");
-impl_fmt_generic!(
-    ChunkedGeometryCollectionArray<2>,
+    ChunkedGeometryCollectionArray,
     "ChunkedGeometryCollectionArray"
 );
 // impl_fmt_generic!(ChunkedWKBArray<O>, "ChunkedWKBArray");

--- a/rust/geoarrow/src/io/display/scalar.rs
+++ b/rust/geoarrow/src/io/display/scalar.rs
@@ -37,13 +37,13 @@ pub(crate) fn write_geometry(
     Ok(())
 }
 
-impl fmt::Display for Point<'_, 2> {
+impl fmt::Display for Point<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_geometry(f, self.to_geo_geometry(), 80)
     }
 }
 
-impl fmt::Display for Rect<'_, 2> {
+impl fmt::Display for Rect<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_geometry(f, self.to_geo_geometry(), 80)
     }
@@ -59,14 +59,14 @@ macro_rules! impl_fmt {
     };
 }
 
-impl_fmt!(LineString<'_, 2>);
-impl_fmt!(Polygon<'_, 2>);
-impl_fmt!(MultiPoint<'_, 2>);
-impl_fmt!(MultiLineString<'_, 2>);
-impl_fmt!(MultiPolygon<'_, 2>);
-impl_fmt!(GeometryCollection<'_, 2>);
+impl_fmt!(LineString<'_>);
+impl_fmt!(Polygon<'_>);
+impl_fmt!(MultiPoint<'_>);
+impl_fmt!(MultiLineString<'_>);
+impl_fmt!(MultiPolygon<'_>);
+impl_fmt!(GeometryCollection<'_>);
 
-impl fmt::Display for Geometry<'_, 2> {
+impl fmt::Display for Geometry<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write_geometry(f, self.to_geo_geometry(), 80)
     }

--- a/rust/geoarrow/src/io/display/scalar.rs
+++ b/rust/geoarrow/src/io/display/scalar.rs
@@ -84,6 +84,7 @@ impl<O: OffsetSizeTrait> fmt::Display for WKB<'_, O> {
 #[cfg(test)]
 mod test {
     use crate::array::PointArray;
+    use crate::datatypes::Dimension;
     use crate::io::wkb::ToWKB;
     use crate::test::{multipolygon, point};
     use crate::trait_::ArrayAccessor;
@@ -100,7 +101,7 @@ mod test {
     #[test]
     fn test_display_point_5_decimals() {
         let point = geo::Point::from((0.12345, 1.23456));
-        let point_array: PointArray<2> = vec![point].as_slice().into();
+        let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
         let result = point_array.value(0).to_string();
         let expected = "<POINT(0.123 1.234)>";
         assert_eq!(result, expected);

--- a/rust/geoarrow/src/io/flatgeobuf/reader/async.rs
+++ b/rust/geoarrow/src/io/flatgeobuf/reader/async.rs
@@ -63,7 +63,7 @@ pub async fn read_flatgeobuf_async(
 
     macro_rules! impl_read {
         ($builder:ty, $geom_type:ty, $dim:expr) => {{
-            let mut builder = GeoTableBuilder::<$builder>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<$builder>::new_with_options($dim, options);
             while let Some(feature) = selection.next().await? {
                 feature.process_properties(&mut builder)?;
                 builder.properties_end()?;
@@ -83,67 +83,63 @@ pub async fn read_flatgeobuf_async(
 
     match (geometry_type, has_z) {
         (GeometryType::Point, false) => {
-            impl_read!(PointBuilder<2>, super::core::Point, Dimension::XY)
+            impl_read!(PointBuilder, super::core::Point, Dimension::XY)
         }
         (GeometryType::LineString, false) => {
-            impl_read!(LineStringBuilder<2>, super::core::LineString, Dimension::XY)
+            impl_read!(LineStringBuilder, super::core::LineString, Dimension::XY)
         }
         (GeometryType::Polygon, false) => {
-            impl_read!(PolygonBuilder<2>, super::core::Polygon, Dimension::XY)
+            impl_read!(PolygonBuilder, super::core::Polygon, Dimension::XY)
         }
         (GeometryType::MultiPoint, false) => {
-            impl_read!(MultiPointBuilder<2>, super::core::MultiPoint, Dimension::XY)
+            impl_read!(MultiPointBuilder, super::core::MultiPoint, Dimension::XY)
         }
         (GeometryType::MultiLineString, false) => impl_read!(
-            MultiLineStringBuilder<2>,
+            MultiLineStringBuilder,
             super::core::MultiLineString,
             Dimension::XY
         ),
         (GeometryType::MultiPolygon, false) => impl_read!(
-            MultiPolygonBuilder<2>,
+            MultiPolygonBuilder,
             super::core::MultiPolygon,
             Dimension::XY
         ),
         (GeometryType::Unknown, false) => {
-            let mut builder =
-                GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MixedGeometryStreamBuilder>::new_with_options(
+                Dimension::XY,
+                options,
+            );
             selection.process_features(&mut builder).await?;
             let table = builder.finish()?;
             table.downcast(true)
         }
         (GeometryType::Point, true) => {
-            impl_read!(PointBuilder<3>, super::core::Point, Dimension::XYZ)
+            impl_read!(PointBuilder, super::core::Point, Dimension::XYZ)
         }
         (GeometryType::LineString, true) => {
-            impl_read!(
-                LineStringBuilder<3>,
-                super::core::LineString,
-                Dimension::XYZ
-            )
+            impl_read!(LineStringBuilder, super::core::LineString, Dimension::XYZ)
         }
         (GeometryType::Polygon, true) => {
-            impl_read!(PolygonBuilder<3>, super::core::Polygon, Dimension::XYZ)
+            impl_read!(PolygonBuilder, super::core::Polygon, Dimension::XYZ)
         }
         (GeometryType::MultiPoint, true) => {
-            impl_read!(
-                MultiPointBuilder<3>,
-                super::core::MultiPoint,
-                Dimension::XYZ
-            )
+            impl_read!(MultiPointBuilder, super::core::MultiPoint, Dimension::XYZ)
         }
         (GeometryType::MultiLineString, true) => impl_read!(
-            MultiLineStringBuilder<3>,
+            MultiLineStringBuilder,
             super::core::MultiLineString,
             Dimension::XYZ
         ),
         (GeometryType::MultiPolygon, true) => impl_read!(
-            MultiPolygonBuilder<3>,
+            MultiPolygonBuilder,
             super::core::MultiPolygon,
             Dimension::XYZ
         ),
         (GeometryType::Unknown, true) => {
-            let mut builder =
-                GeoTableBuilder::<MixedGeometryStreamBuilder<3>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MixedGeometryStreamBuilder>::new_with_options(
+                Dimension::XYZ,
+                options,
+            );
             selection.process_features(&mut builder).await?;
             let table = builder.finish()?;
             table.downcast(true)

--- a/rust/geoarrow/src/io/flatgeobuf/reader/sync.rs
+++ b/rust/geoarrow/src/io/flatgeobuf/reader/sync.rs
@@ -69,7 +69,7 @@ pub fn read_flatgeobuf<R: Read + Seek>(
 
     macro_rules! impl_read {
         ($builder:ty, $geom_type:ty, $dim:expr) => {{
-            let mut builder = GeoTableBuilder::<$builder>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<$builder>::new_with_options($dim, options);
             while let Some(feature) = selection.next()? {
                 feature.process_properties(&mut builder)?;
                 builder.properties_end()?;
@@ -89,67 +89,63 @@ pub fn read_flatgeobuf<R: Read + Seek>(
 
     match (geometry_type, has_z) {
         (GeometryType::Point, false) => {
-            impl_read!(PointBuilder<2>, super::core::Point, Dimension::XY)
+            impl_read!(PointBuilder, super::core::Point, Dimension::XY)
         }
         (GeometryType::LineString, false) => {
-            impl_read!(LineStringBuilder<2>, super::core::LineString, Dimension::XY)
+            impl_read!(LineStringBuilder, super::core::LineString, Dimension::XY)
         }
         (GeometryType::Polygon, false) => {
-            impl_read!(PolygonBuilder<2>, super::core::Polygon, Dimension::XY)
+            impl_read!(PolygonBuilder, super::core::Polygon, Dimension::XY)
         }
         (GeometryType::MultiPoint, false) => {
-            impl_read!(MultiPointBuilder<2>, super::core::MultiPoint, Dimension::XY)
+            impl_read!(MultiPointBuilder, super::core::MultiPoint, Dimension::XY)
         }
         (GeometryType::MultiLineString, false) => impl_read!(
-            MultiLineStringBuilder<2>,
+            MultiLineStringBuilder,
             super::core::MultiLineString,
             Dimension::XY
         ),
         (GeometryType::MultiPolygon, false) => impl_read!(
-            MultiPolygonBuilder<2>,
+            MultiPolygonBuilder,
             super::core::MultiPolygon,
             Dimension::XY
         ),
         (GeometryType::Unknown, false) => {
-            let mut builder =
-                GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MixedGeometryStreamBuilder>::new_with_options(
+                Dimension::XY,
+                options,
+            );
             selection.process_features(&mut builder)?;
             let table = builder.finish()?;
             table.downcast(true)
         }
         (GeometryType::Point, true) => {
-            impl_read!(PointBuilder<3>, super::core::Point, Dimension::XYZ)
+            impl_read!(PointBuilder, super::core::Point, Dimension::XYZ)
         }
         (GeometryType::LineString, true) => {
-            impl_read!(
-                LineStringBuilder<3>,
-                super::core::LineString,
-                Dimension::XYZ
-            )
+            impl_read!(LineStringBuilder, super::core::LineString, Dimension::XYZ)
         }
         (GeometryType::Polygon, true) => {
-            impl_read!(PolygonBuilder<3>, super::core::Polygon, Dimension::XYZ)
+            impl_read!(PolygonBuilder, super::core::Polygon, Dimension::XYZ)
         }
         (GeometryType::MultiPoint, true) => {
-            impl_read!(
-                MultiPointBuilder<3>,
-                super::core::MultiPoint,
-                Dimension::XYZ
-            )
+            impl_read!(MultiPointBuilder, super::core::MultiPoint, Dimension::XYZ)
         }
         (GeometryType::MultiLineString, true) => impl_read!(
-            MultiLineStringBuilder<3>,
+            MultiLineStringBuilder,
             super::core::MultiLineString,
             Dimension::XYZ
         ),
         (GeometryType::MultiPolygon, true) => impl_read!(
-            MultiPolygonBuilder<3>,
+            MultiPolygonBuilder,
             super::core::MultiPolygon,
             Dimension::XYZ
         ),
         (GeometryType::Unknown, true) => {
-            let mut builder =
-                GeoTableBuilder::<MixedGeometryStreamBuilder<3>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MixedGeometryStreamBuilder>::new_with_options(
+                Dimension::XYZ,
+                options,
+            );
             selection.process_features(&mut builder)?;
             let table = builder.finish()?;
             // TODO: 3d downcasting not implemented

--- a/rust/geoarrow/src/io/geojson/reader.rs
+++ b/rust/geoarrow/src/io/geojson/reader.rs
@@ -3,6 +3,7 @@ use geozero::GeozeroDatasource;
 use std::io::Read;
 
 use crate::array::CoordType;
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::io::geozero::table::{GeoTableBuilder, GeoTableBuilderOptions};
@@ -20,7 +21,8 @@ pub fn read_geojson<R: Read>(reader: R, batch_size: Option<usize>) -> Result<Tab
         None,
         Default::default(),
     );
-    let mut geo_table = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
+    let mut geo_table =
+        GeoTableBuilder::<MixedGeometryStreamBuilder>::new_with_options(Dimension::XY, options);
     geojson.process(&mut geo_table)?;
     geo_table.finish()
 }

--- a/rust/geoarrow/src/io/geojson_lines/reader.rs
+++ b/rust/geoarrow/src/io/geojson_lines/reader.rs
@@ -3,6 +3,7 @@ use geozero::GeozeroDatasource;
 use std::io::BufRead;
 
 use crate::array::CoordType;
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::io::geozero::table::{GeoTableBuilder, GeoTableBuilderOptions};
@@ -24,7 +25,8 @@ pub fn read_geojson_lines<R: BufRead>(reader: R, batch_size: Option<usize>) -> R
         None,
         Default::default(),
     );
-    let mut geo_table = GeoTableBuilder::<MixedGeometryStreamBuilder<2>>::new_with_options(options);
+    let mut geo_table =
+        GeoTableBuilder::<MixedGeometryStreamBuilder>::new_with_options(Dimension::XY, options);
     geojson_line_reader.process(&mut geo_table)?;
     geo_table.finish()
 }

--- a/rust/geoarrow/src/io/geos/array/geometrycollection.rs
+++ b/rust/geoarrow/src/io/geos/array/geometrycollection.rs
@@ -2,7 +2,7 @@ use crate::array::{GeometryCollectionArray, GeometryCollectionBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometryCollection;
 
-impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder<D> {
+impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
@@ -14,11 +14,11 @@ impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder<D> {
     }
 }
 
-impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionArray<D> {
+impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionArray {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: GeometryCollectionBuilder<D> = value.try_into()?;
+        let mutable_arr: GeometryCollectionBuilder = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/rust/geoarrow/src/io/geos/array/geometrycollection.rs
+++ b/rust/geoarrow/src/io/geos/array/geometrycollection.rs
@@ -2,7 +2,7 @@ use crate::array::{GeometryCollectionArray, GeometryCollectionBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometryCollection;
 
-impl<const D: usize> TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder<D> {
+impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
@@ -14,7 +14,7 @@ impl<const D: usize> TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder<
     }
 }
 
-impl<const D: usize> TryFrom<Vec<geos::Geometry>> for GeometryCollectionArray<D> {
+impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {

--- a/rust/geoarrow/src/io/geos/array/geometrycollection.rs
+++ b/rust/geoarrow/src/io/geos/array/geometrycollection.rs
@@ -1,23 +1,26 @@
 use crate::array::{GeometryCollectionArray, GeometryCollectionBuilder};
+use crate::datatypes::Dimension;
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometryCollection;
 
-impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionBuilder {
+impl TryFrom<(Vec<geos::Geometry>, Dimension)> for GeometryCollectionBuilder {
     type Error = GeoArrowError;
 
-    fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
+    fn try_from(
+        (value, dim): (Vec<geos::Geometry>, Dimension),
+    ) -> std::result::Result<Self, Self::Error> {
         let geoms: Vec<GEOSGeometryCollection> = value
             .into_iter()
             .map(GEOSGeometryCollection::new_unchecked)
             .collect();
-        Self::from_geometry_collections(&geoms, Default::default(), Default::default(), false)
+        Self::from_geometry_collections(&geoms, dim, Default::default(), Default::default(), false)
     }
 }
 
-impl TryFrom<Vec<geos::Geometry>> for GeometryCollectionArray {
+impl TryFrom<(Vec<geos::Geometry>, Dimension)> for GeometryCollectionArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: (Vec<geos::Geometry>, Dimension)) -> std::result::Result<Self, Self::Error> {
         let mutable_arr: GeometryCollectionBuilder = value.try_into()?;
         Ok(mutable_arr.into())
     }

--- a/rust/geoarrow/src/io/geos/array/linestring.rs
+++ b/rust/geoarrow/src/io/geos/array/linestring.rs
@@ -2,7 +2,7 @@ use crate::array::{LineStringArray, LineStringBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSLineString;
 
-impl LineStringBuilder<D> {
+impl LineStringBuilder {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSLineString>> = value
@@ -13,7 +13,7 @@ impl LineStringBuilder<D> {
     }
 }
 
-impl LineStringArray<D> {
+impl LineStringArray {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = LineStringBuilder::from_geos(value)?;
         Ok(mutable_arr.into())
@@ -34,7 +34,7 @@ mod test {
             .iter()
             .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
             .collect();
-        let round_trip = LineStringArray::<2>::from_geos(geos_geoms).unwrap();
+        let round_trip = LineStringArray::from_geos(geos_geoms).unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/rust/geoarrow/src/io/geos/array/linestring.rs
+++ b/rust/geoarrow/src/io/geos/array/linestring.rs
@@ -1,21 +1,22 @@
 use crate::array::{LineStringArray, LineStringBuilder};
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSLineString;
 
 impl LineStringBuilder {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSLineString>> = value
             .into_iter()
             .map(|geom| geom.map(GEOSLineString::new_unchecked))
             .collect();
-        Ok(geos_objects.into())
+        Ok((geos_objects, dim).into())
     }
 }
 
 impl LineStringArray {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr = LineStringBuilder::from_geos(value)?;
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
+        let mutable_arr = LineStringBuilder::from_geos(value, dim)?;
         Ok(mutable_arr.into())
     }
 }
@@ -34,7 +35,7 @@ mod test {
             .iter()
             .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
             .collect();
-        let round_trip = LineStringArray::from_geos(geos_geoms).unwrap();
+        let round_trip = LineStringArray::from_geos(geos_geoms, Dimension::XY).unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/rust/geoarrow/src/io/geos/array/linestring.rs
+++ b/rust/geoarrow/src/io/geos/array/linestring.rs
@@ -2,7 +2,7 @@ use crate::array::{LineStringArray, LineStringBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSLineString;
 
-impl<const D: usize> LineStringBuilder<D> {
+impl LineStringBuilder<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSLineString>> = value
@@ -13,7 +13,7 @@ impl<const D: usize> LineStringBuilder<D> {
     }
 }
 
-impl<const D: usize> LineStringArray<D> {
+impl LineStringArray<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = LineStringBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/mixed.rs
+++ b/rust/geoarrow/src/io/geos/array/mixed.rs
@@ -2,7 +2,7 @@ use crate::array::{MixedGeometryArray, MixedGeometryBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometry;
 
-impl TryFrom<Vec<geos::Geometry>> for MixedGeometryBuilder<D> {
+impl TryFrom<Vec<geos::Geometry>> for MixedGeometryBuilder {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
@@ -11,11 +11,11 @@ impl TryFrom<Vec<geos::Geometry>> for MixedGeometryBuilder<D> {
     }
 }
 
-impl TryFrom<Vec<geos::Geometry>> for MixedGeometryArray<D> {
+impl TryFrom<Vec<geos::Geometry>> for MixedGeometryArray {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
-        let mutable_arr: MixedGeometryBuilder<D> = value.try_into()?;
+        let mutable_arr: MixedGeometryBuilder = value.try_into()?;
         Ok(mutable_arr.into())
     }
 }

--- a/rust/geoarrow/src/io/geos/array/mixed.rs
+++ b/rust/geoarrow/src/io/geos/array/mixed.rs
@@ -1,20 +1,23 @@
 use crate::array::{MixedGeometryArray, MixedGeometryBuilder};
+use crate::datatypes::Dimension;
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometry;
 
-impl TryFrom<Vec<geos::Geometry>> for MixedGeometryBuilder {
+impl TryFrom<(Vec<geos::Geometry>, Dimension)> for MixedGeometryBuilder {
     type Error = GeoArrowError;
 
-    fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
+    fn try_from(
+        (value, dim): (Vec<geos::Geometry>, Dimension),
+    ) -> std::result::Result<Self, Self::Error> {
         let geoms: Vec<GEOSGeometry> = value.into_iter().map(GEOSGeometry::new).collect();
-        Self::from_geometries(&geoms, Default::default(), Default::default(), false)
+        Self::from_geometries(&geoms, dim, Default::default(), Default::default(), false)
     }
 }
 
-impl TryFrom<Vec<geos::Geometry>> for MixedGeometryArray {
+impl TryFrom<(Vec<geos::Geometry>, Dimension)> for MixedGeometryArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: (Vec<geos::Geometry>, Dimension)) -> std::result::Result<Self, Self::Error> {
         let mutable_arr: MixedGeometryBuilder = value.try_into()?;
         Ok(mutable_arr.into())
     }

--- a/rust/geoarrow/src/io/geos/array/mixed.rs
+++ b/rust/geoarrow/src/io/geos/array/mixed.rs
@@ -2,7 +2,7 @@ use crate::array::{MixedGeometryArray, MixedGeometryBuilder};
 use crate::error::GeoArrowError;
 use crate::io::geos::scalar::GEOSGeometry;
 
-impl<const D: usize> TryFrom<Vec<geos::Geometry>> for MixedGeometryBuilder<D> {
+impl TryFrom<Vec<geos::Geometry>> for MixedGeometryBuilder<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {
@@ -11,7 +11,7 @@ impl<const D: usize> TryFrom<Vec<geos::Geometry>> for MixedGeometryBuilder<D> {
     }
 }
 
-impl<const D: usize> TryFrom<Vec<geos::Geometry>> for MixedGeometryArray<D> {
+impl TryFrom<Vec<geos::Geometry>> for MixedGeometryArray<D> {
     type Error = GeoArrowError;
 
     fn try_from(value: Vec<geos::Geometry>) -> std::result::Result<Self, Self::Error> {

--- a/rust/geoarrow/src/io/geos/array/multilinestring.rs
+++ b/rust/geoarrow/src/io/geos/array/multilinestring.rs
@@ -2,7 +2,7 @@ use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiLineString;
 
-impl<const D: usize> MultiLineStringBuilder<D> {
+impl MultiLineStringBuilder<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiLineString>> = value
@@ -13,7 +13,7 @@ impl<const D: usize> MultiLineStringBuilder<D> {
     }
 }
 
-impl<const D: usize> MultiLineStringArray<D> {
+impl MultiLineStringArray<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = MultiLineStringBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/multilinestring.rs
+++ b/rust/geoarrow/src/io/geos/array/multilinestring.rs
@@ -1,21 +1,22 @@
 use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiLineString;
 
 impl MultiLineStringBuilder {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiLineString>> = value
             .into_iter()
             .map(|geom| geom.map(GEOSMultiLineString::new_unchecked))
             .collect();
-        Ok(geos_objects.into())
+        Ok((geos_objects, dim).into())
     }
 }
 
 impl MultiLineStringArray {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr = MultiLineStringBuilder::from_geos(value)?;
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
+        let mutable_arr = MultiLineStringBuilder::from_geos(value, dim)?;
         Ok(mutable_arr.into())
     }
 }
@@ -34,7 +35,7 @@ mod test {
             .iter()
             .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
             .collect();
-        let round_trip = MultiLineStringArray::<2>::from_geos(geos_geoms).unwrap();
+        let round_trip = MultiLineStringArray::from_geos(geos_geoms, Dimension::XY).unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/rust/geoarrow/src/io/geos/array/multilinestring.rs
+++ b/rust/geoarrow/src/io/geos/array/multilinestring.rs
@@ -2,7 +2,7 @@ use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiLineString;
 
-impl MultiLineStringBuilder<D> {
+impl MultiLineStringBuilder {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiLineString>> = value
@@ -13,7 +13,7 @@ impl MultiLineStringBuilder<D> {
     }
 }
 
-impl MultiLineStringArray<D> {
+impl MultiLineStringArray {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = MultiLineStringBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/multipoint.rs
+++ b/rust/geoarrow/src/io/geos/array/multipoint.rs
@@ -2,7 +2,7 @@ use crate::array::{MultiPointArray, MultiPointBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiPoint;
 
-impl MultiPointBuilder<D> {
+impl MultiPointBuilder {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiPoint>> = value
@@ -13,7 +13,7 @@ impl MultiPointBuilder<D> {
     }
 }
 
-impl MultiPointArray<D> {
+impl MultiPointArray {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = MultiPointBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/multipoint.rs
+++ b/rust/geoarrow/src/io/geos/array/multipoint.rs
@@ -2,7 +2,7 @@ use crate::array::{MultiPointArray, MultiPointBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiPoint;
 
-impl<const D: usize> MultiPointBuilder<D> {
+impl MultiPointBuilder<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiPoint>> = value
@@ -13,7 +13,7 @@ impl<const D: usize> MultiPointBuilder<D> {
     }
 }
 
-impl<const D: usize> MultiPointArray<D> {
+impl MultiPointArray<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = MultiPointBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/multipoint.rs
+++ b/rust/geoarrow/src/io/geos/array/multipoint.rs
@@ -1,21 +1,22 @@
 use crate::array::{MultiPointArray, MultiPointBuilder};
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiPoint;
 
 impl MultiPointBuilder {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiPoint>> = value
             .into_iter()
             .map(|geom| geom.map(GEOSMultiPoint::new_unchecked))
             .collect();
-        Ok(geos_objects.into())
+        Ok((geos_objects, dim).into())
     }
 }
 
 impl MultiPointArray {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr = MultiPointBuilder::from_geos(value)?;
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
+        let mutable_arr = MultiPointBuilder::from_geos(value, dim)?;
         Ok(mutable_arr.into())
     }
 }
@@ -34,7 +35,7 @@ mod test {
             .iter()
             .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
             .collect();
-        let round_trip = MultiPointArray::<2>::from_geos(geos_geoms).unwrap();
+        let round_trip = MultiPointArray::from_geos(geos_geoms, Dimension::XY).unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/rust/geoarrow/src/io/geos/array/multipolygon.rs
+++ b/rust/geoarrow/src/io/geos/array/multipolygon.rs
@@ -2,7 +2,7 @@ use crate::array::{MultiPolygonArray, MultiPolygonBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiPolygon;
 
-impl MultiPolygonBuilder<D> {
+impl MultiPolygonBuilder {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiPolygon>> = value
@@ -13,7 +13,7 @@ impl MultiPolygonBuilder<D> {
     }
 }
 
-impl MultiPolygonArray<D> {
+impl MultiPolygonArray {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = MultiPolygonBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/multipolygon.rs
+++ b/rust/geoarrow/src/io/geos/array/multipolygon.rs
@@ -1,21 +1,22 @@
 use crate::array::{MultiPolygonArray, MultiPolygonBuilder};
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiPolygon;
 
 impl MultiPolygonBuilder {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiPolygon>> = value
             .into_iter()
             .map(|geom| geom.map(GEOSMultiPolygon::new_unchecked))
             .collect();
-        Ok(geos_objects.into())
+        Ok((geos_objects, dim).into())
     }
 }
 
 impl MultiPolygonArray {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr = MultiPolygonBuilder::from_geos(value)?;
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
+        let mutable_arr = MultiPolygonBuilder::from_geos(value, dim)?;
         Ok(mutable_arr.into())
     }
 }
@@ -34,7 +35,7 @@ mod test {
             .iter()
             .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
             .collect();
-        let round_trip = MultiPolygonArray::<2>::from_geos(geos_geoms).unwrap();
+        let round_trip = MultiPolygonArray::from_geos(geos_geoms, Dimension::XY).unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/rust/geoarrow/src/io/geos/array/multipolygon.rs
+++ b/rust/geoarrow/src/io/geos/array/multipolygon.rs
@@ -2,7 +2,7 @@ use crate::array::{MultiPolygonArray, MultiPolygonBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSMultiPolygon;
 
-impl<const D: usize> MultiPolygonBuilder<D> {
+impl MultiPolygonBuilder<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSMultiPolygon>> = value
@@ -13,7 +13,7 @@ impl<const D: usize> MultiPolygonBuilder<D> {
     }
 }
 
-impl<const D: usize> MultiPolygonArray<D> {
+impl MultiPolygonArray<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = MultiPolygonBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/point.rs
+++ b/rust/geoarrow/src/io/geos/array/point.rs
@@ -2,7 +2,7 @@ use crate::array::{PointArray, PointBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSPoint;
 
-impl PointBuilder<D> {
+impl PointBuilder {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_linestring_objects: Vec<Option<GEOSPoint>> = value
@@ -13,7 +13,7 @@ impl PointBuilder<D> {
     }
 }
 
-impl PointArray<D> {
+impl PointArray {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = PointBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/point.rs
+++ b/rust/geoarrow/src/io/geos/array/point.rs
@@ -1,21 +1,22 @@
 use crate::array::{PointArray, PointBuilder};
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSPoint;
 
 impl PointBuilder {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_linestring_objects: Vec<Option<GEOSPoint>> = value
             .into_iter()
             .map(|geom| geom.map(GEOSPoint::new_unchecked))
             .collect();
-        Ok(geos_linestring_objects.into())
+        Ok((geos_linestring_objects, dim).into())
     }
 }
 
 impl PointArray {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr = PointBuilder::from_geos(value)?;
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
+        let mutable_arr = PointBuilder::from_geos(value, dim)?;
         Ok(mutable_arr.into())
     }
 }
@@ -33,7 +34,7 @@ mod test {
             .iter()
             .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
             .collect();
-        let round_trip = PointArray::<2>::from_geos(geos_geoms).unwrap();
+        let round_trip = PointArray::from_geos(geos_geoms, Dimension::XY).unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/rust/geoarrow/src/io/geos/array/point.rs
+++ b/rust/geoarrow/src/io/geos/array/point.rs
@@ -2,7 +2,7 @@ use crate::array::{PointArray, PointBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSPoint;
 
-impl<const D: usize> PointBuilder<D> {
+impl PointBuilder<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_linestring_objects: Vec<Option<GEOSPoint>> = value
@@ -13,7 +13,7 @@ impl<const D: usize> PointBuilder<D> {
     }
 }
 
-impl<const D: usize> PointArray<D> {
+impl PointArray<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = PointBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/polygon.rs
+++ b/rust/geoarrow/src/io/geos/array/polygon.rs
@@ -2,7 +2,7 @@ use crate::array::{PolygonArray, PolygonBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSPolygon;
 
-impl PolygonBuilder<D> {
+impl PolygonBuilder {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSPolygon>> = value
@@ -14,7 +14,7 @@ impl PolygonBuilder<D> {
     }
 }
 
-impl PolygonArray<D> {
+impl PolygonArray {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = PolygonBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/array/polygon.rs
+++ b/rust/geoarrow/src/io/geos/array/polygon.rs
@@ -1,22 +1,23 @@
 use crate::array::{PolygonArray, PolygonBuilder};
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSPolygon;
 
 impl PolygonBuilder {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSPolygon>> = value
             .into_iter()
             .map(|geom| geom.map(GEOSPolygon::new_unchecked))
             .collect();
 
-        Ok(geos_objects.into())
+        Ok((geos_objects, dim).into())
     }
 }
 
 impl PolygonArray {
-    pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
-        let mutable_arr = PolygonBuilder::from_geos(value)?;
+    pub fn from_geos(value: Vec<Option<geos::Geometry>>, dim: Dimension) -> Result<Self> {
+        let mutable_arr = PolygonBuilder::from_geos(value, dim)?;
         Ok(mutable_arr.into())
     }
 }
@@ -35,7 +36,7 @@ mod test {
             .iter()
             .map(|opt_x| opt_x.map(|x| x.to_geos().unwrap()))
             .collect();
-        let round_trip = PolygonArray::<2>::from_geos(geos_geoms).unwrap();
+        let round_trip = PolygonArray::from_geos(geos_geoms, Dimension::XY).unwrap();
         assert_eq!(arr, round_trip);
     }
 }

--- a/rust/geoarrow/src/io/geos/array/polygon.rs
+++ b/rust/geoarrow/src/io/geos/array/polygon.rs
@@ -2,7 +2,7 @@ use crate::array::{PolygonArray, PolygonBuilder};
 use crate::error::Result;
 use crate::io::geos::scalar::GEOSPolygon;
 
-impl<const D: usize> PolygonBuilder<D> {
+impl PolygonBuilder<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         // TODO: don't use new_unchecked
         let geos_objects: Vec<Option<GEOSPolygon>> = value
@@ -14,7 +14,7 @@ impl<const D: usize> PolygonBuilder<D> {
     }
 }
 
-impl<const D: usize> PolygonArray<D> {
+impl PolygonArray<D> {
     pub fn from_geos(value: Vec<Option<geos::Geometry>>) -> Result<Self> {
         let mutable_arr = PolygonBuilder::from_geos(value)?;
         Ok(mutable_arr.into())

--- a/rust/geoarrow/src/io/geos/scalar/geometry.rs
+++ b/rust/geoarrow/src/io/geos/scalar/geometry.rs
@@ -10,10 +10,10 @@ use geo_traits::{
 };
 use geos::Geom;
 
-impl<'a, const D: usize> TryFrom<&'a Geometry<'_, D>> for geos::Geometry {
+impl<'a> TryFrom<&'a Geometry<'_>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Geometry<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Geometry<'_>) -> std::result::Result<geos::Geometry, geos::Error> {
         match value {
             Geometry::Point(g) => g.try_into(),
             Geometry::LineString(g) => g.try_into(),

--- a/rust/geoarrow/src/io/geos/scalar/geometrycollection.rs
+++ b/rust/geoarrow/src/io/geos/scalar/geometrycollection.rs
@@ -3,11 +3,11 @@ use crate::scalar::GeometryCollection;
 use geo_traits::GeometryCollectionTrait;
 use geos::Geom;
 
-impl<'a, const D: usize> TryFrom<&'a GeometryCollection<'_, D>> for geos::Geometry {
+impl<'a> TryFrom<&'a GeometryCollection<'_>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a GeometryCollection<'_, D>,
+        value: &'a GeometryCollection<'_>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_geometry_collection(
             value

--- a/rust/geoarrow/src/io/geos/scalar/linestring.rs
+++ b/rust/geoarrow/src/io/geos/scalar/linestring.rs
@@ -5,10 +5,10 @@ use crate::scalar::LineString;
 use geo_traits::LineStringTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, const D: usize> TryFrom<&'a LineString<'_, D>> for geos::Geometry {
+impl<'a> TryFrom<&'a LineString<'_>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a LineString<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a LineString<'_>) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = value.geom_offsets.start_end(value.geom_index);
 
         let sliced_coords = value.coords.clone().slice(start, end - start);
@@ -17,7 +17,7 @@ impl<'a, const D: usize> TryFrom<&'a LineString<'_, D>> for geos::Geometry {
     }
 }
 
-impl<const D: usize> LineString<'_, D> {
+impl LineString<'_> {
     pub fn to_geos_linear_ring(&self) -> std::result::Result<geos::Geometry, geos::Error> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
 

--- a/rust/geoarrow/src/io/geos/scalar/multilinestring.rs
+++ b/rust/geoarrow/src/io/geos/scalar/multilinestring.rs
@@ -4,11 +4,11 @@ use crate::scalar::MultiLineString;
 use geo_traits::MultiLineStringTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, const D: usize> TryFrom<&'a MultiLineString<'_, D>> for geos::Geometry {
+impl<'a> TryFrom<&'a MultiLineString<'_>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiLineString<'_, D>,
+        value: &'a MultiLineString<'_>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multiline_string(
             value

--- a/rust/geoarrow/src/io/geos/scalar/multipoint.rs
+++ b/rust/geoarrow/src/io/geos/scalar/multipoint.rs
@@ -4,10 +4,10 @@ use crate::scalar::MultiPoint;
 use geo_traits::MultiPointTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, const D: usize> TryFrom<&'a MultiPoint<'_, D>> for geos::Geometry {
+impl<'a> TryFrom<&'a MultiPoint<'_>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a MultiPoint<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a MultiPoint<'_>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipoint(
             value
                 .points()

--- a/rust/geoarrow/src/io/geos/scalar/multipolygon.rs
+++ b/rust/geoarrow/src/io/geos/scalar/multipolygon.rs
@@ -7,9 +7,7 @@ use geos::{Geom, GeometryTypes};
 impl<'a> TryFrom<&'a MultiPolygon<'_>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(
-        value: &'a MultiPolygon<'_>,
-    ) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a MultiPolygon<'_>) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipolygon(
             value
                 .polygons()

--- a/rust/geoarrow/src/io/geos/scalar/multipolygon.rs
+++ b/rust/geoarrow/src/io/geos/scalar/multipolygon.rs
@@ -4,11 +4,11 @@ use crate::scalar::MultiPolygon;
 use geo_traits::MultiPolygonTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, const D: usize> TryFrom<&'a MultiPolygon<'_, D>> for geos::Geometry {
+impl<'a> TryFrom<&'a MultiPolygon<'_>> for geos::Geometry {
     type Error = geos::Error;
 
     fn try_from(
-        value: &'a MultiPolygon<'_, D>,
+        value: &'a MultiPolygon<'_>,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
         geos::Geometry::create_multipolygon(
             value

--- a/rust/geoarrow/src/io/geos/scalar/point.rs
+++ b/rust/geoarrow/src/io/geos/scalar/point.rs
@@ -4,10 +4,10 @@ use crate::scalar::Point;
 use geo_traits::PointTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, const D: usize> TryFrom<&'a Point<'_, D>> for geos::Geometry {
+impl<'a> TryFrom<&'a Point<'_>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(point: &'a Point<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(point: &'a Point<'_>) -> std::result::Result<geos::Geometry, geos::Error> {
         if let Some(coord) = PointTrait::coord(&point) {
             let coord_seq = (&coord).try_into()?;
             Ok(geos::Geometry::create_point(coord_seq)?)

--- a/rust/geoarrow/src/io/geos/scalar/polygon.rs
+++ b/rust/geoarrow/src/io/geos/scalar/polygon.rs
@@ -4,10 +4,10 @@ use crate::scalar::Polygon;
 use geo_traits::PolygonTrait;
 use geos::{Geom, GeometryTypes};
 
-impl<'a, const D: usize> TryFrom<&'a Polygon<'_, D>> for geos::Geometry {
+impl<'a> TryFrom<&'a Polygon<'_>> for geos::Geometry {
     type Error = geos::Error;
 
-    fn try_from(value: &'a Polygon<'_, D>) -> std::result::Result<geos::Geometry, geos::Error> {
+    fn try_from(value: &'a Polygon<'_>) -> std::result::Result<geos::Geometry, geos::Error> {
         if let Some(exterior) = value.exterior() {
             let exterior = exterior.to_geos_linear_ring()?;
             let interiors = value

--- a/rust/geoarrow/src/io/geozero/array/dynamic.rs
+++ b/rust/geoarrow/src/io/geozero/array/dynamic.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::dynamic::NativeArrayDyn;
 use crate::array::AsNativeArray;
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 
 impl GeozeroGeometry for NativeArrayDyn {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
@@ -10,47 +10,30 @@ impl GeozeroGeometry for NativeArrayDyn {
         Self: Sized,
     {
         macro_rules! impl_process {
-            ($cast_func:ident, $dim:expr) => {{
-                let arr = self.inner().as_ref();
-                arr.$cast_func::<$dim>().process_geom(processor)
-            }};
             ($cast_func:ident) => {{
                 let arr = self.inner().as_ref();
                 arr.$cast_func().process_geom(processor)
             }};
         }
 
-        use Dimension::*;
         use NativeType::*;
 
         match self.inner().data_type() {
-            Point(_, XY) => impl_process!(as_point, 2),
-            LineString(_, XY) => impl_process!(as_line_string, 2),
-            Polygon(_, XY) => impl_process!(as_polygon, 2),
-            MultiPoint(_, XY) => impl_process!(as_multi_point, 2),
-            MultiLineString(_, XY) => {
-                impl_process!(as_multi_line_string, 2)
+            Point(_, _) => impl_process!(as_point),
+            LineString(_, _) => impl_process!(as_line_string),
+            Polygon(_, _) => impl_process!(as_polygon),
+            MultiPoint(_, _) => impl_process!(as_multi_point),
+            MultiLineString(_, _) => {
+                impl_process!(as_multi_line_string)
             }
-            MultiPolygon(_, XY) => impl_process!(as_multi_polygon, 2),
-            Mixed(_, XY) => impl_process!(as_mixed, 2),
-            GeometryCollection(_, XY) => {
-                impl_process!(as_geometry_collection, 2)
-            }
-            Point(_, XYZ) => impl_process!(as_point, 3),
-            LineString(_, XYZ) => impl_process!(as_line_string, 3),
-            Polygon(_, XYZ) => impl_process!(as_polygon, 3),
-            MultiPoint(_, XYZ) => impl_process!(as_multi_point, 3),
-            MultiLineString(_, XYZ) => {
-                impl_process!(as_multi_line_string, 3)
-            }
-            MultiPolygon(_, XYZ) => impl_process!(as_multi_polygon, 3),
-            Mixed(_, XYZ) => impl_process!(as_mixed, 3),
-            GeometryCollection(_, XYZ) => {
-                impl_process!(as_geometry_collection, 3)
+            MultiPolygon(_, _) => impl_process!(as_multi_polygon),
+            Mixed(_, _) => impl_process!(as_mixed),
+            GeometryCollection(_, _) => {
+                impl_process!(as_geometry_collection)
             }
             _ => todo!(),
             // WKB => impl_process!(as_wkb),
-            // Rect(XY) => impl_process!(as_rect, 2)
+            // Rect(_) => impl_process!(as_rect)
             // Rect(XYZ) => impl_process!(as_rect, 3)
         }
     }
@@ -71,7 +54,7 @@ mod test {
     fn test() {
         let arr = point::point_array();
         let geom_arr = NativeArrayDyn::new(Arc::new(arr));
-        let test = geom_arr.as_any().downcast_ref::<PointArray<2>>().unwrap();
+        let test = geom_arr.as_any().downcast_ref::<PointArray>().unwrap();
         dbg!(geom_arr.to_geo().unwrap());
         dbg!(test);
     }

--- a/rust/geoarrow/src/io/geozero/array/geometrycollection.rs
+++ b/rust/geoarrow/src/io/geozero/array/geometrycollection.rs
@@ -4,7 +4,7 @@ use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<const D: usize> GeozeroGeometry for GeometryCollectionArray<D> {
+impl GeozeroGeometry for GeometryCollectionArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/array/geometrycollection.rs
+++ b/rust/geoarrow/src/io/geozero/array/geometrycollection.rs
@@ -4,7 +4,7 @@ use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl GeozeroGeometry for GeometryCollectionArray<D> {
+impl GeozeroGeometry for GeometryCollectionArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/array/linestring.rs
+++ b/rust/geoarrow/src/io/geozero/array/linestring.rs
@@ -6,7 +6,7 @@ use crate::io::geozero::scalar::process_line_string;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 
-impl<const D: usize> GeozeroGeometry for LineStringArray<D> {
+impl GeozeroGeometry for LineStringArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -24,7 +24,7 @@ impl<const D: usize> GeozeroGeometry for LineStringArray<D> {
 }
 
 /// GeoZero trait to convert to GeoArrow LineStringArray.
-pub trait ToLineStringArray<const D: usize> {
+pub trait ToLineStringArray {
     /// Convert to GeoArrow LineStringArray
     fn to_line_string_array(&self) -> geozero::error::Result<LineStringArray<D>>;
 
@@ -45,7 +45,7 @@ impl<T: GeozeroGeometry, const D: usize> ToLineStringArray<D> for T {
 }
 
 #[allow(unused_variables)]
-impl<const D: usize> GeomProcessor for LineStringBuilder<D> {
+impl GeomProcessor for LineStringBuilder<D> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         let capacity = LineStringCapacity::new(0, size);
         self.reserve(capacity);

--- a/rust/geoarrow/src/io/geozero/array/mixed.rs
+++ b/rust/geoarrow/src/io/geozero/array/mixed.rs
@@ -9,7 +9,7 @@ use crate::ArrayBase;
 use crate::NativeArray;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<const D: usize> GeozeroGeometry for MixedGeometryArray<D> {
+impl GeozeroGeometry for MixedGeometryArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -28,7 +28,7 @@ impl<const D: usize> GeozeroGeometry for MixedGeometryArray<D> {
 
 // TODO: Add "promote to multi" here
 /// GeoZero trait to convert to GeoArrow MixedArray.
-pub trait ToMixedArray<const D: usize> {
+pub trait ToMixedArray {
     /// Convert to GeoArrow MixedArray
     fn to_mixed_geometry_array(&self) -> geozero::error::Result<MixedGeometryArray<D>>;
 
@@ -55,7 +55,7 @@ impl<T: GeozeroGeometry, const D: usize> ToMixedArray<D> for T {
 ///
 /// Converting an [`MixedGeometryStreamBuilder`] into a [`MixedGeometryArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct MixedGeometryStreamBuilder<const D: usize> {
+pub struct MixedGeometryStreamBuilder {
     builder: MixedGeometryBuilder<D>,
     // Note: we don't know if, when `linestring_end` is called, that means a ring of a polygon has
     // finished or if a tagged line string has finished. This means we can't have an "unknown" enum
@@ -64,7 +64,7 @@ pub struct MixedGeometryStreamBuilder<const D: usize> {
     current_geom_type: GeometryType,
 }
 
-impl<const D: usize> MixedGeometryStreamBuilder<D> {
+impl MixedGeometryStreamBuilder<D> {
     pub fn new() -> Self {
         Self::new_with_options(Default::default(), Default::default(), true)
     }
@@ -89,14 +89,14 @@ impl<const D: usize> MixedGeometryStreamBuilder<D> {
     }
 }
 
-impl<const D: usize> Default for MixedGeometryStreamBuilder<D> {
+impl Default for MixedGeometryStreamBuilder<D> {
     fn default() -> Self {
         Self::new()
     }
 }
 
 #[allow(unused_variables)]
-impl<const D: usize> GeomProcessor for MixedGeometryStreamBuilder<D> {
+impl GeomProcessor for MixedGeometryStreamBuilder<D> {
     fn xy(&mut self, x: f64, y: f64, idx: usize) -> geozero::error::Result<()> {
         match self.current_geom_type {
             GeometryType::Point => {
@@ -258,7 +258,7 @@ impl<const D: usize> GeomProcessor for MixedGeometryStreamBuilder<D> {
     }
 }
 
-impl<const D: usize> GeometryArrayBuilder for MixedGeometryStreamBuilder<D> {
+impl GeometryArrayBuilder for MixedGeometryStreamBuilder<D> {
     fn len(&self) -> usize {
         self.builder.len()
     }

--- a/rust/geoarrow/src/io/geozero/array/multilinestring.rs
+++ b/rust/geoarrow/src/io/geozero/array/multilinestring.rs
@@ -6,7 +6,7 @@ use crate::io::geozero::scalar::process_multi_line_string;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 
-impl<const D: usize> GeozeroGeometry for MultiLineStringArray<D> {
+impl GeozeroGeometry for MultiLineStringArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -24,7 +24,7 @@ impl<const D: usize> GeozeroGeometry for MultiLineStringArray<D> {
 }
 
 /// GeoZero trait to convert to GeoArrow MultiLineStringArray.
-pub trait ToMultiLineStringArray<const D: usize> {
+pub trait ToMultiLineStringArray {
     /// Convert to GeoArrow MultiLineStringArray
     fn to_line_string_array(&self) -> geozero::error::Result<MultiLineStringArray<D>>;
 
@@ -45,7 +45,7 @@ impl<T: GeozeroGeometry, const D: usize> ToMultiLineStringArray<D> for T {
 }
 
 #[allow(unused_variables)]
-impl<const D: usize> GeomProcessor for MultiLineStringBuilder<D> {
+impl GeomProcessor for MultiLineStringBuilder<D> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         let capacity = MultiLineStringCapacity::new(0, 0, size);

--- a/rust/geoarrow/src/io/geozero/array/multipoint.rs
+++ b/rust/geoarrow/src/io/geozero/array/multipoint.rs
@@ -5,7 +5,7 @@ use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<const D: usize> GeozeroGeometry for MultiPointArray<D> {
+impl GeozeroGeometry for MultiPointArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -23,7 +23,7 @@ impl<const D: usize> GeozeroGeometry for MultiPointArray<D> {
 }
 
 /// GeoZero trait to convert to GeoArrow MultiPointArray.
-pub trait ToMultiPointArray<const D: usize> {
+pub trait ToMultiPointArray {
     /// Convert to GeoArrow MultiPointArray
     fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<D>>;
 
@@ -44,7 +44,7 @@ impl<T: GeozeroGeometry, const D: usize> ToMultiPointArray<D> for T {
 }
 
 #[allow(unused_variables)]
-impl<const D: usize> GeomProcessor for MultiPointBuilder<D> {
+impl GeomProcessor for MultiPointBuilder<D> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         let capacity = MultiPointCapacity::new(0, size);
         self.reserve(capacity);

--- a/rust/geoarrow/src/io/geozero/array/multipoint.rs
+++ b/rust/geoarrow/src/io/geozero/array/multipoint.rs
@@ -1,11 +1,12 @@
 use crate::array::multipoint::MultiPointCapacity;
 use crate::array::{MultiPointArray, MultiPointBuilder};
+use crate::datatypes::Dimension;
 use crate::io::geozero::scalar::process_multi_point;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl GeozeroGeometry for MultiPointArray<D> {
+impl GeozeroGeometry for MultiPointArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -25,26 +26,26 @@ impl GeozeroGeometry for MultiPointArray<D> {
 /// GeoZero trait to convert to GeoArrow MultiPointArray.
 pub trait ToMultiPointArray {
     /// Convert to GeoArrow MultiPointArray
-    fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<D>>;
+    fn to_multi_point_array(&self, dim: Dimension) -> geozero::error::Result<MultiPointArray>;
 
     /// Convert to a GeoArrow MultiPointBuilder
-    fn to_multi_point_builder(&self) -> geozero::error::Result<MultiPointBuilder<D>>;
+    fn to_multi_point_builder(&self, dim: Dimension) -> geozero::error::Result<MultiPointBuilder>;
 }
 
-impl<T: GeozeroGeometry, const D: usize> ToMultiPointArray<D> for T {
-    fn to_multi_point_array(&self) -> geozero::error::Result<MultiPointArray<D>> {
-        Ok(self.to_multi_point_builder()?.into())
+impl<T: GeozeroGeometry> ToMultiPointArray for T {
+    fn to_multi_point_array(&self, dim: Dimension) -> geozero::error::Result<MultiPointArray> {
+        Ok(self.to_multi_point_builder(dim)?.into())
     }
 
-    fn to_multi_point_builder(&self) -> geozero::error::Result<MultiPointBuilder<D>> {
-        let mut mutable_array = MultiPointBuilder::new();
+    fn to_multi_point_builder(&self, dim: Dimension) -> geozero::error::Result<MultiPointBuilder> {
+        let mut mutable_array = MultiPointBuilder::new(dim);
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
     }
 }
 
 #[allow(unused_variables)]
-impl GeomProcessor for MultiPointBuilder<D> {
+impl GeomProcessor for MultiPointBuilder {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         let capacity = MultiPointCapacity::new(0, size);
         self.reserve(capacity);
@@ -93,7 +94,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> Result<()> {
-        let arr: MultiPointArray<2> = vec![mp0(), mp1()].as_slice().into();
+        let arr: MultiPointArray = (vec![mp0(), mp1()].as_slice(), Dimension::XY).into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(MULTIPOINT(0 1,1 2),MULTIPOINT(3 4,5 6))";
         assert_eq!(wkt, expected);
@@ -108,7 +109,7 @@ mod test {
                 .map(Geometry::MultiPoint)
                 .collect(),
         );
-        let multi_point_array: MultiPointArray<2> = geo.to_multi_point_array().unwrap();
+        let multi_point_array = geo.to_multi_point_array(Dimension::XY).unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), mp0());
         assert_eq!(multi_point_array.value_as_geo(1), mp1());
         Ok(())

--- a/rust/geoarrow/src/io/geozero/array/multipolygon.rs
+++ b/rust/geoarrow/src/io/geozero/array/multipolygon.rs
@@ -6,7 +6,7 @@ use crate::io::geozero::scalar::process_multi_polygon;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 
-impl<const D: usize> GeozeroGeometry for MultiPolygonArray<D> {
+impl GeozeroGeometry for MultiPolygonArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -24,7 +24,7 @@ impl<const D: usize> GeozeroGeometry for MultiPolygonArray<D> {
 }
 
 /// GeoZero trait to convert to GeoArrow MultiPolygonArray.
-pub trait ToMultiPolygonArray<const D: usize> {
+pub trait ToMultiPolygonArray {
     /// Convert to GeoArrow MultiPolygonArray
     fn to_line_string_array(&self) -> geozero::error::Result<MultiPolygonArray<D>>;
 
@@ -45,7 +45,7 @@ impl<T: GeozeroGeometry, const D: usize> ToMultiPolygonArray<D> for T {
 }
 
 #[allow(unused_variables)]
-impl<const D: usize> GeomProcessor for MultiPolygonBuilder<D> {
+impl GeomProcessor for MultiPolygonBuilder<D> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         let capacity = MultiPolygonCapacity::new(0, 0, 0, size);

--- a/rust/geoarrow/src/io/geozero/array/point.rs
+++ b/rust/geoarrow/src/io/geozero/array/point.rs
@@ -4,7 +4,7 @@ use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<const D: usize> GeozeroGeometry for PointArray<D> {
+impl GeozeroGeometry for PointArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -22,7 +22,7 @@ impl<const D: usize> GeozeroGeometry for PointArray<D> {
 }
 
 /// GeoZero trait to convert to GeoArrow PointArray.
-pub trait ToPointArray<const D: usize> {
+pub trait ToPointArray {
     /// Convert to GeoArrow PointArray
     fn to_point_array(&self) -> geozero::error::Result<PointArray<D>>;
 
@@ -43,7 +43,7 @@ impl<T: GeozeroGeometry, const D: usize> ToPointArray<D> for T {
 }
 
 #[allow(unused_variables)]
-impl<const D: usize> GeomProcessor for PointBuilder<D> {
+impl GeomProcessor for PointBuilder<D> {
     fn empty_point(&mut self, idx: usize) -> geozero::error::Result<()> {
         self.push_empty();
         Ok(())

--- a/rust/geoarrow/src/io/geozero/array/polygon.rs
+++ b/rust/geoarrow/src/io/geozero/array/polygon.rs
@@ -5,7 +5,7 @@ use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl<const D: usize> GeozeroGeometry for PolygonArray<D> {
+impl GeozeroGeometry for PolygonArray<D> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -23,7 +23,7 @@ impl<const D: usize> GeozeroGeometry for PolygonArray<D> {
 }
 
 /// GeoZero trait to convert to GeoArrow PolygonArray.
-pub trait ToPolygonArray<const D: usize> {
+pub trait ToPolygonArray {
     /// Convert to GeoArrow PolygonArray
     fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<D>>;
 
@@ -44,7 +44,7 @@ impl<T: GeozeroGeometry, const D: usize> ToPolygonArray<D> for T {
 }
 
 #[allow(unused_variables)]
-impl<const D: usize> GeomProcessor for PolygonBuilder<D> {
+impl GeomProcessor for PolygonBuilder<D> {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         let capacity = PolygonCapacity::new(0, 0, size);

--- a/rust/geoarrow/src/io/geozero/array/polygon.rs
+++ b/rust/geoarrow/src/io/geozero/array/polygon.rs
@@ -1,11 +1,12 @@
 use crate::array::polygon::PolygonCapacity;
 use crate::array::{PolygonArray, PolygonBuilder};
+use crate::datatypes::Dimension;
 use crate::io::geozero::scalar::process_polygon;
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-impl GeozeroGeometry for PolygonArray<D> {
+impl GeozeroGeometry for PolygonArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,
@@ -25,26 +26,26 @@ impl GeozeroGeometry for PolygonArray<D> {
 /// GeoZero trait to convert to GeoArrow PolygonArray.
 pub trait ToPolygonArray {
     /// Convert to GeoArrow PolygonArray
-    fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<D>>;
+    fn to_line_string_array(&self, dim: Dimension) -> geozero::error::Result<PolygonArray>;
 
     /// Convert to a GeoArrow PolygonBuilder
-    fn to_line_string_builder(&self) -> geozero::error::Result<PolygonBuilder<D>>;
+    fn to_line_string_builder(&self, dim: Dimension) -> geozero::error::Result<PolygonBuilder>;
 }
 
-impl<T: GeozeroGeometry, const D: usize> ToPolygonArray<D> for T {
-    fn to_line_string_array(&self) -> geozero::error::Result<PolygonArray<D>> {
-        Ok(self.to_line_string_builder()?.into())
+impl<T: GeozeroGeometry> ToPolygonArray for T {
+    fn to_line_string_array(&self, dim: Dimension) -> geozero::error::Result<PolygonArray> {
+        Ok(self.to_line_string_builder(dim)?.into())
     }
 
-    fn to_line_string_builder(&self) -> geozero::error::Result<PolygonBuilder<D>> {
-        let mut mutable_array = PolygonBuilder::new();
+    fn to_line_string_builder(&self, dim: Dimension) -> geozero::error::Result<PolygonBuilder> {
+        let mut mutable_array = PolygonBuilder::new(dim);
         self.process_geom(&mut mutable_array)?;
         Ok(mutable_array)
     }
 }
 
 #[allow(unused_variables)]
-impl GeomProcessor for PolygonBuilder<D> {
+impl GeomProcessor for PolygonBuilder {
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> geozero::error::Result<()> {
         // reserve `size` geometries
         let capacity = PolygonCapacity::new(0, 0, size);
@@ -112,7 +113,7 @@ mod test {
 
     #[test]
     fn geozero_process_geom() -> geozero::error::Result<()> {
-        let arr: PolygonArray<2> = vec![p0(), p1()].as_slice().into();
+        let arr: PolygonArray = (vec![p0(), p1()].as_slice(), Dimension::XY).into();
         let wkt = arr.to_wkt()?;
         let expected = "GEOMETRYCOLLECTION(POLYGON((-111 45,-111 41,-104 41,-104 45,-111 45)),POLYGON((-111 45,-111 41,-104 41,-104 45,-111 45),(-110 44,-110 42,-105 42,-105 44,-110 44)))";
         assert_eq!(wkt, expected);
@@ -127,7 +128,7 @@ mod test {
                 .map(Geometry::Polygon)
                 .collect(),
         );
-        let multi_point_array: PolygonArray<2> = geo.to_line_string_array().unwrap();
+        let multi_point_array = geo.to_line_string_array(Dimension::XY).unwrap();
         assert_eq!(multi_point_array.value_as_geo(0), p0());
         assert_eq!(multi_point_array.value_as_geo(1), p1());
         Ok(())

--- a/rust/geoarrow/src/io/geozero/scalar/geometry.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/geometry.rs
@@ -35,7 +35,7 @@ pub(crate) fn process_geometry<P: GeomProcessor>(
     Ok(())
 }
 
-impl<const D: usize> GeozeroGeometry for Geometry<'_, D> {
+impl GeozeroGeometry for Geometry<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/scalar/geometry.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/geometry.rs
@@ -1,3 +1,4 @@
+use crate::datatypes::Dimension;
 use crate::io::geozero::scalar::geometry_collection::process_geometry_collection;
 use crate::io::geozero::scalar::linestring::process_line_string;
 use crate::io::geozero::scalar::multilinestring::process_multi_line_string;
@@ -45,12 +46,12 @@ impl GeozeroGeometry for Geometry<'_> {
 }
 
 pub trait ToGeometry<O: OffsetSizeTrait> {
-    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<2>>;
+    fn to_geometry(&self, dim: Dimension) -> geozero::error::Result<OwnedGeometry>;
 }
 
 impl<T: GeozeroGeometry, O: OffsetSizeTrait> ToGeometry<O> for T {
-    fn to_geometry(&self) -> geozero::error::Result<OwnedGeometry<2>> {
-        let arr = self.to_mixed_geometry_array()?;
+    fn to_geometry(&self, dim: Dimension) -> geozero::error::Result<OwnedGeometry> {
+        let arr = self.to_mixed_geometry_array(dim)?;
         assert_eq!(arr.len(), 1);
         Ok(OwnedGeometry::from(arr.value(0)))
     }

--- a/rust/geoarrow/src/io/geozero/scalar/geometry_array.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/geometry_array.rs
@@ -1,5 +1,5 @@
 use crate::array::AsNativeArray;
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::io::geozero::scalar::geometry_collection::process_geometry_collection;
 use crate::io::geozero::scalar::linestring::process_line_string;
 use crate::io::geozero::scalar::multilinestring::process_multi_line_string;
@@ -18,16 +18,16 @@ pub fn process_geometry_scalar_array<P: GeomProcessor>(
     processor: &mut P,
 ) -> geozero::error::Result<()> {
     macro_rules! impl_process {
-        ($process_func:ident, $cast_func:ident, $dim:expr) => {
+        ($process_func:ident, $cast_func:ident) => {
             $process_func(
-                &geom.inner().as_ref().$cast_func::<$dim>().value(0),
+                &geom.inner().as_ref().$cast_func().value(0),
                 geom_idx,
                 processor,
             )
         };
-        ($process_func:ident, true, $cast_func:ident, $dim:expr) => {
+        ($process_func:ident, true, $cast_func:ident) => {
             $process_func(
-                &geom.inner().as_ref().$cast_func::<$dim>().value(0),
+                &geom.inner().as_ref().$cast_func().value(0),
                 true,
                 geom_idx,
                 processor,
@@ -35,32 +35,20 @@ pub fn process_geometry_scalar_array<P: GeomProcessor>(
         };
     }
 
-    use Dimension::*;
     use NativeType::*;
 
     match geom.data_type() {
-        Point(_, XY) => impl_process!(process_point, as_point, 2),
-        LineString(_, XY) => impl_process!(process_line_string, as_line_string, 2),
-        Polygon(_, XY) => impl_process!(process_polygon, true, as_polygon, 2),
-        MultiPoint(_, XY) => impl_process!(process_multi_point, as_multi_point, 2),
-        MultiLineString(_, XY) => impl_process!(process_multi_line_string, as_multi_line_string, 2),
-        MultiPolygon(_, XY) => impl_process!(process_multi_polygon, as_multi_polygon, 2),
-        Mixed(_, XY) => impl_process!(process_geometry, as_mixed, 2),
-        GeometryCollection(_, XY) => {
-            impl_process!(process_geometry_collection, as_geometry_collection, 2)
+        Point(_, _) => impl_process!(process_point, as_point),
+        LineString(_, _) => impl_process!(process_line_string, as_line_string),
+        Polygon(_, _) => impl_process!(process_polygon, true, as_polygon),
+        MultiPoint(_, _) => impl_process!(process_multi_point, as_multi_point),
+        MultiLineString(_, _) => impl_process!(process_multi_line_string, as_multi_line_string),
+        MultiPolygon(_, _) => impl_process!(process_multi_polygon, as_multi_polygon),
+        Mixed(_, _) => impl_process!(process_geometry, as_mixed),
+        GeometryCollection(_, _) => {
+            impl_process!(process_geometry_collection, as_geometry_collection)
         }
-        Point(_, XYZ) => impl_process!(process_point, as_point, 3),
-        LineString(_, XYZ) => impl_process!(process_line_string, as_line_string, 3),
-        Polygon(_, XYZ) => impl_process!(process_polygon, true, as_polygon, 3),
-        MultiPoint(_, XYZ) => impl_process!(process_multi_point, as_multi_point, 3),
-        MultiLineString(_, XYZ) => {
-            impl_process!(process_multi_line_string, as_multi_line_string, 3)
-        }
-        MultiPolygon(_, XYZ) => impl_process!(process_multi_polygon, as_multi_polygon, 3),
-        Mixed(_, XYZ) => impl_process!(process_geometry, as_mixed, 3),
-        GeometryCollection(_, XYZ) => {
-            impl_process!(process_geometry_collection, as_geometry_collection, 3)
-        }
+
         // WKB => {
         //     let arr = &geom.inner().as_ref();
         //     let wkb_arr = arr.as_wkb().value(0);

--- a/rust/geoarrow/src/io/geozero/scalar/geometry_collection.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/geometry_collection.rs
@@ -18,7 +18,7 @@ pub(crate) fn process_geometry_collection<P: GeomProcessor>(
     Ok(())
 }
 
-impl<const D: usize> GeozeroGeometry for GeometryCollection<'_, D> {
+impl GeozeroGeometry for GeometryCollection<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/scalar/linestring.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/linestring.rs
@@ -18,7 +18,7 @@ pub(crate) fn process_line_string<P: GeomProcessor>(
     Ok(())
 }
 
-impl<const D: usize> GeozeroGeometry for LineString<'_, D> {
+impl GeozeroGeometry for LineString<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/scalar/multilinestring.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/multilinestring.rs
@@ -24,7 +24,7 @@ pub(crate) fn process_multi_line_string<P: GeomProcessor>(
     Ok(())
 }
 
-impl<const D: usize> GeozeroGeometry for MultiLineString<'_, D> {
+impl GeozeroGeometry for MultiLineString<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/scalar/multipoint.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/multipoint.rs
@@ -18,7 +18,7 @@ pub(crate) fn process_multi_point<P: GeomProcessor>(
     Ok(())
 }
 
-impl<const D: usize> GeozeroGeometry for MultiPoint<'_, D> {
+impl GeozeroGeometry for MultiPoint<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/scalar/multipolygon.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/multipolygon.rs
@@ -18,7 +18,7 @@ pub(crate) fn process_multi_polygon<P: GeomProcessor>(
     Ok(())
 }
 
-impl<const D: usize> GeozeroGeometry for MultiPolygon<'_, D> {
+impl GeozeroGeometry for MultiPolygon<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/scalar/point.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/point.rs
@@ -62,7 +62,7 @@ pub(crate) fn process_point_as_coord<P: GeomProcessor>(
     Ok(())
 }
 
-impl<const D: usize> GeozeroGeometry for Point<'_, D> {
+impl GeozeroGeometry for Point<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/scalar/polygon.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/polygon.rs
@@ -39,7 +39,7 @@ pub(crate) fn process_polygon<P: GeomProcessor>(
     Ok(())
 }
 
-impl<const D: usize> GeozeroGeometry for Polygon<'_, D> {
+impl GeozeroGeometry for Polygon<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow/src/io/geozero/table/builder/table.rs
+++ b/rust/geoarrow/src/io/geozero/table/builder/table.rs
@@ -238,7 +238,7 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
 
 impl<G: GeometryArrayBuilder + GeomProcessor> Default for GeoTableBuilder<G> {
     fn default() -> Self {
-        Self::new()
+        Self::new(Dimension::XY)
     }
 }
 

--- a/rust/geoarrow/src/io/geozero/table/data_source.rs
+++ b/rust/geoarrow/src/io/geozero/table/data_source.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::array::{from_arrow_array, AsNativeArray};
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::io::geozero::scalar::{
     process_geometry, process_geometry_collection, process_line_string, process_multi_line_string,
     process_multi_point, process_multi_polygon, process_point, process_polygon,
@@ -369,68 +369,36 @@ fn process_geometry_n<P: GeomProcessor>(
     let i = within_batch_row_idx;
     use NativeType::*;
     match arr.data_type() {
-        Point(_, Dimension::XY) => {
-            let geom = arr.as_point::<2>().value(i);
+        Point(_, _) => {
+            let geom = arr.as_point().value(i);
             process_point(&geom, 0, processor)?;
         }
-        LineString(_, Dimension::XY) => {
-            let geom = arr.as_line_string::<2>().value(i);
+        LineString(_, _) => {
+            let geom = arr.as_line_string().value(i);
             process_line_string(&geom, 0, processor)?;
         }
-        Polygon(_, Dimension::XY) => {
-            let geom = arr.as_polygon::<2>().value(i);
+        Polygon(_, _) => {
+            let geom = arr.as_polygon().value(i);
             process_polygon(&geom, true, 0, processor)?;
         }
-        MultiPoint(_, Dimension::XY) => {
-            let geom = arr.as_multi_point::<2>().value(i);
+        MultiPoint(_, _) => {
+            let geom = arr.as_multi_point().value(i);
             process_multi_point(&geom, 0, processor)?;
         }
-        MultiLineString(_, Dimension::XY) => {
-            let geom = arr.as_multi_line_string::<2>().value(i);
+        MultiLineString(_, _) => {
+            let geom = arr.as_multi_line_string().value(i);
             process_multi_line_string(&geom, 0, processor)?;
         }
-        MultiPolygon(_, Dimension::XY) => {
-            let geom = arr.as_multi_polygon::<2>().value(i);
+        MultiPolygon(_, _) => {
+            let geom = arr.as_multi_polygon().value(i);
             process_multi_polygon(&geom, 0, processor)?;
         }
-        Mixed(_, Dimension::XY) => {
-            let geom = arr.as_mixed::<2>().value(i);
+        Mixed(_, _) => {
+            let geom = arr.as_mixed().value(i);
             process_geometry(&geom, 0, processor)?;
         }
-        GeometryCollection(_, Dimension::XY) => {
-            let geom = arr.as_geometry_collection::<2>().value(i);
-            process_geometry_collection(&geom, 0, processor)?;
-        }
-        Point(_, Dimension::XYZ) => {
-            let geom = arr.as_point::<3>().value(i);
-            process_point(&geom, 0, processor)?;
-        }
-        LineString(_, Dimension::XYZ) => {
-            let geom = arr.as_line_string::<3>().value(i);
-            process_line_string(&geom, 0, processor)?;
-        }
-        Polygon(_, Dimension::XYZ) => {
-            let geom = arr.as_polygon::<3>().value(i);
-            process_polygon(&geom, true, 0, processor)?;
-        }
-        MultiPoint(_, Dimension::XYZ) => {
-            let geom = arr.as_multi_point::<3>().value(i);
-            process_multi_point(&geom, 0, processor)?;
-        }
-        MultiLineString(_, Dimension::XYZ) => {
-            let geom = arr.as_multi_line_string::<3>().value(i);
-            process_multi_line_string(&geom, 0, processor)?;
-        }
-        MultiPolygon(_, Dimension::XYZ) => {
-            let geom = arr.as_multi_polygon::<3>().value(i);
-            process_multi_polygon(&geom, 0, processor)?;
-        }
-        Mixed(_, Dimension::XYZ) => {
-            let geom = arr.as_mixed::<3>().value(i);
-            process_geometry(&geom, 0, processor)?;
-        }
-        GeometryCollection(_, Dimension::XYZ) => {
-            let geom = arr.as_geometry_collection::<3>().value(i);
+        GeometryCollection(_, _) => {
+            let geom = arr.as_geometry_collection().value(i);
             process_geometry_collection(&geom, 0, processor)?;
         }
         // WKB => {

--- a/rust/geoarrow/src/io/parquet/reader/metadata.rs
+++ b/rust/geoarrow/src/io/parquet/reader/metadata.rs
@@ -11,6 +11,7 @@ use parquet::schema::types::SchemaDescriptor;
 use serde_json::Value;
 
 use crate::array::{CoordType, RectArray, RectBuilder};
+use crate::datatypes::Dimension;
 use crate::error::{GeoArrowError, Result};
 use crate::io::parquet::metadata::{GeoParquetBboxCovering, GeoParquetMetadata};
 use crate::io::parquet::reader::parse::infer_target_schema;
@@ -159,10 +160,7 @@ impl GeoParquetReaderMetadata {
     ///
     /// As of GeoParquet 1.1 you won't need to pass in these column names, as they'll be specified
     /// in the metadata.
-    pub fn row_groups_bounds(
-        &self,
-        paths: Option<&GeoParquetBboxCovering>,
-    ) -> Result<RectArray<2>> {
+    pub fn row_groups_bounds(&self, paths: Option<&GeoParquetBboxCovering>) -> Result<RectArray> {
         let paths = if let Some(paths) = paths {
             paths
         } else {
@@ -183,7 +181,8 @@ impl GeoParquetReaderMetadata {
             .iter()
             .map(|rg_meta| geo_statistics.get_bbox(rg_meta))
             .collect::<Result<Vec<_>>>()?;
-        let rect_array = RectBuilder::from_rects(rects.iter(), Default::default()).finish();
+        let rect_array =
+            RectBuilder::from_rects(rects.iter(), Dimension::XY, Default::default()).finish();
         Ok(rect_array)
     }
 

--- a/rust/geoarrow/src/io/parquet/reader/parse.rs
+++ b/rust/geoarrow/src/io/parquet/reader/parse.rs
@@ -226,14 +226,14 @@ fn parse_wkb_column(arr: &dyn Array, target_geo_data_type: NativeType) -> Result
     }
 }
 
-fn parse_point_column<const D: usize>(array: &dyn Array) -> Result<Arc<dyn Array>> {
+fn parse_point_column(array: &dyn Array) -> Result<Arc<dyn Array>> {
     let geom_arr: PointArray<D> = array.try_into()?;
     Ok(geom_arr.into_array_ref())
 }
 
 macro_rules! impl_parse_fn {
     ($fn_name:ident, $geoarrow_type:ty) => {
-        fn $fn_name<const D: usize>(array: &dyn Array) -> Result<Arc<dyn Array>> {
+        fn $fn_name(array: &dyn Array) -> Result<Arc<dyn Array>> {
             match array.data_type() {
                 DataType::List(_) | DataType::LargeList(_) => {
                     let geom_arr: $geoarrow_type = array.try_into()?;

--- a/rust/geoarrow/src/io/parquet/reader/spatial_filter.rs
+++ b/rust/geoarrow/src/io/parquet/reader/spatial_filter.rs
@@ -18,6 +18,7 @@ use parquet::schema::types::{ColumnPath, SchemaDescriptor};
 
 use crate::algorithm::geo::BoundingRect;
 use crate::array::{NativeArrayDyn, RectArray, RectBuilder};
+use crate::datatypes::Dimension;
 use crate::error::{GeoArrowError, Result};
 use crate::io::parquet::metadata::GeoParquetBboxCovering;
 use crate::trait_::ArrayAccessor;
@@ -147,8 +148,8 @@ impl<'a> ParquetBboxStatistics<'a> {
     }
 
     /// Extract the bounding boxes for a sequence of row groups
-    pub fn get_bboxes(&self, row_groups: &[RowGroupMetaData]) -> Result<RectArray<2>> {
-        let mut builder = RectBuilder::with_capacity(row_groups.len());
+    pub fn get_bboxes(&self, row_groups: &[RowGroupMetaData]) -> Result<RectArray> {
+        let mut builder = RectBuilder::with_capacity(Dimension::XY, row_groups.len());
         for rg_meta in row_groups.iter() {
             builder.push_rect(Some(&self.get_bbox(rg_meta)?));
         }

--- a/rust/geoarrow/src/io/parquet/test.rs
+++ b/rust/geoarrow/src/io/parquet/test.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 
 use crate::array::MixedGeometryBuilder;
 use crate::chunked_array::ChunkedNativeArrayDyn;
+use crate::datatypes::Dimension;
 use crate::error::Result;
 use crate::io::parquet::{write_geoparquet, GeoParquetRecordBatchReaderBuilder};
 use crate::table::Table;
@@ -41,7 +42,7 @@ fn round_trip_nybb() -> Result<()> {
 // Test from https://github.com/geoarrow/geoarrow-rs/pull/717
 #[test]
 fn mixed_geometry_roundtrip() {
-    let mut builder = MixedGeometryBuilder::<2>::new();
+    let mut builder = MixedGeometryBuilder::new(Dimension::XY);
     builder
         .push_point(Some(&geo::point!(x: -105., y: 40.)))
         .unwrap();

--- a/rust/geoarrow/src/io/parquet/writer/metadata.rs
+++ b/rust/geoarrow/src/io/parquet/writer/metadata.rs
@@ -79,34 +79,32 @@ impl ColumnInfo {
         let array_ref = array.as_ref();
 
         // We only have to do this for mixed arrays because other arrays are statically known
-        match array_ref.data_type() {
-            NativeType::Mixed(_, _) => {
-                let mixed_arr = array_ref.as_mixed();
-                if mixed_arr.has_points() {
-                    self.geometry_types.insert(GeoParquetGeometryType::Point);
-                }
-                if mixed_arr.has_line_strings() {
-                    self.geometry_types
-                        .insert(GeoParquetGeometryType::LineString);
-                }
-                if mixed_arr.has_polygons() {
-                    self.geometry_types.insert(GeoParquetGeometryType::Polygon);
-                }
-                if mixed_arr.has_multi_points() {
-                    self.geometry_types
-                        .insert(GeoParquetGeometryType::MultiPoint);
-                }
-                if mixed_arr.has_multi_line_strings() {
-                    self.geometry_types
-                        .insert(GeoParquetGeometryType::MultiLineString);
-                }
-                if mixed_arr.has_multi_polygons() {
-                    self.geometry_types
-                        .insert(GeoParquetGeometryType::MultiPolygon);
-                }
+        if let NativeType::Mixed(_, _) = array_ref.data_type() {
+            let mixed_arr = array_ref.as_mixed();
+            if mixed_arr.has_points() {
+                self.geometry_types.insert(GeoParquetGeometryType::Point);
             }
-            _ => (),
+            if mixed_arr.has_line_strings() {
+                self.geometry_types
+                    .insert(GeoParquetGeometryType::LineString);
+            }
+            if mixed_arr.has_polygons() {
+                self.geometry_types.insert(GeoParquetGeometryType::Polygon);
+            }
+            if mixed_arr.has_multi_points() {
+                self.geometry_types
+                    .insert(GeoParquetGeometryType::MultiPoint);
+            }
+            if mixed_arr.has_multi_line_strings() {
+                self.geometry_types
+                    .insert(GeoParquetGeometryType::MultiLineString);
+            }
+            if mixed_arr.has_multi_polygons() {
+                self.geometry_types
+                    .insert(GeoParquetGeometryType::MultiPolygon);
+            }
         }
+
         Ok(())
     }
 

--- a/rust/geoarrow/src/io/parquet/writer/metadata.rs
+++ b/rust/geoarrow/src/io/parquet/writer/metadata.rs
@@ -80,33 +80,8 @@ impl ColumnInfo {
 
         // We only have to do this for mixed arrays because other arrays are statically known
         match array_ref.data_type() {
-            NativeType::Mixed(_, Dimension::XY) => {
-                let mixed_arr = array_ref.as_mixed::<2>();
-                if mixed_arr.has_points() {
-                    self.geometry_types.insert(GeoParquetGeometryType::Point);
-                }
-                if mixed_arr.has_line_strings() {
-                    self.geometry_types
-                        .insert(GeoParquetGeometryType::LineString);
-                }
-                if mixed_arr.has_polygons() {
-                    self.geometry_types.insert(GeoParquetGeometryType::Polygon);
-                }
-                if mixed_arr.has_multi_points() {
-                    self.geometry_types
-                        .insert(GeoParquetGeometryType::MultiPoint);
-                }
-                if mixed_arr.has_multi_line_strings() {
-                    self.geometry_types
-                        .insert(GeoParquetGeometryType::MultiLineString);
-                }
-                if mixed_arr.has_multi_polygons() {
-                    self.geometry_types
-                        .insert(GeoParquetGeometryType::MultiPolygon);
-                }
-            }
-            NativeType::Mixed(_, Dimension::XYZ) => {
-                let mixed_arr = array_ref.as_mixed::<3>();
+            NativeType::Mixed(_, _) => {
+                let mixed_arr = array_ref.as_mixed();
                 if mixed_arr.has_points() {
                     self.geometry_types.insert(GeoParquetGeometryType::Point);
                 }

--- a/rust/geoarrow/src/io/postgis/reader.rs
+++ b/rust/geoarrow/src/io/postgis/reader.rs
@@ -172,7 +172,7 @@ pub async fn read_postgis<'c, E: Executor<'c, Database = Postgres>>(
 ) -> Result<Option<Table>> {
     let query = sqlx::query::<Postgres>(sql);
     let mut result_stream = query.fetch(executor);
-    let mut table_builder: Option<GeoTableBuilder<MixedGeometryStreamBuilder<2>>> = None;
+    let mut table_builder: Option<GeoTableBuilder<MixedGeometryStreamBuilder>> = None;
 
     // TODO: try out chunking with `result_stream.try_chunks`
     let mut row_idx = 0;

--- a/rust/geoarrow/src/io/postgis/reader.rs
+++ b/rust/geoarrow/src/io/postgis/reader.rs
@@ -10,6 +10,7 @@ use sqlx::{Column, Decode, Executor, Postgres, Row, Type, TypeInfo};
 use std::io::Cursor;
 use std::sync::Arc;
 
+use crate::datatypes::Dimension;
 use crate::error::{GeoArrowError, Result};
 use crate::io::geozero::array::MixedGeometryStreamBuilder;
 use crate::io::geozero::table::{GeoTableBuilder, GeoTableBuilderOptions};
@@ -160,7 +161,7 @@ impl<G: GeometryArrayBuilder + GeomProcessor> GeoTableBuilder<G> {
         options.properties_schema = Some(Arc::new(schema.finish()));
 
         // Create builder and add this row
-        let mut builder = Self::new_with_options(options);
+        let mut builder = Self::new_with_options(Dimension::XY, options);
         builder.add_postgres_row(0, row)?;
         Ok(builder)
     }

--- a/rust/geoarrow/src/io/shapefile/reader.rs
+++ b/rust/geoarrow/src/io/shapefile/reader.rs
@@ -7,6 +7,7 @@ use geozero::FeatureProcessor;
 use shapefile::{Reader, ShapeReader, ShapeType};
 
 use crate::array::{MultiLineStringBuilder, MultiPointBuilder, MultiPolygonBuilder, PointBuilder};
+use crate::datatypes::Dimension;
 use crate::error::{GeoArrowError, Result};
 use crate::io::geozero::table::builder::anyvalue::AnyBuilder;
 use crate::io::geozero::table::builder::properties::PropertiesBatchBuilder;
@@ -52,7 +53,8 @@ pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Ta
 
     match geometry_type {
         ShapeType::Point => {
-            let mut builder = GeoTableBuilder::<PointBuilder<2>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<PointBuilder>::new_with_options(Dimension::XY, options);
 
             for geom_and_record in
                 reader.iter_shapes_and_records_as::<shapefile::Point, dbase::Record>()
@@ -75,7 +77,8 @@ pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Ta
             builder.finish()
         }
         ShapeType::PointZ => {
-            let mut builder = GeoTableBuilder::<PointBuilder<3>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<PointBuilder>::new_with_options(Dimension::XYZ, options);
 
             for geom_and_record in
                 reader.iter_shapes_and_records_as::<shapefile::PointZ, dbase::Record>()
@@ -98,7 +101,8 @@ pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Ta
             builder.finish()
         }
         ShapeType::Multipoint => {
-            let mut builder = GeoTableBuilder::<MultiPointBuilder<2>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MultiPointBuilder>::new_with_options(Dimension::XY, options);
 
             for geom_and_record in
                 reader.iter_shapes_and_records_as::<shapefile::Multipoint, dbase::Record>()
@@ -121,7 +125,8 @@ pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Ta
             builder.finish()
         }
         ShapeType::MultipointZ => {
-            let mut builder = GeoTableBuilder::<MultiPointBuilder<3>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MultiPointBuilder>::new_with_options(Dimension::XYZ, options);
 
             for geom_and_record in
                 reader.iter_shapes_and_records_as::<shapefile::MultipointZ, dbase::Record>()

--- a/rust/geoarrow/src/io/shapefile/reader.rs
+++ b/rust/geoarrow/src/io/shapefile/reader.rs
@@ -150,7 +150,7 @@ pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Ta
         }
         ShapeType::Polyline => {
             let mut builder =
-                GeoTableBuilder::<MultiLineStringBuilder<2>>::new_with_options(options);
+                GeoTableBuilder::<MultiLineStringBuilder>::new_with_options(Dimension::XY, options);
 
             for geom_and_record in
                 reader.iter_shapes_and_records_as::<shapefile::Polyline, dbase::Record>()
@@ -173,8 +173,10 @@ pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Ta
             builder.finish()
         }
         ShapeType::PolylineZ => {
-            let mut builder =
-                GeoTableBuilder::<MultiLineStringBuilder<3>>::new_with_options(options);
+            let mut builder = GeoTableBuilder::<MultiLineStringBuilder>::new_with_options(
+                Dimension::XYZ,
+                options,
+            );
 
             for geom_and_record in
                 reader.iter_shapes_and_records_as::<shapefile::PolylineZ, dbase::Record>()
@@ -197,7 +199,8 @@ pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Ta
             builder.finish()
         }
         ShapeType::Polygon => {
-            let mut builder = GeoTableBuilder::<MultiPolygonBuilder<2>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MultiPolygonBuilder>::new_with_options(Dimension::XY, options);
 
             for geom_and_record in
                 reader.iter_shapes_and_records_as::<shapefile::Polygon, dbase::Record>()
@@ -220,7 +223,8 @@ pub fn read_shapefile<T: Read + Seek>(shp_reader: T, dbf_reader: T) -> Result<Ta
             builder.finish()
         }
         ShapeType::PolygonZ => {
-            let mut builder = GeoTableBuilder::<MultiPolygonBuilder<3>>::new_with_options(options);
+            let mut builder =
+                GeoTableBuilder::<MultiPolygonBuilder>::new_with_options(Dimension::XYZ, options);
 
             for geom_and_record in
                 reader.iter_shapes_and_records_as::<shapefile::PolygonZ, dbase::Record>()

--- a/rust/geoarrow/src/io/wkb/writer/geometry.rs
+++ b/rust/geoarrow/src/io/wkb/writer/geometry.rs
@@ -45,21 +45,25 @@ impl<O: OffsetSizeTrait> From<&MixedGeometryArray> for WKBArray<O> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::datatypes::Dimension;
     use crate::test::multilinestring::{ml0, ml1};
     use crate::test::point::{p0, p1};
 
     #[test]
     fn round_trip() {
-        let orig_arr: MixedGeometryArray = vec![
-            Some(geo::Geometry::MultiLineString(ml0())),
-            Some(geo::Geometry::MultiLineString(ml1())),
-            Some(geo::Geometry::Point(p0())),
-            Some(geo::Geometry::Point(p1())),
-        ]
-        .try_into()
-        .unwrap();
+        let orig_arr: MixedGeometryArray = (
+            vec![
+                Some(geo::Geometry::MultiLineString(ml0())),
+                Some(geo::Geometry::MultiLineString(ml1())),
+                Some(geo::Geometry::Point(p0())),
+                Some(geo::Geometry::Point(p1())),
+            ],
+            Dimension::XY,
+        )
+            .try_into()
+            .unwrap();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MixedGeometryArray = wkb_arr.try_into().unwrap();
+        let new_arr: MixedGeometryArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }
@@ -67,17 +71,20 @@ mod test {
     #[ignore = "None not allowed in geometry array."]
     #[test]
     fn round_trip_null() {
-        let orig_arr: MixedGeometryArray = vec![
-            Some(geo::Geometry::MultiLineString(ml0())),
-            Some(geo::Geometry::MultiLineString(ml1())),
-            Some(geo::Geometry::Point(p0())),
-            Some(geo::Geometry::Point(p1())),
-            None,
-        ]
-        .try_into()
-        .unwrap();
+        let orig_arr: MixedGeometryArray = (
+            vec![
+                Some(geo::Geometry::MultiLineString(ml0())),
+                Some(geo::Geometry::MultiLineString(ml1())),
+                Some(geo::Geometry::Point(p0())),
+                Some(geo::Geometry::Point(p1())),
+                None,
+            ],
+            Dimension::XY,
+        )
+            .try_into()
+            .unwrap();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MixedGeometryArray = wkb_arr.try_into().unwrap();
+        let new_arr: MixedGeometryArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/geometry.rs
+++ b/rust/geoarrow/src/io/wkb/writer/geometry.rs
@@ -9,8 +9,8 @@ use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use std::io::Cursor;
 
-impl<O: OffsetSizeTrait, const D: usize> From<&MixedGeometryArray<D>> for WKBArray<O> {
-    fn from(value: &MixedGeometryArray<D>) -> Self {
+impl<O: OffsetSizeTrait> From<&MixedGeometryArray> for WKBArray<O> {
+    fn from(value: &MixedGeometryArray) -> Self {
         let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -50,7 +50,7 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MixedGeometryArray<2> = vec![
+        let orig_arr: MixedGeometryArray = vec![
             Some(geo::Geometry::MultiLineString(ml0())),
             Some(geo::Geometry::MultiLineString(ml1())),
             Some(geo::Geometry::Point(p0())),
@@ -59,7 +59,7 @@ mod test {
         .try_into()
         .unwrap();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MixedGeometryArray<2> = wkb_arr.try_into().unwrap();
+        let new_arr: MixedGeometryArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }
@@ -67,7 +67,7 @@ mod test {
     #[ignore = "None not allowed in geometry array."]
     #[test]
     fn round_trip_null() {
-        let orig_arr: MixedGeometryArray<2> = vec![
+        let orig_arr: MixedGeometryArray = vec![
             Some(geo::Geometry::MultiLineString(ml0())),
             Some(geo::Geometry::MultiLineString(ml1())),
             Some(geo::Geometry::Point(p0())),
@@ -77,7 +77,7 @@ mod test {
         .try_into()
         .unwrap();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MixedGeometryArray<2> = wkb_arr.try_into().unwrap();
+        let new_arr: MixedGeometryArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/geometrycollection.rs
+++ b/rust/geoarrow/src/io/wkb/writer/geometrycollection.rs
@@ -46,6 +46,7 @@ impl<O: OffsetSizeTrait> From<&GeometryCollectionArray> for WKBArray<O> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::datatypes::Dimension;
     use crate::test::multipoint;
     use crate::test::multipolygon;
 
@@ -61,9 +62,10 @@ mod test {
             geo::Geometry::MultiPolygon(multipolygon::mp1()),
         ]);
 
-        let orig_arr: GeometryCollectionArray = vec![Some(gc0), Some(gc1), None].into();
+        let orig_arr: GeometryCollectionArray =
+            (vec![Some(gc0), Some(gc1), None], Dimension::XY).into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: GeometryCollectionArray = wkb_arr.try_into().unwrap();
+        let new_arr: GeometryCollectionArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/geometrycollection.rs
+++ b/rust/geoarrow/src/io/wkb/writer/geometrycollection.rs
@@ -8,8 +8,8 @@ use std::io::Cursor;
 use wkb::writer::{geometry_collection_wkb_size, write_geometry_collection};
 use wkb::Endianness;
 
-impl<O: OffsetSizeTrait, const D: usize> From<&GeometryCollectionArray<D>> for WKBArray<O> {
-    fn from(value: &GeometryCollectionArray<D>) -> Self {
+impl<O: OffsetSizeTrait> From<&GeometryCollectionArray> for WKBArray<O> {
+    fn from(value: &GeometryCollectionArray) -> Self {
         let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -61,9 +61,9 @@ mod test {
             geo::Geometry::MultiPolygon(multipolygon::mp1()),
         ]);
 
-        let orig_arr: GeometryCollectionArray<2> = vec![Some(gc0), Some(gc1), None].into();
+        let orig_arr: GeometryCollectionArray = vec![Some(gc0), Some(gc1), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: GeometryCollectionArray<2> = wkb_arr.try_into().unwrap();
+        let new_arr: GeometryCollectionArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/linestring.rs
+++ b/rust/geoarrow/src/io/wkb/writer/linestring.rs
@@ -44,23 +44,25 @@ impl<O: OffsetSizeTrait> From<&LineStringArray> for WKBArray<O> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::datatypes::Dimension;
     use crate::test::linestring::{ls0, ls1};
 
     #[test]
     fn round_trip() {
-        let orig_arr: LineStringArray = vec![Some(ls0()), Some(ls1()), None].into();
+        let orig_arr: LineStringArray =
+            (vec![Some(ls0()), Some(ls1()), None], Dimension::XY).into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: LineStringArray = wkb_arr.try_into().unwrap();
+        let new_arr: LineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }
 
-    // TODO: parsing WKBArray<i64> into LineStringArray<i32> not yet implemented
     #[test]
     fn round_trip_to_i64() {
-        let orig_arr: LineStringArray = vec![Some(ls0()), Some(ls1()), None].into();
+        let orig_arr: LineStringArray =
+            (vec![Some(ls0()), Some(ls1()), None], Dimension::XY).into();
         let wkb_arr: WKBArray<i64> = (&orig_arr).into();
-        let new_arr: LineStringArray = wkb_arr.try_into().unwrap();
+        let new_arr: LineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/linestring.rs
+++ b/rust/geoarrow/src/io/wkb/writer/linestring.rs
@@ -8,8 +8,8 @@ use std::io::Cursor;
 use wkb::writer::{line_string_wkb_size, write_line_string};
 use wkb::Endianness;
 
-impl<O: OffsetSizeTrait, const D: usize> From<&LineStringArray<D>> for WKBArray<O> {
-    fn from(value: &LineStringArray<D>) -> Self {
+impl<O: OffsetSizeTrait> From<&LineStringArray> for WKBArray<O> {
+    fn from(value: &LineStringArray) -> Self {
         let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -48,9 +48,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: LineStringArray<2> = vec![Some(ls0()), Some(ls1()), None].into();
+        let orig_arr: LineStringArray = vec![Some(ls0()), Some(ls1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: LineStringArray<2> = wkb_arr.try_into().unwrap();
+        let new_arr: LineStringArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }
@@ -58,9 +58,9 @@ mod test {
     // TODO: parsing WKBArray<i64> into LineStringArray<i32> not yet implemented
     #[test]
     fn round_trip_to_i64() {
-        let orig_arr: LineStringArray<2> = vec![Some(ls0()), Some(ls1()), None].into();
+        let orig_arr: LineStringArray = vec![Some(ls0()), Some(ls1()), None].into();
         let wkb_arr: WKBArray<i64> = (&orig_arr).into();
-        let new_arr: LineStringArray<2> = wkb_arr.try_into().unwrap();
+        let new_arr: LineStringArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/multilinestring.rs
+++ b/rust/geoarrow/src/io/wkb/writer/multilinestring.rs
@@ -8,8 +8,8 @@ use std::io::Cursor;
 use wkb::writer::{multi_line_string_wkb_size, write_multi_line_string};
 use wkb::Endianness;
 
-impl<O: OffsetSizeTrait, const D: usize> From<&MultiLineStringArray<D>> for WKBArray<O> {
-    fn from(value: &MultiLineStringArray<D>) -> Self {
+impl<O: OffsetSizeTrait> From<&MultiLineStringArray> for WKBArray<O> {
+    fn from(value: &MultiLineStringArray) -> Self {
         let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -50,9 +50,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiLineStringArray<2> = vec![Some(ml0()), Some(ml1()), None].into();
+        let orig_arr: MultiLineStringArray = vec![Some(ml0()), Some(ml1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiLineStringArray<2> = wkb_arr.try_into().unwrap();
+        let new_arr: MultiLineStringArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/multilinestring.rs
+++ b/rust/geoarrow/src/io/wkb/writer/multilinestring.rs
@@ -46,13 +46,15 @@ impl<O: OffsetSizeTrait> From<&MultiLineStringArray> for WKBArray<O> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::datatypes::Dimension;
     use crate::test::multilinestring::{ml0, ml1};
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiLineStringArray = vec![Some(ml0()), Some(ml1()), None].into();
+        let orig_arr: MultiLineStringArray =
+            (vec![Some(ml0()), Some(ml1()), None], Dimension::XY).into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiLineStringArray = wkb_arr.try_into().unwrap();
+        let new_arr: MultiLineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/multipoint.rs
+++ b/rust/geoarrow/src/io/wkb/writer/multipoint.rs
@@ -44,13 +44,15 @@ impl<O: OffsetSizeTrait> From<&MultiPointArray> for WKBArray<O> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::datatypes::Dimension;
     use crate::test::multipoint::{mp0, mp1};
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiPointArray = vec![Some(mp0()), Some(mp1()), None].into();
+        let orig_arr: MultiPointArray =
+            (vec![Some(mp0()), Some(mp1()), None], Dimension::XY).into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiPointArray = wkb_arr.try_into().unwrap();
+        let new_arr: MultiPointArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/multipoint.rs
+++ b/rust/geoarrow/src/io/wkb/writer/multipoint.rs
@@ -8,8 +8,8 @@ use std::io::Cursor;
 use wkb::writer::{multi_point_wkb_size, write_multi_point};
 use wkb::Endianness;
 
-impl<O: OffsetSizeTrait, const D: usize> From<&MultiPointArray<D>> for WKBArray<O> {
-    fn from(value: &MultiPointArray<D>) -> Self {
+impl<O: OffsetSizeTrait> From<&MultiPointArray> for WKBArray<O> {
+    fn from(value: &MultiPointArray) -> Self {
         let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -48,9 +48,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiPointArray<2> = vec![Some(mp0()), Some(mp1()), None].into();
+        let orig_arr: MultiPointArray = vec![Some(mp0()), Some(mp1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiPointArray<2> = wkb_arr.try_into().unwrap();
+        let new_arr: MultiPointArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/multipolygon.rs
+++ b/rust/geoarrow/src/io/wkb/writer/multipolygon.rs
@@ -8,8 +8,8 @@ use std::io::Cursor;
 use wkb::writer::{multi_polygon_wkb_size, write_multi_polygon};
 use wkb::Endianness;
 
-impl<O: OffsetSizeTrait, const D: usize> From<&MultiPolygonArray<D>> for WKBArray<O> {
-    fn from(value: &MultiPolygonArray<D>) -> Self {
+impl<O: OffsetSizeTrait> From<&MultiPolygonArray> for WKBArray<O> {
+    fn from(value: &MultiPolygonArray) -> Self {
         let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -50,9 +50,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiPolygonArray<2> = vec![Some(mp0()), Some(mp1()), None].into();
+        let orig_arr: MultiPolygonArray = vec![Some(mp0()), Some(mp1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiPolygonArray<2> = wkb_arr.try_into().unwrap();
+        let new_arr: MultiPolygonArray = wkb_arr.try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/multipolygon.rs
+++ b/rust/geoarrow/src/io/wkb/writer/multipolygon.rs
@@ -46,13 +46,15 @@ impl<O: OffsetSizeTrait> From<&MultiPolygonArray> for WKBArray<O> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::datatypes::Dimension;
     use crate::test::multipolygon::{mp0, mp1};
 
     #[test]
     fn round_trip() {
-        let orig_arr: MultiPolygonArray = vec![Some(mp0()), Some(mp1()), None].into();
+        let orig_arr: MultiPolygonArray =
+            (vec![Some(mp0()), Some(mp1()), None], Dimension::XY).into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: MultiPolygonArray = wkb_arr.try_into().unwrap();
+        let new_arr: MultiPolygonArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/point.rs
+++ b/rust/geoarrow/src/io/wkb/writer/point.rs
@@ -46,23 +46,27 @@ impl<O: OffsetSizeTrait> From<&PointArray> for WKBArray<O> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::datatypes::Dimension;
     use crate::test::point::{p0, p1, p2};
 
     #[test]
     fn round_trip() {
-        // TODO: test with nulls
-        let orig_arr: PointArray = vec![Some(p0()), Some(p1()), Some(p2())].into();
+        let orig_arr: PointArray = (vec![Some(p0()), Some(p1()), Some(p2())], Dimension::XY).into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: PointArray = wkb_arr.try_into().unwrap();
+        let new_arr: PointArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }
 
     #[test]
     fn round_trip_with_null() {
-        let orig_arr: PointArray = vec![Some(p0()), None, Some(p1()), None, Some(p2())].into();
+        let orig_arr: PointArray = (
+            vec![Some(p0()), None, Some(p1()), None, Some(p2())],
+            Dimension::XY,
+        )
+            .into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: PointArray = wkb_arr.try_into().unwrap();
+        let new_arr: PointArray = (wkb_arr, Dimension::XY).try_into().unwrap();
 
         assert_eq!(orig_arr, new_arr);
     }

--- a/rust/geoarrow/src/io/wkb/writer/polygon.rs
+++ b/rust/geoarrow/src/io/wkb/writer/polygon.rs
@@ -44,15 +44,16 @@ impl<O: OffsetSizeTrait> From<&PolygonArray> for WKBArray<O> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::datatypes::Dimension;
     use crate::test::polygon::{p0, p1};
     use crate::trait_::ArrayAccessor;
     use geozero::{CoordDimensions, ToWkb};
 
     #[test]
     fn round_trip() {
-        let orig_arr: PolygonArray = vec![Some(p0()), Some(p1()), None].into();
+        let orig_arr: PolygonArray = (vec![Some(p0()), Some(p1()), None], Dimension::XY).into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: PolygonArray = wkb_arr.clone().try_into().unwrap();
+        let new_arr: PolygonArray = (wkb_arr.clone(), Dimension::XY).try_into().unwrap();
 
         let wkb0 = geo::Geometry::Polygon(p0())
             .to_wkb(CoordDimensions::xy())

--- a/rust/geoarrow/src/io/wkb/writer/polygon.rs
+++ b/rust/geoarrow/src/io/wkb/writer/polygon.rs
@@ -8,8 +8,8 @@ use std::io::Cursor;
 use wkb::writer::{polygon_wkb_size, write_polygon};
 use wkb::Endianness;
 
-impl<O: OffsetSizeTrait, const D: usize> From<&PolygonArray<D>> for WKBArray<O> {
-    fn from(value: &PolygonArray<D>) -> Self {
+impl<O: OffsetSizeTrait> From<&PolygonArray> for WKBArray<O> {
+    fn from(value: &PolygonArray) -> Self {
         let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
@@ -50,9 +50,9 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_arr: PolygonArray<2> = vec![Some(p0()), Some(p1()), None].into();
+        let orig_arr: PolygonArray = vec![Some(p0()), Some(p1()), None].into();
         let wkb_arr: WKBArray<i32> = (&orig_arr).into();
-        let new_arr: PolygonArray<2> = wkb_arr.clone().try_into().unwrap();
+        let new_arr: PolygonArray = wkb_arr.clone().try_into().unwrap();
 
         let wkb0 = geo::Geometry::Polygon(p0())
             .to_wkb(CoordDimensions::xy())

--- a/rust/geoarrow/src/io/wkt/reader/mod.rs
+++ b/rust/geoarrow/src/io/wkt/reader/mod.rs
@@ -5,6 +5,7 @@ use arrow_array::{Array, GenericStringArray, OffsetSizeTrait};
 
 use crate::array::metadata::ArrayMetadata;
 use crate::array::{CoordType, MixedGeometryBuilder};
+use crate::datatypes::Dimension;
 use crate::NativeArray;
 
 // mod wkt_trait;
@@ -21,7 +22,9 @@ impl<O: OffsetSizeTrait> ParseWKT for GenericStringArray<O> {
 
     fn parse_wkt(&self, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self::Output {
         // TODO: switch this prefer_multi to true when we use downcasting here.
-        let mut builder = MixedGeometryBuilder::new_with_options(coord_type, metadata, false);
+        // TODO: Support xyz, xyzm, etc WKT input
+        let mut builder =
+            MixedGeometryBuilder::new_with_options(Dimension::XY, coord_type, metadata, false);
         for i in 0..self.len() {
             if self.is_valid(i) {
                 let w = wkt::Wkt::<f64>::from_str(self.value(i)).unwrap();

--- a/rust/geoarrow/src/io/wkt/reader/mod.rs
+++ b/rust/geoarrow/src/io/wkt/reader/mod.rs
@@ -21,7 +21,7 @@ impl<O: OffsetSizeTrait> ParseWKT for GenericStringArray<O> {
 
     fn parse_wkt(&self, coord_type: CoordType, metadata: Arc<ArrayMetadata>) -> Self::Output {
         // TODO: switch this prefer_multi to true when we use downcasting here.
-        let mut builder = MixedGeometryBuilder::<2>::new_with_options(coord_type, metadata, false);
+        let mut builder = MixedGeometryBuilder::new_with_options(coord_type, metadata, false);
         for i in 0..self.len() {
             if self.is_valid(i) {
                 let w = wkt::Wkt::<f64>::from_str(self.value(i)).unwrap();

--- a/rust/geoarrow/src/io/wkt/writer/api.rs
+++ b/rust/geoarrow/src/io/wkt/writer/api.rs
@@ -3,7 +3,7 @@ use arrow_array::OffsetSizeTrait;
 
 use crate::array::{AsChunkedNativeArray, AsNativeArray, WKTArray};
 use crate::chunked_array::{ChunkedGeometryArray, ChunkedNativeArray};
-use crate::datatypes::{Dimension, NativeType};
+use crate::datatypes::NativeType;
 use crate::io::wkt::writer::scalar::{
     geometry_collection_to_wkt, geometry_to_wkt, line_string_to_wkt, multi_line_string_to_wkt,
     multi_point_to_wkt, multi_polygon_to_wkt, point_to_wkt, polygon_to_wkt, rect_to_wkt,
@@ -24,12 +24,11 @@ impl ToWKT for &dyn NativeArray {
         let metadata = self.metadata();
         let mut output_array = GenericStringBuilder::<O>::new();
 
-        use Dimension::*;
         use NativeType::*;
 
         macro_rules! impl_to_wkt {
-            ($cast_func:ident, $dim:expr, $to_wkt_func:expr) => {
-                for maybe_geom in self.$cast_func::<$dim>().iter() {
+            ($cast_func:ident, $to_wkt_func:expr) => {
+                for maybe_geom in self.$cast_func().iter() {
                     output_array
                         .append_option(maybe_geom.map(|geom| $to_wkt_func(&geom).to_string()));
                 }
@@ -37,32 +36,19 @@ impl ToWKT for &dyn NativeArray {
         }
 
         match self.data_type() {
-            Point(_, XY) => impl_to_wkt!(as_point, 2, point_to_wkt),
-            LineString(_, XY) => impl_to_wkt!(as_line_string, 2, line_string_to_wkt),
-            Polygon(_, XY) => impl_to_wkt!(as_polygon, 2, polygon_to_wkt),
-            MultiPoint(_, XY) => impl_to_wkt!(as_multi_point, 2, multi_point_to_wkt),
-            MultiLineString(_, XY) => {
-                impl_to_wkt!(as_multi_line_string, 2, multi_line_string_to_wkt)
+            Point(_, _) => impl_to_wkt!(as_point, point_to_wkt),
+            LineString(_, _) => impl_to_wkt!(as_line_string, line_string_to_wkt),
+            Polygon(_, _) => impl_to_wkt!(as_polygon, polygon_to_wkt),
+            MultiPoint(_, _) => impl_to_wkt!(as_multi_point, multi_point_to_wkt),
+            MultiLineString(_, _) => {
+                impl_to_wkt!(as_multi_line_string, multi_line_string_to_wkt)
             }
-            MultiPolygon(_, XY) => impl_to_wkt!(as_multi_polygon, 2, multi_polygon_to_wkt),
-            Mixed(_, XY) => impl_to_wkt!(as_mixed, 2, geometry_to_wkt),
-            GeometryCollection(_, XY) => {
-                impl_to_wkt!(as_geometry_collection, 2, geometry_collection_to_wkt)
+            MultiPolygon(_, _) => impl_to_wkt!(as_multi_polygon, multi_polygon_to_wkt),
+            Mixed(_, _) => impl_to_wkt!(as_mixed, geometry_to_wkt),
+            GeometryCollection(_, _) => {
+                impl_to_wkt!(as_geometry_collection, geometry_collection_to_wkt)
             }
-            Point(_, XYZ) => impl_to_wkt!(as_point, 3, point_to_wkt),
-            LineString(_, XYZ) => impl_to_wkt!(as_line_string, 3, line_string_to_wkt),
-            Polygon(_, XYZ) => impl_to_wkt!(as_polygon, 3, polygon_to_wkt),
-            MultiPoint(_, XYZ) => impl_to_wkt!(as_multi_point, 3, multi_point_to_wkt),
-            MultiLineString(_, XYZ) => {
-                impl_to_wkt!(as_multi_line_string, 3, multi_line_string_to_wkt)
-            }
-            MultiPolygon(_, XYZ) => impl_to_wkt!(as_multi_polygon, 3, multi_polygon_to_wkt),
-            Mixed(_, XYZ) => impl_to_wkt!(as_mixed, 3, geometry_to_wkt),
-            GeometryCollection(_, XYZ) => {
-                impl_to_wkt!(as_geometry_collection, 3, geometry_collection_to_wkt)
-            }
-            Rect(XY) => impl_to_wkt!(as_rect, 2, rect_to_wkt),
-            Rect(XYZ) => impl_to_wkt!(as_rect, 3, rect_to_wkt),
+            Rect(_) => impl_to_wkt!(as_rect, rect_to_wkt),
         }
 
         WKTArray::new(output_array.finish(), metadata)
@@ -73,38 +59,24 @@ impl ToWKT for &dyn ChunkedNativeArray {
     type Output<O: OffsetSizeTrait> = ChunkedGeometryArray<WKTArray<O>>;
 
     fn to_wkt<O: OffsetSizeTrait>(&self) -> Self::Output<O> {
-        use Dimension::*;
         use NativeType::*;
 
         macro_rules! impl_to_wkt {
-            ($cast_func:ident, $dim:expr) => {
-                ChunkedGeometryArray::new(
-                    self.$cast_func::<$dim>()
-                        .map(|chunk| chunk.as_ref().to_wkt()),
-                )
+            ($cast_func:ident) => {
+                ChunkedGeometryArray::new(self.$cast_func().map(|chunk| chunk.as_ref().to_wkt()))
             };
         }
 
         match self.data_type() {
-            Point(_, XY) => impl_to_wkt!(as_point, 2),
-            LineString(_, XY) => impl_to_wkt!(as_line_string, 2),
-            Polygon(_, XY) => impl_to_wkt!(as_polygon, 2),
-            MultiPoint(_, XY) => impl_to_wkt!(as_multi_point, 2),
-            MultiLineString(_, XY) => impl_to_wkt!(as_multi_line_string, 2),
-            MultiPolygon(_, XY) => impl_to_wkt!(as_multi_polygon, 2),
-            Mixed(_, XY) => impl_to_wkt!(as_mixed, 2),
-            GeometryCollection(_, XY) => impl_to_wkt!(as_geometry_collection, 2),
-            Rect(XY) => impl_to_wkt!(as_rect, 2),
-
-            Point(_, XYZ) => impl_to_wkt!(as_point, 3),
-            LineString(_, XYZ) => impl_to_wkt!(as_line_string, 3),
-            Polygon(_, XYZ) => impl_to_wkt!(as_polygon, 3),
-            MultiPoint(_, XYZ) => impl_to_wkt!(as_multi_point, 3),
-            MultiLineString(_, XYZ) => impl_to_wkt!(as_multi_line_string, 3),
-            MultiPolygon(_, XYZ) => impl_to_wkt!(as_multi_polygon, 3),
-            Mixed(_, XYZ) => impl_to_wkt!(as_mixed, 3),
-            GeometryCollection(_, XYZ) => impl_to_wkt!(as_geometry_collection, 3),
-            Rect(XYZ) => impl_to_wkt!(as_rect, 3),
+            Point(_, _) => impl_to_wkt!(as_point),
+            LineString(_, _) => impl_to_wkt!(as_line_string),
+            Polygon(_, _) => impl_to_wkt!(as_polygon),
+            MultiPoint(_, _) => impl_to_wkt!(as_multi_point),
+            MultiLineString(_, _) => impl_to_wkt!(as_multi_line_string),
+            MultiPolygon(_, _) => impl_to_wkt!(as_multi_polygon),
+            Mixed(_, _) => impl_to_wkt!(as_mixed),
+            GeometryCollection(_, _) => impl_to_wkt!(as_geometry_collection),
+            Rect(_) => impl_to_wkt!(as_rect),
         }
     }
 }

--- a/rust/geoarrow/src/lib.rs
+++ b/rust/geoarrow/src/lib.rs
@@ -39,16 +39,19 @@
 //!
 //! ```
 //! use geoarrow::array::PointArray;
+//! use geoarrow::datatypes::Dimension;
 //!
 //! let point = geo::point!(x: 1., y: 2.);
-//! let array: PointArray<2> = vec![point].as_slice().into();
+//! let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
 //! ```
 //!
 //! Or you can use builders, e.g. [PointBuilder](crate::array::PointBuilder):
 //!
 //! ```
 //! use geoarrow::array::PointBuilder;
-//! let mut builder = PointBuilder::<2>::new();
+//! use geoarrow::datatypes::Dimension;
+//!
+//! let mut builder = PointBuilder::new(Dimension::XY);
 //! builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
 //! let array = builder.finish();
 //! ```

--- a/rust/geoarrow/src/scalar/geometry/owned.rs
+++ b/rust/geoarrow/src/scalar/geometry/owned.rs
@@ -36,8 +36,8 @@ impl<'a> From<&'a OwnedGeometry> for Geometry<'a> {
     }
 }
 
-impl<'a> From<&'a OwnedGeometry<2>> for geo::Geometry {
-    fn from(value: &'a OwnedGeometry<2>) -> Self {
+impl<'a> From<&'a OwnedGeometry> for geo::Geometry {
+    fn from(value: &'a OwnedGeometry) -> Self {
         let geom = Geometry::from(value);
         geom.into()
     }

--- a/rust/geoarrow/src/scalar/geometry/owned.rs
+++ b/rust/geoarrow/src/scalar/geometry/owned.rs
@@ -9,19 +9,19 @@ use geo_traits::{
 #[derive(Clone, Debug)]
 // TODO: come back to this in #449
 #[allow(clippy::large_enum_variant)]
-pub enum OwnedGeometry<const D: usize> {
-    Point(crate::scalar::OwnedPoint<D>),
-    LineString(crate::scalar::OwnedLineString<D>),
-    Polygon(crate::scalar::OwnedPolygon<D>),
-    MultiPoint(crate::scalar::OwnedMultiPoint<D>),
-    MultiLineString(crate::scalar::OwnedMultiLineString<D>),
-    MultiPolygon(crate::scalar::OwnedMultiPolygon<D>),
-    GeometryCollection(crate::scalar::OwnedGeometryCollection<D>),
-    Rect(crate::scalar::OwnedRect<D>),
+pub enum OwnedGeometry {
+    Point(crate::scalar::OwnedPoint),
+    LineString(crate::scalar::OwnedLineString),
+    Polygon(crate::scalar::OwnedPolygon),
+    MultiPoint(crate::scalar::OwnedMultiPoint),
+    MultiLineString(crate::scalar::OwnedMultiLineString),
+    MultiPolygon(crate::scalar::OwnedMultiPolygon),
+    GeometryCollection(crate::scalar::OwnedGeometryCollection),
+    Rect(crate::scalar::OwnedRect),
 }
 
-impl<'a, const D: usize> From<&'a OwnedGeometry<D>> for Geometry<'a, D> {
-    fn from(value: &'a OwnedGeometry<D>) -> Self {
+impl<'a> From<&'a OwnedGeometry> for Geometry<'a> {
+    fn from(value: &'a OwnedGeometry) -> Self {
         use OwnedGeometry::*;
         match value {
             Point(geom) => Geometry::Point(geom.into()),
@@ -43,8 +43,8 @@ impl<'a> From<&'a OwnedGeometry<2>> for geo::Geometry {
     }
 }
 
-impl<'a, const D: usize> From<Geometry<'a, D>> for OwnedGeometry<D> {
-    fn from(value: Geometry<'a, D>) -> Self {
+impl<'a> From<Geometry<'a>> for OwnedGeometry {
+    fn from(value: Geometry<'a>) -> Self {
         use OwnedGeometry::*;
         match value {
             Geometry::Point(geom) => Point(geom.into()),
@@ -66,16 +66,16 @@ impl<'a, const D: usize> From<Geometry<'a, D>> for OwnedGeometry<D> {
 //     }
 // }
 
-impl<const D: usize> GeometryTrait for OwnedGeometry<D> {
+impl GeometryTrait for OwnedGeometry {
     type T = f64;
-    type PointType<'b> = OwnedPoint<D> where Self: 'b;
-    type LineStringType<'b> = OwnedLineString<D> where Self: 'b;
-    type PolygonType<'b> = OwnedPolygon<D> where Self: 'b;
-    type MultiPointType<'b> = OwnedMultiPoint<D> where Self: 'b;
-    type MultiLineStringType<'b> = OwnedMultiLineString<D> where Self: 'b;
-    type MultiPolygonType<'b> = OwnedMultiPolygon<D> where Self: 'b;
-    type GeometryCollectionType<'b> = OwnedGeometryCollection<D> where Self: 'b;
-    type RectType<'b> = OwnedRect<D> where Self: 'b;
+    type PointType<'b> = OwnedPoint where Self: 'b;
+    type LineStringType<'b> = OwnedLineString where Self: 'b;
+    type PolygonType<'b> = OwnedPolygon where Self: 'b;
+    type MultiPointType<'b> = OwnedMultiPoint where Self: 'b;
+    type MultiLineStringType<'b> = OwnedMultiLineString where Self: 'b;
+    type MultiPolygonType<'b> = OwnedMultiPolygon where Self: 'b;
+    type GeometryCollectionType<'b> = OwnedGeometryCollection where Self: 'b;
+    type RectType<'b> = OwnedRect where Self: 'b;
     type TriangleType<'b> = UnimplementedTriangle<f64> where Self: 'b;
     type LineType<'b> = UnimplementedLine<f64> where Self: 'b;
 
@@ -96,14 +96,14 @@ impl<const D: usize> GeometryTrait for OwnedGeometry<D> {
         &self,
     ) -> geo_traits::GeometryType<
         '_,
-        OwnedPoint<D>,
-        OwnedLineString<D>,
-        OwnedPolygon<D>,
-        OwnedMultiPoint<D>,
-        OwnedMultiLineString<D>,
-        OwnedMultiPolygon<D>,
-        OwnedGeometryCollection<D>,
-        OwnedRect<D>,
+        OwnedPoint,
+        OwnedLineString,
+        OwnedPolygon,
+        OwnedMultiPoint,
+        OwnedMultiLineString,
+        OwnedMultiPolygon,
+        OwnedGeometryCollection,
+        OwnedRect,
         UnimplementedTriangle<f64>,
         UnimplementedLine<f64>,
     > {
@@ -120,7 +120,7 @@ impl<const D: usize> GeometryTrait for OwnedGeometry<D> {
     }
 }
 
-impl<G: GeometryTrait<T = f64>> PartialEq<G> for OwnedGeometry<2> {
+impl<G: GeometryTrait<T = f64>> PartialEq<G> for OwnedGeometry {
     fn eq(&self, other: &G) -> bool {
         geometry_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/geometry/scalar.rs
+++ b/rust/geoarrow/src/scalar/geometry/scalar.rs
@@ -11,18 +11,18 @@ use rstar::{RTreeObject, AABB};
 
 /// A Geometry is an enum over the various underlying _zero copy_ GeoArrow scalar types.
 #[derive(Debug)]
-pub enum Geometry<'a, const D: usize> {
-    Point(crate::scalar::Point<'a, D>),
-    LineString(crate::scalar::LineString<'a, D>),
-    Polygon(crate::scalar::Polygon<'a, D>),
-    MultiPoint(crate::scalar::MultiPoint<'a, D>),
-    MultiLineString(crate::scalar::MultiLineString<'a, D>),
-    MultiPolygon(crate::scalar::MultiPolygon<'a, D>),
-    GeometryCollection(crate::scalar::GeometryCollection<'a, D>),
-    Rect(crate::scalar::Rect<'a, D>),
+pub enum Geometry<'a> {
+    Point(crate::scalar::Point<'a>),
+    LineString(crate::scalar::LineString<'a>),
+    Polygon(crate::scalar::Polygon<'a>),
+    MultiPoint(crate::scalar::MultiPoint<'a>),
+    MultiLineString(crate::scalar::MultiLineString<'a>),
+    MultiPolygon(crate::scalar::MultiPolygon<'a>),
+    GeometryCollection(crate::scalar::GeometryCollection<'a>),
+    Rect(crate::scalar::Rect<'a>),
 }
 
-impl<'a, const D: usize> NativeScalar for Geometry<'a, D> {
+impl<'a> NativeScalar for Geometry<'a> {
     type ScalarGeo = geo::Geometry;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -48,16 +48,16 @@ impl<'a, const D: usize> NativeScalar for Geometry<'a, D> {
     }
 }
 
-impl<'a, const D: usize> GeometryTrait for Geometry<'a, D> {
+impl<'a> GeometryTrait for Geometry<'a> {
     type T = f64;
-    type PointType<'b> = Point<'b, D> where Self: 'b;
-    type LineStringType<'b> = LineString<'b, D> where Self: 'b;
-    type PolygonType<'b> = Polygon<'b, D> where Self: 'b;
-    type MultiPointType<'b> = MultiPoint<'b, D> where Self: 'b;
-    type MultiLineStringType<'b> = MultiLineString<'b, D> where Self: 'b;
-    type MultiPolygonType<'b> = MultiPolygon<'b, D> where Self: 'b;
-    type GeometryCollectionType<'b> = GeometryCollection<'b, D> where Self: 'b;
-    type RectType<'b> = Rect<'b, D> where Self: 'b;
+    type PointType<'b> = Point<'b> where Self: 'b;
+    type LineStringType<'b> = LineString<'b> where Self: 'b;
+    type PolygonType<'b> = Polygon<'b> where Self: 'b;
+    type MultiPointType<'b> = MultiPoint<'b> where Self: 'b;
+    type MultiLineStringType<'b> = MultiLineString<'b> where Self: 'b;
+    type MultiPolygonType<'b> = MultiPolygon<'b> where Self: 'b;
+    type GeometryCollectionType<'b> = GeometryCollection<'b> where Self: 'b;
+    type RectType<'b> = Rect<'b> where Self: 'b;
     type LineType<'b> = UnimplementedLine<f64> where Self: 'b;
     type TriangleType<'b> = UnimplementedTriangle<f64> where Self: 'b;
 
@@ -78,14 +78,14 @@ impl<'a, const D: usize> GeometryTrait for Geometry<'a, D> {
         &self,
     ) -> geo_traits::GeometryType<
         '_,
-        Point<'_, D>,
-        LineString<'_, D>,
-        Polygon<'_, D>,
-        MultiPoint<'_, D>,
-        MultiLineString<'_, D>,
-        MultiPolygon<'_, D>,
-        GeometryCollection<'_, D>,
-        Rect<'_, D>,
+        Point<'_>,
+        LineString<'_>,
+        Polygon<'_>,
+        MultiPoint<'_>,
+        MultiLineString<'_>,
+        MultiPolygon<'_>,
+        GeometryCollection<'_>,
+        Rect<'_>,
         UnimplementedTriangle<f64>,
         UnimplementedLine<f64>,
     > {
@@ -102,16 +102,16 @@ impl<'a, const D: usize> GeometryTrait for Geometry<'a, D> {
     }
 }
 
-impl<'a, const D: usize> GeometryTrait for &'a Geometry<'a, D> {
+impl<'a> GeometryTrait for &'a Geometry<'a> {
     type T = f64;
-    type PointType<'b> = Point<'b, D> where Self: 'b;
-    type LineStringType<'b> = LineString<'b, D> where Self: 'b;
-    type PolygonType<'b> = Polygon<'b, D> where Self: 'b;
-    type MultiPointType<'b> = MultiPoint<'b, D> where Self: 'b;
-    type MultiLineStringType<'b> = MultiLineString<'b, D> where Self: 'b;
-    type MultiPolygonType<'b> = MultiPolygon<'b, D> where Self: 'b;
-    type GeometryCollectionType<'b> = GeometryCollection<'b, D> where Self: 'b;
-    type RectType<'b> = Rect<'b, D> where Self: 'b;
+    type PointType<'b> = Point<'b> where Self: 'b;
+    type LineStringType<'b> = LineString<'b> where Self: 'b;
+    type PolygonType<'b> = Polygon<'b> where Self: 'b;
+    type MultiPointType<'b> = MultiPoint<'b> where Self: 'b;
+    type MultiLineStringType<'b> = MultiLineString<'b> where Self: 'b;
+    type MultiPolygonType<'b> = MultiPolygon<'b> where Self: 'b;
+    type GeometryCollectionType<'b> = GeometryCollection<'b> where Self: 'b;
+    type RectType<'b> = Rect<'b> where Self: 'b;
     type LineType<'b> = UnimplementedLine<f64> where Self: 'b;
     type TriangleType<'b> = UnimplementedTriangle<f64> where Self: 'b;
 
@@ -132,14 +132,14 @@ impl<'a, const D: usize> GeometryTrait for &'a Geometry<'a, D> {
         &self,
     ) -> geo_traits::GeometryType<
         'a,
-        Point<'a, D>,
-        LineString<'a, D>,
-        Polygon<'a, D>,
-        MultiPoint<'a, D>,
-        MultiLineString<'a, D>,
-        MultiPolygon<'a, D>,
-        GeometryCollection<'a, D>,
-        Rect<'a, D>,
+        Point<'a>,
+        LineString<'a>,
+        Polygon<'a>,
+        MultiPoint<'a>,
+        MultiLineString<'a>,
+        MultiPolygon<'a>,
+        GeometryCollection<'a>,
+        Rect<'a>,
         UnimplementedTriangle<f64>,
         UnimplementedLine<f64>,
     > {
@@ -156,7 +156,7 @@ impl<'a, const D: usize> GeometryTrait for &'a Geometry<'a, D> {
     }
 }
 
-impl RTreeObject for Geometry<'_, 2> {
+impl RTreeObject for Geometry<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -173,19 +173,19 @@ impl RTreeObject for Geometry<'_, 2> {
     }
 }
 
-impl<const D: usize> From<Geometry<'_, D>> for geo::Geometry {
-    fn from(value: Geometry<'_, D>) -> Self {
+impl From<Geometry<'_>> for geo::Geometry {
+    fn from(value: Geometry<'_>) -> Self {
         geometry_to_geo(&value)
     }
 }
 
-impl<const D: usize> From<&Geometry<'_, D>> for geo::Geometry {
-    fn from(value: &Geometry<'_, D>) -> Self {
+impl From<&Geometry<'_>> for geo::Geometry {
+    fn from(value: &Geometry<'_>) -> Self {
         geometry_to_geo(value)
     }
 }
 
-impl<const D: usize, G: GeometryTrait<T = f64>> PartialEq<G> for Geometry<'_, D> {
+impl<G: GeometryTrait<T = f64>> PartialEq<G> for Geometry<'_> {
     fn eq(&self, other: &G) -> bool {
         geometry_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/geometrycollection/owned.rs
+++ b/rust/geoarrow/src/scalar/geometrycollection/owned.rs
@@ -60,7 +60,7 @@ impl GeometryCollectionTrait for OwnedGeometryCollection {
     type GeometryType<'b> = Geometry<'b> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match self.coords.dim() {
+        match self.array.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
             Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }

--- a/rust/geoarrow/src/scalar/geometrycollection/owned.rs
+++ b/rust/geoarrow/src/scalar/geometrycollection/owned.rs
@@ -7,7 +7,7 @@ use geo_traits::GeometryCollectionTrait;
 
 #[derive(Clone, Debug)]
 pub struct OwnedGeometryCollection {
-    array: MixedGeometryArray<D>,
+    array: MixedGeometryArray,
 
     /// Offsets into the geometry array where each geometry starts
     geom_offsets: OffsetBuffer<i32>,
@@ -15,9 +15,9 @@ pub struct OwnedGeometryCollection {
     geom_index: usize,
 }
 
-impl OwnedGeometryCollection<D> {
+impl OwnedGeometryCollection {
     pub fn new(
-        array: MixedGeometryArray<D>,
+        array: MixedGeometryArray,
         geom_offsets: OffsetBuffer<i32>,
         geom_index: usize,
     ) -> Self {
@@ -29,33 +29,33 @@ impl OwnedGeometryCollection<D> {
     }
 }
 
-impl<'a> From<&'a OwnedGeometryCollection<D>> for GeometryCollection<'a> {
-    fn from(value: &'a OwnedGeometryCollection<D>) -> Self {
+impl<'a> From<&'a OwnedGeometryCollection> for GeometryCollection<'a> {
+    fn from(value: &'a OwnedGeometryCollection) -> Self {
         Self::new(&value.array, &value.geom_offsets, value.geom_index)
     }
 }
 
-impl<'a> From<&'a OwnedGeometryCollection<2>> for geo::GeometryCollection {
-    fn from(value: &'a OwnedGeometryCollection<2>) -> Self {
+impl<'a> From<&'a OwnedGeometryCollection> for geo::GeometryCollection {
+    fn from(value: &'a OwnedGeometryCollection) -> Self {
         let geom = GeometryCollection::from(value);
         geom.into()
     }
 }
 
-impl<'a> From<GeometryCollection<'a>> for OwnedGeometryCollection<D> {
+impl<'a> From<GeometryCollection<'a>> for OwnedGeometryCollection {
     fn from(value: GeometryCollection<'a>) -> Self {
         let (array, geom_offsets, geom_index) = value.into_inner();
         Self::new(array.clone(), geom_offsets.clone(), geom_index)
     }
 }
 
-impl From<OwnedGeometryCollection<D>> for GeometryCollectionArray<D> {
-    fn from(value: OwnedGeometryCollection<D>) -> Self {
+impl From<OwnedGeometryCollection> for GeometryCollectionArray {
+    fn from(value: OwnedGeometryCollection) -> Self {
         Self::new(value.array, value.geom_offsets, None, Default::default())
     }
 }
 
-impl GeometryCollectionTrait for OwnedGeometryCollection<D> {
+impl GeometryCollectionTrait for OwnedGeometryCollection {
     type T = f64;
     type GeometryType<'b> = Geometry<'b> where Self: 'b;
 
@@ -75,7 +75,7 @@ impl GeometryCollectionTrait for OwnedGeometryCollection<D> {
     }
 }
 
-impl<G: GeometryCollectionTrait<T = f64>> PartialEq<G> for OwnedGeometryCollection<2> {
+impl<G: GeometryCollectionTrait<T = f64>> PartialEq<G> for OwnedGeometryCollection {
     fn eq(&self, other: &G) -> bool {
         geometry_collection_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/geometrycollection/owned.rs
+++ b/rust/geoarrow/src/scalar/geometrycollection/owned.rs
@@ -2,6 +2,7 @@ use crate::algorithm::native::eq::geometry_collection_eq;
 use crate::array::{GeometryCollectionArray, MixedGeometryArray};
 use crate::datatypes::Dimension;
 use crate::scalar::{Geometry, GeometryCollection};
+use crate::NativeArray;
 use arrow_buffer::OffsetBuffer;
 use geo_traits::GeometryCollectionTrait;
 
@@ -60,7 +61,7 @@ impl GeometryCollectionTrait for OwnedGeometryCollection {
     type GeometryType<'b> = Geometry<'b> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match self.array.dim() {
+        match self.array.dimension() {
             Dimension::XY => geo_traits::Dimensions::Xy,
             Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }

--- a/rust/geoarrow/src/scalar/geometrycollection/scalar.rs
+++ b/rust/geoarrow/src/scalar/geometrycollection/scalar.rs
@@ -1,6 +1,7 @@
 use crate::algorithm::native::eq::geometry_collection_eq;
 use crate::array::util::OffsetBufferUtils;
 use crate::array::MixedGeometryArray;
+use crate::datatypes::Dimension;
 use crate::io::geo::geometry_collection_to_geo;
 use crate::scalar::Geometry;
 use crate::trait_::ArrayAccessor;
@@ -11,7 +12,7 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a GeometryCollection
 #[derive(Debug, Clone)]
-pub struct GeometryCollection<'a, const D: usize> {
+pub struct GeometryCollection<'a> {
     pub(crate) array: &'a MixedGeometryArray<D>,
 
     /// Offsets into the geometry array where each geometry starts
@@ -22,7 +23,7 @@ pub struct GeometryCollection<'a, const D: usize> {
     start_offset: usize,
 }
 
-impl<'a, const D: usize> GeometryCollection<'a, D> {
+impl<'a> GeometryCollection<'a> {
     pub fn new(
         array: &'a MixedGeometryArray<D>,
         geom_offsets: &'a OffsetBuffer<i32>,
@@ -42,7 +43,7 @@ impl<'a, const D: usize> GeometryCollection<'a, D> {
     }
 }
 
-impl<'a, const D: usize> NativeScalar for GeometryCollection<'a, D> {
+impl<'a> NativeScalar for GeometryCollection<'a> {
     type ScalarGeo = geo::GeometryCollection;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -59,16 +60,14 @@ impl<'a, const D: usize> NativeScalar for GeometryCollection<'a, D> {
     }
 }
 
-impl<'a, const D: usize> GeometryCollectionTrait for GeometryCollection<'a, D> {
+impl<'a> GeometryCollectionTrait for GeometryCollection<'a> {
     type T = f64;
-    type GeometryType<'b> = Geometry<'a, D> where Self: 'b;
+    type GeometryType<'b> = Geometry<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: pass through field information from array
-        match D {
-            2 => geo_traits::Dimensions::Xy,
-            3 => geo_traits::Dimensions::Xyz,
-            _ => todo!(),
+        match self.coords.dim() {
+            Dimension::XY => geo_traits::Dimensions::Xy,
+            Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
     }
 
@@ -82,16 +81,14 @@ impl<'a, const D: usize> GeometryCollectionTrait for GeometryCollection<'a, D> {
     }
 }
 
-impl<'a, const D: usize> GeometryCollectionTrait for &'a GeometryCollection<'a, D> {
+impl<'a> GeometryCollectionTrait for &'a GeometryCollection<'a> {
     type T = f64;
-    type GeometryType<'b> = Geometry<'a, D> where Self: 'b;
+    type GeometryType<'b> = Geometry<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: pass through field information from array
-        match D {
-            2 => geo_traits::Dimensions::Xy,
-            3 => geo_traits::Dimensions::Xyz,
-            _ => todo!(),
+        match self.coords.dim() {
+            Dimension::XY => geo_traits::Dimensions::Xy,
+            Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
     }
 
@@ -105,20 +102,14 @@ impl<'a, const D: usize> GeometryCollectionTrait for &'a GeometryCollection<'a, 
     }
 }
 
-// impl<O: OffsetSizeTrait> From<GeometryCollection<'_, 2>> for geo::GeometryCollection {
-//     fn from(value: GeometryCollection<'_, 2>) -> Self {
-//         (&value).into()
-//     }
-// }
-
-impl<const D: usize> From<&GeometryCollection<'_, D>> for geo::GeometryCollection {
-    fn from(value: &GeometryCollection<'_, D>) -> Self {
+impl From<&GeometryCollection<'_>> for geo::GeometryCollection {
+    fn from(value: &GeometryCollection<'_>) -> Self {
         geometry_collection_to_geo(value)
     }
 }
 
-impl<const D: usize> From<GeometryCollection<'_, D>> for geo::Geometry {
-    fn from(value: GeometryCollection<'_, D>) -> Self {
+impl From<GeometryCollection<'_>> for geo::Geometry {
+    fn from(value: GeometryCollection<'_>) -> Self {
         geo::Geometry::GeometryCollection(value.into())
     }
 }
@@ -133,9 +124,7 @@ impl RTreeObject for GeometryCollection<'_, 2> {
     }
 }
 
-impl<const D: usize, G: GeometryCollectionTrait<T = f64>> PartialEq<G>
-    for GeometryCollection<'_, D>
-{
+impl<G: GeometryCollectionTrait<T = f64>> PartialEq<G> for GeometryCollection<'_> {
     fn eq(&self, other: &G) -> bool {
         geometry_collection_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/geometrycollection/scalar.rs
+++ b/rust/geoarrow/src/scalar/geometrycollection/scalar.rs
@@ -6,6 +6,7 @@ use crate::io::geo::geometry_collection_to_geo;
 use crate::scalar::Geometry;
 use crate::trait_::ArrayAccessor;
 use crate::trait_::NativeScalar;
+use crate::NativeArray;
 use arrow_buffer::OffsetBuffer;
 use geo_traits::GeometryCollectionTrait;
 use rstar::{RTreeObject, AABB};
@@ -65,7 +66,7 @@ impl<'a> GeometryCollectionTrait for GeometryCollection<'a> {
     type GeometryType<'b> = Geometry<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match self.array.dim() {
+        match self.array.dimension() {
             Dimension::XY => geo_traits::Dimensions::Xy,
             Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
@@ -86,7 +87,7 @@ impl<'a> GeometryCollectionTrait for &'a GeometryCollection<'a> {
     type GeometryType<'b> = Geometry<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match self.array.dim() {
+        match self.array.dimension() {
             Dimension::XY => geo_traits::Dimensions::Xy,
             Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }

--- a/rust/geoarrow/src/scalar/geometrycollection/scalar.rs
+++ b/rust/geoarrow/src/scalar/geometrycollection/scalar.rs
@@ -13,7 +13,7 @@ use rstar::{RTreeObject, AABB};
 /// An Arrow equivalent of a GeometryCollection
 #[derive(Debug, Clone)]
 pub struct GeometryCollection<'a> {
-    pub(crate) array: &'a MixedGeometryArray<D>,
+    pub(crate) array: &'a MixedGeometryArray,
 
     /// Offsets into the geometry array where each geometry starts
     pub(crate) geom_offsets: &'a OffsetBuffer<i32>,
@@ -25,7 +25,7 @@ pub struct GeometryCollection<'a> {
 
 impl<'a> GeometryCollection<'a> {
     pub fn new(
-        array: &'a MixedGeometryArray<D>,
+        array: &'a MixedGeometryArray,
         geom_offsets: &'a OffsetBuffer<i32>,
         geom_index: usize,
     ) -> Self {
@@ -38,7 +38,7 @@ impl<'a> GeometryCollection<'a> {
         }
     }
 
-    pub fn into_inner(&self) -> (&MixedGeometryArray<D>, &OffsetBuffer<i32>, usize) {
+    pub fn into_inner(&self) -> (&MixedGeometryArray, &OffsetBuffer<i32>, usize) {
         (self.array, self.geom_offsets, self.geom_index)
     }
 }
@@ -65,7 +65,7 @@ impl<'a> GeometryCollectionTrait for GeometryCollection<'a> {
     type GeometryType<'b> = Geometry<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match self.coords.dim() {
+        match self.array.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
             Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
@@ -86,7 +86,7 @@ impl<'a> GeometryCollectionTrait for &'a GeometryCollection<'a> {
     type GeometryType<'b> = Geometry<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match self.coords.dim() {
+        match self.array.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
             Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
@@ -114,7 +114,7 @@ impl From<GeometryCollection<'_>> for geo::Geometry {
     }
 }
 
-impl RTreeObject for GeometryCollection<'_, 2> {
+impl RTreeObject for GeometryCollection<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {

--- a/rust/geoarrow/src/scalar/linestring/owned.rs
+++ b/rust/geoarrow/src/scalar/linestring/owned.rs
@@ -5,7 +5,7 @@ use arrow_buffer::OffsetBuffer;
 use geo_traits::LineStringTrait;
 
 #[derive(Clone, Debug)]
-pub struct OwnedLineString<const D: usize> {
+pub struct OwnedLineString {
     coords: CoordBuffer,
 
     /// Offsets into the coordinate array where each geometry starts
@@ -14,7 +14,7 @@ pub struct OwnedLineString<const D: usize> {
     geom_index: usize,
 }
 
-impl<const D: usize> OwnedLineString<D> {
+impl OwnedLineString {
     pub fn new(coords: CoordBuffer, geom_offsets: OffsetBuffer<i32>, geom_index: usize) -> Self {
         Self {
             coords,
@@ -24,33 +24,33 @@ impl<const D: usize> OwnedLineString<D> {
     }
 }
 
-impl<'a, const D: usize> From<&'a OwnedLineString<D>> for LineString<'a, D> {
-    fn from(value: &'a OwnedLineString<D>) -> Self {
+impl<'a> From<&'a OwnedLineString> for LineString<'a> {
+    fn from(value: &'a OwnedLineString) -> Self {
         Self::new(&value.coords, &value.geom_offsets, value.geom_index)
     }
 }
 
-impl From<OwnedLineString<2>> for geo::LineString {
-    fn from(value: OwnedLineString<2>) -> Self {
+impl From<OwnedLineString> for geo::LineString {
+    fn from(value: OwnedLineString) -> Self {
         let geom = LineString::from(&value);
         geom.into()
     }
 }
 
-impl<'a, const D: usize> From<LineString<'a, D>> for OwnedLineString<D> {
-    fn from(value: LineString<'a, D>) -> Self {
+impl<'a> From<LineString<'a>> for OwnedLineString {
+    fn from(value: LineString<'a>) -> Self {
         let (coords, geom_offsets, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_offsets, geom_index)
     }
 }
 
-impl<const D: usize> From<OwnedLineString<D>> for LineStringArray<D> {
-    fn from(value: OwnedLineString<D>) -> Self {
+impl From<OwnedLineString> for LineStringArray {
+    fn from(value: OwnedLineString) -> Self {
         Self::new(value.coords, value.geom_offsets, None, Default::default())
     }
 }
 
-impl<const D: usize> LineStringTrait for OwnedLineString<D> {
+impl LineStringTrait for OwnedLineString {
     type T = f64;
     type CoordType<'b> = Coord<'b> where Self: 'b;
 
@@ -67,7 +67,7 @@ impl<const D: usize> LineStringTrait for OwnedLineString<D> {
     }
 }
 
-impl<G: LineStringTrait<T = f64>> PartialEq<G> for OwnedLineString<2> {
+impl<G: LineStringTrait<T = f64>> PartialEq<G> for OwnedLineString {
     fn eq(&self, other: &G) -> bool {
         line_string_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/linestring/scalar.rs
+++ b/rust/geoarrow/src/scalar/linestring/scalar.rs
@@ -11,7 +11,7 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a LineString
 #[derive(Debug, Clone)]
-pub struct LineString<'a, const D: usize> {
+pub struct LineString<'a> {
     pub(crate) coords: &'a CoordBuffer,
 
     /// Offsets into the coordinate array where each geometry starts
@@ -22,7 +22,7 @@ pub struct LineString<'a, const D: usize> {
     start_offset: usize,
 }
 
-impl<'a, const D: usize> LineString<'a, D> {
+impl<'a> LineString<'a> {
     pub fn new(
         coords: &'a CoordBuffer,
         geom_offsets: &'a OffsetBuffer<i32>,
@@ -38,7 +38,7 @@ impl<'a, const D: usize> LineString<'a, D> {
     }
 
     pub fn into_owned_inner(self) -> (CoordBuffer, OffsetBuffer<i32>, usize) {
-        let arr = LineStringArray::<D>::new(
+        let arr = LineStringArray::new(
             self.coords.clone(),
             self.geom_offsets.clone(),
             None,
@@ -50,7 +50,7 @@ impl<'a, const D: usize> LineString<'a, D> {
     }
 }
 
-impl<'a, const D: usize> NativeScalar for LineString<'a, D> {
+impl<'a> NativeScalar for LineString<'a> {
     type ScalarGeo = geo::LineString;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -67,7 +67,7 @@ impl<'a, const D: usize> NativeScalar for LineString<'a, D> {
     }
 }
 
-impl<'a, const D: usize> LineStringTrait for LineString<'a, D> {
+impl<'a> LineStringTrait for LineString<'a> {
     type T = f64;
     type CoordType<'b> = Coord<'a> where Self: 'b;
 
@@ -85,7 +85,7 @@ impl<'a, const D: usize> LineStringTrait for LineString<'a, D> {
     }
 }
 
-impl<'a, const D: usize> LineStringTrait for &'a LineString<'a, D> {
+impl<'a> LineStringTrait for &'a LineString<'a> {
     type T = f64;
     type CoordType<'b> = Coord<'a> where Self: 'b;
 
@@ -103,25 +103,25 @@ impl<'a, const D: usize> LineStringTrait for &'a LineString<'a, D> {
     }
 }
 
-impl<const D: usize> From<LineString<'_, D>> for geo::LineString {
-    fn from(value: LineString<'_, D>) -> Self {
+impl From<LineString<'_>> for geo::LineString {
+    fn from(value: LineString<'_>) -> Self {
         (&value).into()
     }
 }
 
-impl<const D: usize> From<&LineString<'_, D>> for geo::LineString {
-    fn from(value: &LineString<'_, D>) -> Self {
+impl From<&LineString<'_>> for geo::LineString {
+    fn from(value: &LineString<'_>) -> Self {
         line_string_to_geo(value)
     }
 }
 
-impl<const D: usize> From<LineString<'_, D>> for geo::Geometry {
-    fn from(value: LineString<'_, D>) -> Self {
+impl From<LineString<'_>> for geo::Geometry {
+    fn from(value: LineString<'_>) -> Self {
         geo::Geometry::LineString(value.into())
     }
 }
 
-impl RTreeObject for LineString<'_, 2> {
+impl RTreeObject for LineString<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -130,7 +130,7 @@ impl RTreeObject for LineString<'_, 2> {
     }
 }
 
-impl<G: LineStringTrait<T = f64>> PartialEq<G> for LineString<'_, 2> {
+impl<G: LineStringTrait<T = f64>> PartialEq<G> for LineString<'_> {
     fn eq(&self, other: &G) -> bool {
         line_string_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/linestring/scalar.rs
+++ b/rust/geoarrow/src/scalar/linestring/scalar.rs
@@ -145,8 +145,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: LineStringArray<2> = vec![ls0(), ls1()].as_slice().into();
-        let arr2: LineStringArray<2> = vec![ls0(), ls0()].as_slice().into();
+        let arr1: LineStringArray = vec![ls0(), ls1()].as_slice().into();
+        let arr2: LineStringArray = vec![ls0(), ls0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/linestring/scalar.rs
+++ b/rust/geoarrow/src/scalar/linestring/scalar.rs
@@ -139,14 +139,15 @@ impl<G: LineStringTrait<T = f64>> PartialEq<G> for LineString<'_> {
 #[cfg(test)]
 mod test {
     use crate::array::LineStringArray;
+    use crate::datatypes::Dimension;
     use crate::test::linestring::{ls0, ls1};
     use crate::trait_::ArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: LineStringArray = vec![ls0(), ls1()].as_slice().into();
-        let arr2: LineStringArray = vec![ls0(), ls0()].as_slice().into();
+        let arr1: LineStringArray = (vec![ls0(), ls1()].as_slice(), Dimension::XY).into();
+        let arr2: LineStringArray = (vec![ls0(), ls0()].as_slice(), Dimension::XY).into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/multilinestring/owned.rs
+++ b/rust/geoarrow/src/scalar/multilinestring/owned.rs
@@ -44,8 +44,8 @@ impl<'a> From<&'a OwnedMultiLineString> for MultiLineString<'a> {
     }
 }
 
-impl From<OwnedMultiLineString<2>> for geo::MultiLineString {
-    fn from(value: OwnedMultiLineString<2>) -> Self {
+impl From<OwnedMultiLineString> for geo::MultiLineString {
+    fn from(value: OwnedMultiLineString) -> Self {
         let geom = MultiLineString::from(&value);
         geom.into()
     }
@@ -90,7 +90,7 @@ impl MultiLineStringTrait for OwnedMultiLineString {
     }
 }
 
-impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for OwnedMultiLineString<2> {
+impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for OwnedMultiLineString {
     fn eq(&self, other: &G) -> bool {
         multi_line_string_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/multilinestring/owned.rs
+++ b/rust/geoarrow/src/scalar/multilinestring/owned.rs
@@ -1,11 +1,12 @@
 use crate::algorithm::native::eq::multi_line_string_eq;
 use crate::array::{CoordBuffer, MultiLineStringArray};
+use crate::datatypes::Dimension;
 use crate::scalar::{LineString, MultiLineString};
 use arrow_buffer::OffsetBuffer;
 use geo_traits::MultiLineStringTrait;
 
 #[derive(Clone, Debug)]
-pub struct OwnedMultiLineString<const D: usize> {
+pub struct OwnedMultiLineString {
     coords: CoordBuffer,
 
     /// Offsets into the coordinate array where each geometry starts
@@ -16,7 +17,7 @@ pub struct OwnedMultiLineString<const D: usize> {
     geom_index: usize,
 }
 
-impl<const D: usize> OwnedMultiLineString<D> {
+impl OwnedMultiLineString {
     pub fn new(
         coords: CoordBuffer,
         geom_offsets: OffsetBuffer<i32>,
@@ -32,8 +33,8 @@ impl<const D: usize> OwnedMultiLineString<D> {
     }
 }
 
-impl<'a, const D: usize> From<&'a OwnedMultiLineString<D>> for MultiLineString<'a, D> {
-    fn from(value: &'a OwnedMultiLineString<D>) -> Self {
+impl<'a> From<&'a OwnedMultiLineString> for MultiLineString<'a> {
+    fn from(value: &'a OwnedMultiLineString) -> Self {
         Self::new(
             &value.coords,
             &value.geom_offsets,
@@ -50,15 +51,15 @@ impl From<OwnedMultiLineString<2>> for geo::MultiLineString {
     }
 }
 
-impl<'a, const D: usize> From<MultiLineString<'a, D>> for OwnedMultiLineString<D> {
-    fn from(value: MultiLineString<'a, D>) -> Self {
+impl<'a> From<MultiLineString<'a>> for OwnedMultiLineString {
+    fn from(value: MultiLineString<'a>) -> Self {
         let (coords, geom_offsets, ring_offsets, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_offsets, ring_offsets, geom_index)
     }
 }
 
-impl<const D: usize> From<OwnedMultiLineString<D>> for MultiLineStringArray<D> {
-    fn from(value: OwnedMultiLineString<D>) -> Self {
+impl From<OwnedMultiLineString> for MultiLineStringArray {
+    fn from(value: OwnedMultiLineString) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -69,16 +70,14 @@ impl<const D: usize> From<OwnedMultiLineString<D>> for MultiLineStringArray<D> {
     }
 }
 
-impl<const D: usize> MultiLineStringTrait for OwnedMultiLineString<D> {
+impl MultiLineStringTrait for OwnedMultiLineString {
     type T = f64;
-    type LineStringType<'b> = LineString<'b, D> where Self: 'b;
+    type LineStringType<'b> = LineString<'b> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: pass through field information from array
-        match D {
-            2 => geo_traits::Dimensions::Xy,
-            3 => geo_traits::Dimensions::Xyz,
-            _ => todo!(),
+        match self.coords.dim() {
+            Dimension::XY => geo_traits::Dimensions::Xy,
+            Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
     }
 

--- a/rust/geoarrow/src/scalar/multilinestring/scalar.rs
+++ b/rust/geoarrow/src/scalar/multilinestring/scalar.rs
@@ -131,7 +131,7 @@ impl From<MultiLineString<'_>> for geo::Geometry {
     }
 }
 
-impl RTreeObject for MultiLineString<'_, 2> {
+impl RTreeObject for MultiLineString<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -140,7 +140,7 @@ impl RTreeObject for MultiLineString<'_, 2> {
     }
 }
 
-impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for MultiLineString<'_, 2> {
+impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for MultiLineString<'_> {
     fn eq(&self, other: &G) -> bool {
         multi_line_string_eq(self, other)
     }
@@ -155,8 +155,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiLineStringArray<2> = vec![ml0(), ml1()].as_slice().into();
-        let arr2: MultiLineStringArray<2> = vec![ml0(), ml0()].as_slice().into();
+        let arr1: MultiLineStringArray = vec![ml0(), ml1()].as_slice().into();
+        let arr2: MultiLineStringArray = vec![ml0(), ml0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/multilinestring/scalar.rs
+++ b/rust/geoarrow/src/scalar/multilinestring/scalar.rs
@@ -11,7 +11,7 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a MultiLineString
 #[derive(Debug, Clone)]
-pub struct MultiLineString<'a, const D: usize> {
+pub struct MultiLineString<'a> {
     pub(crate) coords: &'a CoordBuffer,
 
     /// Offsets into the ring array where each geometry starts
@@ -25,7 +25,7 @@ pub struct MultiLineString<'a, const D: usize> {
     start_offset: usize,
 }
 
-impl<'a, const D: usize> MultiLineString<'a, D> {
+impl<'a> MultiLineString<'a> {
     pub fn new(
         coords: &'a CoordBuffer,
         geom_offsets: &'a OffsetBuffer<i32>,
@@ -43,7 +43,7 @@ impl<'a, const D: usize> MultiLineString<'a, D> {
     }
 
     pub fn into_owned_inner(self) -> (CoordBuffer, OffsetBuffer<i32>, OffsetBuffer<i32>, usize) {
-        let arr = MultiLineStringArray::<D>::new(
+        let arr = MultiLineStringArray::new(
             self.coords.clone(),
             self.geom_offsets.clone(),
             self.ring_offsets.clone(),
@@ -60,7 +60,7 @@ impl<'a, const D: usize> MultiLineString<'a, D> {
     }
 }
 
-impl<'a, const D: usize> NativeScalar for MultiLineString<'a, D> {
+impl<'a> NativeScalar for MultiLineString<'a> {
     type ScalarGeo = geo::MultiLineString;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -77,9 +77,9 @@ impl<'a, const D: usize> NativeScalar for MultiLineString<'a, D> {
     }
 }
 
-impl<'a, const D: usize> MultiLineStringTrait for MultiLineString<'a, D> {
+impl<'a> MultiLineStringTrait for MultiLineString<'a> {
     type T = f64;
-    type LineStringType<'b> = LineString<'a, D> where Self: 'b;
+    type LineStringType<'b> = LineString<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
         self.coords.dim().into()
@@ -95,9 +95,9 @@ impl<'a, const D: usize> MultiLineStringTrait for MultiLineString<'a, D> {
     }
 }
 
-impl<'a, const D: usize> MultiLineStringTrait for &'a MultiLineString<'a, D> {
+impl<'a> MultiLineStringTrait for &'a MultiLineString<'a> {
     type T = f64;
-    type LineStringType<'b> = LineString<'a, D> where Self: 'b;
+    type LineStringType<'b> = LineString<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
         self.coords.dim().into()
@@ -113,20 +113,20 @@ impl<'a, const D: usize> MultiLineStringTrait for &'a MultiLineString<'a, D> {
     }
 }
 
-impl<const D: usize> From<MultiLineString<'_, D>> for geo::MultiLineString {
-    fn from(value: MultiLineString<'_, D>) -> Self {
+impl From<MultiLineString<'_>> for geo::MultiLineString {
+    fn from(value: MultiLineString<'_>) -> Self {
         (&value).into()
     }
 }
 
-impl<const D: usize> From<&MultiLineString<'_, D>> for geo::MultiLineString {
-    fn from(value: &MultiLineString<'_, D>) -> Self {
+impl From<&MultiLineString<'_>> for geo::MultiLineString {
+    fn from(value: &MultiLineString<'_>) -> Self {
         multi_line_string_to_geo(value)
     }
 }
 
-impl<const D: usize> From<MultiLineString<'_, D>> for geo::Geometry {
-    fn from(value: MultiLineString<'_, D>) -> Self {
+impl From<MultiLineString<'_>> for geo::Geometry {
+    fn from(value: MultiLineString<'_>) -> Self {
         geo::Geometry::MultiLineString(value.into())
     }
 }

--- a/rust/geoarrow/src/scalar/multilinestring/scalar.rs
+++ b/rust/geoarrow/src/scalar/multilinestring/scalar.rs
@@ -149,14 +149,15 @@ impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for MultiLineString<'_> {
 #[cfg(test)]
 mod test {
     use crate::array::MultiLineStringArray;
+    use crate::datatypes::Dimension;
     use crate::test::multilinestring::{ml0, ml1};
     use crate::trait_::ArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiLineStringArray = vec![ml0(), ml1()].as_slice().into();
-        let arr2: MultiLineStringArray = vec![ml0(), ml0()].as_slice().into();
+        let arr1: MultiLineStringArray = (vec![ml0(), ml1()].as_slice(), Dimension::XY).into();
+        let arr2: MultiLineStringArray = (vec![ml0(), ml0()].as_slice(), Dimension::XY).into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/multipoint/scalar.rs
+++ b/rust/geoarrow/src/scalar/multipoint/scalar.rs
@@ -2,6 +2,7 @@ use crate::algorithm::native::bounding_rect::bounding_rect_multipoint;
 use crate::algorithm::native::eq::multi_point_eq;
 use crate::array::util::OffsetBufferUtils;
 use crate::array::{CoordBuffer, MultiPointArray};
+use crate::datatypes::Dimension;
 use crate::io::geo::multi_point_to_geo;
 use crate::scalar::Point;
 use crate::trait_::NativeScalar;
@@ -11,7 +12,7 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a MultiPoint
 #[derive(Debug, Clone)]
-pub struct MultiPoint<'a, const D: usize> {
+pub struct MultiPoint<'a> {
     /// Buffer of coordinates
     pub(crate) coords: &'a CoordBuffer,
 
@@ -23,7 +24,7 @@ pub struct MultiPoint<'a, const D: usize> {
     start_offset: usize,
 }
 
-impl<'a, const D: usize> MultiPoint<'a, D> {
+impl<'a> MultiPoint<'a> {
     pub fn new(
         coords: &'a CoordBuffer,
         geom_offsets: &'a OffsetBuffer<i32>,
@@ -39,7 +40,7 @@ impl<'a, const D: usize> MultiPoint<'a, D> {
     }
 
     pub fn into_owned_inner(self) -> (CoordBuffer, OffsetBuffer<i32>, usize) {
-        let arr = MultiPointArray::<D>::new(
+        let arr = MultiPointArray::new(
             self.coords.clone(),
             self.geom_offsets.clone(),
             None,
@@ -51,7 +52,7 @@ impl<'a, const D: usize> MultiPoint<'a, D> {
     }
 }
 
-impl<'a, const D: usize> NativeScalar for MultiPoint<'a, D> {
+impl<'a> NativeScalar for MultiPoint<'a> {
     type ScalarGeo = geo::MultiPoint;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -68,16 +69,14 @@ impl<'a, const D: usize> NativeScalar for MultiPoint<'a, D> {
     }
 }
 
-impl<'a, const D: usize> MultiPointTrait for MultiPoint<'a, D> {
+impl<'a> MultiPointTrait for MultiPoint<'a> {
     type T = f64;
-    type PointType<'b> = Point<'a, D> where Self: 'b;
+    type PointType<'b> = Point<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: pass through field information from array
-        match D {
-            2 => geo_traits::Dimensions::Xy,
-            3 => geo_traits::Dimensions::Xyz,
-            _ => todo!(),
+        match self.coords.dim() {
+            Dimension::XY => geo_traits::Dimensions::Xy,
+            Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
     }
 
@@ -91,16 +90,14 @@ impl<'a, const D: usize> MultiPointTrait for MultiPoint<'a, D> {
     }
 }
 
-impl<'a, const D: usize> MultiPointTrait for &'a MultiPoint<'a, D> {
+impl<'a> MultiPointTrait for &'a MultiPoint<'a> {
     type T = f64;
-    type PointType<'b> = Point<'a, D> where Self: 'b;
+    type PointType<'b> = Point<'a> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: pass through field information from array
-        match D {
-            2 => geo_traits::Dimensions::Xy,
-            3 => geo_traits::Dimensions::Xyz,
-            _ => todo!(),
+        match self.coords.dim() {
+            Dimension::XY => geo_traits::Dimensions::Xy,
+            Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
     }
 
@@ -114,20 +111,20 @@ impl<'a, const D: usize> MultiPointTrait for &'a MultiPoint<'a, D> {
     }
 }
 
-impl<const D: usize> From<MultiPoint<'_, D>> for geo::MultiPoint {
-    fn from(value: MultiPoint<'_, D>) -> Self {
+impl From<MultiPoint<'_>> for geo::MultiPoint {
+    fn from(value: MultiPoint<'_>) -> Self {
         (&value).into()
     }
 }
 
-impl<const D: usize> From<&MultiPoint<'_, D>> for geo::MultiPoint {
-    fn from(value: &MultiPoint<'_, D>) -> Self {
+impl From<&MultiPoint<'_>> for geo::MultiPoint {
+    fn from(value: &MultiPoint<'_>) -> Self {
         multi_point_to_geo(value)
     }
 }
 
-impl<const D: usize> From<MultiPoint<'_, D>> for geo::Geometry {
-    fn from(value: MultiPoint<'_, D>) -> Self {
+impl From<MultiPoint<'_>> for geo::Geometry {
+    fn from(value: MultiPoint<'_>) -> Self {
         geo::Geometry::MultiPoint(value.into())
     }
 }
@@ -141,7 +138,7 @@ impl RTreeObject for MultiPoint<'_, 2> {
     }
 }
 
-impl<const D: usize, G: MultiPointTrait<T = f64>> PartialEq<G> for MultiPoint<'_, D> {
+impl<G: MultiPointTrait<T = f64>> PartialEq<G> for MultiPoint<'_> {
     fn eq(&self, other: &G) -> bool {
         multi_point_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/multipoint/scalar.rs
+++ b/rust/geoarrow/src/scalar/multipoint/scalar.rs
@@ -129,7 +129,7 @@ impl From<MultiPoint<'_>> for geo::Geometry {
     }
 }
 
-impl RTreeObject for MultiPoint<'_, 2> {
+impl RTreeObject for MultiPoint<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -153,8 +153,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiPointArray<2> = vec![mp0(), mp1()].as_slice().into();
-        let arr2: MultiPointArray<2> = vec![mp0(), mp0()].as_slice().into();
+        let arr1: MultiPointArray = vec![mp0(), mp1()].as_slice().into();
+        let arr2: MultiPointArray = vec![mp0(), mp0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/multipoint/scalar.rs
+++ b/rust/geoarrow/src/scalar/multipoint/scalar.rs
@@ -147,14 +147,15 @@ impl<G: MultiPointTrait<T = f64>> PartialEq<G> for MultiPoint<'_> {
 #[cfg(test)]
 mod test {
     use crate::array::MultiPointArray;
+    use crate::datatypes::Dimension;
     use crate::test::multipoint::{mp0, mp1};
     use crate::trait_::ArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiPointArray = vec![mp0(), mp1()].as_slice().into();
-        let arr2: MultiPointArray = vec![mp0(), mp0()].as_slice().into();
+        let arr1: MultiPointArray = (vec![mp0(), mp1()].as_slice(), Dimension::XY).into();
+        let arr2: MultiPointArray = (vec![mp0(), mp0()].as_slice(), Dimension::XY).into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/multipolygon/scalar.rs
+++ b/rust/geoarrow/src/scalar/multipolygon/scalar.rs
@@ -183,8 +183,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiPolygonArray<2> = vec![mp0(), mp1()].as_slice().into();
-        let arr2: MultiPolygonArray<2> = vec![mp0(), mp0()].as_slice().into();
+        let arr1: MultiPolygonArray = vec![mp0(), mp1()].as_slice().into();
+        let arr2: MultiPolygonArray = vec![mp0(), mp0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/multipolygon/scalar.rs
+++ b/rust/geoarrow/src/scalar/multipolygon/scalar.rs
@@ -177,14 +177,15 @@ impl<G: MultiPolygonTrait<T = f64>> PartialEq<G> for MultiPolygon<'_> {
 #[cfg(test)]
 mod test {
     use crate::array::MultiPolygonArray;
+    use crate::datatypes::Dimension;
     use crate::test::multipolygon::{mp0, mp1};
     use crate::trait_::ArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiPolygonArray = vec![mp0(), mp1()].as_slice().into();
-        let arr2: MultiPolygonArray = vec![mp0(), mp0()].as_slice().into();
+        let arr1: MultiPolygonArray = (vec![mp0(), mp1()].as_slice(), Dimension::XY).into();
+        let arr2: MultiPolygonArray = (vec![mp0(), mp0()].as_slice(), Dimension::XY).into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/point/owned.rs
+++ b/rust/geoarrow/src/scalar/point/owned.rs
@@ -5,12 +5,12 @@ use crate::scalar::{Coord, Point};
 use geo_traits::PointTrait;
 
 #[derive(Clone, Debug)]
-pub struct OwnedPoint<const D: usize> {
+pub struct OwnedPoint {
     coords: CoordBuffer,
     geom_index: usize,
 }
 
-impl<const D: usize> OwnedPoint<D> {
+impl OwnedPoint {
     pub fn new(coords: CoordBuffer, geom_index: usize) -> Self {
         Self { coords, geom_index }
     }
@@ -20,26 +20,26 @@ impl<const D: usize> OwnedPoint<D> {
     }
 }
 
-impl<'a, const D: usize> From<&'a OwnedPoint<D>> for Point<'a, D> {
-    fn from(value: &'a OwnedPoint<D>) -> Self {
+impl<'a> From<&'a OwnedPoint> for Point<'a> {
+    fn from(value: &'a OwnedPoint) -> Self {
         Self::new(&value.coords, value.geom_index)
     }
 }
 
-impl<'a, const D: usize> From<Point<'a, D>> for OwnedPoint<D> {
-    fn from(value: Point<'a, D>) -> Self {
+impl<'a> From<Point<'a>> for OwnedPoint {
+    fn from(value: Point<'a>) -> Self {
         let (coords, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_index)
     }
 }
 
-impl<const D: usize> From<OwnedPoint<D>> for PointArray<D> {
-    fn from(value: OwnedPoint<D>) -> Self {
+impl From<OwnedPoint> for PointArray {
+    fn from(value: OwnedPoint) -> Self {
         Self::new(value.coords, None, Default::default())
     }
 }
 
-impl<const D: usize> PointTrait for OwnedPoint<D> {
+impl PointTrait for OwnedPoint {
     type T = f64;
     type CoordType<'a> = Coord<'a>;
 
@@ -57,19 +57,19 @@ impl<const D: usize> PointTrait for OwnedPoint<D> {
     }
 }
 
-impl<const D: usize> From<OwnedPoint<D>> for geo::Point {
-    fn from(value: OwnedPoint<D>) -> Self {
+impl From<OwnedPoint> for geo::Point {
+    fn from(value: OwnedPoint) -> Self {
         (&value).into()
     }
 }
 
-impl<const D: usize> From<&OwnedPoint<D>> for geo::Point {
-    fn from(value: &OwnedPoint<D>) -> Self {
+impl From<&OwnedPoint> for geo::Point {
+    fn from(value: &OwnedPoint) -> Self {
         point_to_geo(value)
     }
 }
 
-impl<const D: usize> PartialEq for OwnedPoint<D> {
+impl PartialEq for OwnedPoint {
     fn eq(&self, other: &Self) -> bool {
         point_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/point/scalar.rs
+++ b/rust/geoarrow/src/scalar/point/scalar.rs
@@ -9,12 +9,12 @@ use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a Point
 #[derive(Debug, Clone)]
-pub struct Point<'a, const D: usize> {
+pub struct Point<'a> {
     coords: &'a CoordBuffer,
     geom_index: usize,
 }
 
-impl<'a, const D: usize> Point<'a, D> {
+impl<'a> Point<'a> {
     pub fn new(coords: &'a CoordBuffer, geom_index: usize) -> Self {
         Point { coords, geom_index }
     }
@@ -29,7 +29,7 @@ impl<'a, const D: usize> Point<'a, D> {
     }
 }
 
-impl<'a, const D: usize> NativeScalar for Point<'a, D> {
+impl<'a> NativeScalar for Point<'a> {
     type ScalarGeo = geo::Point;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -46,7 +46,7 @@ impl<'a, const D: usize> NativeScalar for Point<'a, D> {
     }
 }
 
-impl<'a, const D: usize> PointTrait for Point<'a, D> {
+impl<'a> PointTrait for Point<'a> {
     type T = f64;
     type CoordType<'b> = Coord<'a> where Self: 'b;
 
@@ -64,7 +64,7 @@ impl<'a, const D: usize> PointTrait for Point<'a, D> {
     }
 }
 
-impl<'a, const D: usize> PointTrait for &Point<'a, D> {
+impl<'a> PointTrait for &Point<'a> {
     type T = f64;
     type CoordType<'b> = Coord<'a> where Self: 'b;
 
@@ -82,25 +82,25 @@ impl<'a, const D: usize> PointTrait for &Point<'a, D> {
     }
 }
 
-impl<const D: usize> From<Point<'_, D>> for geo::Point {
-    fn from(value: Point<'_, D>) -> Self {
+impl From<Point<'_>> for geo::Point {
+    fn from(value: Point<'_>) -> Self {
         (&value).into()
     }
 }
 
-impl<const D: usize> From<&Point<'_, D>> for geo::Point {
-    fn from(value: &Point<'_, D>) -> Self {
+impl From<&Point<'_>> for geo::Point {
+    fn from(value: &Point<'_>) -> Self {
         point_to_geo(value)
     }
 }
 
-impl<const D: usize> From<Point<'_, D>> for geo::Geometry {
-    fn from(value: Point<'_, D>) -> Self {
+impl From<Point<'_>> for geo::Geometry {
+    fn from(value: Point<'_>) -> Self {
         geo::Geometry::Point(value.into())
     }
 }
 
-impl<const D: usize> RTreeObject for Point<'_, D> {
+impl RTreeObject for Point<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -109,7 +109,7 @@ impl<const D: usize> RTreeObject for Point<'_, D> {
     }
 }
 
-impl<G: PointTrait<T = f64>, const D: usize> PartialEq<G> for Point<'_, D> {
+impl<G: PointTrait<T = f64>> PartialEq<G> for Point<'_> {
     fn eq(&self, other: &G) -> bool {
         point_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/point/scalar.rs
+++ b/rust/geoarrow/src/scalar/point/scalar.rs
@@ -126,12 +126,12 @@ mod test {
         let x1 = vec![0., 1., 2.];
         let y1 = vec![3., 4., 5.];
         let buf1 = CoordBuffer::Separated((x1, y1).try_into().unwrap());
-        let arr1 = PointArray::<2>::new(buf1, None, Default::default());
+        let arr1 = PointArray::new(buf1, None, Default::default());
 
         let x2 = vec![0., 100., 2.];
         let y2 = vec![3., 400., 5.];
         let buf2 = CoordBuffer::Separated((x2, y2).try_into().unwrap());
-        let arr2 = PointArray::<2>::new(buf2, None, Default::default());
+        let arr2 = PointArray::new(buf2, None, Default::default());
 
         assert_eq!(arr1.value(0), arr2.value(0));
     }

--- a/rust/geoarrow/src/scalar/polygon/owned.rs
+++ b/rust/geoarrow/src/scalar/polygon/owned.rs
@@ -17,7 +17,7 @@ pub struct OwnedPolygon {
     geom_index: usize,
 }
 
-impl OwnedPolygon<D> {
+impl OwnedPolygon {
     pub fn new(
         coords: CoordBuffer,
         geom_offsets: OffsetBuffer<i32>,
@@ -33,8 +33,8 @@ impl OwnedPolygon<D> {
     }
 }
 
-impl<'a> From<&'a OwnedPolygon<D>> for Polygon<'a> {
-    fn from(value: &'a OwnedPolygon<D>) -> Self {
+impl<'a> From<&'a OwnedPolygon> for Polygon<'a> {
+    fn from(value: &'a OwnedPolygon) -> Self {
         Self::new(
             &value.coords,
             &value.geom_offsets,
@@ -44,22 +44,22 @@ impl<'a> From<&'a OwnedPolygon<D>> for Polygon<'a> {
     }
 }
 
-impl From<OwnedPolygon<2>> for geo::Polygon {
-    fn from(value: OwnedPolygon<2>) -> Self {
+impl From<OwnedPolygon> for geo::Polygon {
+    fn from(value: OwnedPolygon) -> Self {
         let geom = Polygon::from(&value);
         geom.into()
     }
 }
 
-impl<'a> From<Polygon<'a>> for OwnedPolygon<D> {
+impl<'a> From<Polygon<'a>> for OwnedPolygon {
     fn from(value: Polygon<'a>) -> Self {
         let (coords, geom_offsets, ring_offsets, geom_index) = value.into_owned_inner();
         Self::new(coords, geom_offsets, ring_offsets, geom_index)
     }
 }
 
-impl From<OwnedPolygon<D>> for PolygonArray<D> {
-    fn from(value: OwnedPolygon<D>) -> Self {
+impl From<OwnedPolygon> for PolygonArray {
+    fn from(value: OwnedPolygon) -> Self {
         Self::new(
             value.coords,
             value.geom_offsets,
@@ -70,9 +70,9 @@ impl From<OwnedPolygon<D>> for PolygonArray<D> {
     }
 }
 
-impl PolygonTrait for OwnedPolygon<D> {
+impl PolygonTrait for OwnedPolygon {
     type T = f64;
-    type RingType<'b> = LineString<'b,  D> where Self: 'b;
+    type RingType<'b> = LineString<'b> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
         match self.coords.dim() {
@@ -94,7 +94,7 @@ impl PolygonTrait for OwnedPolygon<D> {
     }
 }
 
-impl<G: PolygonTrait<T = f64>> PartialEq<G> for OwnedPolygon<2> {
+impl<G: PolygonTrait<T = f64>> PartialEq<G> for OwnedPolygon {
     fn eq(&self, other: &G) -> bool {
         polygon_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/polygon/scalar.rs
+++ b/rust/geoarrow/src/scalar/polygon/scalar.rs
@@ -175,14 +175,15 @@ impl<G: PolygonTrait<T = f64>> PartialEq<G> for Polygon<'_> {
 #[cfg(test)]
 mod test {
     use crate::array::PolygonArray;
+    use crate::datatypes::Dimension;
     use crate::test::polygon::{p0, p1};
     use crate::trait_::ArrayAccessor;
 
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: PolygonArray = vec![p0(), p1()].as_slice().into();
-        let arr2: PolygonArray = vec![p0(), p0()].as_slice().into();
+        let arr1: PolygonArray = (vec![p0(), p1()].as_slice(), Dimension::XY).into();
+        let arr2: PolygonArray = (vec![p0(), p0()].as_slice(), Dimension::XY).into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/polygon/scalar.rs
+++ b/rust/geoarrow/src/scalar/polygon/scalar.rs
@@ -157,7 +157,7 @@ impl From<Polygon<'_>> for geo::Geometry {
     }
 }
 
-impl RTreeObject for Polygon<'_, 2> {
+impl RTreeObject for Polygon<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -181,8 +181,8 @@ mod test {
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: PolygonArray<2> = vec![p0(), p1()].as_slice().into();
-        let arr2: PolygonArray<2> = vec![p0(), p0()].as_slice().into();
+        let arr1: PolygonArray = vec![p0(), p1()].as_slice().into();
+        let arr2: PolygonArray = vec![p0(), p0()].as_slice().into();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow/src/scalar/rect/owned.rs
+++ b/rust/geoarrow/src/scalar/rect/owned.rs
@@ -1,5 +1,6 @@
 use crate::algorithm::native::eq::rect_eq;
 use crate::array::{RectArray, SeparatedCoordBuffer};
+use crate::datatypes::Dimension;
 use crate::scalar::{Rect, SeparatedCoord};
 use geo_traits::RectTrait;
 
@@ -10,7 +11,7 @@ pub struct OwnedRect {
     geom_index: usize,
 }
 
-impl OwnedRect<D> {
+impl OwnedRect {
     pub fn new(
         lower: SeparatedCoordBuffer,
         upper: SeparatedCoordBuffer,
@@ -24,31 +25,31 @@ impl OwnedRect<D> {
     }
 }
 
-impl<'a> From<&'a OwnedRect<D>> for Rect<'a> {
-    fn from(value: &'a OwnedRect<D>) -> Self {
+impl<'a> From<&'a OwnedRect> for Rect<'a> {
+    fn from(value: &'a OwnedRect) -> Self {
         Self::new(&value.lower, &value.upper, value.geom_index)
     }
 }
 
-impl<'a> From<Rect<'a>> for OwnedRect<D> {
+impl<'a> From<Rect<'a>> for OwnedRect {
     fn from(value: Rect<'a>) -> Self {
         let (lower, upper, geom_index) = value.into_owned_inner();
         Self::new(lower, upper, geom_index)
     }
 }
 
-impl From<OwnedRect<D>> for RectArray<D> {
-    fn from(value: OwnedRect<D>) -> Self {
+impl From<OwnedRect> for RectArray {
+    fn from(value: OwnedRect) -> Self {
         Self::new(value.lower, value.upper, None, Default::default())
     }
 }
 
-impl RectTrait for OwnedRect<D> {
+impl RectTrait for OwnedRect {
     type T = f64;
     type CoordType<'b> = SeparatedCoord<'b> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        match self.coords.dim() {
+        match self.lower.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
             Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
@@ -63,7 +64,7 @@ impl RectTrait for OwnedRect<D> {
     }
 }
 
-impl<G: RectTrait<T = f64>> PartialEq<G> for OwnedRect<2> {
+impl<G: RectTrait<T = f64>> PartialEq<G> for OwnedRect {
     fn eq(&self, other: &G) -> bool {
         rect_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/rect/owned.rs
+++ b/rust/geoarrow/src/scalar/rect/owned.rs
@@ -4,13 +4,13 @@ use crate::scalar::{Rect, SeparatedCoord};
 use geo_traits::RectTrait;
 
 #[derive(Clone, Debug)]
-pub struct OwnedRect<const D: usize> {
+pub struct OwnedRect {
     lower: SeparatedCoordBuffer,
     upper: SeparatedCoordBuffer,
     geom_index: usize,
 }
 
-impl<const D: usize> OwnedRect<D> {
+impl OwnedRect<D> {
     pub fn new(
         lower: SeparatedCoordBuffer,
         upper: SeparatedCoordBuffer,
@@ -24,35 +24,33 @@ impl<const D: usize> OwnedRect<D> {
     }
 }
 
-impl<'a, const D: usize> From<&'a OwnedRect<D>> for Rect<'a, D> {
+impl<'a> From<&'a OwnedRect<D>> for Rect<'a> {
     fn from(value: &'a OwnedRect<D>) -> Self {
         Self::new(&value.lower, &value.upper, value.geom_index)
     }
 }
 
-impl<'a, const D: usize> From<Rect<'a, D>> for OwnedRect<D> {
-    fn from(value: Rect<'a, D>) -> Self {
+impl<'a> From<Rect<'a>> for OwnedRect<D> {
+    fn from(value: Rect<'a>) -> Self {
         let (lower, upper, geom_index) = value.into_owned_inner();
         Self::new(lower, upper, geom_index)
     }
 }
 
-impl<const D: usize> From<OwnedRect<D>> for RectArray<D> {
+impl From<OwnedRect<D>> for RectArray<D> {
     fn from(value: OwnedRect<D>) -> Self {
         Self::new(value.lower, value.upper, None, Default::default())
     }
 }
 
-impl<const D: usize> RectTrait for OwnedRect<D> {
+impl RectTrait for OwnedRect<D> {
     type T = f64;
     type CoordType<'b> = SeparatedCoord<'b> where Self: 'b;
 
     fn dim(&self) -> geo_traits::Dimensions {
-        // TODO: pass through field information from array
-        match D {
-            2 => geo_traits::Dimensions::Xy,
-            3 => geo_traits::Dimensions::Xyz,
-            _ => todo!(),
+        match self.coords.dim() {
+            Dimension::XY => geo_traits::Dimensions::Xy,
+            Dimension::XYZ => geo_traits::Dimensions::Xyz,
         }
     }
 

--- a/rust/geoarrow/src/scalar/rect/scalar.rs
+++ b/rust/geoarrow/src/scalar/rect/scalar.rs
@@ -87,7 +87,7 @@ impl From<Rect<'_>> for geo::Geometry {
 }
 
 impl RTreeObject for Rect<'_> {
-    type Envelope = AABB<[f64; D]>;
+    type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
         let lower = self.min();

--- a/rust/geoarrow/src/scalar/rect/scalar.rs
+++ b/rust/geoarrow/src/scalar/rect/scalar.rs
@@ -8,13 +8,13 @@ use crate::trait_::NativeScalar;
 use geo_traits::RectTrait;
 
 #[derive(Debug, Clone)]
-pub struct Rect<'a, const D: usize> {
+pub struct Rect<'a> {
     lower: &'a SeparatedCoordBuffer,
     upper: &'a SeparatedCoordBuffer,
     pub(crate) geom_index: usize,
 }
 
-impl<'a, const D: usize> Rect<'a, D> {
+impl<'a> Rect<'a> {
     pub fn new(
         lower: &'a SeparatedCoordBuffer,
         upper: &'a SeparatedCoordBuffer,
@@ -32,7 +32,7 @@ impl<'a, const D: usize> Rect<'a, D> {
     }
 }
 
-impl<'a, const D: usize> NativeScalar for Rect<'a, D> {
+impl<'a> NativeScalar for Rect<'a> {
     type ScalarGeo = geo::Rect;
 
     fn to_geo(&self) -> Self::ScalarGeo {
@@ -51,7 +51,7 @@ impl<'a, const D: usize> NativeScalar for Rect<'a, D> {
 }
 
 // TODO: support 3d rects
-impl<'a, const D: usize> RectTrait for Rect<'a, D> {
+impl<'a> RectTrait for Rect<'a> {
     type T = f64;
     type CoordType<'b> = SeparatedCoord<'a> where Self: 'b;
 
@@ -68,25 +68,25 @@ impl<'a, const D: usize> RectTrait for Rect<'a, D> {
     }
 }
 
-impl<const D: usize> From<Rect<'_, D>> for geo::Rect {
-    fn from(value: Rect<'_, D>) -> Self {
+impl From<Rect<'_>> for geo::Rect {
+    fn from(value: Rect<'_>) -> Self {
         (&value).into()
     }
 }
 
-impl<const D: usize> From<&Rect<'_, D>> for geo::Rect {
-    fn from(value: &Rect<'_, D>) -> Self {
+impl From<&Rect<'_>> for geo::Rect {
+    fn from(value: &Rect<'_>) -> Self {
         rect_to_geo(value)
     }
 }
 
-impl<const D: usize> From<Rect<'_, D>> for geo::Geometry {
-    fn from(value: Rect<'_, D>) -> Self {
+impl From<Rect<'_>> for geo::Geometry {
+    fn from(value: Rect<'_>) -> Self {
         geo::Geometry::Rect(value.into())
     }
 }
 
-impl<const D: usize> RTreeObject for Rect<'_, D> {
+impl RTreeObject for Rect<'_> {
     type Envelope = AABB<[f64; D]>;
 
     fn envelope(&self) -> Self::Envelope {
@@ -100,7 +100,7 @@ impl<const D: usize> RTreeObject for Rect<'_, D> {
     }
 }
 
-impl<G: RectTrait<T = f64>, const D: usize> PartialEq<G> for Rect<'_, D> {
+impl<G: RectTrait<T = f64>> PartialEq<G> for Rect<'_> {
     fn eq(&self, other: &G) -> bool {
         rect_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/scalar.rs
+++ b/rust/geoarrow/src/scalar/scalar.rs
@@ -66,7 +66,7 @@ impl GeometryScalar {
         }
     }
 
-    pub fn as_geometry<const D: usize>(&self) -> Option<Geometry<'_, D>> {
+    pub fn as_geometry(&self) -> Option<Geometry<'_>> {
         use NativeType::*;
 
         // Note: we use `.downcast_ref` directly here because we need to pass in the generic

--- a/rust/geoarrow/src/scalar/scalar.rs
+++ b/rust/geoarrow/src/scalar/scalar.rs
@@ -71,52 +71,43 @@ impl GeometryScalar {
 
         // Note: we use `.downcast_ref` directly here because we need to pass in the generic
         // TODO: may be able to change this now that we don't have <O>
+        //
+        // TODO: as of Nov 2024 we should be able to switch back to the downcasting helpers
+
         match self.data_type() {
             Point(_, _) => {
-                let arr = self.0.as_any().downcast_ref::<PointArray<D>>().unwrap();
+                let arr = self.0.as_any().downcast_ref::<PointArray>().unwrap();
                 arr.get(0).map(Geometry::Point)
             }
             LineString(_, _) => {
-                let arr = self
-                    .0
-                    .as_any()
-                    .downcast_ref::<LineStringArray<D>>()
-                    .unwrap();
+                let arr = self.0.as_any().downcast_ref::<LineStringArray>().unwrap();
                 arr.get(0).map(Geometry::LineString)
             }
             Polygon(_, _) => {
-                let arr = self.0.as_any().downcast_ref::<PolygonArray<D>>().unwrap();
+                let arr = self.0.as_any().downcast_ref::<PolygonArray>().unwrap();
                 arr.get(0).map(Geometry::Polygon)
             }
             MultiPoint(_, _) => {
-                let arr = self
-                    .0
-                    .as_any()
-                    .downcast_ref::<MultiPointArray<D>>()
-                    .unwrap();
+                let arr = self.0.as_any().downcast_ref::<MultiPointArray>().unwrap();
                 arr.get(0).map(Geometry::MultiPoint)
             }
             MultiLineString(_, _) => {
                 let arr = self
                     .0
                     .as_any()
-                    .downcast_ref::<MultiLineStringArray<D>>()
+                    .downcast_ref::<MultiLineStringArray>()
                     .unwrap();
                 arr.get(0).map(Geometry::MultiLineString)
             }
             MultiPolygon(_, _) => {
-                let arr = self
-                    .0
-                    .as_any()
-                    .downcast_ref::<MultiPolygonArray<D>>()
-                    .unwrap();
+                let arr = self.0.as_any().downcast_ref::<MultiPolygonArray>().unwrap();
                 arr.get(0).map(Geometry::MultiPolygon)
             }
             Mixed(_, _) => {
                 let arr = self
                     .0
                     .as_any()
-                    .downcast_ref::<MixedGeometryArray<D>>()
+                    .downcast_ref::<MixedGeometryArray>()
                     .unwrap();
                 arr.get(0)
             }
@@ -124,12 +115,12 @@ impl GeometryScalar {
                 let arr = self
                     .0
                     .as_any()
-                    .downcast_ref::<GeometryCollectionArray<D>>()
+                    .downcast_ref::<GeometryCollectionArray>()
                     .unwrap();
                 arr.get(0).map(Geometry::GeometryCollection)
             }
             Rect(_) => {
-                let arr = self.0.as_any().downcast_ref::<RectArray<D>>().unwrap();
+                let arr = self.0.as_any().downcast_ref::<RectArray>().unwrap();
                 arr.get(0).map(Geometry::Rect)
             }
         }
@@ -137,57 +128,23 @@ impl GeometryScalar {
 
     pub fn to_geo(&self) -> geo::Geometry {
         macro_rules! impl_to_geo {
-            ($cast_func:ident, $dim:expr) => {{
-                self.0
-                    .as_ref()
-                    .$cast_func::<$dim>()
-                    .value(0)
-                    .to_geo_geometry()
+            ($cast_func:ident) => {{
+                self.0.as_ref().$cast_func().value(0).to_geo_geometry()
             }};
         }
 
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => impl_to_geo!(as_point, 2),
-            LineString(_, XY) => impl_to_geo!(as_line_string, 2),
-            Polygon(_, XY) => impl_to_geo!(as_polygon, 2),
-            MultiPoint(_, XY) => impl_to_geo!(as_multi_point, 2),
-            MultiLineString(_, XY) => {
-                impl_to_geo!(as_multi_line_string, 2)
-            }
-            MultiPolygon(_, XY) => impl_to_geo!(as_multi_polygon, 2),
-            Mixed(_, XY) => impl_to_geo!(as_mixed, 2),
-            GeometryCollection(_, XY) => {
-                impl_to_geo!(as_geometry_collection, 2)
-            }
-            Rect(XY) => impl_to_geo!(as_rect, 2),
-            Point(_, XYZ) => impl_to_geo!(as_point, 3),
-            LineString(_, XYZ) => impl_to_geo!(as_line_string, 3),
-            Polygon(_, XYZ) => impl_to_geo!(as_polygon, 3),
-            MultiPoint(_, XYZ) => impl_to_geo!(as_multi_point, 3),
-            MultiLineString(_, XYZ) => {
-                impl_to_geo!(as_multi_line_string, 3)
-            }
-            MultiPolygon(_, XYZ) => impl_to_geo!(as_multi_polygon, 3),
-            Mixed(_, XYZ) => impl_to_geo!(as_mixed, 3),
-            GeometryCollection(_, XYZ) => {
-                impl_to_geo!(as_geometry_collection, 3)
-            }
-            Rect(XYZ) => impl_to_geo!(as_rect, 3),
-            // WKB => {
-            //     let arr = self.0.as_ref();
-            //     let wkb_arr = arr.as_wkb().value(0);
-            //     let wkb_object = wkb_arr.to_wkb_object();
-            //     geometry_to_geo(&wkb_object)
-            // }
-            // LargeWKB => {
-            //     let arr = self.0.as_ref();
-            //     let wkb_arr = arr.as_large_wkb().value(0);
-            //     let wkb_object = wkb_arr.to_wkb_object();
-            //     geometry_to_geo(&wkb_object)
-            // }
+            Point(_, _) => impl_to_geo!(as_point),
+            LineString(_, _) => impl_to_geo!(as_line_string),
+            Polygon(_, _) => impl_to_geo!(as_polygon),
+            MultiPoint(_, _) => impl_to_geo!(as_multi_point),
+            MultiLineString(_, _) => impl_to_geo!(as_multi_line_string),
+            MultiPolygon(_, _) => impl_to_geo!(as_multi_polygon),
+            Mixed(_, _) => impl_to_geo!(as_mixed),
+            GeometryCollection(_, _) => impl_to_geo!(as_geometry_collection),
+            Rect(_) => impl_to_geo!(as_rect),
         }
     }
 

--- a/rust/geoarrow/src/table.rs
+++ b/rust/geoarrow/src/table.rs
@@ -55,9 +55,10 @@ impl Table {
     /// use arrow_array::RecordBatch;
     /// use arrow_schema::{Schema, SchemaRef};
     /// use geoarrow::{NativeArray, ArrayBase, array::PointArray, table::Table};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let field = array.extension_field();
     /// let schema: SchemaRef = Schema::new(vec![field]).into();
     /// let columns = vec![array.into_array_ref()];
@@ -95,10 +96,11 @@ impl Table {
     ///     table::Table,
     ///     chunked_array::ChunkedGeometryArray
     /// };
+    /// use geoarrow::datatypes::Dimension;
     /// use std::sync::Arc;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let chunked_array = ChunkedGeometryArray::new(vec![array]);
     ///
     /// let id_array = Int32Array::from(vec![1]);

--- a/rust/geoarrow/src/test/geoarrow_data/mod.rs
+++ b/rust/geoarrow/src/test/geoarrow_data/mod.rs
@@ -17,12 +17,22 @@ macro_rules! geoarrow_data_impl {
                 .unwrap()
         }
     };
+    ($fn_name:ident, $file_part:tt, $return_type:ty, "WKB") => {
+        pub(crate) fn $fn_name() -> $return_type {
+            let path = format!(
+                "fixtures/geoarrow-data/example/example-{}.arrow",
+                $file_part
+            );
+            let geometry_dyn_column = read_geometry_column(&path);
+            geometry_dyn_column.as_ref().try_into().unwrap()
+        }
+    };
 }
 
 // Point
 geoarrow_data_impl!(example_point_interleaved, "point-interleaved", PointArray);
 geoarrow_data_impl!(example_point_separated, "point", PointArray);
-geoarrow_data_impl!(example_point_wkb, "point-wkb", WKBArray<i64>);
+geoarrow_data_impl!(example_point_wkb, "point-wkb", WKBArray<i64>, "WKB");
 
 // LineString
 geoarrow_data_impl!(
@@ -31,7 +41,12 @@ geoarrow_data_impl!(
     LineStringArray
 );
 geoarrow_data_impl!(example_linestring_separated, "linestring", LineStringArray);
-geoarrow_data_impl!(example_linestring_wkb, "linestring-wkb", WKBArray<i64>);
+geoarrow_data_impl!(
+    example_linestring_wkb,
+    "linestring-wkb",
+    WKBArray<i64>,
+    "WKB"
+);
 
 // Polygon
 geoarrow_data_impl!(
@@ -40,7 +55,7 @@ geoarrow_data_impl!(
     PolygonArray
 );
 geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray);
-geoarrow_data_impl!(example_polygon_wkb, "polygon-wkb", WKBArray<i64>);
+geoarrow_data_impl!(example_polygon_wkb, "polygon-wkb", WKBArray<i64>, "WKB");
 
 // MultiPoint
 geoarrow_data_impl!(
@@ -49,7 +64,12 @@ geoarrow_data_impl!(
     MultiPointArray
 );
 geoarrow_data_impl!(example_multipoint_separated, "multipoint", MultiPointArray);
-geoarrow_data_impl!(example_multipoint_wkb, "multipoint-wkb", WKBArray<i64>);
+geoarrow_data_impl!(
+    example_multipoint_wkb,
+    "multipoint-wkb",
+    WKBArray<i64>,
+    "WKB"
+);
 
 // MultiLineString
 geoarrow_data_impl!(
@@ -65,7 +85,8 @@ geoarrow_data_impl!(
 geoarrow_data_impl!(
     example_multilinestring_wkb,
     "multilinestring-wkb",
-    WKBArray<i64>
+    WKBArray<i64>,
+    "WKB"
 );
 
 // MultiPolygon
@@ -79,4 +100,9 @@ geoarrow_data_impl!(
     "multipolygon",
     MultiPolygonArray
 );
-geoarrow_data_impl!(example_multipolygon_wkb, "multipolygon-wkb", WKBArray<i64>);
+geoarrow_data_impl!(
+    example_multipolygon_wkb,
+    "multipolygon-wkb",
+    WKBArray<i64>,
+    "WKB"
+);

--- a/rust/geoarrow/src/test/geoarrow_data/mod.rs
+++ b/rust/geoarrow/src/test/geoarrow_data/mod.rs
@@ -1,6 +1,7 @@
 pub mod util;
 
 use crate::array::*;
+use crate::datatypes::Dimension;
 use crate::test::geoarrow_data::util::read_geometry_column;
 
 macro_rules! geoarrow_data_impl {
@@ -11,65 +12,55 @@ macro_rules! geoarrow_data_impl {
                 $file_part
             );
             let geometry_dyn_column = read_geometry_column(&path);
-            geometry_dyn_column.as_ref().try_into().unwrap()
+            (geometry_dyn_column.as_ref(), Dimension::XY)
+                .try_into()
+                .unwrap()
         }
     };
 }
 
 // Point
-geoarrow_data_impl!(
-    example_point_interleaved,
-    "point-interleaved",
-    PointArray<2>
-);
-geoarrow_data_impl!(example_point_separated, "point", PointArray<2>);
+geoarrow_data_impl!(example_point_interleaved, "point-interleaved", PointArray);
+geoarrow_data_impl!(example_point_separated, "point", PointArray);
 geoarrow_data_impl!(example_point_wkb, "point-wkb", WKBArray<i64>);
 
 // LineString
 geoarrow_data_impl!(
     example_linestring_interleaved,
     "linestring-interleaved",
-    LineStringArray<2>
+    LineStringArray
 );
-geoarrow_data_impl!(
-    example_linestring_separated,
-    "linestring",
-    LineStringArray<2>
-);
+geoarrow_data_impl!(example_linestring_separated, "linestring", LineStringArray);
 geoarrow_data_impl!(example_linestring_wkb, "linestring-wkb", WKBArray<i64>);
 
 // Polygon
 geoarrow_data_impl!(
     example_polygon_interleaved,
     "polygon-interleaved",
-    PolygonArray<2>
+    PolygonArray
 );
-geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray<2>);
+geoarrow_data_impl!(example_polygon_separated, "polygon", PolygonArray);
 geoarrow_data_impl!(example_polygon_wkb, "polygon-wkb", WKBArray<i64>);
 
 // MultiPoint
 geoarrow_data_impl!(
     example_multipoint_interleaved,
     "multipoint-interleaved",
-    MultiPointArray<2>
+    MultiPointArray
 );
-geoarrow_data_impl!(
-    example_multipoint_separated,
-    "multipoint",
-    MultiPointArray<2>
-);
+geoarrow_data_impl!(example_multipoint_separated, "multipoint", MultiPointArray);
 geoarrow_data_impl!(example_multipoint_wkb, "multipoint-wkb", WKBArray<i64>);
 
 // MultiLineString
 geoarrow_data_impl!(
     example_multilinestring_interleaved,
     "multilinestring-interleaved",
-    MultiLineStringArray<2>
+    MultiLineStringArray
 );
 geoarrow_data_impl!(
     example_multilinestring_separated,
     "multilinestring",
-    MultiLineStringArray<2>
+    MultiLineStringArray
 );
 geoarrow_data_impl!(
     example_multilinestring_wkb,
@@ -81,11 +72,11 @@ geoarrow_data_impl!(
 geoarrow_data_impl!(
     example_multipolygon_interleaved,
     "multipolygon-interleaved",
-    MultiPolygonArray<2>
+    MultiPolygonArray
 );
 geoarrow_data_impl!(
     example_multipolygon_separated,
     "multipolygon",
-    MultiPolygonArray<2>
+    MultiPolygonArray
 );
 geoarrow_data_impl!(example_multipolygon_wkb, "multipolygon-wkb", WKBArray<i64>);

--- a/rust/geoarrow/src/test/linestring.rs
+++ b/rust/geoarrow/src/test/linestring.rs
@@ -1,6 +1,7 @@
 use geo::{line_string, LineString};
 
-use crate::array::LineStringArray;
+use crate::array::{LineStringArray, LineStringBuilder};
+use crate::datatypes::Dimension;
 
 pub(crate) fn ls0() -> LineString {
     line_string![
@@ -17,10 +18,13 @@ pub(crate) fn ls1() -> LineString {
 }
 
 #[allow(dead_code)]
-pub(crate) fn ls_array() -> LineStringArray<2> {
-    vec![ls0(), ls1()].as_slice().into()
-}
-
-pub(crate) fn large_ls_array() -> LineStringArray<2> {
-    vec![ls0(), ls1()].as_slice().into()
+pub(crate) fn ls_array() -> LineStringArray {
+    let geoms = vec![ls0(), ls1()];
+    LineStringBuilder::from_line_strings(
+        &geoms,
+        Dimension::XY,
+        Default::default(),
+        Default::default(),
+    )
+    .finish()
 }

--- a/rust/geoarrow/src/test/multilinestring.rs
+++ b/rust/geoarrow/src/test/multilinestring.rs
@@ -1,6 +1,7 @@
 use geo::{line_string, MultiLineString};
 
-use crate::array::MultiLineStringArray;
+use crate::array::{MultiLineStringArray, MultiLineStringBuilder};
+use crate::datatypes::Dimension;
 
 pub(crate) fn ml0() -> MultiLineString {
     MultiLineString::new(vec![line_string![
@@ -28,6 +29,13 @@ pub(crate) fn ml1() -> MultiLineString {
     ])
 }
 
-pub(crate) fn ml_array() -> MultiLineStringArray<2> {
-    vec![ml0(), ml1()].as_slice().into()
+pub(crate) fn ml_array() -> MultiLineStringArray {
+    let geoms = vec![ml0(), ml1()];
+    MultiLineStringBuilder::from_multi_line_strings(
+        &geoms,
+        Dimension::XY,
+        Default::default(),
+        Default::default(),
+    )
+    .finish()
 }

--- a/rust/geoarrow/src/test/multipoint.rs
+++ b/rust/geoarrow/src/test/multipoint.rs
@@ -1,6 +1,7 @@
 use geo::{point, MultiPoint};
 
 use crate::array::{MultiPointArray, MultiPointBuilder};
+use crate::datatypes::Dimension;
 
 pub(crate) fn mp0() -> MultiPoint {
     MultiPoint::new(vec![
@@ -26,5 +27,11 @@ pub(crate) fn mp1() -> MultiPoint {
 
 pub(crate) fn mp_array() -> MultiPointArray {
     let geoms = vec![mp0(), mp1()];
-    MultiPointBuilder::from_multi_points(&geoms, Default::default(), Default::default()).finish()
+    MultiPointBuilder::from_multi_points(
+        &geoms,
+        Dimension::XY,
+        Default::default(),
+        Default::default(),
+    )
+    .finish()
 }

--- a/rust/geoarrow/src/test/multipoint.rs
+++ b/rust/geoarrow/src/test/multipoint.rs
@@ -1,6 +1,6 @@
 use geo::{point, MultiPoint};
 
-use crate::array::MultiPointArray;
+use crate::array::{MultiPointArray, MultiPointBuilder};
 
 pub(crate) fn mp0() -> MultiPoint {
     MultiPoint::new(vec![
@@ -24,6 +24,7 @@ pub(crate) fn mp1() -> MultiPoint {
     ])
 }
 
-pub(crate) fn mp_array() -> MultiPointArray<2> {
-    vec![mp0(), mp1()].as_slice().into()
+pub(crate) fn mp_array() -> MultiPointArray {
+    let geoms = vec![mp0(), mp1()];
+    MultiPointBuilder::from_multi_points(&geoms, Default::default(), Default::default()).finish()
 }

--- a/rust/geoarrow/src/test/multipolygon.rs
+++ b/rust/geoarrow/src/test/multipolygon.rs
@@ -1,6 +1,7 @@
 use geo::{polygon, MultiPolygon};
 
 use crate::array::MultiPolygonArray;
+use crate::datatypes::Dimension;
 
 pub(crate) fn mp0() -> MultiPolygon {
     MultiPolygon::new(vec![
@@ -47,5 +48,5 @@ pub(crate) fn mp1() -> MultiPolygon {
 }
 
 pub(crate) fn mp_array() -> MultiPolygonArray {
-    vec![mp0(), mp1()].as_slice().into()
+    (vec![mp0(), mp1()].as_slice(), Dimension::XY).into()
 }

--- a/rust/geoarrow/src/test/multipolygon.rs
+++ b/rust/geoarrow/src/test/multipolygon.rs
@@ -46,6 +46,6 @@ pub(crate) fn mp1() -> MultiPolygon {
     ])
 }
 
-pub(crate) fn mp_array() -> MultiPolygonArray<2> {
+pub(crate) fn mp_array() -> MultiPolygonArray {
     vec![mp0(), mp1()].as_slice().into()
 }

--- a/rust/geoarrow/src/test/point.rs
+++ b/rust/geoarrow/src/test/point.rs
@@ -73,7 +73,7 @@ impl CoordTrait for CoordZ {
 }
 
 pub(crate) fn point_z_array() -> PointArray {
-    let mut builder = PointBuilder::with_capacity(3);
+    let mut builder = PointBuilder::with_capacity(Dimension::XYZ, 3);
     let coords = vec![
         CoordZ {
             x: 0.,

--- a/rust/geoarrow/src/test/point.rs
+++ b/rust/geoarrow/src/test/point.rs
@@ -31,7 +31,7 @@ pub(crate) fn p2() -> Point {
 }
 
 pub(crate) fn point_array() -> PointArray {
-    let geoms = vec![p0(), p1(), p2()];
+    let geoms = [p0(), p1(), p2()];
     PointBuilder::from_points(
         geoms.iter(),
         Dimension::XY,

--- a/rust/geoarrow/src/test/point.rs
+++ b/rust/geoarrow/src/test/point.rs
@@ -29,8 +29,9 @@ pub(crate) fn p2() -> Point {
     )
 }
 
-pub(crate) fn point_array() -> PointArray<2> {
-    vec![p0(), p1(), p2()].as_slice().into()
+pub(crate) fn point_array() -> PointArray {
+    let geoms = vec![p0(), p1(), p2()];
+    PointBuilder::from_points(geoms.iter(), Default::default(), Default::default()).finish()
 }
 
 struct CoordZ {
@@ -64,7 +65,7 @@ impl CoordTrait for CoordZ {
     }
 }
 
-pub(crate) fn point_z_array() -> PointArray<3> {
+pub(crate) fn point_z_array() -> PointArray {
     let mut builder = PointBuilder::with_capacity(3);
     let coords = vec![
         CoordZ {

--- a/rust/geoarrow/src/test/point.rs
+++ b/rust/geoarrow/src/test/point.rs
@@ -6,6 +6,7 @@ use arrow_schema::{DataType, Field, Schema};
 use geo::{point, Point};
 
 use crate::array::{PointArray, PointBuilder};
+use crate::datatypes::Dimension;
 use crate::table::Table;
 use crate::test::properties;
 use crate::ArrayBase;
@@ -31,7 +32,13 @@ pub(crate) fn p2() -> Point {
 
 pub(crate) fn point_array() -> PointArray {
     let geoms = vec![p0(), p1(), p2()];
-    PointBuilder::from_points(geoms.iter(), Default::default(), Default::default()).finish()
+    PointBuilder::from_points(
+        geoms.iter(),
+        Dimension::XY,
+        Default::default(),
+        Default::default(),
+    )
+    .finish()
 }
 
 struct CoordZ {

--- a/rust/geoarrow/src/test/polygon.rs
+++ b/rust/geoarrow/src/test/polygon.rs
@@ -1,4 +1,4 @@
-use crate::array::PolygonArray;
+use crate::array::{PolygonArray, PolygonBuilder};
 use geo::{polygon, Polygon};
 
 pub(crate) fn p0() -> Polygon {
@@ -29,6 +29,7 @@ pub(crate) fn p1() -> Polygon {
     )
 }
 
-pub(crate) fn p_array() -> PolygonArray<2> {
-    vec![p0(), p1()].as_slice().into()
+pub(crate) fn p_array() -> PolygonArray {
+    let geoms = vec![p0(), p1()];
+    PolygonBuilder::from_polygons(&geoms, Default::default(), Default::default()).finish()
 }

--- a/rust/geoarrow/src/test/polygon.rs
+++ b/rust/geoarrow/src/test/polygon.rs
@@ -1,4 +1,5 @@
 use crate::array::{PolygonArray, PolygonBuilder};
+use crate::datatypes::Dimension;
 use geo::{polygon, Polygon};
 
 pub(crate) fn p0() -> Polygon {
@@ -31,5 +32,11 @@ pub(crate) fn p1() -> Polygon {
 
 pub(crate) fn p_array() -> PolygonArray {
     let geoms = vec![p0(), p1()];
-    PolygonBuilder::from_polygons(&geoms, Default::default(), Default::default()).finish()
+    PolygonBuilder::from_polygons(
+        &geoms,
+        Dimension::XY,
+        Default::default(),
+        Default::default(),
+    )
+    .finish()
 }

--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -398,9 +398,9 @@ pub trait SerializedArray: ArrayBase {
 pub type SerializedArrayRef = Arc<dyn SerializedArray>;
 
 /// Trait for accessing generic `Geometry` scalars
-pub trait NativeGeometryAccessor<const D: usize>: NativeArray {
+pub trait NativeGeometryAccessor: NativeArray {
     /// Returns the element at index `i` as a `Geometry`, not considering validity.
-    fn value_as_geometry(&self, index: usize) -> Geometry<'_, D> {
+    fn value_as_geometry(&self, index: usize) -> Geometry<'_> {
         assert!(index <= self.len());
         unsafe { self.value_as_geometry_unchecked(index) }
     }
@@ -410,10 +410,10 @@ pub trait NativeGeometryAccessor<const D: usize>: NativeArray {
     /// # Safety
     ///
     /// Caller is responsible for ensuring that the index is within the bounds of the array
-    unsafe fn value_as_geometry_unchecked(&self, index: usize) -> Geometry<'_, D>;
+    unsafe fn value_as_geometry_unchecked(&self, index: usize) -> Geometry<'_>;
 
     /// Returns the value at slot `i` as a `Geometry`, considering validity.
-    fn get_as_geometry(&self, index: usize) -> Option<Geometry<'_, D>> {
+    fn get_as_geometry(&self, index: usize) -> Option<Geometry<'_>> {
         if self.is_null(index) {
             return None;
         }
@@ -426,7 +426,7 @@ pub trait NativeGeometryAccessor<const D: usize>: NativeArray {
     /// # Safety
     ///
     /// Caller is responsible for ensuring that the index is within the bounds of the array
-    unsafe fn get_as_geometry_unchecked(&self, index: usize) -> Option<Geometry<'_, D>> {
+    unsafe fn get_as_geometry_unchecked(&self, index: usize) -> Option<Geometry<'_>> {
         if self.is_null(index) {
             return None;
         }
@@ -689,7 +689,7 @@ pub trait ArrayAccessor<'a>: ArrayBase {
 /// Trait for geometry array methods that return `Self`.
 ///
 /// TODO Horrible name, to be changed to a better name in the future!!
-pub trait GeometryArraySelfMethods<const D: usize> {
+pub trait GeometryArraySelfMethods {
     /// Creates a new array with replaced coordinates.
     ///
     /// This is useful if you want to apply an operation to _every_ coordinate in unison, such as a

--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -44,10 +44,11 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, datatypes::NativeType, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     /// use arrow_schema::DataType;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(matches!(point_array.storage_type(), DataType::FixedSizeList(_, _)));
     /// ```
     fn storage_type(&self) -> DataType;
@@ -59,9 +60,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let field = point_array.extension_field();
     /// assert_eq!(field.name(), "geometry");
     /// ```
@@ -73,9 +75,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert_eq!(point_array.extension_name(), "geoarrow.point");
     /// ```
     fn extension_name(&self) -> &str;
@@ -89,9 +92,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     /// ```
     ///
     /// use geoarrow::{array::PointArray, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let array_ref = point_array.into_array_ref();
     /// ```
     #[must_use]
@@ -106,9 +110,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     /// ```
     ///
     /// use geoarrow::{array::PointArray, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let array_ref = point_array.to_array_ref();
     /// ```
     #[must_use]
@@ -120,9 +125,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert_eq!(point_array.len(), 1);
     /// ```
     fn len(&self) -> usize;
@@ -133,9 +139,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, ArrayBase};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(!point_array.is_empty());
     /// ```
     fn is_empty(&self) -> bool {
@@ -152,9 +159,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{ArrayBase, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(array.nulls().is_none());
     /// ```
     fn nulls(&self) -> Option<&NullBuffer>;
@@ -165,9 +173,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{ArrayBase, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let metadata = array.metadata();
     /// ```
     fn metadata(&self) -> Arc<ArrayMetadata>;
@@ -180,9 +189,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{ArrayBase, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert_eq!(array.null_count(), 0);
     /// ```
     #[inline]
@@ -196,9 +206,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{ArrayBase, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(!array.is_null(0));
     /// ```
     ///
@@ -216,9 +227,10 @@ pub trait ArrayBase: std::fmt::Debug + Send + Sync {
     ///
     /// ```
     /// use geoarrow::{ArrayBase, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(array.is_valid(0));
     /// ```
     ///
@@ -245,9 +257,10 @@ pub trait NativeArray: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, datatypes::NativeType, NativeArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(matches!(point_array.data_type(), NativeType::Point(_, _)));
     /// ```
     fn data_type(&self) -> NativeType;
@@ -258,9 +271,10 @@ pub trait NativeArray: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{array::{PointArray, CoordType}, NativeArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert_eq!(point_array.coord_type(), CoordType::Interleaved);
     /// ```
     fn coord_type(&self) -> CoordType;
@@ -276,9 +290,10 @@ pub trait NativeArray: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{array::{PointArray, CoordType}, NativeArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let point_array: PointArray<2> = vec![point].as_slice().into();
+    /// let point_array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let point_array = point_array.to_coord_type(CoordType::Separated);
     /// ```
     #[must_use]
@@ -290,9 +305,10 @@ pub trait NativeArray: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{NativeArray, array::{PointArray, metadata::{ArrayMetadata, Edges}}};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let metadata = ArrayMetadata {
     ///     crs: None,
     ///     edges: Some(Edges::Spherical),
@@ -308,9 +324,10 @@ pub trait NativeArray: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{NativeArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let array_ref = array.as_ref();
     /// ```
     fn as_ref(&self) -> &dyn NativeArray;
@@ -324,10 +341,11 @@ pub trait NativeArray: ArrayBase {
     ///     array::PointArray,
     ///     trait_::{GeometryArraySelfMethods, ArrayAccessor, NativeArray, ArrayBase}
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point_0 = geo::point!(x: 1., y: 2.);
     /// let point_1 = geo::point!(x: 3., y: 4.);
-    /// let array: PointArray<2> = vec![point_0, point_1].as_slice().into();
+    /// let array: PointArray = (vec![point_0, point_1].as_slice(), Dimension::XY).into();
     /// let smaller_array = array.slice(1, 1);
     /// assert_eq!(smaller_array.len(), 1);
     /// let value = smaller_array.value_as_geo(0);
@@ -347,10 +365,11 @@ pub trait NativeArray: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{array::PointArray, trait_::GeometryArraySelfMethods};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point_0 = geo::point!(x: 1., y: 2.);
     /// let point_1 = geo::point!(x: 3., y: 4.);
-    /// let array: PointArray<2> = vec![point_0, point_1].as_slice().into();
+    /// let array: PointArray = (vec![point_0, point_1].as_slice(), Dimension::XY).into();
     /// let smaller_array = array.owned_slice(1, 1);
     /// ```
     #[must_use]
@@ -373,9 +392,10 @@ pub trait SerializedArray: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{NativeArray, array::{PointArray, metadata::{ArrayMetadata, Edges}}};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let metadata = ArrayMetadata {
     ///     crs: None,
     ///     edges: Some(Edges::Spherical),
@@ -391,9 +411,10 @@ pub trait SerializedArray: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{NativeArray, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let array_ref = array.as_ref();
     /// ```
     fn as_ref(&self) -> &dyn SerializedArray;
@@ -514,10 +535,11 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
     /// use geo_traits::{PointTrait, CoordTrait};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
-    /// let value = array.value(0); // geoarrow::scalar::Point<2>
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
+    /// let value = array.value(0); // geoarrow::scalar::Point
     /// assert_eq!(value.coord().x(), 1.);
     /// assert_eq!(value.coord().y(), 2.);
     /// ```
@@ -536,11 +558,12 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// unsafe {
-    ///     let value = array.value_unchecked(0); // geoarrow::scalar::Point<2>
+    ///     let value = array.value_unchecked(0); // geoarrow::scalar::Point
     /// }
     /// ```
     ///
@@ -555,9 +578,10 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(array.get(0).is_some());
     /// ```
     fn get(&'a self, index: usize) -> Option<Self::Item> {
@@ -574,9 +598,10 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// unsafe {
     ///     assert!(array.get_unchecked(0).is_some());
     /// }
@@ -600,9 +625,10 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
     /// use geo_traits::{PointTrait, CoordTrait};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let value = array.value_as_geo(0); // geo::Point
     /// assert_eq!(value.coord().unwrap().x(), 1.);
     /// assert_eq!(value.coord().unwrap().y(), 2.);
@@ -617,9 +643,10 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert!(array.get_as_geo(0).is_some());
     /// ```
     fn get_as_geo(&'a self, i: usize) -> Option<Self::ItemGeo> {
@@ -636,9 +663,10 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let maybe_points: Vec<Option<_>> = array.iter().collect();
     /// ```
     fn iter(&'a self) -> impl ExactSizeIterator<Item = Option<Self::Item>> + 'a {
@@ -651,9 +679,10 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let points: Vec<_> = array.iter_values().collect();
     /// ```
     fn iter_values(&'a self) -> impl ExactSizeIterator<Item = Self::Item> + 'a {
@@ -666,9 +695,10 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let maybe_points: Vec<Option<_>> = array.iter_geo().collect();
     /// ```
     fn iter_geo(&'a self) -> impl ExactSizeIterator<Item = Option<Self::ItemGeo>> + 'a {
@@ -681,9 +711,10 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     ///
     /// ```
     /// use geoarrow::{trait_::ArrayAccessor, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let points: Vec<_> = array.iter_geo_values().collect();
     /// ```
     fn iter_geo_values(&'a self) -> impl ExactSizeIterator<Item = Self::ItemGeo> + 'a {
@@ -710,7 +741,7 @@ pub trait GeometryArraySelfMethods {
     /// };
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let coords = CoordBuffer::Interleaved(InterleavedCoordBuffer::new(vec![3., 4.].into(), Dimension::XY));
     /// let array = array.with_coords(coords);
     /// let value = array.value_as_geo(0);
@@ -728,10 +759,11 @@ pub trait GeometryArraySelfMethods {
     ///     array::{PointArray, CoordType, CoordBuffer},
     ///     trait_::{ArrayAccessor, GeometryArraySelfMethods},
     /// };
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point_0 = geo::point!(x: 1., y: 2.);
     /// let point_1 = geo::point!(x: 3., y: 4.);
-    /// let array_interleaved: PointArray<2> = vec![point_0, point_1].as_slice().into();
+    /// let array_interleaved: PointArray = (vec![point_0, point_1].as_slice(), Dimension::XY).into();
     /// let array_separated = array_interleaved.into_coord_type(CoordType::Separated);
     /// assert!(matches!(array_separated.coords(), &CoordBuffer::Separated(_)));
     /// ```
@@ -749,9 +781,10 @@ pub trait IntoArrow {
     ///
     /// ```
     /// use geoarrow::{trait_::IntoArrow, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let arrow_array = array.into_arrow();
     /// ```
     fn into_arrow(self) -> Self::ArrowArray;
@@ -768,9 +801,10 @@ pub trait NativeScalar {
     ///
     /// ```
     /// use geoarrow::{trait_::{NativeScalar, ArrayAccessor}, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let point = array.value(0).to_geo(); // array.value_as_geo(0) does the same thing
     /// assert_eq!(point.x(), 1.);
     /// assert_eq!(point.y(), 2.);
@@ -783,9 +817,10 @@ pub trait NativeScalar {
     ///
     /// ```
     /// use geoarrow::{trait_::{NativeScalar, ArrayAccessor}, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let geometry = array.value(0).to_geo_geometry();
     /// ```
     fn to_geo_geometry(&self) -> geo::Geometry;
@@ -796,9 +831,10 @@ pub trait NativeScalar {
     ///
     /// ```
     /// use geoarrow::{trait_::{NativeScalar, ArrayAccessor}, array::PointArray};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let point = geo::point!(x: 1., y: 2.);
-    /// let array: PointArray<2> = vec![point].as_slice().into();
+    /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let geometry = array.value(0).to_geos().unwrap();
     /// ```
     #[cfg(feature = "geos")]
@@ -818,6 +854,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let mut builder = PointBuilder::new(Dimension::XY);
     /// assert_eq!(builder.len(), 0);
@@ -832,6 +869,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let mut builder = PointBuilder::new(Dimension::XY);
     /// assert!(builder.is_empty());
@@ -848,6 +886,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let builder = PointBuilder::new(Dimension::XY);
     /// assert!(builder.nulls().is_empty());
@@ -860,6 +899,8 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
+    /// use geoarrow::datatypes::Dimension;
+    ///
     /// let builder = PointBuilder::new(Dimension::XY);
     /// ```
     fn new(dim: Dimension) -> Self;
@@ -873,11 +914,14 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///     array::{PointBuilder, CoordType, metadata::{ArrayMetadata, Edges}},
     ///     trait_::GeometryArrayBuilder,
     /// };
+    /// use geoarrow::datatypes::Dimension;
+    ///
     /// let metadata = ArrayMetadata {
     ///     crs: None,
     ///     edges: Some(Edges::Spherical),
     /// };
-    /// let builder = PointBuilder::<2>::with_geom_capacity_and_options(
+    /// let builder = PointBuilder::with_geom_capacity_and_options(
+    ///     Dimension::XY,
     ///     2,
     ///     CoordType::Interleaved,
     ///     metadata.into()
@@ -899,7 +943,9 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///     array::PointBuilder,
     ///     trait_::GeometryArrayBuilder,
     /// };
-    /// let builder = PointBuilder::<2>::with_geom_capacity(2);
+    /// use geoarrow::datatypes::Dimension;
+    ///
+    /// let builder = PointBuilder::with_geom_capacity(Dimension::XY, 2);
     /// ```
     fn with_geom_capacity(dim: Dimension, geom_capacity: usize) -> Self {
         GeometryArrayBuilder::with_geom_capacity_and_options(
@@ -922,6 +968,8 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///     array::{PointBuilder, metadata::{ArrayMetadata, Edges}},
     ///     trait_::GeometryArrayBuilder,
     /// };
+    /// use geoarrow::datatypes::Dimension;
+    ///
     /// let mut builder = PointBuilder::new(Dimension::XY);
     /// let metadata = ArrayMetadata {
     ///     crs: None,
@@ -937,6 +985,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::{GeometryArrayBuilder, NativeArray, ArrayBase}};
+    /// use geoarrow::datatypes::Dimension;
     ///
     /// let mut builder = PointBuilder::new(Dimension::XY);
     /// builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
@@ -951,6 +1000,8 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::{PointBuilder, CoordType}, trait_::GeometryArrayBuilder};
+    /// use geoarrow::datatypes::Dimension;
+    ///
     /// let builder = PointBuilder::new(Dimension::XY);
     /// assert_eq!(builder.coord_type(), CoordType::Interleaved);
     /// ```
@@ -962,6 +1013,8 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::{PointBuilder, CoordType}, trait_::GeometryArrayBuilder};
+    /// use geoarrow::datatypes::Dimension;
+    ///
     /// let builder = PointBuilder::new(Dimension::XY);
     /// let metadata = builder.metadata();
     /// ```
@@ -987,6 +1040,8 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
+    /// use geoarrow::datatypes::Dimension;
+    ///
     /// let builder = PointBuilder::new(Dimension::XY);
     /// let array_ref = builder.into_array_ref();
     /// ```

--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -814,7 +814,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
     ///
-    /// let mut builder = PointBuilder::<2>::new();
+    /// let mut builder = PointBuilder::new(Dimension::XY);
     /// assert_eq!(builder.len(), 0);
     /// builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
     /// assert_eq!(builder.len(), 1);
@@ -828,7 +828,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
     ///
-    /// let mut builder = PointBuilder::<2>::new();
+    /// let mut builder = PointBuilder::new(Dimension::XY);
     /// assert!(builder.is_empty());
     /// builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
     /// assert!(!builder.is_empty());
@@ -844,7 +844,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
     ///
-    /// let builder = PointBuilder::<2>::new();
+    /// let builder = PointBuilder::new(Dimension::XY);
     /// assert!(builder.nulls().is_empty());
     /// ```
     fn nulls(&self) -> &NullBufferBuilder;
@@ -855,7 +855,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
-    /// let builder = PointBuilder::<2>::new();
+    /// let builder = PointBuilder::new(Dimension::XY);
     /// ```
     fn new() -> Self;
 
@@ -915,7 +915,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///     array::{PointBuilder, metadata::{ArrayMetadata, Edges}},
     ///     trait_::GeometryArrayBuilder,
     /// };
-    /// let mut builder = PointBuilder::<2>::new();
+    /// let mut builder = PointBuilder::new(Dimension::XY);
     /// let metadata = ArrayMetadata {
     ///     crs: None,
     ///     edges: Some(Edges::Spherical),
@@ -931,7 +931,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::{GeometryArrayBuilder, NativeArray, ArrayBase}};
     ///
-    /// let mut builder = PointBuilder::<2>::new();
+    /// let mut builder = PointBuilder::new(Dimension::XY);
     /// builder.push_point(Some(&geo::point!(x: 1., y: 2.)));
     /// let array = builder.finish();
     /// assert_eq!(array.len(), 1);
@@ -944,7 +944,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::{PointBuilder, CoordType}, trait_::GeometryArrayBuilder};
-    /// let builder = PointBuilder::<2>::new();
+    /// let builder = PointBuilder::new(Dimension::XY);
     /// assert_eq!(builder.coord_type(), CoordType::Interleaved);
     /// ```
     fn coord_type(&self) -> CoordType;
@@ -955,7 +955,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::{PointBuilder, CoordType}, trait_::GeometryArrayBuilder};
-    /// let builder = PointBuilder::<2>::new();
+    /// let builder = PointBuilder::new(Dimension::XY);
     /// let metadata = builder.metadata();
     /// ```
     fn metadata(&self) -> Arc<ArrayMetadata>;
@@ -980,7 +980,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     ///
     /// ```
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
-    /// let builder = PointBuilder::<2>::new();
+    /// let builder = PointBuilder::new(Dimension::XY);
     /// let array_ref = builder.into_array_ref();
     /// ```
     fn into_array_ref(self) -> Arc<dyn Array>;

--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -265,6 +265,7 @@ pub trait NativeArray: ArrayBase {
     /// ```
     fn coord_type(&self) -> CoordType;
 
+    /// The dimension of this array.
     fn dimension(&self) -> Dimension {
         self.data_type().dimension()
     }

--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -2,7 +2,7 @@
 
 use crate::array::metadata::ArrayMetadata;
 use crate::array::{CoordBuffer, CoordType};
-use crate::datatypes::{NativeType, SerializedType};
+use crate::datatypes::{Dimension, NativeType, SerializedType};
 use crate::error::Result;
 use crate::scalar::Geometry;
 use arrow_array::{Array, ArrayRef};
@@ -857,7 +857,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
     /// let builder = PointBuilder::new(Dimension::XY);
     /// ```
-    fn new() -> Self;
+    fn new(dim: Dimension) -> Self;
 
     /// Creates a new builder with capacity and other options.
     ///
@@ -879,6 +879,7 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// );
     /// ```
     fn with_geom_capacity_and_options(
+        dim: Dimension,
         geom_capacity: usize,
         coord_type: CoordType,
         metadata: Arc<ArrayMetadata>,
@@ -895,8 +896,9 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// };
     /// let builder = PointBuilder::<2>::with_geom_capacity(2);
     /// ```
-    fn with_geom_capacity(geom_capacity: usize) -> Self {
+    fn with_geom_capacity(dim: Dimension, geom_capacity: usize) -> Self {
         GeometryArrayBuilder::with_geom_capacity_and_options(
+            dim,
             geom_capacity,
             Default::default(),
             Default::default(),

--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -265,6 +265,10 @@ pub trait NativeArray: ArrayBase {
     /// ```
     fn coord_type(&self) -> CoordType;
 
+    fn dimension(&self) -> Dimension {
+        self.data_type().dimension()
+    }
+
     /// Converts this array to the same type of array but with the provided [CoordType].
     ///
     /// # Examples


### PR DESCRIPTION
Removes the `const D: usize` generic on each array type, delegating the coordinate dimension to the coordinate buffer. 

Closes https://github.com/geoarrow/geoarrow-rs/issues/822, for https://github.com/geoarrow/geoarrow-rs/issues/801. Builds on https://github.com/geoarrow/geoarrow-rs/pull/845