### PR TITLE
Unknown capacity and builder

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "approx"
@@ -140,7 +140,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
  "num",
 ]
 
@@ -330,7 +330,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -451,9 +451,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "byteorder"
@@ -463,15 +463,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -563,6 +563,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,9 +580,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -722,7 +732,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -768,7 +778,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -779,12 +789,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -967,7 +977,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1227,9 +1237,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1276,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -1315,12 +1325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1415,9 +1419,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1443,7 +1447,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.16",
+ "rustls 0.23.19",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -1624,7 +1628,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1650,12 +1654,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1696,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -1711,10 +1715,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1857,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libm"
@@ -1886,9 +1891,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1973,11 +1978,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1995,7 +1999,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2140,7 +2144,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2228,7 +2232,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2239,9 +2243,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.0+3.4.0"
+version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a709e02f2b4aca747929cca5ed248880847c650233cf8b8cdc48f40aaf4898a6"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 dependencies = [
  "cc",
 ]
@@ -2293,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "53.2.0"
+version = "53.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea02606ba6f5e856561d8d507dba8bac060aefca2a6c0f1aa1d361fed91ff3e"
+checksum = "2b449890367085eb65d7d3321540abc3d7babbd179ce31df0016e90719114191"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2312,7 +2316,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "lz4_flex",
  "num",
  "num-bigint",
@@ -2397,7 +2401,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2461,15 +2465,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a7d5beecc52a491b54d6dd05c7a45ba1801666a5baad9fdbfc6fef8d2d206c"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
@@ -2500,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2608,7 +2612,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2621,7 +2625,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2668,10 +2672,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustc-hash 2.1.0",
+ "rustls 0.23.19",
  "socket2",
- "thiserror 2.0.3",
+ "thiserror 2.0.4",
  "tokio",
  "tracing",
 ]
