### PR TITLE
Remove infallible accessor for `Point::coord`

### DIFF
--- a/rust/geoarrow/src/algorithm/native/map_coords.rs
+++ b/rust/geoarrow/src/algorithm/native/map_coords.rs
@@ -10,7 +10,7 @@ use crate::trait_::ArrayAccessor;
 use crate::NativeArray;
 use geo_traits::{
     CoordTrait, GeometryCollectionTrait, GeometryTrait, GeometryType, LineStringTrait,
-    MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PolygonTrait, RectTrait,
+    MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait, RectTrait,
 };
 
 /// Note: this will currently always create a _two-dimensional_ output array because it returns a [`geo::Coord`].
@@ -52,7 +52,7 @@ impl MapCoords for Point<'_> {
         F: Fn(&crate::scalar::Coord) -> std::result::Result<geo::Coord, E> + Sync,
         GeoArrowError: From<E>,
     {
-        Ok(geo::Point(map_op(&self.coord())?))
+        Ok(geo::Point(map_op(&self.coord().unwrap())?))
     }
 }
 
@@ -229,7 +229,7 @@ impl MapCoords for PointArray {
         );
         for maybe_geom in self.iter() {
             if let Some(geom) = maybe_geom {
-                let result = geom.coord().try_map_coords(&map_op)?;
+                let result = geom.coord().unwrap().try_map_coords(&map_op)?;
                 builder.push_coord(Some(&result));
             } else {
                 builder.push_null()

--- a/rust/geoarrow/src/scalar/point/scalar.rs
+++ b/rust/geoarrow/src/scalar/point/scalar.rs
@@ -19,10 +19,6 @@ impl<'a> Point<'a> {
         Point { coords, geom_index }
     }
 
-    pub fn coord(&self) -> Coord {
-        self.coords.value(self.geom_index)
-    }
-
     pub fn into_owned_inner(self) -> (CoordBuffer, usize) {
         let coords = self.coords.owned_slice(self.geom_index, 1);
         (coords, self.geom_index)

--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -540,8 +540,8 @@ pub trait ArrayAccessor<'a>: ArrayBase {
     /// let point = geo::point!(x: 1., y: 2.);
     /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// let value = array.value(0); // geoarrow::scalar::Point
-    /// assert_eq!(value.coord().x(), 1.);
-    /// assert_eq!(value.coord().y(), 2.);
+    /// assert_eq!(value.coord().unwrap().x(), 1.);
+    /// assert_eq!(value.coord().unwrap().y(), 2.);
     /// ```
     ///
     /// # Panics


### PR DESCRIPTION
This forces the use of `PointTrait::coord`, which returns `Option<Coord>`, which is `None` if the point is empty.

Closes https://github.com/geoarrow/geoarrow-rs/issues/840