### PR TITLE
downcast geometry array

### DIFF
--- a/rust/geoarrow/src/algorithm/native/cast.rs
+++ b/rust/geoarrow/src/algorithm/native/cast.rs
@@ -28,7 +28,7 @@ impl Default for CastOptions {
 
 /// Note: not currently used and outdated
 #[allow(dead_code)]
-fn can_cast_types(from_type: &NativeType, to_type: &NativeType) -> bool {
+fn can_cast_types(from_type: NativeType, to_type: NativeType) -> bool {
     if from_type == to_type {
         return true;
     }
@@ -51,13 +51,13 @@ pub trait Cast {
     type Output;
 
     /// Note: **does not currently implement dimension casts**
-    fn cast(&self, to_type: &NativeType) -> Self::Output;
+    fn cast(&self, to_type: NativeType) -> Self::Output;
 }
 
 impl Cast for PointArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         use NativeType::*;
 
         let array = self.to_coord_type(to_type.coord_type());
@@ -77,7 +77,7 @@ impl Cast for PointArray {
 impl Cast for LineStringArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         use NativeType::*;
 
         let array = self.to_coord_type(to_type.coord_type());
@@ -98,7 +98,7 @@ impl Cast for LineStringArray {
 impl Cast for PolygonArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         use NativeType::*;
 
         let array = self.to_coord_type(to_type.coord_type());
@@ -119,7 +119,7 @@ impl Cast for PolygonArray {
 impl Cast for MultiPointArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         use NativeType::*;
 
         let array = self.to_coord_type(to_type.coord_type());
@@ -140,7 +140,7 @@ impl Cast for MultiPointArray {
 impl Cast for MultiLineStringArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         use NativeType::*;
 
         let array = self.to_coord_type(to_type.coord_type());
@@ -160,7 +160,7 @@ impl Cast for MultiLineStringArray {
 impl Cast for MultiPolygonArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         use NativeType::*;
 
         let array = self.to_coord_type(to_type.coord_type());
@@ -180,7 +180,7 @@ impl Cast for MultiPolygonArray {
 impl Cast for MixedGeometryArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         use NativeType::*;
 
         let array = self.to_coord_type(to_type.coord_type());
@@ -194,7 +194,6 @@ impl Cast for MixedGeometryArray {
             MultiPolygon(_, _) => Ok(Arc::new(MultiPolygonArray::try_from(array)?)),
             Mixed(_, _) => Ok(Arc::new(array)),
             GeometryCollection(_, _) => Ok(Arc::new(GeometryCollectionArray::from(array))),
-            // Geometry(_) => Ok(Arc::new(GeometryArray::from(array))),
             dt => Err(GeoArrowError::General(format!(
                 "invalid cast to type {dt:?}"
             ))),
@@ -205,7 +204,7 @@ impl Cast for MixedGeometryArray {
 impl Cast for GeometryCollectionArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         use NativeType::*;
 
         let array = self.to_coord_type(to_type.coord_type());
@@ -230,7 +229,7 @@ impl Cast for GeometryCollectionArray {
 impl Cast for GeometryArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         // TODO: validate dimension
         let array = self.to_coord_type(to_type.coord_type());
         let mixed_array = MixedGeometryArray::try_from(array)?;
@@ -241,7 +240,7 @@ impl Cast for GeometryArray {
 impl Cast for &dyn NativeArray {
     type Output = Result<Arc<dyn NativeArray>>;
 
-    fn cast(&self, to_type: &NativeType) -> Self::Output {
+    fn cast(&self, to_type: NativeType) -> Self::Output {
         // TODO: not working :/
         // if self.data_type() == to_type {
         //     return Ok(Arc::new(self.to_owned()));
@@ -269,7 +268,7 @@ macro_rules! impl_chunked_cast {
         impl Cast for $chunked_array {
             type Output = Result<Arc<dyn ChunkedNativeArray>>;
 
-            fn cast(&self, to_type: &NativeType) -> Self::Output {
+            fn cast(&self, to_type: NativeType) -> Self::Output {
                 macro_rules! impl_cast {
                     ($method:ident) => {
                         Arc::new(ChunkedGeometryArray::new(

--- a/rust/geoarrow/src/algorithm/native/cast.rs
+++ b/rust/geoarrow/src/algorithm/native/cast.rs
@@ -294,7 +294,7 @@ macro_rules! impl_chunked_cast {
                     Mixed(_, _) => impl_cast!(as_mixed),
                     GeometryCollection(_, _) => impl_cast!(as_geometry_collection),
                     Rect(_) => impl_cast!(as_rect),
-                    Geometry(_) => todo!("cast to unknown"),
+                    Geometry(_) => impl_cast!(as_geometry),
                 };
                 Ok(result)
             }
@@ -312,3 +312,4 @@ impl_chunked_cast!(ChunkedMultiLineStringArray);
 impl_chunked_cast!(ChunkedMultiPolygonArray);
 impl_chunked_cast!(ChunkedMixedGeometryArray);
 impl_chunked_cast!(ChunkedGeometryCollectionArray);
+impl_chunked_cast!(ChunkedUnknownGeometryArray);

--- a/rust/geoarrow/src/algorithm/native/downcast.rs
+++ b/rust/geoarrow/src/algorithm/native/downcast.rs
@@ -405,6 +405,7 @@ impl_chunked_downcast!(ChunkedMultiLineStringArray);
 impl_chunked_downcast!(ChunkedMultiPolygonArray);
 impl_chunked_downcast!(ChunkedMixedGeometryArray);
 impl_chunked_downcast!(ChunkedGeometryCollectionArray);
+impl_chunked_downcast!(ChunkedUnknownGeometryArray);
 
 impl Downcast for ChunkedRectArray {
     type Output = Arc<dyn ChunkedNativeArray>;
@@ -421,38 +422,36 @@ impl Downcast for &dyn ChunkedNativeArray {
     type Output = Arc<dyn ChunkedNativeArray>;
 
     fn downcasted_data_type(&self) -> NativeType {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point().downcasted_data_type(),
-            LineString(_, XY) => self.as_line_string().downcasted_data_type(),
-            Polygon(_, XY) => self.as_polygon().downcasted_data_type(),
-            MultiPoint(_, XY) => self.as_multi_point().downcasted_data_type(),
-            MultiLineString(_, XY) => self.as_multi_line_string().downcasted_data_type(),
-            MultiPolygon(_, XY) => self.as_multi_polygon().downcasted_data_type(),
-            Mixed(_, XY) => self.as_mixed().downcasted_data_type(),
-            GeometryCollection(_, XY) => self.as_geometry_collection().downcasted_data_type(),
-            Rect(XY) => self.as_rect().downcasted_data_type(),
-            _ => todo!("3d support"),
+            Point(_, _) => self.as_point().downcasted_data_type(),
+            LineString(_, _) => self.as_line_string().downcasted_data_type(),
+            Polygon(_, _) => self.as_polygon().downcasted_data_type(),
+            MultiPoint(_, _) => self.as_multi_point().downcasted_data_type(),
+            MultiLineString(_, _) => self.as_multi_line_string().downcasted_data_type(),
+            MultiPolygon(_, _) => self.as_multi_polygon().downcasted_data_type(),
+            Mixed(_, _) => self.as_mixed().downcasted_data_type(),
+            GeometryCollection(_, _) => self.as_geometry_collection().downcasted_data_type(),
+            Rect(_) => self.as_rect().downcasted_data_type(),
+            Geometry(_) => self.as_geometry().downcasted_data_type(),
         }
     }
 
     fn downcast(&self) -> Self::Output {
-        use Dimension::*;
         use NativeType::*;
 
         match self.data_type() {
-            Point(_, XY) => self.as_point().downcast(),
-            LineString(_, XY) => self.as_line_string().downcast(),
-            Polygon(_, XY) => self.as_polygon().downcast(),
-            MultiPoint(_, XY) => self.as_multi_point().downcast(),
-            MultiLineString(_, XY) => self.as_multi_line_string().downcast(),
-            MultiPolygon(_, XY) => self.as_multi_polygon().downcast(),
-            Mixed(_, XY) => self.as_mixed().downcast(),
-            GeometryCollection(_, XY) => self.as_geometry_collection().downcast(),
-            Rect(XY) => self.as_rect().downcast(),
-            _ => todo!("3d support"),
+            Point(_, _) => self.as_point().downcast(),
+            LineString(_, _) => self.as_line_string().downcast(),
+            Polygon(_, _) => self.as_polygon().downcast(),
+            MultiPoint(_, _) => self.as_multi_point().downcast(),
+            MultiLineString(_, _) => self.as_multi_line_string().downcast(),
+            MultiPolygon(_, _) => self.as_multi_polygon().downcast(),
+            Mixed(_, _) => self.as_mixed().downcast(),
+            GeometryCollection(_, _) => self.as_geometry_collection().downcast(),
+            Rect(_) => self.as_rect().downcast(),
+            Geometry(_) => self.as_geometry().downcast(),
         }
     }
 }

--- a/rust/geoarrow/src/array/geometry/array.rs
+++ b/rust/geoarrow/src/array/geometry/array.rs
@@ -459,7 +459,7 @@ impl GeometryArray {
     }
 
     // TODO: recursively expand the types from the geometry collection array
-    pub fn contains_types(&self) -> HashSet<NativeType> {
+    pub fn contained_types(&self) -> HashSet<NativeType> {
         let mut types = HashSet::new();
         if self.has_points(Dimension::XY) {
             types.insert(self.point_xy.data_type());

--- a/rust/geoarrow/src/array/geometry/array.rs
+++ b/rust/geoarrow/src/array/geometry/array.rs
@@ -181,6 +181,7 @@ impl GeometryArray {
         )
     }
 
+    // TODO: handle slicing
     pub fn has_points(&self, dim: Dimension) -> bool {
         match dim {
             Dimension::XY => !self.point_xy.is_empty(),
@@ -220,6 +221,13 @@ impl GeometryArray {
         match dim {
             Dimension::XY => !self.mpolygon_xy.is_empty(),
             Dimension::XYZ => !self.mpolygon_xyz.is_empty(),
+        }
+    }
+
+    pub fn has_geometry_collections(&self, dim: Dimension) -> bool {
+        match dim {
+            Dimension::XY => !self.gc_xy.is_empty(),
+            Dimension::XYZ => !self.gc_xyz.is_empty(),
         }
     }
 
@@ -448,6 +456,56 @@ impl GeometryArray {
             self.gc_xyz.into_coord_type(coord_type),
             self.metadata,
         )
+    }
+
+    // TODO: recursively expand the types from the geometry collection array
+    pub fn contains_types(&self) -> HashSet<NativeType> {
+        let mut types = HashSet::new();
+        if self.has_points(Dimension::XY) {
+            types.insert(self.point_xy.data_type());
+        }
+        if self.has_line_strings(Dimension::XY) {
+            types.insert(self.line_string_xy.data_type());
+        }
+        if self.has_polygons(Dimension::XY) {
+            types.insert(self.polygon_xy.data_type());
+        }
+        if self.has_multi_points(Dimension::XY) {
+            types.insert(self.mpoint_xy.data_type());
+        }
+        if self.has_multi_line_strings(Dimension::XY) {
+            types.insert(self.mline_string_xy.data_type());
+        }
+        if self.has_multi_polygons(Dimension::XY) {
+            types.insert(self.mpolygon_xy.data_type());
+        }
+        if self.has_geometry_collections(Dimension::XY) {
+            types.insert(self.gc_xy.data_type());
+        }
+
+        if self.has_points(Dimension::XYZ) {
+            types.insert(self.point_xyz.data_type());
+        }
+        if self.has_line_strings(Dimension::XYZ) {
+            types.insert(self.line_string_xyz.data_type());
+        }
+        if self.has_polygons(Dimension::XYZ) {
+            types.insert(self.polygon_xyz.data_type());
+        }
+        if self.has_multi_points(Dimension::XYZ) {
+            types.insert(self.mpoint_xyz.data_type());
+        }
+        if self.has_multi_line_strings(Dimension::XYZ) {
+            types.insert(self.mline_string_xyz.data_type());
+        }
+        if self.has_multi_polygons(Dimension::XYZ) {
+            types.insert(self.mpolygon_xyz.data_type());
+        }
+        if self.has_geometry_collections(Dimension::XYZ) {
+            types.insert(self.gc_xyz.data_type());
+        }
+
+        types
     }
 }
 

--- a/rust/geoarrow/src/array/linestring/array.rs
+++ b/rust/geoarrow/src/array/linestring/array.rs
@@ -477,12 +477,13 @@ impl TryFrom<MixedGeometryArray> for LineStringArray {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
+        let (offset, length) = value.slice_offset_length();
         if value.has_only_line_strings() {
-            return Ok(value.line_strings);
+            return Ok(value.line_strings.slice(offset, length));
         }
 
         if value.has_only_multi_line_strings() {
-            return value.multi_line_strings.try_into();
+            return value.multi_line_strings.slice(offset, length).try_into();
         }
 
         let mut capacity = value.line_strings.buffer_lengths();

--- a/rust/geoarrow/src/array/mixed/array.rs
+++ b/rust/geoarrow/src/array/mixed/array.rs
@@ -189,9 +189,11 @@ impl MixedGeometryArray {
                     return true;
                 }
             }
+
+            return false;
         }
 
-        false
+        true
     }
 
     pub fn has_line_strings(&self) -> bool {
@@ -206,9 +208,11 @@ impl MixedGeometryArray {
                     return true;
                 }
             }
+
+            return false;
         }
 
-        false
+        true
     }
 
     pub fn has_polygons(&self) -> bool {
@@ -223,9 +227,11 @@ impl MixedGeometryArray {
                     return true;
                 }
             }
+
+            return false;
         }
 
-        false
+        true
     }
 
     pub fn has_multi_points(&self) -> bool {
@@ -240,9 +246,11 @@ impl MixedGeometryArray {
                     return true;
                 }
             }
+
+            return false;
         }
 
-        false
+        true
     }
 
     pub fn has_multi_line_strings(&self) -> bool {
@@ -257,9 +265,11 @@ impl MixedGeometryArray {
                     return true;
                 }
             }
+
+            return false;
         }
 
-        false
+        true
     }
 
     pub fn has_multi_polygons(&self) -> bool {
@@ -274,9 +284,11 @@ impl MixedGeometryArray {
                     return true;
                 }
             }
+
+            return false;
         }
 
-        false
+        true
     }
 
     pub fn has_only_points(&self) -> bool {

--- a/rust/geoarrow/src/array/multilinestring/array.rs
+++ b/rust/geoarrow/src/array/multilinestring/array.rs
@@ -513,12 +513,13 @@ impl TryFrom<MixedGeometryArray> for MultiLineStringArray {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
+        let (offset, length) = value.slice_offset_length();
         if value.has_only_line_strings() {
-            return Ok(value.line_strings.into());
+            return Ok(value.line_strings.slice(offset, length).into());
         }
 
         if value.has_only_multi_line_strings() {
-            return Ok(value.multi_line_strings);
+            return Ok(value.multi_line_strings.slice(offset, length));
         }
 
         let mut capacity = value.multi_line_strings.buffer_lengths();

--- a/rust/geoarrow/src/array/multipoint/array.rs
+++ b/rust/geoarrow/src/array/multipoint/array.rs
@@ -457,12 +457,13 @@ impl TryFrom<MixedGeometryArray> for MultiPointArray {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
+        let (offset, length) = value.slice_offset_length();
         if value.has_only_points() {
-            return Ok(value.points.into());
+            return Ok(value.points.slice(offset, length).into());
         }
 
         if value.has_only_multi_points() {
-            return Ok(value.multi_points);
+            return Ok(value.multi_points.slice(offset, length));
         }
 
         let mut capacity = value.multi_points.buffer_lengths();

--- a/rust/geoarrow/src/array/multipolygon/array.rs
+++ b/rust/geoarrow/src/array/multipolygon/array.rs
@@ -595,12 +595,13 @@ impl TryFrom<MixedGeometryArray> for MultiPolygonArray {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
+        let (offset, length) = value.slice_offset_length();
         if value.has_only_polygons() {
-            return Ok(value.polygons.into());
+            return Ok(value.polygons.slice(offset, length).into());
         }
 
         if value.has_only_multi_polygons() {
-            return Ok(value.multi_polygons);
+            return Ok(value.multi_polygons.slice(offset, length));
         }
 
         let mut capacity = value.multi_polygons.buffer_lengths();

--- a/rust/geoarrow/src/array/point/array.rs
+++ b/rust/geoarrow/src/array/point/array.rs
@@ -412,12 +412,13 @@ impl TryFrom<MixedGeometryArray> for PointArray {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
+        let (offset, length) = value.slice_offset_length();
         if value.has_only_points() {
-            return Ok(value.points);
+            return Ok(value.points.slice(offset, length));
         }
 
         if value.has_only_multi_points() {
-            return value.multi_points.try_into();
+            return value.multi_points.slice(offset, length).try_into();
         }
 
         let mut builder = PointBuilder::with_capacity_and_options(

--- a/rust/geoarrow/src/array/polygon/array.rs
+++ b/rust/geoarrow/src/array/polygon/array.rs
@@ -552,12 +552,13 @@ impl TryFrom<MixedGeometryArray> for PolygonArray {
             return Err(GeoArrowError::General("Unable to cast".to_string()));
         }
 
+        let (offset, length) = value.slice_offset_length();
         if value.has_only_polygons() {
-            return Ok(value.polygons);
+            return Ok(value.polygons.slice(offset, length));
         }
 
         if value.has_only_multi_polygons() {
-            return value.multi_polygons.try_into();
+            return value.multi_polygons.slice(offset, length).try_into();
         }
 
         let mut capacity = value.polygons.buffer_lengths();

--- a/rust/geoarrow/src/datatypes.rs
+++ b/rust/geoarrow/src/datatypes.rs
@@ -928,13 +928,13 @@ fn parse_geometry_collection(field: &Field) -> Result<NativeType> {
     // We need to parse the _inner_ type of the geometry collection as a union so that we can check
     // what coordinate type it's using.
     match field.data_type() {
-        DataType::List(inner_field) => match parse_geometry(inner_field)? {
+        DataType::List(inner_field) => match parse_mixed(inner_field)? {
             NativeType::Mixed(coord_type, dim) => {
                 Ok(NativeType::GeometryCollection(coord_type, dim))
             }
             _ => panic!(),
         },
-        DataType::LargeList(inner_field) => match parse_geometry(inner_field)? {
+        DataType::LargeList(inner_field) => match parse_mixed(inner_field)? {
             NativeType::Mixed(coord_type, dim) => {
                 Ok(NativeType::GeometryCollection(coord_type, dim))
             }

--- a/rust/geoarrow/src/datatypes.rs
+++ b/rust/geoarrow/src/datatypes.rs
@@ -469,7 +469,7 @@ impl NativeType {
             Mixed(_, _) => "geoarrow.geometry",
             GeometryCollection(_, _) => "geoarrow.geometrycollection",
             Rect(_) => "geoarrow.box",
-            Geometry(_) => "geoarrow.unknown",
+            Geometry(_) => "geoarrow.geometry",
         }
     }
 
@@ -794,7 +794,8 @@ fn parse_multi_polygon(field: &Field) -> Result<NativeType> {
     }
 }
 
-fn parse_geometry(field: &Field) -> Result<NativeType> {
+#[allow(dead_code)]
+fn parse_mixed(field: &Field) -> Result<NativeType> {
     match field.data_type() {
         DataType::Union(fields, _) => {
             let mut coord_types: HashSet<CoordType> = HashSet::new();
@@ -970,7 +971,7 @@ fn parse_rect(field: &Field) -> NativeType {
     }
 }
 
-fn parse_unknown(field: &Field) -> Result<NativeType> {
+fn parse_geometry(field: &Field) -> Result<NativeType> {
     if let DataType::Union(fields, _mode) = field.data_type() {
         let mut coord_types: HashSet<CoordType> = HashSet::new();
 
@@ -1090,10 +1091,11 @@ impl TryFrom<&Field> for NativeType {
                 "geoarrow.multipoint" => parse_multi_point(field)?,
                 "geoarrow.multilinestring" => parse_multi_linestring(field)?,
                 "geoarrow.multipolygon" => parse_multi_polygon(field)?,
-                "geoarrow.geometry" => parse_geometry(field)?,
                 "geoarrow.geometrycollection" => parse_geometry_collection(field)?,
                 "geoarrow.box" => parse_rect(field),
-                "geoarrow.unknown" => parse_unknown(field)?,
+                "geoarrow.geometry" => parse_geometry(field)?,
+                // We always parse geoarrow.geometry to a GeometryArray
+                // "geoarrow.geometry" => parse_mixed(field)?,
                 name => return Err(GeoArrowError::General(format!("Expected GeoArrow native type, got '{}'.\nIf you're passing a serialized GeoArrow type like 'geoarrow.wkb' or 'geoarrow.wkt', you need to parse to a native representation.", name))),
             };
             Ok(data_type)
@@ -1162,7 +1164,7 @@ impl TryFrom<&Field> for AnyType {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::array::MixedGeometryBuilder;
+    use crate::array::GeometryBuilder;
     use crate::{ArrayBase, NativeArray};
 
     #[test]
@@ -1177,7 +1179,7 @@ mod test {
         let data_type: NativeType = field.as_ref().try_into().unwrap();
         assert_eq!(ml_array.data_type(), data_type);
 
-        let mut builder = MixedGeometryBuilder::new(Dimension::XY);
+        let mut builder = GeometryBuilder::new();
         builder.push_point(Some(&crate::test::point::p0())).unwrap();
         builder.push_point(Some(&crate::test::point::p1())).unwrap();
         builder.push_point(Some(&crate::test::point::p2())).unwrap();
@@ -1187,9 +1189,9 @@ mod test {
         builder
             .push_multi_line_string(Some(&crate::test::multilinestring::ml1()))
             .unwrap();
-        let mixed_array = builder.finish();
-        let field = mixed_array.extension_field();
+        let geom_array = builder.finish();
+        let field = geom_array.extension_field();
         let data_type: NativeType = field.as_ref().try_into().unwrap();
-        assert_eq!(mixed_array.data_type(), data_type);
+        assert_eq!(geom_array.data_type(), data_type);
     }
 }

--- a/rust/geoarrow/src/datatypes.rs
+++ b/rust/geoarrow/src/datatypes.rs
@@ -794,7 +794,6 @@ fn parse_multi_polygon(field: &Field) -> Result<NativeType> {
     }
 }
 
-#[allow(dead_code)]
 fn parse_mixed(field: &Field) -> Result<NativeType> {
     match field.data_type() {
         DataType::Union(fields, _) => {

--- a/rust/geoarrow/src/io/wkb/api.rs
+++ b/rust/geoarrow/src/io/wkb/api.rs
@@ -356,6 +356,7 @@ mod test {
             true,
         )
         .unwrap();
+
         let rt_ref = roundtrip.as_ref();
         let rt_mixed_arr = rt_ref.as_mixed();
         let downcasted = rt_mixed_arr.downcast().unwrap();

--- a/rust/geoarrow/src/io/wkb/api.rs
+++ b/rust/geoarrow/src/io/wkb/api.rs
@@ -122,7 +122,7 @@ impl FromWKB for Arc<dyn NativeArray> {
             arr.metadata(),
             true,
         )?;
-        Ok(builder.finish().downcast())
+        builder.finish().downcast()
     }
 }
 
@@ -374,7 +374,7 @@ mod test {
         .unwrap();
         let rt_ref = roundtrip.as_ref();
         let rt_mixed_arr = rt_ref.as_mixed();
-        let downcasted = rt_mixed_arr.downcast();
+        let downcasted = rt_mixed_arr.downcast().unwrap();
         let downcasted_ref = downcasted.as_ref();
         let rt_point_arr = downcasted_ref.as_point();
         assert_eq!(&arr, rt_point_arr);

--- a/rust/geoarrow/src/io/wkb/api.rs
+++ b/rust/geoarrow/src/io/wkb/api.rs
@@ -303,7 +303,7 @@ impl ToWKB for &dyn ChunkedNativeArray {
                 ChunkedGeometryArray::new(self.as_geometry_collection().map(|chunk| chunk.into()))
             }
             Rect(_) => todo!(),
-            Geometry(_) => ChunkedGeometryArray::new(self.as_mixed().map(|chunk| chunk.into())),
+            Geometry(_) => ChunkedGeometryArray::new(self.as_geometry().map(|chunk| chunk.into())),
         }
     }
 }

--- a/rust/geoarrow/src/table.rs
+++ b/rust/geoarrow/src/table.rs
@@ -152,7 +152,7 @@ impl Table {
     /// let index = table.default_geometry_column_idx().unwrap();
     ///
     /// // Change to separated storage of coordinates
-    /// table.cast_geometry(index, &NativeType::LineString(CoordType::Separated, Dimension::XY)).unwrap();
+    /// table.cast_geometry(index, NativeType::LineString(CoordType::Separated, Dimension::XY)).unwrap();
     /// # }
     /// ```
     pub fn cast_geometry(&mut self, index: usize, to_type: NativeType) -> Result<()> {

--- a/rust/geoarrow/src/table.rs
+++ b/rust/geoarrow/src/table.rs
@@ -156,7 +156,7 @@ impl Table {
     /// table.cast_geometry(index, &NativeType::LineString(CoordType::Separated, Dimension::XY)).unwrap();
     /// # }
     /// ```
-    pub fn cast_geometry(&mut self, index: usize, to_type: &NativeType) -> Result<()> {
+    pub fn cast_geometry(&mut self, index: usize, to_type: NativeType) -> Result<()> {
         let orig_field = self.schema().field(index);
 
         let array_slices = self

--- a/rust/geoarrow/src/table.rs
+++ b/rust/geoarrow/src/table.rs
@@ -29,7 +29,6 @@ pub(crate) static GEOARROW_EXTENSION_NAMES: Set<&'static str> = phf_set! {
     "geoarrow.geometrycollection",
     "geoarrow.wkb",
     "geoarrow.wkt",
-    "geoarrow.unknown",
     "ogc.wkb",
 };
 


### PR DESCRIPTION
todo:

- [x] Change downcast to be implemented in terms of `resolve_types` and `cast`. 
- [x] Handle slicing in `GeometryArray::has_points`. I.e. bring back the slice offset and length. Then if the array has been sliced and the point array exists, check if the point values are within the bounds of the current slice. The fastest way to do this should be to check the length of the point array, then as you're iterating through the type_ids array, once you've seen that many ids pointing to the point array, you know the array is fully there. Or, in the cast of downcasting you really only care about whether _any_ geometry exists. So you can short-circuit as soon as you've seen the first point.
- [x] Ensure we apply slicing when exporting the GeometryArray. E.g. in the `TryFrom` impl from GeometryArray to `PointArray`, we need to call the slice when we export.
- [ ] recursively expand the types from the geometry collection array. But only if the geometry collection array has only a single geometry per row and it could be split up.

Closes https://github.com/geoarrow/geoarrow-rs/issues/416