@@ -2686,11 +2690,11 @@ dependencies = [
  "getrandom",
  "rand",
  "ring",
- "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustc-hash 2.1.0",
+ "rustls 0.23.19",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.4",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2851,7 +2855,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.16",
+ "rustls 0.23.19",
  "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -2896,9 +2900,9 @@ checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
 name = "rsa"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
 dependencies = [
  "const-oid",
  "digest",
@@ -2939,9 +2943,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc_version"
@@ -2954,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2978,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "once_cell",
  "ring",
@@ -2992,15 +2996,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -3068,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -3104,7 +3107,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3149,14 +3165,14 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -3263,7 +3279,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3274,9 +3290,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3566,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3577,9 +3593,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -3592,7 +3608,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3602,7 +3618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3646,11 +3662,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.4",
 ]
 
 [[package]]
@@ -3661,18 +3677,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3688,9 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3741,9 +3757,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3763,7 +3779,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3782,7 +3798,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.19",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3836,9 +3852,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3848,20 +3864,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -3896,9 +3912,9 @@ checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"
@@ -3941,9 +3957,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4013,9 +4029,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4024,36 +4040,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4061,22 +4078,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-streams"
@@ -4093,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4383,9 +4400,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4395,13 +4412,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -4423,27 +4440,27 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -4472,7 +4489,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/python/geoarrow-core/src/interop/shapely/to_shapely.rs
+++ b/python/geoarrow-core/src/interop/shapely/to_shapely.rs
@@ -103,6 +103,7 @@ fn pyarray_to_shapely(py: Python, input: PyArray) -> PyGeoArrowResult<Bound<PyAn
                 Rect(_) => rect_arr(py, array.as_ref().as_rect().clone()),
                 Mixed(_, _) => via_wkb(py, array),
                 GeometryCollection(_, _) => via_wkb(py, array),
+                Unknown(_) => via_wkb(py, array),
             }
         }
         AnyType::Serialized(typ) => {

--- a/python/pyo3-geoarrow/src/data_type.rs
+++ b/python/pyo3-geoarrow/src/data_type.rs
@@ -124,8 +124,9 @@ impl PyNativeType {
         let enums_mod = py.import_bound(intern!(py, "geoarrow.rust.core.enums"))?;
         let coord_type = enums_mod.getattr(intern!(py, "Dimension"))?;
         match self.0.dimension() {
-            Dimension::XY => Ok(coord_type.getattr(intern!(py, "XY"))?.into()),
-            Dimension::XYZ => Ok(coord_type.getattr(intern!(py, "XYZ"))?.into()),
+            Some(Dimension::XY) => Ok(coord_type.getattr(intern!(py, "XY"))?.into()),
+            Some(Dimension::XYZ) => Ok(coord_type.getattr(intern!(py, "XYZ"))?.into()),
+            None => Ok(py.None()),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geo_index/rtree.rs
+++ b/rust/geoarrow/src/algorithm/geo_index/rtree.rs
@@ -51,6 +51,7 @@ impl_rtree!(MultiPolygonArray, bounding_rect_multipolygon);
 impl_rtree!(MixedGeometryArray, bounding_rect_geometry);
 impl_rtree!(GeometryCollectionArray, bounding_rect_geometry_collection);
 impl_rtree!(RectArray, bounding_rect_rect);
+impl_rtree!(UnknownGeometryArray, bounding_rect_geometry);
 
 impl RTree for &dyn NativeArray {
     type Output = OwnedRTree<f64>;
@@ -74,6 +75,7 @@ impl RTree for &dyn NativeArray {
             Mixed(_, _) => impl_method!(as_mixed),
             GeometryCollection(_, _) => impl_method!(as_geometry_collection),
             Rect(_) => impl_method!(as_rect),
+            Unknown(_) => impl_method!(as_unknown),
         }
     }
 }
@@ -108,6 +110,7 @@ impl RTree for &dyn ChunkedNativeArray {
             Mixed(_, _) => impl_method!(as_mixed),
             GeometryCollection(_, _) => impl_method!(as_geometry_collection),
             Rect(_) => impl_method!(as_rect),
+            Unknown(_) => todo!("Chunked unknown array"), // impl_method!(as_unknown),
         };
         Ok(result)
     }

--- a/rust/geoarrow/src/algorithm/geos/area.rs
+++ b/rust/geoarrow/src/algorithm/geos/area.rs
@@ -51,6 +51,7 @@ iter_geos_impl!(MultiPolygonArray);
 iter_geos_impl!(MixedGeometryArray);
 iter_geos_impl!(GeometryCollectionArray);
 iter_geos_impl!(RectArray);
+iter_geos_impl!(UnknownGeometryArray);
 
 impl Area for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -68,6 +69,7 @@ impl Area for &dyn NativeArray {
             Mixed(_, _) => self.as_mixed().area(),
             GeometryCollection(_, _) => self.as_geometry_collection().area(),
             Rect(_) => self.as_rect().area(),
+            Unknown(_) => self.as_unknown().area(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/is_empty.rs
+++ b/rust/geoarrow/src/algorithm/geos/is_empty.rs
@@ -1,4 +1,5 @@
 use crate::algorithm::native::Unary;
+use crate::array::unknown::UnknownGeometryArray;
 use crate::array::*;
 use crate::chunked_array::{ChunkedArray, ChunkedGeometryArray};
 use crate::datatypes::NativeType;
@@ -36,6 +37,7 @@ iter_geos_impl!(MultiPolygonArray);
 iter_geos_impl!(MixedGeometryArray);
 iter_geos_impl!(GeometryCollectionArray);
 iter_geos_impl!(RectArray);
+iter_geos_impl!(UnknownGeometryArray);
 
 impl IsEmpty for &dyn NativeArray {
     type Output = Result<BooleanArray>;
@@ -53,6 +55,7 @@ impl IsEmpty for &dyn NativeArray {
             Mixed(_, _) => IsEmpty::is_empty(self.as_mixed()),
             GeometryCollection(_, _) => IsEmpty::is_empty(self.as_geometry_collection()),
             Rect(_) => IsEmpty::is_empty(self.as_rect()),
+            Unknown(_) => IsEmpty::is_empty(self.as_unknown()),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/is_ring.rs
+++ b/rust/geoarrow/src/algorithm/geos/is_ring.rs
@@ -36,6 +36,7 @@ iter_geos_impl!(MultiPolygonArray);
 iter_geos_impl!(MixedGeometryArray);
 iter_geos_impl!(GeometryCollectionArray);
 iter_geos_impl!(RectArray);
+iter_geos_impl!(UnknownGeometryArray);
 
 impl IsRing for &dyn NativeArray {
     type Output = Result<BooleanArray>;
@@ -53,6 +54,7 @@ impl IsRing for &dyn NativeArray {
             Mixed(_, _) => self.as_mixed().is_ring(),
             GeometryCollection(_, _) => self.as_geometry_collection().is_ring(),
             Rect(_) => self.as_rect().is_ring(),
+            Unknown(_) => self.as_unknown().is_ring(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/is_simple.rs
+++ b/rust/geoarrow/src/algorithm/geos/is_simple.rs
@@ -36,6 +36,7 @@ iter_geos_impl!(MultiPolygonArray);
 iter_geos_impl!(MixedGeometryArray);
 iter_geos_impl!(GeometryCollectionArray);
 iter_geos_impl!(RectArray);
+iter_geos_impl!(UnknownGeometryArray);
 
 impl IsSimple for &dyn NativeArray {
     type Output = Result<BooleanArray>;
@@ -53,6 +54,7 @@ impl IsSimple for &dyn NativeArray {
             Mixed(_, _) => self.as_mixed().is_simple(),
             GeometryCollection(_, _) => self.as_geometry_collection().is_simple(),
             Rect(_) => self.as_rect().is_simple(),
+            Unknown(_) => self.as_unknown().is_simple(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/is_valid.rs
+++ b/rust/geoarrow/src/algorithm/geos/is_valid.rs
@@ -37,6 +37,7 @@ iter_geos_impl!(MultiPolygonArray);
 iter_geos_impl!(MixedGeometryArray);
 iter_geos_impl!(GeometryCollectionArray);
 iter_geos_impl!(RectArray);
+iter_geos_impl!(UnknownGeometryArray);
 
 impl IsValid for &dyn NativeArray {
     type Output = Result<BooleanArray>;
@@ -54,6 +55,7 @@ impl IsValid for &dyn NativeArray {
             Mixed(_, _) => IsValid::is_valid(self.as_mixed()),
             GeometryCollection(_, _) => IsValid::is_valid(self.as_geometry_collection()),
             Rect(_) => IsValid::is_valid(self.as_rect()),
+            Unknown(_) => IsValid::is_valid(self.as_unknown()),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/geos/length.rs
+++ b/rust/geoarrow/src/algorithm/geos/length.rs
@@ -44,6 +44,7 @@ iter_geos_impl!(MultiPolygonArray);
 iter_geos_impl!(MixedGeometryArray);
 iter_geos_impl!(GeometryCollectionArray);
 iter_geos_impl!(RectArray);
+iter_geos_impl!(UnknownGeometryArray);
 
 impl Length for &dyn NativeArray {
     type Output = Result<Float64Array>;
@@ -61,6 +62,7 @@ impl Length for &dyn NativeArray {
             Mixed(_, _) => self.as_mixed().length(),
             GeometryCollection(_, _) => self.as_geometry_collection().length(),
             Rect(_) => self.as_rect().length(),
+            Unknown(_) => self.as_unknown().length(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/native/cast.rs
+++ b/rust/geoarrow/src/algorithm/native/cast.rs
@@ -275,6 +275,7 @@ macro_rules! impl_chunked_cast_non_generic {
                     Mixed(_, _) => impl_cast!(as_mixed),
                     GeometryCollection(_, _) => impl_cast!(as_geometry_collection),
                     Rect(_) => impl_cast!(as_rect),
+                    Unknown(_) => todo!("cast to unknown"),
                 };
                 Ok(result)
             }
@@ -313,6 +314,7 @@ macro_rules! impl_chunked_cast_generic {
                     Mixed(_, _) => impl_cast!(as_mixed),
                     GeometryCollection(_, _) => impl_cast!(as_geometry_collection),
                     Rect(_) => impl_cast!(as_rect),
+                    Unknown(_) => todo!("cast to unknown"),
                 };
                 Ok(result)
             }

--- a/rust/geoarrow/src/algorithm/native/explode.rs
+++ b/rust/geoarrow/src/algorithm/native/explode.rs
@@ -200,6 +200,7 @@ impl Explode for &dyn ChunkedNativeArray {
             Mixed(_, _) => self.as_mixed().explode(),
             GeometryCollection(_, _) => self.as_geometry_collection().explode(),
             Rect(_) => self.as_rect().explode(),
+            _ => todo!("explode unknown"),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/native/total_bounds.rs
+++ b/rust/geoarrow/src/algorithm/native/total_bounds.rs
@@ -51,6 +51,7 @@ impl_array!(MultiLineStringArray, add_multi_line_string);
 impl_array!(MultiPolygonArray, add_multi_polygon);
 impl_array!(MixedGeometryArray, add_geometry);
 impl_array!(GeometryCollectionArray, add_geometry_collection);
+impl_array!(UnknownGeometryArray, add_geometry);
 
 // impl<O: OffsetSizeTrait> TotalBounds for WKBArray<O> {
 //     fn total_bounds(&self) -> BoundingRect {
@@ -76,6 +77,7 @@ impl TotalBounds for &dyn NativeArray {
             Mixed(_, _) => self.as_mixed().total_bounds(),
             GeometryCollection(_, _) => self.as_geometry_collection().total_bounds(),
             Rect(_) => self.as_rect().total_bounds(),
+            Unknown(_) => self.as_unknown().total_bounds(),
             // WKB => self.as_wkb().total_bounds(),
             // LargeWKB => self.as_large_wkb().total_bounds(),
         }
@@ -105,6 +107,7 @@ impl TotalBounds for &dyn ChunkedNativeArray {
             Mixed(_, _) => self.as_mixed().total_bounds(),
             GeometryCollection(_, _) => self.as_geometry_collection().total_bounds(),
             Rect(_) => self.as_rect().total_bounds(),
+            Unknown(_) => self.as_unknown().total_bounds(),
         }
     }
 }

--- a/rust/geoarrow/src/algorithm/native/unary.rs
+++ b/rust/geoarrow/src/algorithm/native/unary.rs
@@ -2,6 +2,7 @@ use arrow_array::types::ArrowPrimitiveType;
 use arrow_array::{BooleanArray, OffsetSizeTrait, PrimitiveArray};
 use arrow_buffer::{BooleanBufferBuilder, BufferBuilder};
 
+use crate::array::unknown::UnknownGeometryArray;
 use crate::array::*;
 use crate::datatypes::Dimension;
 use crate::trait_::ArrayAccessor;
@@ -96,6 +97,7 @@ impl Unary<'_> for MultiPolygonArray {}
 impl Unary<'_> for MixedGeometryArray {}
 impl Unary<'_> for GeometryCollectionArray {}
 impl Unary<'_> for RectArray {}
+impl Unary<'_> for UnknownGeometryArray {}
 impl<O: OffsetSizeTrait> Unary<'_> for WKBArray<O> {}
 
 #[allow(dead_code)]
@@ -155,3 +157,4 @@ impl UnaryPoint<'_> for MultiPolygonArray {}
 impl UnaryPoint<'_> for MixedGeometryArray {}
 impl UnaryPoint<'_> for GeometryCollectionArray {}
 impl UnaryPoint<'_> for RectArray {}
+impl UnaryPoint<'_> for UnknownGeometryArray {}

--- a/rust/geoarrow/src/array/cast.rs
+++ b/rust/geoarrow/src/array/cast.rs
@@ -1,3 +1,4 @@
+use crate::array::unknown::UnknownGeometryArray;
 use crate::array::*;
 use crate::chunked_array::*;
 
@@ -87,6 +88,15 @@ pub trait AsNativeArray {
     fn as_rect(&self) -> &RectArray {
         self.as_rect_opt().unwrap()
     }
+
+    /// Downcast this to a [`UnknownGeometryArray`] returning `None` if not possible
+    fn as_unknown_opt(&self) -> Option<&UnknownGeometryArray>;
+
+    /// Downcast this to a [`UnknownGeometryArray`] panicking if not possible
+    #[inline]
+    fn as_unknown(&self) -> &UnknownGeometryArray {
+        self.as_unknown_opt().unwrap()
+    }
 }
 
 impl AsNativeArray for &dyn NativeArray {
@@ -133,6 +143,11 @@ impl AsNativeArray for &dyn NativeArray {
     #[inline]
     fn as_rect_opt(&self) -> Option<&RectArray> {
         self.as_any().downcast_ref::<RectArray>()
+    }
+
+    #[inline]
+    fn as_unknown_opt(&self) -> Option<&UnknownGeometryArray> {
+        self.as_any().downcast_ref::<UnknownGeometryArray>()
     }
 }
 
@@ -254,6 +269,15 @@ pub trait AsChunkedNativeArray {
     fn as_rect(&self) -> &ChunkedRectArray {
         self.as_rect_opt().unwrap()
     }
+
+    /// Downcast this to a [`ChunkedUnknownGeometryArray`] returning `None` if not possible
+    fn as_unknown_opt(&self) -> Option<&ChunkedUnknownGeometryArray>;
+
+    /// Downcast this to a [`ChunkedUnknownGeometryArray`] panicking if not possible
+    #[inline]
+    fn as_unknown(&self) -> &ChunkedUnknownGeometryArray {
+        self.as_unknown_opt().unwrap()
+    }
 }
 
 impl AsChunkedNativeArray for &dyn ChunkedNativeArray {
@@ -301,6 +325,11 @@ impl AsChunkedNativeArray for &dyn ChunkedNativeArray {
     #[inline]
     fn as_rect_opt(&self) -> Option<&ChunkedRectArray> {
         self.as_any().downcast_ref::<ChunkedRectArray>()
+    }
+
+    #[inline]
+    fn as_unknown_opt(&self) -> Option<&ChunkedUnknownGeometryArray> {
+        self.as_any().downcast_ref::<ChunkedUnknownGeometryArray>()
     }
 }
 

--- a/rust/geoarrow/src/array/dynamic.rs
+++ b/rust/geoarrow/src/array/dynamic.rs
@@ -29,6 +29,7 @@ impl NativeArrayDyn {
     pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Self> {
         let data_type = NativeType::try_from(field)?;
 
+        // TODO: have to figure out when to parse as a MixedGeometry array vs Unknown Array
         use NativeType::*;
         let geo_arr: Arc<dyn NativeArray> = match data_type {
             Point(_, _) => Arc::new(PointArray::try_from((array, field))?),
@@ -42,6 +43,7 @@ impl NativeArrayDyn {
                 Arc::new(GeometryCollectionArray::try_from((array, field))?)
             }
             Rect(_) => Arc::new(RectArray::try_from((array, field))?),
+            Unknown(_) => todo!("from_arrow_array unknown"),
         };
 
         Ok(Self(geo_arr))

--- a/rust/geoarrow/src/array/geometrycollection/array.rs
+++ b/rust/geoarrow/src/array/geometrycollection/array.rs
@@ -26,7 +26,7 @@ use geo_traits::GeometryCollectionTrait;
 /// validity bitmap.
 #[derive(Debug, Clone)]
 pub struct GeometryCollectionArray {
-    // Always NativeType::GeometryCollection or NativeType::LargeGeometryCollection
+    // Always NativeType::GeometryCollection
     data_type: NativeType,
 
     metadata: Arc<ArrayMetadata>,

--- a/rust/geoarrow/src/array/linestring/array.rs
+++ b/rust/geoarrow/src/array/linestring/array.rs
@@ -30,7 +30,7 @@ use super::LineStringBuilder;
 /// bitmap.
 #[derive(Debug, Clone)]
 pub struct LineStringArray {
-    // Always NativeType::LineString or NativeType::LargeLineString
+    // Always NativeType::LineString
     data_type: NativeType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,

--- a/rust/geoarrow/src/array/linestring/array.rs
+++ b/rust/geoarrow/src/array/linestring/array.rs
@@ -405,7 +405,10 @@ impl TryFrom<(&dyn Array, &Field)> for LineStringArray {
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
         let geom_type = NativeType::try_from(field)?;
-        let mut arr: Self = (arr, geom_type.dimension()).try_into()?;
+        let dim = geom_type
+            .dimension()
+            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
+        let mut arr: Self = (arr, dim).try_into()?;
         arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
         Ok(arr)
     }

--- a/rust/geoarrow/src/array/mixed/array.rs
+++ b/rust/geoarrow/src/array/mixed/array.rs
@@ -55,7 +55,7 @@ use geo_traits::GeometryTrait;
 /// - 37: GeometryCollection ZM
 #[derive(Debug, Clone, PartialEq)]
 pub struct MixedGeometryArray {
-    /// Always NativeType::Mixed or NativeType::LargeMixed
+    /// Always NativeType::Mixed
     data_type: NativeType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,

--- a/rust/geoarrow/src/array/mixed/array.rs
+++ b/rust/geoarrow/src/array/mixed/array.rs
@@ -427,31 +427,7 @@ impl<'a> crate::trait_::NativeGEOSGeometryAccessor<'a> for MixedGeometryArray {
         &'a self,
         index: usize,
     ) -> std::result::Result<geos::Geometry, geos::Error> {
-        let type_id = self.type_ids[index];
-        let offset = self.offsets[index] as usize;
-
-        let geom = match type_id {
-            1 => Geometry::Point(self.points.value(offset)),
-            2 => Geometry::LineString(self.line_strings.value(offset)),
-            3 => Geometry::Polygon(self.polygons.value(offset)),
-            4 => Geometry::MultiPoint(self.multi_points.value(offset)),
-            5 => Geometry::MultiLineString(self.multi_line_strings.value(offset)),
-            6 => Geometry::MultiPolygon(self.multi_polygons.value(offset)),
-            7 => {
-                panic!("nested geometry collections not supported")
-            }
-            11 => Geometry::Point(self.points.value(offset)),
-            12 => Geometry::LineString(self.line_strings.value(offset)),
-            13 => Geometry::Polygon(self.polygons.value(offset)),
-            14 => Geometry::MultiPoint(self.multi_points.value(offset)),
-            15 => Geometry::MultiLineString(self.multi_line_strings.value(offset)),
-            16 => Geometry::MultiPolygon(self.multi_polygons.value(offset)),
-            17 => {
-                panic!("nested geometry collections not supported")
-            }
-            _ => panic!("unknown type_id {}", type_id),
-        };
-
+        let geom = NativeGeometryAccessor::value_as_geometry_unchecked(self, index);
         (&geom).try_into()
     }
 }

--- a/rust/geoarrow/src/array/mod.rs
+++ b/rust/geoarrow/src/array/mod.rs
@@ -20,6 +20,7 @@ pub use multipolygon::{MultiPolygonArray, MultiPolygonBuilder, MultiPolygonCapac
 pub use point::{PointArray, PointBuilder};
 pub use polygon::{PolygonArray, PolygonBuilder, PolygonCapacity};
 pub use rect::{RectArray, RectBuilder};
+pub use unknown::{UnknownCapacity, UnknownGeometryArray, UnknownGeometryBuilder};
 pub use wkt::WKTArray;
 
 pub use crate::trait_::{ArrayBase, NativeArray, SerializedArray};

--- a/rust/geoarrow/src/array/mod.rs
+++ b/rust/geoarrow/src/array/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod offset_builder;
 pub(crate) mod point;
 pub(crate) mod polygon;
 pub(crate) mod rect;
+pub(crate) mod unknown;
 pub(crate) mod util;
 pub(crate) mod wkt;
 

--- a/rust/geoarrow/src/array/multilinestring/array.rs
+++ b/rust/geoarrow/src/array/multilinestring/array.rs
@@ -458,7 +458,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiLineStringArray {
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
         let geom_type = NativeType::try_from(field)?;
-        let mut arr: Self = (arr, geom_type.dimension()).try_into()?;
+        let dim = geom_type
+            .dimension()
+            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
+        let mut arr: Self = (arr, dim).try_into()?;
         arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
         Ok(arr)
     }

--- a/rust/geoarrow/src/array/multilinestring/array.rs
+++ b/rust/geoarrow/src/array/multilinestring/array.rs
@@ -28,7 +28,7 @@ use super::MultiLineStringBuilder;
 /// bitmap.
 #[derive(Debug, Clone)]
 pub struct MultiLineStringArray {
-    // Always NativeType::MultiLineString or NativeType::LargeMultiLineString
+    // Always NativeType::MultiLineString
     data_type: NativeType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,

--- a/rust/geoarrow/src/array/multipoint/array.rs
+++ b/rust/geoarrow/src/array/multipoint/array.rs
@@ -27,7 +27,7 @@ use geo_traits::MultiPointTrait;
 /// bitmap.
 #[derive(Debug, Clone)]
 pub struct MultiPointArray {
-    // Always NativeType::MultiPoint or NativeType::LargeMultiPoint
+    // Always NativeType::MultiPoint
     data_type: NativeType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,

--- a/rust/geoarrow/src/array/multipoint/array.rs
+++ b/rust/geoarrow/src/array/multipoint/array.rs
@@ -393,7 +393,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPointArray {
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
         let geom_type = NativeType::try_from(field)?;
-        let mut arr: Self = (arr, geom_type.dimension()).try_into()?;
+        let dim = geom_type
+            .dimension()
+            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
+        let mut arr: Self = (arr, dim).try_into()?;
         arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
         Ok(arr)
     }

--- a/rust/geoarrow/src/array/multipolygon/array.rs
+++ b/rust/geoarrow/src/array/multipolygon/array.rs
@@ -28,7 +28,7 @@ use super::MultiPolygonBuilder;
 /// bitmap.
 #[derive(Debug, Clone)]
 pub struct MultiPolygonArray {
-    // Always NativeType::MultiPolygon or NativeType::LargeMultiPolygon
+    // Always NativeType::MultiPolygon
     data_type: NativeType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,

--- a/rust/geoarrow/src/array/multipolygon/array.rs
+++ b/rust/geoarrow/src/array/multipolygon/array.rs
@@ -552,7 +552,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPolygonArray {
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
         let geom_type = NativeType::try_from(field)?;
-        let mut arr: Self = (arr, geom_type.dimension()).try_into()?;
+        let dim = geom_type
+            .dimension()
+            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
+        let mut arr: Self = (arr, dim).try_into()?;
         arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
         Ok(arr)
     }

--- a/rust/geoarrow/src/array/point/array.rs
+++ b/rust/geoarrow/src/array/point/array.rs
@@ -333,7 +333,10 @@ impl TryFrom<(&dyn Array, &Field)> for PointArray {
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
         let geom_type = NativeType::try_from(field)?;
-        let mut arr: Self = (arr, geom_type.dimension()).try_into()?;
+        let dim = geom_type
+            .dimension()
+            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
+        let mut arr: Self = (arr, dim).try_into()?;
         arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
         Ok(arr)
     }

--- a/rust/geoarrow/src/array/polygon/array.rs
+++ b/rust/geoarrow/src/array/polygon/array.rs
@@ -460,7 +460,10 @@ impl TryFrom<(&dyn Array, &Field)> for PolygonArray {
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
         let geom_type = NativeType::try_from(field)?;
-        let mut arr: Self = (arr, geom_type.dimension()).try_into()?;
+        let dim = geom_type
+            .dimension()
+            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
+        let mut arr: Self = (arr, dim).try_into()?;
         arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
         Ok(arr)
     }

--- a/rust/geoarrow/src/array/polygon/array.rs
+++ b/rust/geoarrow/src/array/polygon/array.rs
@@ -31,7 +31,7 @@ use super::PolygonBuilder;
 #[derive(Debug, Clone)]
 // #[derive(Debug, Clone, PartialEq)]
 pub struct PolygonArray {
-    // Always NativeType::Polygon or NativeType::LargePolygon
+    // Always NativeType::Polygon
     data_type: NativeType,
 
     pub(crate) metadata: Arc<ArrayMetadata>,

--- a/rust/geoarrow/src/array/unknown/array.rs
+++ b/rust/geoarrow/src/array/unknown/array.rs
@@ -1,0 +1,1032 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arrow_array::{Array, OffsetSizeTrait, UnionArray};
+use arrow_buffer::{NullBuffer, ScalarBuffer};
+use arrow_schema::{DataType, Field, UnionMode};
+
+use crate::array::metadata::ArrayMetadata;
+use crate::array::unknown::builder::UnknownGeometryBuilder;
+use crate::array::unknown::capacity::UnknownCapacity;
+use crate::array::{
+    CoordType, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray,
+    PointArray, PolygonArray, WKBArray,
+};
+use crate::datatypes::{Dimension, NativeType};
+use crate::error::{GeoArrowError, Result};
+use crate::scalar::Geometry;
+use crate::trait_::{ArrayAccessor, GeometryArraySelfMethods, IntoArrow, NativeGeometryAccessor};
+use crate::{ArrayBase, NativeArray};
+use geo_traits::GeometryTrait;
+
+/// # Invariants
+///
+/// - All arrays must have the same dimension
+/// - All arrays must have the same coordinate layout (interleaved or separated)
+///
+/// - 1: Point
+/// - 2: LineString
+/// - 3: Polygon
+/// - 4: MultiPoint
+/// - 5: MultiLineString
+/// - 6: MultiPolygon
+/// - 7: GeometryCollection
+/// - 11: Point Z
+/// - 12: LineString Z
+/// - 13: Polygon Z
+/// - 14: MultiPoint Z
+/// - 15: MultiLineString Z
+/// - 16: MultiPolygon Z
+/// - 17: GeometryCollection Z
+/// - 21: Point M
+/// - 22: LineString M
+/// - 23: Polygon M
+/// - 24: MultiPoint M
+/// - 25: MultiLineString M
+/// - 26: MultiPolygon M
+/// - 27: GeometryCollection M
+/// - 31: Point ZM
+/// - 32: LineString ZM
+/// - 33: Polygon ZM
+/// - 34: MultiPoint ZM
+/// - 35: MultiLineString ZM
+/// - 36: MultiPolygon ZM
+/// - 37: GeometryCollection ZM
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnknownGeometryArray {
+    /// Always NativeType::Unknown
+    data_type: NativeType,
+
+    pub(crate) metadata: Arc<ArrayMetadata>,
+
+    /// Invariant: every item in `type_ids` is `> 0 && < fields.len()` if `type_ids` are not provided. If `type_ids` exist in the NativeType, then every item in `type_ids` is `> 0 && `
+    pub(crate) type_ids: ScalarBuffer<i8>,
+
+    /// Invariant: `offsets.len() == type_ids.len()`
+    pub(crate) offsets: ScalarBuffer<i32>,
+
+    // In the future we'll additionally have xym, xyzm array variants.
+    point_xy: PointArray,
+    line_string_xy: LineStringArray,
+    polygon_xy: PolygonArray,
+    mpoint_xy: MultiPointArray,
+    mline_string_xy: MultiLineStringArray,
+    mpolygon_xy: MultiPolygonArray,
+
+    point_xyz: PointArray,
+    line_string_xyz: LineStringArray,
+    polygon_xyz: PolygonArray,
+    mpoint_xyz: MultiPointArray,
+    mline_string_xyz: MultiLineStringArray,
+    mpolygon_xyz: MultiPolygonArray,
+
+    /// An offset used for slicing into this array. The offset will be 0 if the array has not been
+    /// sliced.
+    ///
+    /// In order to slice this array efficiently (and zero-cost) we can't slice the underlying
+    /// fields directly. If this were always a _sparse_ union array, we could! We could then always
+    /// slice from offset to length of each underlying array. But we're under the assumption that
+    /// most or all of the time we have a dense union array, where the `offsets` buffer is defined.
+    /// In that case, to know how to slice each underlying array, we'd have to walk the `type_ids`
+    /// and `offsets` arrays (in O(N) time) to figure out how to slice the underlying arrays.
+    ///
+    /// Instead, we store the slice offset.
+    ///
+    /// Note that this offset is only for slicing into the **fields**, i.e. the geometry arrays.
+    /// The `type_ids` and `offsets` arrays are sliced as usual.
+    ///
+    /// TODO: when exporting this array, export to arrow2 and then slice from scratch because we
+    /// can't set the `offset` in a UnionArray constructor
+    pub(crate) slice_offset: usize,
+}
+
+impl UnknownGeometryArray {
+    /// Create a new MixedGeometryArray from parts
+    ///
+    /// # Implementation
+    ///
+    /// This function is `O(1)`.
+    ///
+    /// # Panics
+    ///
+    /// - if the validity is not `None` and its length is different from the number of geometries
+    /// - if the largest geometry offset does not match the number of coordinates
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        type_ids: ScalarBuffer<i8>,
+        offsets: ScalarBuffer<i32>,
+        point_xy: PointArray,
+        line_string_xy: LineStringArray,
+        polygon_xy: PolygonArray,
+        mpoint_xy: MultiPointArray,
+        mline_string_xy: MultiLineStringArray,
+        mpolygon_xy: MultiPolygonArray,
+        point_xyz: PointArray,
+        line_string_xyz: LineStringArray,
+        polygon_xyz: PolygonArray,
+        mpoint_xyz: MultiPointArray,
+        mline_string_xyz: MultiLineStringArray,
+        mpolygon_xyz: MultiPolygonArray,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        let mut coord_types = HashSet::new();
+        coord_types.insert(point_xy.coord_type());
+        coord_types.insert(line_string_xy.coord_type());
+        coord_types.insert(polygon_xy.coord_type());
+        coord_types.insert(mpoint_xy.coord_type());
+        coord_types.insert(mline_string_xy.coord_type());
+        coord_types.insert(mpolygon_xy.coord_type());
+
+        coord_types.insert(point_xyz.coord_type());
+        coord_types.insert(line_string_xyz.coord_type());
+        coord_types.insert(polygon_xyz.coord_type());
+        coord_types.insert(mpoint_xyz.coord_type());
+        coord_types.insert(mline_string_xyz.coord_type());
+        coord_types.insert(mpolygon_xyz.coord_type());
+        assert_eq!(coord_types.len(), 1);
+
+        let coord_type = coord_types.into_iter().next().unwrap();
+
+        let data_type = NativeType::Unknown(coord_type);
+
+        Self {
+            data_type,
+            type_ids,
+            offsets,
+            point_xy,
+            line_string_xy,
+            polygon_xy,
+            mpoint_xy,
+            mline_string_xy,
+            mpolygon_xy,
+            point_xyz,
+            line_string_xyz,
+            polygon_xyz,
+            mpoint_xyz,
+            mline_string_xyz,
+            mpolygon_xyz,
+            slice_offset: 0,
+            metadata,
+        }
+    }
+
+    /// The lengths of each buffer contained in this array.
+    pub fn buffer_lengths(&self) -> UnknownCapacity {
+        UnknownCapacity::new(
+            0,
+            self.point_xy.buffer_lengths(),
+            self.line_string_xy.buffer_lengths(),
+            self.polygon_xy.buffer_lengths(),
+            self.mpoint_xy.buffer_lengths(),
+            self.mline_string_xy.buffer_lengths(),
+            self.mpolygon_xy.buffer_lengths(),
+            self.point_xyz.buffer_lengths(),
+            self.line_string_xyz.buffer_lengths(),
+            self.polygon_xyz.buffer_lengths(),
+            self.mpoint_xyz.buffer_lengths(),
+            self.mline_string_xyz.buffer_lengths(),
+            self.mpolygon_xyz.buffer_lengths(),
+            false,
+        )
+    }
+
+    // TODO: restore to enable downcasting
+
+    // pub fn has_points(&self) -> bool {
+    //     !self.points.is_empty()
+    // }
+
+    // pub fn has_line_strings(&self) -> bool {
+    //     !self.line_strings.is_empty()
+    // }
+
+    // pub fn has_polygons(&self) -> bool {
+    //     !self.polygons.is_empty()
+    // }
+
+    // pub fn has_multi_points(&self) -> bool {
+    //     !self.multi_points.is_empty()
+    // }
+
+    // pub fn has_multi_line_strings(&self) -> bool {
+    //     !self.multi_line_strings.is_empty()
+    // }
+
+    // pub fn has_multi_polygons(&self) -> bool {
+    //     !self.multi_polygons.is_empty()
+    // }
+
+    // pub fn has_only_points(&self) -> bool {
+    //     self.has_points()
+    //         && !self.has_line_strings()
+    //         && !self.has_polygons()
+    //         && !self.has_multi_points()
+    //         && !self.has_multi_line_strings()
+    //         && !self.has_multi_polygons()
+    // }
+
+    // pub fn has_only_line_strings(&self) -> bool {
+    //     !self.has_points()
+    //         && self.has_line_strings()
+    //         && !self.has_polygons()
+    //         && !self.has_multi_points()
+    //         && !self.has_multi_line_strings()
+    //         && !self.has_multi_polygons()
+    // }
+
+    // pub fn has_only_polygons(&self) -> bool {
+    //     !self.has_points()
+    //         && !self.has_line_strings()
+    //         && self.has_polygons()
+    //         && !self.has_multi_points()
+    //         && !self.has_multi_line_strings()
+    //         && !self.has_multi_polygons()
+    // }
+
+    // pub fn has_only_multi_points(&self) -> bool {
+    //     !self.has_points()
+    //         && !self.has_line_strings()
+    //         && !self.has_polygons()
+    //         && self.has_multi_points()
+    //         && !self.has_multi_line_strings()
+    //         && !self.has_multi_polygons()
+    // }
+
+    // pub fn has_only_multi_line_strings(&self) -> bool {
+    //     !self.has_points()
+    //         && !self.has_line_strings()
+    //         && !self.has_polygons()
+    //         && !self.has_multi_points()
+    //         && self.has_multi_line_strings()
+    //         && !self.has_multi_polygons()
+    // }
+
+    // pub fn has_only_multi_polygons(&self) -> bool {
+    //     !self.has_points()
+    //         && !self.has_line_strings()
+    //         && !self.has_polygons()
+    //         && !self.has_multi_points()
+    //         && !self.has_multi_line_strings()
+    //         && self.has_multi_polygons()
+    // }
+
+    /// The number of bytes occupied by this array.
+    pub fn num_bytes(&self) -> usize {
+        self.buffer_lengths().num_bytes()
+    }
+
+    /// Slices this [`MixedGeometryArray`] in place.
+    ///
+    /// # Implementation
+    ///
+    /// This operation is `O(F)` where `F` is the number of fields.
+    ///
+    /// # Panic
+    ///
+    /// This function panics iff `offset + length > self.len()`.
+    #[inline]
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        Self {
+            data_type: self.data_type,
+            type_ids: self.type_ids.slice(offset, length),
+            offsets: self.offsets.slice(offset, length),
+
+            point_xy: self.point_xy.clone(),
+            line_string_xy: self.line_string_xy.clone(),
+            polygon_xy: self.polygon_xy.clone(),
+            mpoint_xy: self.mpoint_xy.clone(),
+            mline_string_xy: self.mline_string_xy.clone(),
+            mpolygon_xy: self.mpolygon_xy.clone(),
+
+            point_xyz: self.point_xyz.clone(),
+            line_string_xyz: self.line_string_xyz.clone(),
+            polygon_xyz: self.polygon_xyz.clone(),
+            mpoint_xyz: self.mpoint_xyz.clone(),
+            mline_string_xyz: self.mline_string_xyz.clone(),
+            mpolygon_xyz: self.mpolygon_xyz.clone(),
+
+            slice_offset: self.slice_offset + offset,
+            metadata: self.metadata.clone(),
+        }
+    }
+
+    pub fn owned_slice(&self, _offset: usize, _length: usize) -> Self {
+        todo!()
+    }
+
+    pub fn to_coord_type(&self, coord_type: CoordType) -> Self {
+        self.clone().into_coord_type(coord_type)
+    }
+
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        Self::new(
+            self.type_ids,
+            self.offsets,
+            self.point_xy.into_coord_type(coord_type),
+            self.line_string_xy.into_coord_type(coord_type),
+            self.polygon_xy.into_coord_type(coord_type),
+            self.mpoint_xy.into_coord_type(coord_type),
+            self.mline_string_xy.into_coord_type(coord_type),
+            self.mpolygon_xy.into_coord_type(coord_type),
+            self.point_xyz.into_coord_type(coord_type),
+            self.line_string_xyz.into_coord_type(coord_type),
+            self.polygon_xyz.into_coord_type(coord_type),
+            self.mpoint_xyz.into_coord_type(coord_type),
+            self.mline_string_xyz.into_coord_type(coord_type),
+            self.mpolygon_xyz.into_coord_type(coord_type),
+            self.metadata,
+        )
+    }
+}
+
+impl ArrayBase for UnknownGeometryArray {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn storage_type(&self) -> DataType {
+        self.data_type.to_data_type()
+    }
+
+    fn extension_field(&self) -> Arc<Field> {
+        Arc::new(
+            self.data_type
+                .to_field_with_metadata("geometry", true, &self.metadata),
+        )
+    }
+
+    fn extension_name(&self) -> &str {
+        self.data_type.extension_name()
+    }
+
+    fn into_array_ref(self) -> Arc<dyn Array> {
+        Arc::new(self.into_arrow())
+    }
+
+    fn to_array_ref(&self) -> arrow_array::ArrayRef {
+        self.clone().into_array_ref()
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
+    }
+
+    /// Returns the number of geometries in this array
+    #[inline]
+    fn len(&self) -> usize {
+        // Note that `type_ids` is sliced as usual, and thus always has the correct length.
+        self.type_ids.len()
+    }
+
+    /// Returns the optional validity.
+    #[inline]
+    fn nulls(&self) -> Option<&NullBuffer> {
+        None
+    }
+}
+
+impl NativeArray for UnknownGeometryArray {
+    fn data_type(&self) -> NativeType {
+        self.data_type
+    }
+
+    fn coord_type(&self) -> crate::array::CoordType {
+        self.data_type.coord_type()
+    }
+
+    fn to_coord_type(&self, coord_type: CoordType) -> Arc<dyn NativeArray> {
+        Arc::new(self.clone().into_coord_type(coord_type))
+    }
+
+    fn with_metadata(&self, metadata: Arc<ArrayMetadata>) -> crate::trait_::NativeArrayRef {
+        let mut arr = self.clone();
+        arr.metadata = metadata;
+        Arc::new(arr)
+    }
+
+    fn as_ref(&self) -> &dyn NativeArray {
+        self
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> Arc<dyn NativeArray> {
+        Arc::new(self.slice(offset, length))
+    }
+
+    fn owned_slice(&self, offset: usize, length: usize) -> Arc<dyn NativeArray> {
+        Arc::new(self.owned_slice(offset, length))
+    }
+}
+
+impl GeometryArraySelfMethods for UnknownGeometryArray {
+    fn with_coords(self, _coords: crate::array::CoordBuffer) -> Self {
+        todo!();
+    }
+
+    fn into_coord_type(self, _coord_type: crate::array::CoordType) -> Self {
+        todo!();
+    }
+}
+
+impl NativeGeometryAccessor for UnknownGeometryArray {
+    unsafe fn value_as_geometry_unchecked(&self, index: usize) -> crate::scalar::Geometry {
+        let type_id = self.type_ids[index];
+        let offset = self.offsets[index] as usize;
+
+        match type_id {
+            1 => Geometry::Point(self.point_xy.value(offset)),
+            2 => Geometry::LineString(self.line_string_xy.value(offset)),
+            3 => Geometry::Polygon(self.polygon_xy.value(offset)),
+            4 => Geometry::MultiPoint(self.mpoint_xy.value(offset)),
+            5 => Geometry::MultiLineString(self.mline_string_xy.value(offset)),
+            6 => Geometry::MultiPolygon(self.mpolygon_xy.value(offset)),
+            7 => {
+                panic!("nested geometry collections not supported")
+            }
+            11 => Geometry::Point(self.point_xyz.value(offset)),
+            12 => Geometry::LineString(self.line_string_xyz.value(offset)),
+            13 => Geometry::Polygon(self.polygon_xyz.value(offset)),
+            14 => Geometry::MultiPoint(self.mpoint_xyz.value(offset)),
+            15 => Geometry::MultiLineString(self.mline_string_xyz.value(offset)),
+            16 => Geometry::MultiPolygon(self.mpolygon_xyz.value(offset)),
+            17 => {
+                panic!("nested geometry collections not supported")
+            }
+            _ => panic!("unknown type_id {}", type_id),
+        }
+    }
+}
+
+#[cfg(feature = "geos")]
+impl<'a> crate::trait_::NativeGEOSGeometryAccessor<'a> for UnknownGeometryArray {
+    unsafe fn value_as_geometry_unchecked(
+        &'a self,
+        index: usize,
+    ) -> std::result::Result<geos::Geometry, geos::Error> {
+        let geom = NativeGeometryAccessor::value_as_geometry_unchecked(self, index);
+        (&geom).try_into()
+    }
+}
+
+impl<'a> ArrayAccessor<'a> for UnknownGeometryArray {
+    type Item = Geometry<'a>;
+    type ItemGeo = geo::Geometry;
+
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        let type_id = self.type_ids[index];
+        let offset = self.offsets[index] as usize;
+
+        match type_id {
+            1 => Geometry::Point(self.point_xy.value(offset)),
+            2 => Geometry::LineString(self.line_string_xy.value(offset)),
+            3 => Geometry::Polygon(self.polygon_xy.value(offset)),
+            4 => Geometry::MultiPoint(self.mpoint_xy.value(offset)),
+            5 => Geometry::MultiLineString(self.mline_string_xy.value(offset)),
+            6 => Geometry::MultiPolygon(self.mpolygon_xy.value(offset)),
+            7 => {
+                panic!("nested geometry collections not supported")
+            }
+            11 => Geometry::Point(self.point_xyz.value(offset)),
+            12 => Geometry::LineString(self.line_string_xyz.value(offset)),
+            13 => Geometry::Polygon(self.polygon_xyz.value(offset)),
+            14 => Geometry::MultiPoint(self.mpoint_xyz.value(offset)),
+            15 => Geometry::MultiLineString(self.mline_string_xyz.value(offset)),
+            16 => Geometry::MultiPolygon(self.mpolygon_xyz.value(offset)),
+            17 => {
+                panic!("nested geometry collections not supported")
+            }
+            _ => panic!("unknown type_id {}", type_id),
+        }
+    }
+}
+
+impl IntoArrow for UnknownGeometryArray {
+    type ArrowArray = UnionArray;
+
+    fn into_arrow(self) -> Self::ArrowArray {
+        let union_fields = match self.data_type.to_data_type() {
+            DataType::Union(union_fields, _) => union_fields,
+            _ => unreachable!(),
+        };
+
+        let child_arrays = vec![
+            self.point_xy.into_array_ref(),
+            self.line_string_xy.into_array_ref(),
+            self.polygon_xy.into_array_ref(),
+            self.mpoint_xy.into_array_ref(),
+            self.mline_string_xy.into_array_ref(),
+            self.mpolygon_xy.into_array_ref(),
+            self.point_xyz.into_array_ref(),
+            self.line_string_xyz.into_array_ref(),
+            self.polygon_xyz.into_array_ref(),
+            self.mpoint_xyz.into_array_ref(),
+            self.mline_string_xyz.into_array_ref(),
+            self.mpolygon_xyz.into_array_ref(),
+        ];
+
+        UnionArray::try_new(
+            union_fields,
+            self.type_ids,
+            Some(self.offsets),
+            child_arrays,
+        )
+        .unwrap()
+    }
+}
+
+impl TryFrom<&UnionArray> for UnknownGeometryArray {
+    type Error = GeoArrowError;
+
+    fn try_from(value: &UnionArray) -> std::result::Result<Self, Self::Error> {
+        let mut point_xy: Option<PointArray> = None;
+        let mut line_string_xy: Option<LineStringArray> = None;
+        let mut polygon_xy: Option<PolygonArray> = None;
+        let mut mpoint_xy: Option<MultiPointArray> = None;
+        let mut mline_string_xy: Option<MultiLineStringArray> = None;
+        let mut mpolygon_xy: Option<MultiPolygonArray> = None;
+
+        let mut point_xyz: Option<PointArray> = None;
+        let mut line_string_xyz: Option<LineStringArray> = None;
+        let mut polygon_xyz: Option<PolygonArray> = None;
+        let mut mpoint_xyz: Option<MultiPointArray> = None;
+        let mut mline_string_xyz: Option<MultiLineStringArray> = None;
+        let mut mpolygon_xyz: Option<MultiPolygonArray> = None;
+
+        match value.data_type() {
+            DataType::Union(fields, mode) => {
+                if !matches!(mode, UnionMode::Dense) {
+                    return Err(GeoArrowError::General("Expected dense union".to_string()));
+                }
+
+                for (type_id, _field) in fields.iter() {
+                    let dimension = if type_id < 10 {
+                        Dimension::XY
+                    } else if type_id < 20 {
+                        Dimension::XYZ
+                    } else {
+                        return Err(GeoArrowError::General(format!(
+                            "Unsupported type_id: {}",
+                            type_id
+                        )));
+                    };
+
+                    match type_id {
+                        1 => {
+                            point_xy = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        2 => {
+                            line_string_xy = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        3 => {
+                            polygon_xy = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        4 => {
+                            mpoint_xy = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        5 => {
+                            mline_string_xy = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        6 => {
+                            mpolygon_xy = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        11 => {
+                            point_xyz = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        12 => {
+                            line_string_xyz = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        13 => {
+                            polygon_xyz = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        14 => {
+                            mpoint_xyz = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        15 => {
+                            mline_string_xyz = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        16 => {
+                            mpolygon_xyz = Some(
+                                (value.child(type_id).as_ref(), dimension)
+                                    .try_into()
+                                    .unwrap(),
+                            );
+                        }
+                        _ => {
+                            return Err(GeoArrowError::General(format!(
+                                "Unexpected type_id {}",
+                                type_id
+                            )))
+                        }
+                    }
+                }
+            }
+            _ => panic!("expected union type"),
+        };
+
+        let type_ids = value.type_ids().clone();
+        // This is after checking for dense union
+        let offsets = value.offsets().unwrap().clone();
+
+        Ok(Self::new(
+            type_ids,
+            offsets,
+            point_xy.unwrap_or_default(),
+            line_string_xy.unwrap_or_default(),
+            polygon_xy.unwrap_or_default(),
+            mpoint_xy.unwrap_or_default(),
+            mline_string_xy.unwrap_or_default(),
+            mpolygon_xy.unwrap_or_default(),
+            point_xyz.unwrap_or_default(),
+            line_string_xyz.unwrap_or_default(),
+            polygon_xyz.unwrap_or_default(),
+            mpoint_xyz.unwrap_or_default(),
+            mline_string_xyz.unwrap_or_default(),
+            mpolygon_xyz.unwrap_or_default(),
+            Default::default(),
+        ))
+    }
+}
+
+impl TryFrom<&dyn Array> for UnknownGeometryArray {
+    type Error = GeoArrowError;
+
+    fn try_from(value: &dyn Array) -> Result<Self> {
+        match value.data_type() {
+            DataType::Union(_, _) => {
+                let downcasted = value.as_any().downcast_ref::<UnionArray>().unwrap();
+                downcasted.try_into()
+            }
+            _ => Err(GeoArrowError::General(format!(
+                "Unexpected type: {:?}",
+                value.data_type()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<(&dyn Array, &Field)> for UnknownGeometryArray {
+    type Error = GeoArrowError;
+
+    fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
+        let mut arr: Self = arr.try_into()?;
+        arr.metadata = Arc::new(ArrayMetadata::try_from(field)?);
+        Ok(arr)
+    }
+}
+
+impl<G: GeometryTrait<T = f64>> TryFrom<&[G]> for UnknownGeometryArray {
+    type Error = GeoArrowError;
+
+    fn try_from(geoms: &[G]) -> Result<Self> {
+        let mut_arr: UnknownGeometryBuilder = geoms.try_into()?;
+        Ok(mut_arr.into())
+    }
+}
+
+impl<G: GeometryTrait<T = f64>> TryFrom<Vec<Option<G>>> for UnknownGeometryArray {
+    type Error = GeoArrowError;
+
+    fn try_from(geoms: Vec<Option<G>>) -> Result<Self> {
+        let mut_arr: UnknownGeometryBuilder = geoms.try_into()?;
+        Ok(mut_arr.into())
+    }
+}
+
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for UnknownGeometryArray {
+    type Error = GeoArrowError;
+
+    fn try_from(value: WKBArray<O>) -> Result<Self> {
+        let mut_arr: UnknownGeometryBuilder = value.try_into()?;
+        Ok(mut_arr.into())
+    }
+}
+
+// impl From<PointArray> for UnknownGeometryArray {
+//     fn from(value: PointArray) -> Self {
+//         let type_ids = match value.dimension() {
+//             Dimension::XY => vec![1; value.len()],
+//             Dimension::XYZ => vec![11; value.len()],
+//         };
+//         let metadata = value.metadata.clone();
+//         Self::new(
+//             ScalarBuffer::from(type_ids),
+//             ScalarBuffer::from_iter(0..value.len() as i32),
+//             value,
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             metadata,
+//         )
+//     }
+// }
+
+// impl From<LineStringArray> for UnknownGeometryArray {
+//     fn from(value: LineStringArray) -> Self {
+//         let type_ids = match value.dimension() {
+//             Dimension::XY => vec![2; value.len()],
+//             Dimension::XYZ => vec![12; value.len()],
+//         };
+//         let metadata = value.metadata.clone();
+//         Self::new(
+//             ScalarBuffer::from(type_ids),
+//             ScalarBuffer::from_iter(0..value.len() as i32),
+//             Default::default(),
+//             value,
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             metadata,
+//         )
+//     }
+// }
+
+// impl From<PolygonArray> for UnknownGeometryArray {
+//     fn from(value: PolygonArray) -> Self {
+//         let type_ids = match value.dimension() {
+//             Dimension::XY => vec![3; value.len()],
+//             Dimension::XYZ => vec![13; value.len()],
+//         };
+//         let metadata = value.metadata.clone();
+//         Self::new(
+//             ScalarBuffer::from(type_ids),
+//             ScalarBuffer::from_iter(0..value.len() as i32),
+//             Default::default(),
+//             Default::default(),
+//             value,
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             metadata,
+//         )
+//     }
+// }
+
+// impl From<MultiPointArray> for UnknownGeometryArray {
+//     fn from(value: MultiPointArray) -> Self {
+//         let type_ids = match value.dimension() {
+//             Dimension::XY => vec![4; value.len()],
+//             Dimension::XYZ => vec![14; value.len()],
+//         };
+//         let metadata = value.metadata.clone();
+//         Self::new(
+//             ScalarBuffer::from(type_ids),
+//             ScalarBuffer::from_iter(0..value.len() as i32),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             value,
+//             Default::default(),
+//             Default::default(),
+//             metadata,
+//         )
+//     }
+// }
+
+// impl From<MultiLineStringArray> for UnknownGeometryArray {
+//     fn from(value: MultiLineStringArray) -> Self {
+//         let type_ids = match value.dimension() {
+//             Dimension::XY => vec![5; value.len()],
+//             Dimension::XYZ => vec![15; value.len()],
+//         };
+//         let metadata = value.metadata.clone();
+//         Self::new(
+//             ScalarBuffer::from(type_ids),
+//             ScalarBuffer::from_iter(0..value.len() as i32),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             value,
+//             Default::default(),
+//             metadata,
+//         )
+//     }
+// }
+
+// impl From<MultiPolygonArray> for UnknownGeometryArray {
+//     fn from(value: MultiPolygonArray) -> Self {
+//         let type_ids = match value.dimension() {
+//             Dimension::XY => vec![6; value.len()],
+//             Dimension::XYZ => vec![16; value.len()],
+//         };
+//         let metadata = value.metadata.clone();
+//         Self::new(
+//             ScalarBuffer::from(type_ids),
+//             ScalarBuffer::from_iter(0..value.len() as i32),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             Default::default(),
+//             value,
+//             metadata,
+//         )
+//     }
+// }
+
+// impl TryFrom<GeometryCollectionArray> for UnknownGeometryArray {
+//     type Error = GeoArrowError;
+
+//     fn try_from(value: GeometryCollectionArray) -> std::result::Result<Self, Self::Error> {
+//         if !can_downcast_multi(&value.geom_offsets) {
+//             return Err(GeoArrowError::General("Unable to cast".to_string()));
+//         }
+
+//         if value.null_count() > 0 {
+//             return Err(GeoArrowError::General(
+//                 "Unable to cast with nulls".to_string(),
+//             ));
+//         }
+
+//         Ok(value.array)
+//     }
+// }
+
+/// Default to an empty array
+impl Default for UnknownGeometryArray {
+    fn default() -> Self {
+        UnknownGeometryBuilder::default().into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::array::MixedGeometryArray;
+    use crate::test::{linestring, multilinestring, multipoint, multipolygon, point, polygon};
+
+    #[test]
+    fn geo_roundtrip_accurate_points() {
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::Point(point::p0()),
+            geo::Geometry::Point(point::p1()),
+            geo::Geometry::Point(point::p2()),
+        ];
+        let arr: MixedGeometryArray = (geoms.as_slice(), Dimension::XY).try_into().unwrap();
+
+        assert_eq!(
+            arr.value_as_geo(0),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()]))
+        );
+        assert_eq!(
+            arr.value_as_geo(1),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p1()]))
+        );
+        assert_eq!(
+            arr.value_as_geo(2),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p2()]))
+        );
+    }
+
+    #[test]
+    fn geo_roundtrip_accurate_all() {
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::Point(point::p0()),
+            geo::Geometry::LineString(linestring::ls0()),
+            geo::Geometry::Polygon(polygon::p0()),
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiLineString(multilinestring::ml0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
+        let arr: MixedGeometryArray = (geoms.as_slice(), Dimension::XY).try_into().unwrap();
+
+        assert_eq!(
+            arr.value_as_geo(0),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()]))
+        );
+        assert_eq!(
+            arr.value_as_geo(1),
+            geo::Geometry::MultiLineString(geo::MultiLineString(vec![linestring::ls0()]))
+        );
+        assert_eq!(
+            arr.value_as_geo(2),
+            geo::Geometry::MultiPolygon(geo::MultiPolygon(vec![polygon::p0()]))
+        );
+        assert_eq!(arr.value_as_geo(3), geoms[3]);
+        assert_eq!(arr.value_as_geo(4), geoms[4]);
+        assert_eq!(arr.value_as_geo(5), geoms[5]);
+    }
+
+    #[test]
+    fn arrow_roundtrip() {
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::Point(point::p0()),
+            geo::Geometry::LineString(linestring::ls0()),
+            geo::Geometry::Polygon(polygon::p0()),
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiLineString(multilinestring::ml0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
+        let arr: MixedGeometryArray = (geoms.as_slice(), Dimension::XY).try_into().unwrap();
+
+        // Round trip to/from arrow-rs
+        let arrow_array = arr.into_arrow();
+        let round_trip_arr: MixedGeometryArray = (&arrow_array).try_into().unwrap();
+
+        assert_eq!(
+            round_trip_arr.value_as_geo(0),
+            geo::Geometry::MultiPoint(geo::MultiPoint(vec![point::p0()]))
+        );
+        assert_eq!(
+            round_trip_arr.value_as_geo(1),
+            geo::Geometry::MultiLineString(geo::MultiLineString(vec![linestring::ls0()]))
+        );
+        assert_eq!(
+            round_trip_arr.value_as_geo(2),
+            geo::Geometry::MultiPolygon(geo::MultiPolygon(vec![polygon::p0()]))
+        );
+        assert_eq!(round_trip_arr.value_as_geo(3), geoms[3]);
+        assert_eq!(round_trip_arr.value_as_geo(4), geoms[4]);
+        assert_eq!(round_trip_arr.value_as_geo(5), geoms[5]);
+    }
+
+    #[test]
+    fn arrow_roundtrip_not_all_types() {
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiLineString(multilinestring::ml0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
+        let arr: MixedGeometryArray = (geoms.as_slice(), Dimension::XY).try_into().unwrap();
+
+        // Round trip to/from arrow-rs
+        let arrow_array = arr.into_arrow();
+        let round_trip_arr: MixedGeometryArray = (&arrow_array).try_into().unwrap();
+
+        assert_eq!(round_trip_arr.value_as_geo(0), geoms[0]);
+        assert_eq!(round_trip_arr.value_as_geo(1), geoms[1]);
+        assert_eq!(round_trip_arr.value_as_geo(2), geoms[2]);
+    }
+
+    #[test]
+    fn arrow_roundtrip_not_all_types2() {
+        let geoms: Vec<geo::Geometry> = vec![
+            geo::Geometry::MultiPoint(multipoint::mp0()),
+            geo::Geometry::MultiPolygon(multipolygon::mp0()),
+        ];
+        let arr: MixedGeometryArray = (geoms.as_slice(), Dimension::XY).try_into().unwrap();
+
+        // Round trip to/from arrow-rs
+        let arrow_array = arr.into_arrow();
+        let round_trip_arr: MixedGeometryArray = (&arrow_array).try_into().unwrap();
+
+        assert_eq!(round_trip_arr.value_as_geo(0), geoms[0]);
+        assert_eq!(round_trip_arr.value_as_geo(1), geoms[1]);
+    }
+}

--- a/rust/geoarrow/src/array/unknown/array.rs
+++ b/rust/geoarrow/src/array/unknown/array.rs
@@ -192,29 +192,47 @@ impl UnknownGeometryArray {
 
     // TODO: restore to enable downcasting
 
-    // pub fn has_points(&self) -> bool {
-    //     !self.points.is_empty()
-    // }
+    pub fn has_points(&self, dim: Dimension) -> bool {
+        match dim {
+            Dimension::XY => !self.point_xy.is_empty(),
+            Dimension::XYZ => !self.point_xyz.is_empty(),
+        }
+    }
 
-    // pub fn has_line_strings(&self) -> bool {
-    //     !self.line_strings.is_empty()
-    // }
+    pub fn has_line_strings(&self, dim: Dimension) -> bool {
+        match dim {
+            Dimension::XY => !self.line_string_xy.is_empty(),
+            Dimension::XYZ => !self.line_string_xyz.is_empty(),
+        }
+    }
 
-    // pub fn has_polygons(&self) -> bool {
-    //     !self.polygons.is_empty()
-    // }
+    pub fn has_polygons(&self, dim: Dimension) -> bool {
+        match dim {
+            Dimension::XY => !self.polygon_xy.is_empty(),
+            Dimension::XYZ => !self.polygon_xyz.is_empty(),
+        }
+    }
 
-    // pub fn has_multi_points(&self) -> bool {
-    //     !self.multi_points.is_empty()
-    // }
+    pub fn has_multi_points(&self, dim: Dimension) -> bool {
+        match dim {
+            Dimension::XY => !self.mpoint_xy.is_empty(),
+            Dimension::XYZ => !self.mpoint_xyz.is_empty(),
+        }
+    }
 
-    // pub fn has_multi_line_strings(&self) -> bool {
-    //     !self.multi_line_strings.is_empty()
-    // }
+    pub fn has_multi_line_strings(&self, dim: Dimension) -> bool {
+        match dim {
+            Dimension::XY => !self.mline_string_xy.is_empty(),
+            Dimension::XYZ => !self.mline_string_xyz.is_empty(),
+        }
+    }
 
-    // pub fn has_multi_polygons(&self) -> bool {
-    //     !self.multi_polygons.is_empty()
-    // }
+    pub fn has_multi_polygons(&self, dim: Dimension) -> bool {
+        match dim {
+            Dimension::XY => !self.mpolygon_xy.is_empty(),
+            Dimension::XYZ => !self.mpolygon_xyz.is_empty(),
+        }
+    }
 
     // pub fn has_only_points(&self) -> bool {
     //     self.has_points()

--- a/rust/geoarrow/src/array/unknown/builder.rs
+++ b/rust/geoarrow/src/array/unknown/builder.rs
@@ -270,7 +270,7 @@ impl<'a> UnknownGeometryBuilder {
         metadata: Arc<ArrayMetadata>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        let counter = UnknownCapacity::from_geometries(geoms)?;
+        let counter = UnknownCapacity::from_geometries(geoms, prefer_multi)?;
         Ok(Self::with_capacity_and_options(
             counter,
             coord_type,
@@ -282,8 +282,9 @@ impl<'a> UnknownGeometryBuilder {
     pub fn reserve_from_iter(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+        prefer_multi: bool,
     ) -> Result<()> {
-        let counter = UnknownCapacity::from_geometries(geoms)?;
+        let counter = UnknownCapacity::from_geometries(geoms, prefer_multi)?;
         self.reserve(counter);
         Ok(())
     }
@@ -291,8 +292,9 @@ impl<'a> UnknownGeometryBuilder {
     pub fn reserve_exact_from_iter(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+        prefer_multi: bool,
     ) -> Result<()> {
-        let counter = UnknownCapacity::from_geometries(geoms)?;
+        let counter = UnknownCapacity::from_geometries(geoms, prefer_multi)?;
         self.reserve_exact(counter);
         Ok(())
     }
@@ -752,12 +754,18 @@ impl From<UnknownGeometryBuilder> for UnknownGeometryArray {
         Self::new(
             other.types.into(),
             other.offsets.into(),
-            other.points.into(),
-            other.line_strings.into(),
-            other.polygons.into(),
-            other.multi_points.into(),
-            other.multi_line_strings.into(),
-            other.multi_polygons.into(),
+            other.point_xy.into(),
+            other.line_string_xy.into(),
+            other.polygon_xy.into(),
+            other.mpoint_xy.into(),
+            other.mline_string_xy.into(),
+            other.mpolygon_xy.into(),
+            other.point_xyz.into(),
+            other.line_string_xyz.into(),
+            other.polygon_xyz.into(),
+            other.mpoint_xyz.into(),
+            other.mline_string_xyz.into(),
+            other.mpolygon_xyz.into(),
             other.metadata,
         )
     }
@@ -805,7 +813,7 @@ impl GeometryArrayBuilder for UnknownGeometryBuilder {
         todo!()
     }
 
-    fn new(dim: Dimension) -> Self {
+    fn new(_dim: Dimension) -> Self {
         Self::new()
     }
 
@@ -814,7 +822,7 @@ impl GeometryArrayBuilder for UnknownGeometryBuilder {
     }
 
     fn with_geom_capacity_and_options(
-        dim: Dimension,
+        _dim: Dimension,
         _geom_capacity: usize,
         coord_type: CoordType,
         metadata: Arc<ArrayMetadata>,
@@ -837,7 +845,7 @@ impl GeometryArrayBuilder for UnknownGeometryBuilder {
     }
 
     fn coord_type(&self) -> CoordType {
-        self.points.coord_type()
+        self.point_xy.coord_type()
     }
 
     fn set_metadata(&mut self, metadata: Arc<ArrayMetadata>) {

--- a/rust/geoarrow/src/array/unknown/builder.rs
+++ b/rust/geoarrow/src/array/unknown/builder.rs
@@ -307,6 +307,7 @@ impl<'a> UnknownGeometryBuilder {
     pub fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
         if let Some(point) = value {
             if self.prefer_multi {
+                self.add_multi_point_type(point.dim().try_into().unwrap());
                 match point.dim() {
                     Dimensions::Xy | Dimensions::Unknown(2) => {
                         self.mpoint_xy.push_point(Some(point))?;
@@ -320,8 +321,8 @@ impl<'a> UnknownGeometryBuilder {
                         )))
                     }
                 }
-                self.add_multi_point_type(point.dim().try_into().unwrap());
             } else {
+                self.add_point_type(point.dim().try_into().unwrap());
                 match point.dim() {
                     Dimensions::Xy | Dimensions::Unknown(2) => {
                         self.point_xy.push_point(Some(point));
@@ -335,8 +336,6 @@ impl<'a> UnknownGeometryBuilder {
                         )))
                     }
                 }
-
-                self.add_point_type(point.dim().try_into().unwrap());
             }
         } else {
             self.push_null();
@@ -374,6 +373,7 @@ impl<'a> UnknownGeometryBuilder {
     ) -> Result<()> {
         if let Some(line_string) = value {
             if self.prefer_multi {
+                self.add_multi_line_string_type(line_string.dim().try_into().unwrap());
                 match line_string.dim() {
                     Dimensions::Xy | Dimensions::Unknown(2) => {
                         self.mline_string_xy.push_line_string(Some(line_string))?;
@@ -387,8 +387,8 @@ impl<'a> UnknownGeometryBuilder {
                         )))
                     }
                 }
-                self.add_multi_line_string_type(line_string.dim().try_into().unwrap());
             } else {
+                self.add_line_string_type(line_string.dim().try_into().unwrap());
                 match line_string.dim() {
                     Dimensions::Xy | Dimensions::Unknown(2) => {
                         self.line_string_xy.push_line_string(Some(line_string))?;
@@ -402,8 +402,6 @@ impl<'a> UnknownGeometryBuilder {
                         )))
                     }
                 }
-
-                self.add_line_string_type(line_string.dim().try_into().unwrap());
             }
         } else {
             self.push_null();
@@ -440,6 +438,7 @@ impl<'a> UnknownGeometryBuilder {
     pub fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
         if let Some(polygon) = value {
             if self.prefer_multi {
+                self.add_multi_polygon_type(polygon.dim().try_into().unwrap());
                 match polygon.dim() {
                     Dimensions::Xy | Dimensions::Unknown(2) => {
                         self.mpolygon_xy.push_polygon(Some(polygon))?;
@@ -453,8 +452,8 @@ impl<'a> UnknownGeometryBuilder {
                         )))
                     }
                 }
-                self.add_multi_polygon_type(polygon.dim().try_into().unwrap());
             } else {
+                self.add_polygon_type(polygon.dim().try_into().unwrap());
                 match polygon.dim() {
                     Dimensions::Xy | Dimensions::Unknown(2) => {
                         self.polygon_xy.push_polygon(Some(polygon))?;
@@ -468,8 +467,6 @@ impl<'a> UnknownGeometryBuilder {
                         )))
                     }
                 }
-
-                self.add_polygon_type(polygon.dim().try_into().unwrap());
             }
         } else {
             self.push_null();
@@ -504,6 +501,7 @@ impl<'a> UnknownGeometryBuilder {
         value: Option<&impl MultiPointTrait<T = f64>>,
     ) -> Result<()> {
         if let Some(multi_point) = value {
+            self.add_multi_point_type(multi_point.dim().try_into().unwrap());
             match multi_point.dim() {
                 Dimensions::Xy | Dimensions::Unknown(2) => {
                     self.mpoint_xy.push_multi_point(Some(multi_point))?;
@@ -517,7 +515,6 @@ impl<'a> UnknownGeometryBuilder {
                     )))
                 }
             }
-            self.add_multi_point_type(multi_point.dim().try_into().unwrap());
         } else {
             self.push_null();
         };
@@ -550,6 +547,7 @@ impl<'a> UnknownGeometryBuilder {
         value: Option<&impl MultiLineStringTrait<T = f64>>,
     ) -> Result<()> {
         if let Some(multi_line_string) = value {
+            self.add_multi_line_string_type(multi_line_string.dim().try_into().unwrap());
             match multi_line_string.dim() {
                 Dimensions::Xy | Dimensions::Unknown(2) => {
                     self.mline_string_xy
@@ -565,7 +563,6 @@ impl<'a> UnknownGeometryBuilder {
                     )))
                 }
             }
-            self.add_multi_line_string_type(multi_line_string.dim().try_into().unwrap());
         } else {
             self.push_null();
         };
@@ -600,6 +597,7 @@ impl<'a> UnknownGeometryBuilder {
         value: Option<&impl MultiPolygonTrait<T = f64>>,
     ) -> Result<()> {
         if let Some(multi_polygon) = value {
+            self.add_multi_polygon_type(multi_polygon.dim().try_into().unwrap());
             match multi_polygon.dim() {
                 Dimensions::Xy | Dimensions::Unknown(2) => {
                     self.mpolygon_xy.push_multi_polygon(Some(multi_polygon))?;
@@ -613,7 +611,6 @@ impl<'a> UnknownGeometryBuilder {
                     )))
                 }
             }
-            self.add_multi_polygon_type(multi_polygon.dim().try_into().unwrap());
         } else {
             self.push_null();
         };

--- a/rust/geoarrow/src/array/unknown/builder.rs
+++ b/rust/geoarrow/src/array/unknown/builder.rs
@@ -1,0 +1,850 @@
+use std::sync::Arc;
+
+use crate::array::metadata::ArrayMetadata;
+use crate::array::unknown::array::UnknownGeometryArray;
+use crate::array::unknown::capacity::UnknownCapacity;
+use crate::array::{
+    CoordType, LineStringBuilder, MultiLineStringBuilder, MultiPointBuilder, MultiPolygonBuilder,
+    PointBuilder, PolygonBuilder, WKBArray,
+};
+use crate::datatypes::Dimension;
+use crate::error::{GeoArrowError, Result};
+use crate::scalar::WKB;
+use crate::trait_::{ArrayAccessor, GeometryArrayBuilder, IntoArrow};
+use crate::{ArrayBase, NativeArray};
+use arrow_array::{OffsetSizeTrait, UnionArray};
+use geo_traits::*;
+
+pub(crate) const DEFAULT_PREFER_MULTI: bool = false;
+
+/// The GeoArrow equivalent to a `Vec<Option<Geometry>>`: a mutable collection of Geometries.
+///
+/// Each Geometry can have a different dimension. All geometries must have the same coordinate
+/// type.
+///
+/// This currently has the caveat that these geometries must be a _primitive_ geometry type. This
+/// does not currently support nested GeometryCollection objects.
+///
+/// Converting an [`UnknownGeometryBuilder`] into a [`UnknownGeometryArray`] is `O(1)`.
+///
+/// # Invariants
+///
+/// - All arrays must have the same coordinate layout (interleaved or separated)
+#[derive(Debug)]
+pub struct UnknownGeometryBuilder {
+    metadata: Arc<ArrayMetadata>,
+
+    // Invariant: every item in `types` is `> 0 && < fields.len()`
+    types: Vec<i8>,
+
+    // In the future we'll additionally have xym, xyzm array variants.
+    point_xy: PointBuilder,
+    line_string_xy: LineStringBuilder,
+    polygon_xy: PolygonBuilder,
+    mpoint_xy: MultiPointBuilder,
+    mline_string_xy: MultiLineStringBuilder,
+    mpolygon_xy: MultiPolygonBuilder,
+
+    point_xyz: PointBuilder,
+    line_string_xyz: LineStringBuilder,
+    polygon_xyz: PolygonBuilder,
+    mpoint_xyz: MultiPointBuilder,
+    mline_string_xyz: MultiLineStringBuilder,
+    mpolygon_xyz: MultiPolygonBuilder,
+
+    // Invariant: `offsets.len() == types.len()`
+    offsets: Vec<i32>,
+
+    /// Whether to prefer multi or single arrays for new geometries.
+    ///
+    /// E.g. if this is `true` and a Point geometry is added, it will be added to the
+    /// MultiPointBuilder. If this is `false`, the Point geometry will be added to the
+    /// PointBuilder.
+    ///
+    /// The idea is that always adding multi-geometries will make it easier to downcast later.
+    pub(crate) prefer_multi: bool,
+}
+
+impl<'a> UnknownGeometryBuilder {
+    /// Creates a new empty [`UnknownGeometryBuilder`].
+    pub fn new() -> Self {
+        Self::new_with_options(Default::default(), Default::default(), DEFAULT_PREFER_MULTI)
+    }
+
+    pub fn new_with_options(
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Self {
+        Self::with_capacity_and_options(Default::default(), coord_type, metadata, prefer_multi)
+    }
+
+    /// Creates a new [`MixedGeometryBuilder`] with given capacity and no validity.
+    pub fn with_capacity(capacity: UnknownCapacity) -> Self {
+        Self::with_capacity_and_options(
+            capacity,
+            Default::default(),
+            Default::default(),
+            DEFAULT_PREFER_MULTI,
+        )
+    }
+
+    pub fn with_capacity_and_options(
+        capacity: UnknownCapacity,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Self {
+        // Don't store array metadata on child arrays
+        Self {
+            metadata,
+            types: vec![],
+            point_xy: PointBuilder::with_capacity_and_options(
+                Dimension::XY,
+                capacity.point_xy(),
+                coord_type,
+                Default::default(),
+            ),
+            line_string_xy: LineStringBuilder::with_capacity_and_options(
+                Dimension::XY,
+                capacity.line_string_xy(),
+                coord_type,
+                Default::default(),
+            ),
+            polygon_xy: PolygonBuilder::with_capacity_and_options(
+                Dimension::XY,
+                capacity.polygon_xy(),
+                coord_type,
+                Default::default(),
+            ),
+            mpoint_xy: MultiPointBuilder::with_capacity_and_options(
+                Dimension::XY,
+                capacity.mpoint_xy(),
+                coord_type,
+                Default::default(),
+            ),
+            mline_string_xy: MultiLineStringBuilder::with_capacity_and_options(
+                Dimension::XY,
+                capacity.mline_string_xy(),
+                coord_type,
+                Default::default(),
+            ),
+            mpolygon_xy: MultiPolygonBuilder::with_capacity_and_options(
+                Dimension::XY,
+                capacity.mpolygon_xy(),
+                coord_type,
+                Default::default(),
+            ),
+            point_xyz: PointBuilder::with_capacity_and_options(
+                Dimension::XYZ,
+                capacity.point_xyz(),
+                coord_type,
+                Default::default(),
+            ),
+            line_string_xyz: LineStringBuilder::with_capacity_and_options(
+                Dimension::XYZ,
+                capacity.line_string_xyz(),
+                coord_type,
+                Default::default(),
+            ),
+            polygon_xyz: PolygonBuilder::with_capacity_and_options(
+                Dimension::XYZ,
+                capacity.polygon_xyz(),
+                coord_type,
+                Default::default(),
+            ),
+            mpoint_xyz: MultiPointBuilder::with_capacity_and_options(
+                Dimension::XYZ,
+                capacity.mpoint_xyz(),
+                coord_type,
+                Default::default(),
+            ),
+            mline_string_xyz: MultiLineStringBuilder::with_capacity_and_options(
+                Dimension::XYZ,
+                capacity.mline_string_xyz(),
+                coord_type,
+                Default::default(),
+            ),
+            mpolygon_xyz: MultiPolygonBuilder::with_capacity_and_options(
+                Dimension::XYZ,
+                capacity.mpolygon_xyz(),
+                coord_type,
+                Default::default(),
+            ),
+            offsets: vec![],
+            prefer_multi,
+        }
+    }
+
+    pub fn reserve(&mut self, capacity: UnknownCapacity) {
+        let total_num_geoms = capacity.total_num_geoms();
+        self.types.reserve(total_num_geoms);
+        self.offsets.reserve(total_num_geoms);
+
+        self.point_xy.reserve(capacity.point_xy());
+        self.line_string_xy.reserve(capacity.line_string_xy());
+        self.polygon_xy.reserve(capacity.polygon_xy());
+        self.mpoint_xy.reserve(capacity.mpoint_xy());
+        self.mline_string_xy.reserve(capacity.mline_string_xy());
+        self.mpolygon_xy.reserve(capacity.mpolygon_xy());
+
+        self.point_xyz.reserve(capacity.point_xyz());
+        self.line_string_xyz.reserve(capacity.line_string_xyz());
+        self.polygon_xyz.reserve(capacity.polygon_xyz());
+        self.mpoint_xyz.reserve(capacity.mpoint_xyz());
+        self.mline_string_xyz.reserve(capacity.mline_string_xyz());
+        self.mpolygon_xyz.reserve(capacity.mpolygon_xyz());
+    }
+
+    pub fn reserve_exact(&mut self, capacity: UnknownCapacity) {
+        let total_num_geoms = capacity.total_num_geoms();
+
+        self.types.reserve_exact(total_num_geoms);
+        self.offsets.reserve_exact(total_num_geoms);
+
+        self.point_xy.reserve_exact(capacity.point_xy());
+        self.line_string_xy.reserve_exact(capacity.line_string_xy());
+        self.polygon_xy.reserve_exact(capacity.polygon_xy());
+        self.mpoint_xy.reserve_exact(capacity.mpoint_xy());
+        self.mline_string_xy
+            .reserve_exact(capacity.mline_string_xy());
+        self.mpolygon_xy.reserve_exact(capacity.mpolygon_xy());
+
+        self.point_xyz.reserve_exact(capacity.point_xyz());
+        self.line_string_xyz
+            .reserve_exact(capacity.line_string_xyz());
+        self.polygon_xyz.reserve_exact(capacity.polygon_xyz());
+        self.mpoint_xyz.reserve_exact(capacity.mpoint_xyz());
+        self.mline_string_xyz
+            .reserve_exact(capacity.mline_string_xyz());
+        self.mpolygon_xyz.reserve_exact(capacity.mpolygon_xyz());
+    }
+
+    // /// The canonical method to create a [`MixedGeometryBuilder`] out of its internal
+    // /// components.
+    // ///
+    // /// # Implementation
+    // ///
+    // /// This function is `O(1)`.
+    // ///
+    // /// # Errors
+    // ///
+    // pub fn try_new(
+    //     coords: CoordBufferBuilder,
+    //     geom_offsets: BufferBuilder<O>,
+    //     ring_offsets: BufferBuilder<O>,
+    //     validity: Option<MutableBitmap>,
+    // ) -> Result<Self> {
+    //     check(
+    //         &coords.clone().into(),
+    //         &geom_offsets.clone().into(),
+    //         &ring_offsets.clone().into(),
+    //         validity.as_ref().map(|x| x.len()),
+    //     )?;
+    //     Ok(Self {
+    //         coords,
+    //         geom_offsets,
+    //         ring_offsets,
+    //         validity,
+    //     })
+    // }
+
+    pub fn finish(self) -> UnknownGeometryArray {
+        self.into()
+    }
+
+    pub fn with_capacity_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<Self> {
+        Self::with_capacity_and_options_from_iter(
+            geoms,
+            Default::default(),
+            Default::default(),
+            DEFAULT_PREFER_MULTI,
+        )
+    }
+
+    pub fn with_capacity_and_options_from_iter(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let counter = UnknownCapacity::from_geometries(geoms)?;
+        Ok(Self::with_capacity_and_options(
+            counter,
+            coord_type,
+            metadata,
+            prefer_multi,
+        ))
+    }
+
+    pub fn reserve_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<()> {
+        let counter = UnknownCapacity::from_geometries(geoms)?;
+        self.reserve(counter);
+        Ok(())
+    }
+
+    pub fn reserve_exact_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<()> {
+        let counter = UnknownCapacity::from_geometries(geoms)?;
+        self.reserve_exact(counter);
+        Ok(())
+    }
+
+    /// Add a new Point to the end of this array.
+    ///
+    /// If `self.prefer_multi` is `true`, it will be stored in the `MultiPointBuilder` child
+    /// array. Otherwise, it will be stored in the `PointBuilder` child array.
+    #[inline]
+    pub fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
+        if let Some(point) = value {
+            if self.prefer_multi {
+                match point.dim() {
+                    Dimensions::Xy | Dimensions::Unknown(2) => {
+                        self.mpoint_xy.push_point(Some(point))?;
+                    }
+                    Dimensions::Xyz | Dimensions::Unknown(3) => {
+                        self.mpoint_xyz.push_point(Some(point))?;
+                    }
+                    dim => {
+                        return Err(GeoArrowError::General(format!(
+                            "Unsupported dimension {dim:?}"
+                        )))
+                    }
+                }
+                self.add_multi_point_type(point.dim().try_into().unwrap());
+            } else {
+                match point.dim() {
+                    Dimensions::Xy | Dimensions::Unknown(2) => {
+                        self.point_xy.push_point(Some(point));
+                    }
+                    Dimensions::Xyz | Dimensions::Unknown(3) => {
+                        self.point_xyz.push_point(Some(point));
+                    }
+                    dim => {
+                        return Err(GeoArrowError::General(format!(
+                            "Unsupported dimension {dim:?}"
+                        )))
+                    }
+                }
+
+                self.add_point_type(point.dim().try_into().unwrap());
+            }
+        } else {
+            self.push_null();
+        };
+
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn add_point_type(&mut self, dim: Dimension) {
+        match dim {
+            Dimension::XY => {
+                self.offsets.push(self.point_xy.len().try_into().unwrap());
+                self.types.push(1)
+            }
+            Dimension::XYZ => {
+                self.offsets.push(self.point_xyz.len().try_into().unwrap());
+                self.types.push(11)
+            }
+        }
+    }
+
+    /// Add a new LineString to the end of this array.
+    ///
+    /// If `self.prefer_multi` is `true`, it will be stored in the `MultiLineStringBuilder` child
+    /// array. Otherwise, it will be stored in the `LineStringBuilder` child array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    #[inline]
+    pub fn push_line_string(
+        &mut self,
+        value: Option<&impl LineStringTrait<T = f64>>,
+    ) -> Result<()> {
+        if let Some(line_string) = value {
+            if self.prefer_multi {
+                match line_string.dim() {
+                    Dimensions::Xy | Dimensions::Unknown(2) => {
+                        self.mline_string_xy.push_line_string(Some(line_string))?;
+                    }
+                    Dimensions::Xyz | Dimensions::Unknown(3) => {
+                        self.mline_string_xyz.push_line_string(Some(line_string))?;
+                    }
+                    dim => {
+                        return Err(GeoArrowError::General(format!(
+                            "Unsupported dimension {dim:?}"
+                        )))
+                    }
+                }
+                self.add_multi_line_string_type(line_string.dim().try_into().unwrap());
+            } else {
+                match line_string.dim() {
+                    Dimensions::Xy | Dimensions::Unknown(2) => {
+                        self.line_string_xy.push_line_string(Some(line_string))?;
+                    }
+                    Dimensions::Xyz | Dimensions::Unknown(3) => {
+                        self.line_string_xyz.push_line_string(Some(line_string))?;
+                    }
+                    dim => {
+                        return Err(GeoArrowError::General(format!(
+                            "Unsupported dimension {dim:?}"
+                        )))
+                    }
+                }
+
+                self.add_line_string_type(line_string.dim().try_into().unwrap());
+            }
+        } else {
+            self.push_null();
+        };
+
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn add_line_string_type(&mut self, dim: Dimension) {
+        match dim {
+            Dimension::XY => {
+                self.offsets
+                    .push(self.line_string_xy.len().try_into().unwrap());
+                self.types.push(2)
+            }
+            Dimension::XYZ => {
+                self.offsets
+                    .push(self.line_string_xyz.len().try_into().unwrap());
+                self.types.push(12)
+            }
+        }
+    }
+
+    /// Add a new Polygon to the end of this array.
+    ///
+    /// If `self.prefer_multi` is `true`, it will be stored in the `MultiPolygonBuilder` child
+    /// array. Otherwise, it will be stored in the `PolygonBuilder` child array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    #[inline]
+    pub fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
+        if let Some(polygon) = value {
+            if self.prefer_multi {
+                match polygon.dim() {
+                    Dimensions::Xy | Dimensions::Unknown(2) => {
+                        self.mpolygon_xy.push_polygon(Some(polygon))?;
+                    }
+                    Dimensions::Xyz | Dimensions::Unknown(3) => {
+                        self.mpolygon_xyz.push_polygon(Some(polygon))?;
+                    }
+                    dim => {
+                        return Err(GeoArrowError::General(format!(
+                            "Unsupported dimension {dim:?}"
+                        )))
+                    }
+                }
+                self.add_multi_polygon_type(polygon.dim().try_into().unwrap());
+            } else {
+                match polygon.dim() {
+                    Dimensions::Xy | Dimensions::Unknown(2) => {
+                        self.polygon_xy.push_polygon(Some(polygon))?;
+                    }
+                    Dimensions::Xyz | Dimensions::Unknown(3) => {
+                        self.polygon_xyz.push_polygon(Some(polygon))?;
+                    }
+                    dim => {
+                        return Err(GeoArrowError::General(format!(
+                            "Unsupported dimension {dim:?}"
+                        )))
+                    }
+                }
+
+                self.add_polygon_type(polygon.dim().try_into().unwrap());
+            }
+        } else {
+            self.push_null();
+        };
+
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn add_polygon_type(&mut self, dim: Dimension) {
+        match dim {
+            Dimension::XY => {
+                self.offsets.push(self.polygon_xy.len().try_into().unwrap());
+                self.types.push(3)
+            }
+            Dimension::XYZ => {
+                self.offsets
+                    .push(self.polygon_xyz.len().try_into().unwrap());
+                self.types.push(13)
+            }
+        }
+    }
+
+    /// Add a new MultiPoint to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    #[inline]
+    pub fn push_multi_point(
+        &mut self,
+        value: Option<&impl MultiPointTrait<T = f64>>,
+    ) -> Result<()> {
+        if let Some(multi_point) = value {
+            match multi_point.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    self.mpoint_xy.push_multi_point(Some(multi_point))?;
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    self.mpoint_xyz.push_multi_point(Some(multi_point))?;
+                }
+                dim => {
+                    return Err(GeoArrowError::General(format!(
+                        "Unsupported dimension {dim:?}"
+                    )))
+                }
+            }
+            self.add_multi_point_type(multi_point.dim().try_into().unwrap());
+        } else {
+            self.push_null();
+        };
+
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn add_multi_point_type(&mut self, dim: Dimension) {
+        match dim {
+            Dimension::XY => {
+                self.offsets.push(self.mpoint_xy.len().try_into().unwrap());
+                self.types.push(4)
+            }
+            Dimension::XYZ => {
+                self.offsets.push(self.mpoint_xyz.len().try_into().unwrap());
+                self.types.push(14)
+            }
+        }
+    }
+
+    /// Add a new MultiLineString to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    #[inline]
+    pub fn push_multi_line_string(
+        &mut self,
+        value: Option<&impl MultiLineStringTrait<T = f64>>,
+    ) -> Result<()> {
+        if let Some(multi_line_string) = value {
+            match multi_line_string.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    self.mline_string_xy
+                        .push_multi_line_string(Some(multi_line_string))?;
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    self.mline_string_xyz
+                        .push_multi_line_string(Some(multi_line_string))?;
+                }
+                dim => {
+                    return Err(GeoArrowError::General(format!(
+                        "Unsupported dimension {dim:?}"
+                    )))
+                }
+            }
+            self.add_multi_line_string_type(multi_line_string.dim().try_into().unwrap());
+        } else {
+            self.push_null();
+        };
+
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn add_multi_line_string_type(&mut self, dim: Dimension) {
+        match dim {
+            Dimension::XY => {
+                self.offsets
+                    .push(self.mline_string_xy.len().try_into().unwrap());
+                self.types.push(5)
+            }
+            Dimension::XYZ => {
+                self.offsets
+                    .push(self.mline_string_xyz.len().try_into().unwrap());
+                self.types.push(15)
+            }
+        }
+    }
+
+    /// Add a new MultiPolygon to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    #[inline]
+    pub fn push_multi_polygon(
+        &mut self,
+        value: Option<&impl MultiPolygonTrait<T = f64>>,
+    ) -> Result<()> {
+        if let Some(multi_polygon) = value {
+            match multi_polygon.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    self.mpolygon_xy.push_multi_polygon(Some(multi_polygon))?;
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    self.mpolygon_xyz.push_multi_polygon(Some(multi_polygon))?;
+                }
+                dim => {
+                    return Err(GeoArrowError::General(format!(
+                        "Unsupported dimension {dim:?}"
+                    )))
+                }
+            }
+            self.add_multi_polygon_type(multi_polygon.dim().try_into().unwrap());
+        } else {
+            self.push_null();
+        };
+
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn add_multi_polygon_type(&mut self, dim: Dimension) {
+        match dim {
+            Dimension::XY => {
+                self.offsets
+                    .push(self.mpolygon_xy.len().try_into().unwrap());
+                self.types.push(6)
+            }
+            Dimension::XYZ => {
+                self.offsets
+                    .push(self.mpolygon_xyz.len().try_into().unwrap());
+                self.types.push(16)
+            }
+        }
+    }
+
+    #[inline]
+    pub fn push_geometry(&mut self, value: Option<&'a impl GeometryTrait<T = f64>>) -> Result<()> {
+        use geo_traits::GeometryType::*;
+
+        if let Some(geom) = value {
+            match geom.as_type() {
+                Point(g) => {
+                    self.push_point(Some(g))?;
+                }
+                LineString(g) => {
+                    self.push_line_string(Some(g))?;
+                }
+                Polygon(g) => {
+                    self.push_polygon(Some(g))?;
+                }
+                MultiPoint(p) => self.push_multi_point(Some(p))?,
+                MultiLineString(p) => self.push_multi_line_string(Some(p))?,
+                MultiPolygon(p) => self.push_multi_polygon(Some(p))?,
+                GeometryCollection(gc) => {
+                    if gc.num_geometries() == 1 {
+                        self.push_geometry(Some(&gc.geometry(0).unwrap()))?
+                    } else {
+                        return Err(GeoArrowError::General(
+                            "nested geometry collections not supported".to_string(),
+                        ));
+                    }
+                }
+                Rect(_) | Triangle(_) | Line(_) => todo!(),
+            };
+        } else {
+            self.push_null();
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn push_null(&mut self) {
+        todo!("push null geometry")
+    }
+
+    pub fn extend_from_iter(
+        &mut self,
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = f64> + 'a)>>,
+    ) {
+        geoms
+            .into_iter()
+            .try_for_each(|maybe_geom| self.push_geometry(maybe_geom))
+            .unwrap();
+    }
+
+    /// Create this builder from a slice of Geometries.
+    pub fn from_geometries(
+        geoms: &[impl GeometryTrait<T = f64>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(Some),
+            coord_type.unwrap_or_default(),
+            metadata,
+            prefer_multi,
+        )?;
+        array.extend_from_iter(geoms.iter().map(Some));
+        Ok(array)
+    }
+
+    /// Create this builder from a slice of nullable Geometries.
+    pub fn from_nullable_geometries(
+        geoms: &[Option<impl GeometryTrait<T = f64>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let mut array = Self::with_capacity_and_options_from_iter(
+            geoms.iter().map(|x| x.as_ref()),
+            coord_type.unwrap_or_default(),
+            metadata,
+            prefer_multi,
+        )?;
+        array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
+        Ok(array)
+    }
+
+    pub(crate) fn from_wkb<W: OffsetSizeTrait>(
+        wkb_objects: &[Option<WKB<'_, W>>],
+        coord_type: Option<CoordType>,
+        metadata: Arc<ArrayMetadata>,
+        prefer_multi: bool,
+    ) -> Result<Self> {
+        let wkb_objects2 = wkb_objects
+            .iter()
+            .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
+            .collect::<Result<Vec<_>>>()?;
+        Self::from_nullable_geometries(&wkb_objects2, coord_type, metadata, prefer_multi)
+    }
+}
+
+impl Default for UnknownGeometryBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntoArrow for UnknownGeometryBuilder {
+    type ArrowArray = UnionArray;
+
+    fn into_arrow(self) -> Self::ArrowArray {
+        todo!()
+    }
+}
+
+impl From<UnknownGeometryBuilder> for UnknownGeometryArray {
+    fn from(other: UnknownGeometryBuilder) -> Self {
+        Self::new(
+            other.types.into(),
+            other.offsets.into(),
+            other.points.into(),
+            other.line_strings.into(),
+            other.polygons.into(),
+            other.multi_points.into(),
+            other.multi_line_strings.into(),
+            other.multi_polygons.into(),
+            other.metadata,
+        )
+    }
+}
+
+impl<G: GeometryTrait<T = f64>> TryFrom<&[G]> for UnknownGeometryBuilder {
+    type Error = GeoArrowError;
+
+    fn try_from(geoms: &[G]) -> Result<Self> {
+        Self::from_geometries(geoms, Default::default(), Default::default(), true)
+    }
+}
+
+impl<G: GeometryTrait<T = f64>> TryFrom<Vec<Option<G>>> for UnknownGeometryBuilder {
+    type Error = GeoArrowError;
+
+    fn try_from(geoms: Vec<Option<G>>) -> Result<Self> {
+        Self::from_nullable_geometries(&geoms, Default::default(), Default::default(), true)
+    }
+}
+
+impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for UnknownGeometryBuilder {
+    type Error = GeoArrowError;
+
+    fn try_from(value: WKBArray<O>) -> std::result::Result<Self, Self::Error> {
+        assert_eq!(
+            value.nulls().map_or(0, |validity| validity.null_count()),
+            0,
+            "Parsing a WKBArray with null elements not supported",
+        );
+
+        let metadata = value.metadata.clone();
+        let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
+        Self::from_wkb(&wkb_objects, Default::default(), metadata, true)
+    }
+}
+
+impl GeometryArrayBuilder for UnknownGeometryBuilder {
+    fn len(&self) -> usize {
+        self.types.len()
+    }
+
+    fn nulls(&self) -> &arrow_buffer::NullBufferBuilder {
+        // Take this method off trait
+        todo!()
+    }
+
+    fn new(dim: Dimension) -> Self {
+        Self::new()
+    }
+
+    fn into_array_ref(self) -> Arc<dyn arrow_array::Array> {
+        Arc::new(self.into_arrow())
+    }
+
+    fn with_geom_capacity_and_options(
+        dim: Dimension,
+        _geom_capacity: usize,
+        coord_type: CoordType,
+        metadata: Arc<ArrayMetadata>,
+    ) -> Self {
+        // We don't know where to allocate the capacity
+        Self::with_capacity_and_options(
+            Default::default(),
+            coord_type,
+            metadata,
+            DEFAULT_PREFER_MULTI,
+        )
+    }
+
+    fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(value)
+    }
+
+    fn finish(self) -> std::sync::Arc<dyn NativeArray> {
+        Arc::new(self.finish())
+    }
+
+    fn coord_type(&self) -> CoordType {
+        self.points.coord_type()
+    }
+
+    fn set_metadata(&mut self, metadata: Arc<ArrayMetadata>) {
+        self.metadata = metadata;
+    }
+
+    fn metadata(&self) -> Arc<ArrayMetadata> {
+        self.metadata.clone()
+    }
+}

--- a/rust/geoarrow/src/array/unknown/capacity.rs
+++ b/rust/geoarrow/src/array/unknown/capacity.rs
@@ -1,7 +1,6 @@
 use std::ops::AddAssign;
 
 use crate::array::linestring::LineStringCapacity;
-use crate::array::mixed::builder::DEFAULT_PREFER_MULTI;
 use crate::array::multilinestring::MultiLineStringCapacity;
 use crate::array::multipoint::MultiPointCapacity;
 use crate::array::multipolygon::MultiPolygonCapacity;
@@ -38,8 +37,43 @@ pub struct UnknownCapacity {
 }
 
 impl UnknownCapacity {
+    pub fn new(
+        nulls: usize,
+        point_xy: usize,
+        line_string_xy: LineStringCapacity,
+        polygon_xy: PolygonCapacity,
+        mpoint_xy: MultiPointCapacity,
+        mline_string_xy: MultiLineStringCapacity,
+        mpolygon_xy: MultiPolygonCapacity,
+
+        point_xyz: usize,
+        line_string_xyz: LineStringCapacity,
+        polygon_xyz: PolygonCapacity,
+        mpoint_xyz: MultiPointCapacity,
+        mline_string_xyz: MultiLineStringCapacity,
+        mpolygon_xyz: MultiPolygonCapacity,
+        prefer_multi: bool,
+    ) -> Self {
+        Self {
+            nulls,
+            point_xy,
+            line_string_xy,
+            polygon_xy,
+            mpoint_xy,
+            mline_string_xy,
+            mpolygon_xy,
+            point_xyz,
+            line_string_xyz,
+            polygon_xyz,
+            mpoint_xyz,
+            mline_string_xyz,
+            mpolygon_xyz,
+            prefer_multi,
+        }
+    }
+
     /// Create a new empty capacity.
-    pub fn new_empty() -> Self {
+    pub fn new_empty(prefer_multi: bool) -> Self {
         Self {
             nulls: 0,
             point_xy: 0,
@@ -54,8 +88,13 @@ impl UnknownCapacity {
             mpoint_xyz: MultiPointCapacity::new_empty(),
             mline_string_xyz: MultiLineStringCapacity::new_empty(),
             mpolygon_xyz: MultiPolygonCapacity::new_empty(),
-            prefer_multi: DEFAULT_PREFER_MULTI,
+            prefer_multi,
         }
+    }
+
+    pub fn with_prefer_multi(mut self, prefer_multi: bool) -> Self {
+        self.prefer_multi = prefer_multi;
+        self
     }
 
     /// Return `true` if the capacity is empty.
@@ -335,8 +374,9 @@ impl UnknownCapacity {
 
     pub fn from_geometries<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+        prefer_multi: bool,
     ) -> Result<Self> {
-        let mut counter = Self::new_empty();
+        let mut counter = Self::new_empty(prefer_multi);
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry(maybe_geom)?;
         }
@@ -345,8 +385,9 @@ impl UnknownCapacity {
 
     pub fn from_owned_geometries<'a>(
         geoms: impl Iterator<Item = Option<(impl GeometryTrait + 'a)>>,
+        prefer_multi: bool,
     ) -> Result<Self> {
-        let mut counter = Self::new_empty();
+        let mut counter = Self::new_empty(prefer_multi);
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry(maybe_geom.as_ref())?;
         }

--- a/rust/geoarrow/src/array/unknown/capacity.rs
+++ b/rust/geoarrow/src/array/unknown/capacity.rs
@@ -1,0 +1,397 @@
+use std::ops::AddAssign;
+
+use crate::array::linestring::LineStringCapacity;
+use crate::array::mixed::builder::DEFAULT_PREFER_MULTI;
+use crate::array::multilinestring::MultiLineStringCapacity;
+use crate::array::multipoint::MultiPointCapacity;
+use crate::array::multipolygon::MultiPolygonCapacity;
+use crate::array::polygon::PolygonCapacity;
+use crate::error::Result;
+use geo_traits::*;
+
+/// A counter for the buffer sizes of a [`UnknownGeometryArray`][crate::array::UnknownGeometryArray].
+///
+/// This can be used to reduce allocations by allocating once for exactly the array size you need.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct UnknownCapacity {
+    /// The number of null geometries. Ideally the builder will assign these to any array that has
+    /// already been allocated. Otherwise we don't know where to assign them.
+    nulls: usize,
+
+    /// Simple: just the total number of points, nulls included
+    point_xy: usize,
+    line_string_xy: LineStringCapacity,
+    polygon_xy: PolygonCapacity,
+    mpoint_xy: MultiPointCapacity,
+    mline_string_xy: MultiLineStringCapacity,
+    mpolygon_xy: MultiPolygonCapacity,
+
+    point_xyz: usize,
+    line_string_xyz: LineStringCapacity,
+    polygon_xyz: PolygonCapacity,
+    mpoint_xyz: MultiPointCapacity,
+    mline_string_xyz: MultiLineStringCapacity,
+    mpolygon_xyz: MultiPolygonCapacity,
+
+    /// Whether to prefer multi or single arrays for new geometries.
+    prefer_multi: bool,
+}
+
+impl UnknownCapacity {
+    /// Create a new empty capacity.
+    pub fn new_empty() -> Self {
+        Self {
+            nulls: 0,
+            point_xy: 0,
+            line_string_xy: LineStringCapacity::new_empty(),
+            polygon_xy: PolygonCapacity::new_empty(),
+            mpoint_xy: MultiPointCapacity::new_empty(),
+            mline_string_xy: MultiLineStringCapacity::new_empty(),
+            mpolygon_xy: MultiPolygonCapacity::new_empty(),
+            point_xyz: 0,
+            line_string_xyz: LineStringCapacity::new_empty(),
+            polygon_xyz: PolygonCapacity::new_empty(),
+            mpoint_xyz: MultiPointCapacity::new_empty(),
+            mline_string_xyz: MultiLineStringCapacity::new_empty(),
+            mpolygon_xyz: MultiPolygonCapacity::new_empty(),
+            prefer_multi: DEFAULT_PREFER_MULTI,
+        }
+    }
+
+    /// Return `true` if the capacity is empty.
+    pub fn is_empty(&self) -> bool {
+        self.point_xy == 0
+            && self.line_string_xy.is_empty()
+            && self.polygon_xy.is_empty()
+            && self.mpoint_xy.is_empty()
+            && self.mline_string_xy.is_empty()
+            && self.mpolygon_xy.is_empty()
+            && self.point_xyz == 0
+            && self.line_string_xyz.is_empty()
+            && self.polygon_xyz.is_empty()
+            && self.mpoint_xyz.is_empty()
+            && self.mline_string_xyz.is_empty()
+            && self.mpolygon_xyz.is_empty()
+    }
+
+    pub fn total_num_geoms(&self) -> usize {
+        let mut total = 0;
+        total += self.point_xy;
+        total += self.line_string_xy.geom_capacity();
+        total += self.polygon_xy.geom_capacity();
+        total += self.mpoint_xy.geom_capacity();
+        total += self.mline_string_xy.geom_capacity();
+        total += self.mpolygon_xy.geom_capacity();
+        total += self.point_xyz;
+        total += self.line_string_xyz.geom_capacity();
+        total += self.polygon_xyz.geom_capacity();
+        total += self.mpoint_xyz.geom_capacity();
+        total += self.mline_string_xyz.geom_capacity();
+        total += self.mpolygon_xyz.geom_capacity();
+        total
+    }
+
+    pub fn point_xy(&self) -> usize {
+        self.point_xy
+    }
+
+    pub fn line_string_xy(&self) -> LineStringCapacity {
+        self.line_string_xy
+    }
+
+    pub fn polygon_xy(&self) -> PolygonCapacity {
+        self.polygon_xy
+    }
+
+    pub fn mpoint_xy(&self) -> MultiPointCapacity {
+        self.mpoint_xy
+    }
+
+    pub fn mline_string_xy(&self) -> MultiLineStringCapacity {
+        self.mline_string_xy
+    }
+
+    pub fn mpolygon_xy(&self) -> MultiPolygonCapacity {
+        self.mpolygon_xy
+    }
+
+    pub fn point_xyz(&self) -> usize {
+        self.point_xyz
+    }
+
+    pub fn line_string_xyz(&self) -> LineStringCapacity {
+        self.line_string_xyz
+    }
+
+    pub fn polygon_xyz(&self) -> PolygonCapacity {
+        self.polygon_xyz
+    }
+
+    pub fn mpoint_xyz(&self) -> MultiPointCapacity {
+        self.mpoint_xyz
+    }
+
+    pub fn mline_string_xyz(&self) -> MultiLineStringCapacity {
+        self.mline_string_xyz
+    }
+
+    pub fn mpolygon_xyz(&self) -> MultiPolygonCapacity {
+        self.mpolygon_xyz
+    }
+
+    // pub fn point_compatible(&self) -> bool {
+    //     self.line_string.is_empty()
+    //         && self.polygon.is_empty()
+    //         && self.multi_point.is_empty()
+    //         && self.multi_line_string.is_empty()
+    //         && self.multi_polygon.is_empty()
+    // }
+
+    // pub fn line_string_compatible(&self) -> bool {
+    //     self.point == 0
+    //         && self.polygon.is_empty()
+    //         && self.multi_point.is_empty()
+    //         && self.multi_line_string.is_empty()
+    //         && self.multi_polygon.is_empty()
+    // }
+
+    // pub fn polygon_compatible(&self) -> bool {
+    //     self.point == 0
+    //         && self.line_string.is_empty()
+    //         && self.multi_point.is_empty()
+    //         && self.multi_line_string.is_empty()
+    //         && self.multi_polygon.is_empty()
+    // }
+
+    // pub fn multi_point_compatible(&self) -> bool {
+    //     self.line_string.is_empty()
+    //         && self.polygon.is_empty()
+    //         && self.multi_line_string.is_empty()
+    //         && self.multi_polygon.is_empty()
+    // }
+
+    // pub fn multi_line_string_compatible(&self) -> bool {
+    //     self.point == 0
+    //         && self.polygon.is_empty()
+    //         && self.multi_point.is_empty()
+    //         && self.multi_polygon.is_empty()
+    // }
+
+    // pub fn multi_polygon_compatible(&self) -> bool {
+    //     self.point == 0
+    //         && self.line_string.is_empty()
+    //         && self.multi_point.is_empty()
+    //         && self.multi_line_string.is_empty()
+    // }
+
+    #[inline]
+    pub fn add_point(&mut self, point: Option<&impl PointTrait>) {
+        if let Some(point) = point {
+            match point.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    if self.prefer_multi {
+                        self.mpoint_xy.add_point_capacity(1);
+                    } else {
+                        self.point_xy += 1;
+                    }
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    if self.prefer_multi {
+                        self.mpoint_xyz.add_point_capacity(1);
+                    } else {
+                        self.point_xyz += 1;
+                    }
+                }
+                _ => todo!(),
+            }
+        } else {
+            self.nulls += 1;
+        }
+    }
+
+    #[inline]
+    pub fn add_line_string(&mut self, line_string: Option<&impl LineStringTrait>) {
+        if let Some(line_string) = line_string {
+            match line_string.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    if self.prefer_multi {
+                        self.mline_string_xy.add_line_string(Some(line_string));
+                    } else {
+                        self.line_string_xy.add_line_string(Some(line_string));
+                    }
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    if self.prefer_multi {
+                        self.mline_string_xyz.add_line_string(Some(line_string));
+                    } else {
+                        self.line_string_xyz.add_line_string(Some(line_string));
+                    }
+                }
+                _ => todo!(),
+            }
+        } else {
+            self.nulls += 1;
+        }
+    }
+
+    #[inline]
+    pub fn add_polygon(&mut self, polygon: Option<&impl PolygonTrait>) {
+        if let Some(polygon) = polygon {
+            match polygon.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    if self.prefer_multi {
+                        self.mpolygon_xy.add_polygon(Some(polygon));
+                    } else {
+                        self.polygon_xy.add_polygon(Some(polygon));
+                    }
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    if self.prefer_multi {
+                        self.mpolygon_xyz.add_polygon(Some(polygon));
+                    } else {
+                        self.polygon_xyz.add_polygon(Some(polygon));
+                    }
+                }
+                _ => todo!(),
+            }
+        } else {
+            self.nulls += 1;
+        }
+    }
+
+    #[inline]
+    pub fn add_multi_point(&mut self, multi_point: Option<&impl MultiPointTrait>) {
+        if let Some(multi_point) = multi_point {
+            match multi_point.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    self.mpoint_xy.add_multi_point(Some(multi_point));
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    self.mpoint_xyz.add_multi_point(Some(multi_point));
+                }
+                _ => todo!(),
+            }
+        } else {
+            self.nulls += 1;
+        }
+    }
+
+    #[inline]
+    pub fn add_multi_line_string(&mut self, multi_line_string: Option<&impl MultiLineStringTrait>) {
+        if let Some(multi_line_string) = multi_line_string {
+            match multi_line_string.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    self.mline_string_xy
+                        .add_multi_line_string(Some(multi_line_string));
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    self.mline_string_xyz
+                        .add_multi_line_string(Some(multi_line_string));
+                }
+                _ => todo!(),
+            }
+        } else {
+            self.nulls += 1;
+        }
+    }
+
+    #[inline]
+    pub fn add_multi_polygon(&mut self, multi_polygon: Option<&impl MultiPolygonTrait>) {
+        if let Some(multi_polygon) = multi_polygon {
+            match multi_polygon.dim() {
+                Dimensions::Xy | Dimensions::Unknown(2) => {
+                    self.mpolygon_xy.add_multi_polygon(Some(multi_polygon));
+                }
+                Dimensions::Xyz | Dimensions::Unknown(3) => {
+                    self.mpolygon_xyz.add_multi_polygon(Some(multi_polygon));
+                }
+                _ => todo!(),
+            }
+        } else {
+            self.nulls += 1;
+        }
+    }
+
+    #[inline]
+    pub fn add_geometry(&mut self, geom: Option<&impl GeometryTrait>) -> Result<()> {
+        if let Some(geom) = geom {
+            match geom.as_type() {
+                geo_traits::GeometryType::Point(g) => self.add_point(Some(g)),
+                geo_traits::GeometryType::LineString(g) => self.add_line_string(Some(g)),
+                geo_traits::GeometryType::Polygon(g) => self.add_polygon(Some(g)),
+                geo_traits::GeometryType::MultiPoint(p) => self.add_multi_point(Some(p)),
+                geo_traits::GeometryType::MultiLineString(p) => self.add_multi_line_string(Some(p)),
+                geo_traits::GeometryType::MultiPolygon(p) => self.add_multi_polygon(Some(p)),
+                geo_traits::GeometryType::GeometryCollection(_) => {
+                    panic!("nested geometry collections not supported")
+                }
+                _ => todo!(),
+            };
+        } else {
+            self.nulls += 1;
+        }
+        Ok(())
+    }
+
+    pub fn from_geometries<'a>(
+        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+    ) -> Result<Self> {
+        let mut counter = Self::new_empty();
+        for maybe_geom in geoms.into_iter() {
+            counter.add_geometry(maybe_geom)?;
+        }
+        Ok(counter)
+    }
+
+    pub fn from_owned_geometries<'a>(
+        geoms: impl Iterator<Item = Option<(impl GeometryTrait + 'a)>>,
+    ) -> Result<Self> {
+        let mut counter = Self::new_empty();
+        for maybe_geom in geoms.into_iter() {
+            counter.add_geometry(maybe_geom.as_ref())?;
+        }
+        Ok(counter)
+    }
+
+    /// The number of bytes an array with this capacity would occupy.
+    pub fn num_bytes(&self) -> usize {
+        let mut count = 0;
+
+        count += self.point_xy * 2 * 8;
+        count += self.line_string_xy.num_bytes();
+        count += self.polygon_xy.num_bytes();
+        count += self.mpoint_xy.num_bytes();
+        count += self.mline_string_xy.num_bytes();
+        count += self.mpolygon_xy.num_bytes();
+
+        count += self.point_xyz * 3 * 8;
+        count += self.line_string_xyz.num_bytes();
+        count += self.polygon_xyz.num_bytes();
+        count += self.mpoint_xyz.num_bytes();
+        count += self.mline_string_xyz.num_bytes();
+        count += self.mpolygon_xyz.num_bytes();
+
+        count
+    }
+}
+
+impl AddAssign for UnknownCapacity {
+    fn add_assign(&mut self, rhs: Self) {
+        self.nulls += rhs.nulls;
+
+        // TODO: implement AddAssign on all of these and switch to using add assign
+        self.point_xy = self.point_xy + rhs.point_xy;
+        self.line_string_xy = self.line_string_xy + rhs.line_string_xy;
+        self.polygon_xy = self.polygon_xy + rhs.polygon_xy;
+        self.mpoint_xy = self.mpoint_xy + rhs.mpoint_xy;
+        self.mline_string_xy = self.mline_string_xy + rhs.mline_string_xy;
+        self.mpolygon_xy = self.mpolygon_xy + rhs.mpolygon_xy;
+
+        self.point_xyz = self.point_xyz + rhs.point_xyz;
+        self.line_string_xyz = self.line_string_xyz + rhs.line_string_xyz;
+        self.polygon_xyz = self.polygon_xyz + rhs.polygon_xyz;
+        self.mpoint_xyz = self.mpoint_xyz + rhs.mpoint_xyz;
+        self.mline_string_xyz = self.mline_string_xyz + rhs.mline_string_xyz;
+        self.mpolygon_xyz = self.mpolygon_xyz + rhs.mpolygon_xyz;
+    }
+}

--- a/rust/geoarrow/src/array/unknown/capacity.rs
+++ b/rust/geoarrow/src/array/unknown/capacity.rs
@@ -37,6 +37,7 @@ pub struct UnknownCapacity {
 }
 
 impl UnknownCapacity {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         nulls: usize,
         point_xy: usize,

--- a/rust/geoarrow/src/array/unknown/mod.rs
+++ b/rust/geoarrow/src/array/unknown/mod.rs
@@ -1,3 +1,7 @@
 mod array;
 mod builder;
 mod capacity;
+
+pub use array::UnknownGeometryArray;
+pub use builder::UnknownGeometryBuilder;
+pub use capacity::UnknownCapacity;

--- a/rust/geoarrow/src/array/unknown/mod.rs
+++ b/rust/geoarrow/src/array/unknown/mod.rs
@@ -1,0 +1,3 @@
+mod array;
+mod builder;
+mod capacity;

--- a/rust/geoarrow/src/chunked_array/dynamic.rs
+++ b/rust/geoarrow/src/chunked_array/dynamic.rs
@@ -69,6 +69,7 @@ impl ChunkedNativeArrayDyn {
                 impl_downcast!(GeometryCollectionArray)
             }
             Rect(_) => impl_downcast!(RectArray),
+            Unknown(_) => impl_downcast!(UnknownGeometryArray),
         };
         Ok(Self(ca))
     }

--- a/rust/geoarrow/src/chunked_array/dynamic.rs
+++ b/rust/geoarrow/src/chunked_array/dynamic.rs
@@ -123,6 +123,7 @@ impl ChunkedNativeArrayDyn {
                 Mixed(_, _) => impl_downcast!(as_mixed),
                 GeometryCollection(_, _) => impl_downcast!(as_geometry_collection),
                 Rect(_) => impl_downcast!(as_rect),
+                Unknown(_) => impl_downcast!(as_unknown),
             };
             Ok(Self(result))
         } else {

--- a/rust/geoarrow/src/chunked_array/mod.rs
+++ b/rust/geoarrow/src/chunked_array/mod.rs
@@ -955,6 +955,7 @@ impl_trait!(ChunkedMultiLineStringArray);
 impl_trait!(ChunkedMultiPolygonArray);
 impl_trait!(ChunkedMixedGeometryArray);
 impl_trait!(ChunkedGeometryCollectionArray);
+impl_trait!(ChunkedUnknownGeometryArray);
 
 impl ChunkedArrayBase for ChunkedRectArray {
     fn as_any(&self) -> &dyn Any {

--- a/rust/geoarrow/src/chunked_array/mod.rs
+++ b/rust/geoarrow/src/chunked_array/mod.rs
@@ -598,8 +598,7 @@ pub type ChunkedGeometryCollectionArray = ChunkedGeometryArray<GeometryCollectio
 /// A chunked rect array.
 pub type ChunkedRectArray = ChunkedGeometryArray<RectArray>;
 /// A chunked unknown geometry array.
-#[allow(dead_code)]
-pub type ChunkedUnknownGeometryArray = ChunkedGeometryArray<Arc<dyn NativeArray>>;
+pub type ChunkedUnknownGeometryArray = ChunkedGeometryArray<UnknownGeometryArray>;
 
 /// A chunked WKB array.
 pub type ChunkedWKBArray<O> = ChunkedGeometryArray<WKBArray<O>>;

--- a/rust/geoarrow/src/datatypes.rs
+++ b/rust/geoarrow/src/datatypes.rs
@@ -79,6 +79,21 @@ impl From<Dimension> for geo_traits::Dimensions {
     }
 }
 
+impl TryFrom<geo_traits::Dimensions> for Dimension {
+    type Error = GeoArrowError;
+
+    fn try_from(value: geo_traits::Dimensions) -> std::result::Result<Self, Self::Error> {
+        match value {
+            geo_traits::Dimensions::Xy | geo_traits::Dimensions::Unknown(2) => Ok(Dimension::XY),
+            geo_traits::Dimensions::Xyz | geo_traits::Dimensions::Unknown(3) => Ok(Dimension::XYZ),
+            _ => Err(GeoArrowError::General(format!(
+                "Unsupported dimension {:?}",
+                value
+            ))),
+        }
+    }
+}
+
 /// A type enum representing "native" GeoArrow geometry types.
 ///
 /// This is designed to aid in downcasting from dynamically-typed geometry arrays.

--- a/rust/geoarrow/src/io/flatgeobuf/writer.rs
+++ b/rust/geoarrow/src/io/flatgeobuf/writer.rs
@@ -85,8 +85,8 @@ fn infer_flatgeobuf_geometry_type(
             flatgeobuf::GeometryType::GeometryCollection,
             matches!(dim, Dimension::XYZ),
         ),
-        // TODO: how to know when WKB has 3d geometries?
-        // WKB | LargeWKB => (flatgeobuf::GeometryType::Unknown, false),
+        // We'll just claim that it does have 3d data. Not sure whether this is bad to lie here?
+        Unknown(_) => (flatgeobuf::GeometryType::Unknown, true),
     };
     Ok((geometry_type, has_z))
 }

--- a/rust/geoarrow/src/io/geozero/scalar/geometry_array.rs
+++ b/rust/geoarrow/src/io/geozero/scalar/geometry_array.rs
@@ -62,6 +62,7 @@ pub fn process_geometry_scalar_array<P: GeomProcessor>(
         //     process_geometry(&wkb_object, geom_idx, processor)
         // }
         Rect(_) => todo!(),
+        Unknown(_) => impl_process!(process_geometry, as_unknown),
     }
 }
 

--- a/rust/geoarrow/src/io/geozero/table/data_source.rs
+++ b/rust/geoarrow/src/io/geozero/table/data_source.rs
@@ -414,6 +414,10 @@ fn process_geometry_n<P: GeomProcessor>(
             // let geom = arr.as_ref().as_rect::<2>().value(i);
             // process_rect
         }
+        Unknown(_) => {
+            let geom = arr.as_unknown().value(i);
+            process_geometry(&geom, 0, processor)?;
+        }
     }
 
     Ok(())

