### PR TITLE
handle `push_null` in the unknown geometry builder

### DIFF
--- a/rust/geoarrow/src/trait_.rs
+++ b/rust/geoarrow/src/trait_.rs
@@ -944,6 +944,9 @@ pub trait GeometryArrayBuilder: std::fmt::Debug + Send + Sync + Sized {
     /// Push a geometry onto this array.
     fn push_geometry(&mut self, value: Option<&impl GeometryTrait<T = f64>>) -> Result<()>;
 
+    // /// Push a null onto this array.
+    // fn push_null(&mut self) -> Result<()>;
+
     /// Sets this builders metadata.
     ///
     /// # Examples


### PR DESCRIPTION
Adding nulls is tricky. We often want to use this builder as a generic builder for data
from unknown sources, which then gets downcasted to an array of a specific type.

In a large majority of the time, this builder will have only data of a single type, which
can then get downcasted to a simple array of a single geometry type and dimension. But in
order for this process to be easy, we want the nulls to be assigned to the same array type
as the actual data.

When there's a valid geometry pushed before the null, we can add the null to an existing
non-null array type, but if there are no valid geometries yet, we don't know which array to
push the null to. This `deferred_nulls` is the number of initial null values that haven't
yet been written to an array, because we don't know which array to write them to.
