### PR TITLE
Use released wkt and wkb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "wkb",
- "wkt 0.11.1",
+ "wkt 0.12.0",
 ]
 
 [[package]]
@@ -4232,8 +4232,9 @@ dependencies = [
 
 [[package]]
 name = "wkb"
-version = "0.1.0"
-source = "git+https://github.com/kylebarron/wkb?rev=51a95fff591c7e66ea10f6effaba0d48b3b0a392#51a95fff591c7e66ea10f6effaba0d48b3b0a392"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e2c084338d6407d24c5a43208aca32128a5d62107eab5ca18314395c4aa3f0"
 dependencies = [
  "byteorder",
  "geo-traits",
@@ -4267,8 +4268,9 @@ dependencies = [
 
 [[package]]
 name = "wkt"
-version = "0.11.1"
-source = "git+https://github.com/georust/wkt?rev=94c32cdbdaf9523b3d71cd4b2d5d3a033efadacb#94c32cdbdaf9523b3d71cd4b2d5d3a033efadacb"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c591649bd1c9d4e28459758bbb5fb5c0edc7a67060b52422f4761c94ffe961"
 dependencies = [
  "geo-traits",
  "geo-types",

--- a/rust/geoarrow/Cargo.toml
+++ b/rust/geoarrow/Cargo.toml
@@ -96,9 +96,8 @@ sqlx = { version = "0.7", optional = true, default-features = false, features = 
 ] }
 thiserror = "1"
 tokio = { version = "1", default-features = false, optional = true }
-# wkt = "0.11"
-wkt = { git = "https://github.com/georust/wkt", rev = "94c32cdbdaf9523b3d71cd4b2d5d3a033efadacb" }
-wkb = { git = "https://github.com/kylebarron/wkb", rev = "51a95fff591c7e66ea10f6effaba0d48b3b0a392" }
+wkt = "0.12"
+wkb = "0.8"
 
 
 [dev-dependencies]


### PR DESCRIPTION
No longer use git dependencies for these two now that the latest versions have been published.