--- a/rust/geoarrow/src/io/parquet/writer/metadata.rs
+++ b/rust/geoarrow/src/io/parquet/writer/metadata.rs
@@ -105,26 +105,26 @@ impl ColumnInfo {
         }
 
         if let NativeType::Unknown(_) = array_ref.data_type() {
-            let arr = array_ref.as_mixed();
-            if mixed_arr.has_points() {
+            let arr = array_ref.as_unknown();
+            if arr.has_points() {
                 self.geometry_types.insert(GeoParquetGeometryType::Point);
             }
-            if mixed_arr.has_line_strings() {
+            if arr.has_line_strings() {
                 self.geometry_types
                     .insert(GeoParquetGeometryType::LineString);
             }
-            if mixed_arr.has_polygons() {
+            if arr.has_polygons() {
                 self.geometry_types.insert(GeoParquetGeometryType::Polygon);
             }
-            if mixed_arr.has_multi_points() {
+            if arr.has_multi_points() {
                 self.geometry_types
                     .insert(GeoParquetGeometryType::MultiPoint);
             }
-            if mixed_arr.has_multi_line_strings() {
+            if arr.has_multi_line_strings() {
                 self.geometry_types
                     .insert(GeoParquetGeometryType::MultiLineString);
             }
-            if mixed_arr.has_multi_polygons() {
+            if arr.has_multi_polygons() {
                 self.geometry_types
                     .insert(GeoParquetGeometryType::MultiPolygon);
             }

--- a/rust/geoarrow/src/io/parquet/writer/metadata.rs
+++ b/rust/geoarrow/src/io/parquet/writer/metadata.rs
@@ -106,25 +106,27 @@ impl ColumnInfo {
 
         if let NativeType::Unknown(_) = array_ref.data_type() {
             let arr = array_ref.as_unknown();
-            if arr.has_points() {
+            if arr.has_points(Dimension::XY) || arr.has_points(Dimension::XYZ) {
                 self.geometry_types.insert(GeoParquetGeometryType::Point);
             }
-            if arr.has_line_strings() {
+            if arr.has_line_strings(Dimension::XY) || arr.has_line_strings(Dimension::XYZ) {
                 self.geometry_types
                     .insert(GeoParquetGeometryType::LineString);
             }
-            if arr.has_polygons() {
+            if arr.has_polygons(Dimension::XY) || arr.has_polygons(Dimension::XYZ) {
                 self.geometry_types.insert(GeoParquetGeometryType::Polygon);
             }
-            if arr.has_multi_points() {
+            if arr.has_multi_points(Dimension::XY) || arr.has_multi_points(Dimension::XYZ) {
                 self.geometry_types
                     .insert(GeoParquetGeometryType::MultiPoint);
             }
-            if arr.has_multi_line_strings() {
+            if arr.has_multi_line_strings(Dimension::XY)
+                || arr.has_multi_line_strings(Dimension::XYZ)
+            {
                 self.geometry_types
                     .insert(GeoParquetGeometryType::MultiLineString);
             }
-            if arr.has_multi_polygons() {
+            if arr.has_multi_polygons(Dimension::XY) || arr.has_multi_polygons(Dimension::XYZ) {
                 self.geometry_types
                     .insert(GeoParquetGeometryType::MultiPolygon);
             }

--- a/rust/geoarrow/src/io/parquet/writer/metadata.rs
+++ b/rust/geoarrow/src/io/parquet/writer/metadata.rs
@@ -76,9 +76,36 @@ impl ColumnInfo {
         let array = NativeArrayDyn::from_arrow_array(array, field)?.into_inner();
         let array_ref = array.as_ref();
 
-        // We only have to do this for mixed arrays because other arrays are statically known
+        // We only have to do this for mixed arrays (and unknown below) because other arrays are
+        // statically known
         if let NativeType::Mixed(_, _) = array_ref.data_type() {
             let mixed_arr = array_ref.as_mixed();
+            if mixed_arr.has_points() {
+                self.geometry_types.insert(GeoParquetGeometryType::Point);
+            }
+            if mixed_arr.has_line_strings() {
+                self.geometry_types
+                    .insert(GeoParquetGeometryType::LineString);
+            }
+            if mixed_arr.has_polygons() {
+                self.geometry_types.insert(GeoParquetGeometryType::Polygon);
+            }
+            if mixed_arr.has_multi_points() {
+                self.geometry_types
+                    .insert(GeoParquetGeometryType::MultiPoint);
+            }
+            if mixed_arr.has_multi_line_strings() {
+                self.geometry_types
+                    .insert(GeoParquetGeometryType::MultiLineString);
+            }
+            if mixed_arr.has_multi_polygons() {
+                self.geometry_types
+                    .insert(GeoParquetGeometryType::MultiPolygon);
+            }
+        }
+
+        if let NativeType::Unknown(_) = array_ref.data_type() {
+            let arr = array_ref.as_mixed();
             if mixed_arr.has_points() {
                 self.geometry_types.insert(GeoParquetGeometryType::Point);
             }
@@ -255,7 +282,7 @@ pub fn get_geometry_types(data_type: &NativeType) -> HashSet<GeoParquetGeometryT
         NativeType::MultiPolygon(_, Dimension::XYZ) => {
             geometry_types.insert(MultiPolygonZ);
         }
-        NativeType::Mixed(_, _) => {
+        NativeType::Mixed(_, _) | NativeType::Unknown(_) => {
             // We don't have access to the actual data here, so we can't inspect better than this.
         }
         NativeType::GeometryCollection(_, Dimension::XY) => {

--- a/rust/geoarrow/src/io/wkb/api.rs
+++ b/rust/geoarrow/src/io/wkb/api.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::algorithm::native::Downcast;
 use crate::array::geometrycollection::GeometryCollectionBuilder;
+use crate::array::unknown::UnknownGeometryBuilder;
 use crate::array::*;
 use crate::chunked_array::*;
 use crate::datatypes::{Dimension, NativeType};
@@ -189,74 +190,56 @@ pub fn from_wkb<O: OffsetSizeTrait>(
     prefer_multi: bool,
 ) -> Result<Arc<dyn NativeArray>> {
     use NativeType::*;
-    let target_dim = target_geo_data_type.dimension();
-
     let wkb_objects: Vec<Option<crate::scalar::WKB<'_, O>>> = arr.iter().collect();
     match target_geo_data_type {
-        Point(coord_type, _) => {
+        Point(coord_type, dim) => {
             let builder =
-                PointBuilder::from_wkb(&wkb_objects, target_dim, Some(coord_type), arr.metadata())?;
+                PointBuilder::from_wkb(&wkb_objects, dim, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
-        LineString(coord_type, _) => {
-            let builder = LineStringBuilder::from_wkb(
-                &wkb_objects,
-                target_dim,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+        LineString(coord_type, dim) => {
+            let builder =
+                LineStringBuilder::from_wkb(&wkb_objects, dim, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
-        Polygon(coord_type, _) => {
-            let builder = PolygonBuilder::from_wkb(
-                &wkb_objects,
-                target_dim,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+        Polygon(coord_type, dim) => {
+            let builder =
+                PolygonBuilder::from_wkb(&wkb_objects, dim, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
-        MultiPoint(coord_type, _) => {
-            let builder = MultiPointBuilder::from_wkb(
-                &wkb_objects,
-                target_dim,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+        MultiPoint(coord_type, dim) => {
+            let builder =
+                MultiPointBuilder::from_wkb(&wkb_objects, dim, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
-        MultiLineString(coord_type, _) => {
+        MultiLineString(coord_type, dim) => {
             let builder = MultiLineStringBuilder::from_wkb(
                 &wkb_objects,
-                target_dim,
+                dim,
                 Some(coord_type),
                 arr.metadata(),
             )?;
             Ok(Arc::new(builder.finish()))
         }
-        MultiPolygon(coord_type, _) => {
-            let builder = MultiPolygonBuilder::from_wkb(
-                &wkb_objects,
-                target_dim,
-                Some(coord_type),
-                arr.metadata(),
-            )?;
+        MultiPolygon(coord_type, dim) => {
+            let builder =
+                MultiPolygonBuilder::from_wkb(&wkb_objects, dim, Some(coord_type), arr.metadata())?;
             Ok(Arc::new(builder.finish()))
         }
-        Mixed(coord_type, _) => {
+        Mixed(coord_type, dim) => {
             let builder = MixedGeometryBuilder::from_wkb(
                 &wkb_objects,
-                target_dim,
+                dim,
                 Some(coord_type),
                 arr.metadata(),
                 prefer_multi,
             )?;
             Ok(Arc::new(builder.finish()))
         }
-        GeometryCollection(coord_type, _) => {
+        GeometryCollection(coord_type, dim) => {
             let builder = GeometryCollectionBuilder::from_wkb(
                 &wkb_objects,
-                target_dim,
+                dim,
                 Some(coord_type),
                 arr.metadata(),
                 prefer_multi,
@@ -267,6 +250,15 @@ pub fn from_wkb<O: OffsetSizeTrait>(
             "Unexpected data type {:?}",
             target_geo_data_type,
         ))),
+        Unknown(coord_type) => {
+            let builder = UnknownGeometryBuilder::from_wkb(
+                &wkb_objects,
+                Some(coord_type),
+                arr.metadata(),
+                prefer_multi,
+            )?;
+            Ok(Arc::new(builder.finish()))
+        }
     }
 }
 
@@ -298,6 +290,7 @@ impl ToWKB for &dyn NativeArray {
             GeometryCollection(_, _) => self.as_geometry_collection().into(),
 
             Rect(_) => todo!(),
+            Unknown(_) => self.as_unknown().into(),
         }
     }
 }
@@ -328,6 +321,7 @@ impl ToWKB for &dyn ChunkedNativeArray {
                 ChunkedGeometryArray::new(self.as_geometry_collection().map(|chunk| chunk.into()))
             }
             Rect(_) => todo!(),
+            Unknown(_) => ChunkedGeometryArray::new(self.as_mixed().map(|chunk| chunk.into())),
         }
     }
 }
@@ -346,6 +340,7 @@ pub fn to_wkb<O: OffsetSizeTrait>(arr: &dyn NativeArray) -> WKBArray<O> {
         Mixed(_, _) => arr.as_mixed().into(),
         GeometryCollection(_, _) => arr.as_geometry_collection().into(),
         Rect(_) => todo!(),
+        Unknown(_) => arr.as_unknown().into(),
     }
 }
 

--- a/rust/geoarrow/src/io/wkb/writer/geometry.rs
+++ b/rust/geoarrow/src/io/wkb/writer/geometry.rs
@@ -4,13 +4,46 @@ use wkb::writer::{geometry_wkb_size, write_geometry};
 use wkb::Endianness;
 
 use crate::array::offset_builder::OffsetsBuilder;
-use crate::array::{MixedGeometryArray, WKBArray};
+use crate::array::{MixedGeometryArray, UnknownGeometryArray, WKBArray};
 use crate::trait_::ArrayAccessor;
 use crate::ArrayBase;
 use std::io::Cursor;
 
 impl<O: OffsetSizeTrait> From<&MixedGeometryArray> for WKBArray<O> {
     fn from(value: &MixedGeometryArray) -> Self {
+        let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
+
+        // First pass: calculate binary array offsets
+        for maybe_geom in value.iter() {
+            if let Some(geom) = maybe_geom {
+                offsets.try_push_usize(geometry_wkb_size(&geom)).unwrap();
+            } else {
+                offsets.extend_constant(1);
+            }
+        }
+
+        let values = {
+            let values = Vec::with_capacity(offsets.last().to_usize().unwrap());
+            let mut writer = Cursor::new(values);
+
+            for geom in value.iter().flatten() {
+                write_geometry(&mut writer, &geom, Endianness::LittleEndian).unwrap();
+            }
+
+            writer.into_inner()
+        };
+
+        let binary_arr = GenericBinaryArray::new(
+            offsets.into(),
+            Buffer::from_vec(values),
+            value.nulls().cloned(),
+        );
+        WKBArray::new(binary_arr, value.metadata())
+    }
+}
+
+impl<O: OffsetSizeTrait> From<&UnknownGeometryArray> for WKBArray<O> {
+    fn from(value: &UnknownGeometryArray) -> Self {
         let mut offsets: OffsetsBuilder<O> = OffsetsBuilder::with_capacity(value.len());
 
         // First pass: calculate binary array offsets

--- a/rust/geoarrow/src/io/wkt/writer/api.rs
+++ b/rust/geoarrow/src/io/wkt/writer/api.rs
@@ -49,6 +49,7 @@ impl ToWKT for &dyn NativeArray {
                 impl_to_wkt!(as_geometry_collection, geometry_collection_to_wkt)
             }
             Rect(_) => impl_to_wkt!(as_rect, rect_to_wkt),
+            Unknown(_) => impl_to_wkt!(as_unknown, geometry_to_wkt),
         }
 
         WKTArray::new(output_array.finish(), metadata)
@@ -77,6 +78,7 @@ impl ToWKT for &dyn ChunkedNativeArray {
             Mixed(_, _) => impl_to_wkt!(as_mixed),
             GeometryCollection(_, _) => impl_to_wkt!(as_geometry_collection),
             Rect(_) => impl_to_wkt!(as_rect),
+            Unknown(_) => impl_to_wkt!(as_unknown),
         }
     }
 }

--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -281,7 +281,8 @@ pub trait NativeArray: ArrayBase {
 
     /// The dimension of this array.
     fn dimension(&self) -> Dimension {
-        self.data_type().dimension()
+        // TODO: remove this trait method now that we have an unknown-dimension array?
+        self.data_type().dimension().unwrap()
     }
 
     /// Converts this array to the same type of array but with the provided [CoordType].


### PR DESCRIPTION
For https://github.com/geoarrow/geoarrow-rs/issues/887.

This adds a new native geometry array and builder, for now called `UnknownGeometryArray` and `UnknownGeometryBuilder`. (Hopefully we'll find better names for this in the future, perhaps even just `GeometryArray`, because it's the most generic array). This is a mixed geometry array that supports _all_ dimensions (XY, XYZ, and in the future XYM and XYZM). 

This is really useful for parsers because we often don't know the geometry schema in advance. E.g. when parsing WKT or WKB from unknown origin, we don't know anything about the data. But this array type still gives us a totally static schema, so we can do streaming stuff.