### PR TITLE
Inline geometry trait accessors

### DIFF
--- a/rust/geoarrow/src/scalar/coord/combined/scalar.rs
+++ b/rust/geoarrow/src/scalar/coord/combined/scalar.rs
@@ -103,6 +103,7 @@ impl PartialEq<SeparatedCoord<'_>> for Coord<'_> {
 impl CoordTrait for Coord<'_> {
     type T = f64;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self {
             Coord::Interleaved(c) => c.dim(),
@@ -110,6 +111,7 @@ impl CoordTrait for Coord<'_> {
         }
     }
 
+    #[inline]
     fn nth_or_panic(&self, n: usize) -> Self::T {
         match self {
             Coord::Interleaved(c) => c.nth_or_panic(n),
@@ -117,6 +119,7 @@ impl CoordTrait for Coord<'_> {
         }
     }
 
+    #[inline]
     fn x(&self) -> Self::T {
         match self {
             Coord::Interleaved(c) => c.x(),
@@ -124,6 +127,7 @@ impl CoordTrait for Coord<'_> {
         }
     }
 
+    #[inline]
     fn y(&self) -> Self::T {
         match self {
             Coord::Interleaved(c) => c.y(),
@@ -135,6 +139,7 @@ impl CoordTrait for Coord<'_> {
 impl CoordTrait for &Coord<'_> {
     type T = f64;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self {
             Coord::Interleaved(c) => c.dim(),
@@ -142,6 +147,7 @@ impl CoordTrait for &Coord<'_> {
         }
     }
 
+    #[inline]
     fn nth_or_panic(&self, n: usize) -> Self::T {
         match self {
             Coord::Interleaved(c) => c.nth_or_panic(n),
@@ -149,6 +155,7 @@ impl CoordTrait for &Coord<'_> {
         }
     }
 
+    #[inline]
     fn x(&self) -> Self::T {
         match self {
             Coord::Interleaved(c) => c.x(),
@@ -156,6 +163,7 @@ impl CoordTrait for &Coord<'_> {
         }
     }
 
+    #[inline]
     fn y(&self) -> Self::T {
         match self {
             Coord::Interleaved(c) => c.y(),

--- a/rust/geoarrow/src/scalar/coord/interleaved/scalar.rs
+++ b/rust/geoarrow/src/scalar/coord/interleaved/scalar.rs
@@ -71,12 +71,14 @@ impl From<&InterleavedCoord<'_>> for geo::Point {
 impl RTreeObject for InterleavedCoord<'_> {
     type Envelope = AABB<[f64; 2]>;
 
+    #[inline]
     fn envelope(&self) -> Self::Envelope {
         AABB::from_point([self.x(), self.y()])
     }
 }
 
 impl PartialEq for InterleavedCoord<'_> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         coord_eq(self, other)
     }
@@ -91,19 +93,23 @@ impl PartialEq<SeparatedCoord<'_>> for InterleavedCoord<'_> {
 impl CoordTrait for InterleavedCoord<'_> {
     type T = f64;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.dim.into()
     }
 
+    #[inline]
     fn nth_or_panic(&self, n: usize) -> Self::T {
         debug_assert!(n < self.dim.size());
         *self.coords.get(self.i * self.dim.size() + n).unwrap()
     }
 
+    #[inline]
     fn x(&self) -> Self::T {
         *self.coords.get(self.i * self.dim.size()).unwrap()
     }
 
+    #[inline]
     fn y(&self) -> Self::T {
         *self.coords.get(self.i * self.dim.size() + 1).unwrap()
     }
@@ -112,19 +118,23 @@ impl CoordTrait for InterleavedCoord<'_> {
 impl CoordTrait for &InterleavedCoord<'_> {
     type T = f64;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.dim.into()
     }
 
+    #[inline]
     fn nth_or_panic(&self, n: usize) -> Self::T {
         debug_assert!(n < self.dim.size());
         *self.coords.get(self.i * self.dim.size() + n).unwrap()
     }
 
+    #[inline]
     fn x(&self) -> Self::T {
         *self.coords.get(self.i * self.dim.size()).unwrap()
     }
 
+    #[inline]
     fn y(&self) -> Self::T {
         *self.coords.get(self.i * self.dim.size() + 1).unwrap()
     }

--- a/rust/geoarrow/src/scalar/coord/separated/scalar.rs
+++ b/rust/geoarrow/src/scalar/coord/separated/scalar.rs
@@ -89,18 +89,22 @@ impl PartialEq<InterleavedCoord<'_>> for SeparatedCoord<'_> {
 impl CoordTrait for SeparatedCoord<'_> {
     type T = f64;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.dim.into()
     }
 
+    #[inline]
     fn nth_or_panic(&self, n: usize) -> Self::T {
         self.buffers[n][self.i]
     }
 
+    #[inline]
     fn x(&self) -> Self::T {
         self.buffers[0][self.i]
     }
 
+    #[inline]
     fn y(&self) -> Self::T {
         self.buffers[1][self.i]
     }
@@ -109,18 +113,22 @@ impl CoordTrait for SeparatedCoord<'_> {
 impl CoordTrait for &SeparatedCoord<'_> {
     type T = f64;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.dim.into()
     }
 
+    #[inline]
     fn nth_or_panic(&self, n: usize) -> Self::T {
         self.buffers[n][self.i]
     }
 
+    #[inline]
     fn x(&self) -> Self::T {
         self.buffers[0][self.i]
     }
 
+    #[inline]
     fn y(&self) -> Self::T {
         self.buffers[1][self.i]
     }

--- a/rust/geoarrow/src/scalar/geometry/scalar.rs
+++ b/rust/geoarrow/src/scalar/geometry/scalar.rs
@@ -101,6 +101,7 @@ impl GeometryTrait for Geometry<'_> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self {
             Geometry::Point(p) => p.dim(),
@@ -114,6 +115,7 @@ impl GeometryTrait for Geometry<'_> {
         }
     }
 
+    #[inline]
     fn as_type(
         &self,
     ) -> geo_traits::GeometryType<
@@ -185,6 +187,7 @@ impl<'a> GeometryTrait for &'a Geometry<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self {
             Geometry::Point(p) => p.dim(),
@@ -198,6 +201,7 @@ impl<'a> GeometryTrait for &'a Geometry<'a> {
         }
     }
 
+    #[inline]
     fn as_type(
         &self,
     ) -> geo_traits::GeometryType<

--- a/rust/geoarrow/src/scalar/geometrycollection/scalar.rs
+++ b/rust/geoarrow/src/scalar/geometrycollection/scalar.rs
@@ -71,6 +71,7 @@ impl<'a> GeometryCollectionTrait for GeometryCollection<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self.array.dimension() {
             Dimension::XY => geo_traits::Dimensions::Xy,
@@ -78,11 +79,13 @@ impl<'a> GeometryCollectionTrait for GeometryCollection<'a> {
         }
     }
 
+    #[inline]
     fn num_geometries(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn geometry_unchecked(&self, i: usize) -> Self::GeometryType<'_> {
         self.array.value(self.start_offset + i)
     }
@@ -95,6 +98,7 @@ impl<'a> GeometryCollectionTrait for &'a GeometryCollection<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self.array.dimension() {
             Dimension::XY => geo_traits::Dimensions::Xy,
@@ -102,11 +106,13 @@ impl<'a> GeometryCollectionTrait for &'a GeometryCollection<'a> {
         }
     }
 
+    #[inline]
     fn num_geometries(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn geometry_unchecked(&self, i: usize) -> Self::GeometryType<'_> {
         self.array.value(self.start_offset + i)
     }

--- a/rust/geoarrow/src/scalar/linestring/scalar.rs
+++ b/rust/geoarrow/src/scalar/linestring/scalar.rs
@@ -72,15 +72,18 @@ impl<'a> LineStringTrait for LineString<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.coords.dim().into()
     }
 
+    #[inline]
     fn num_coords(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
         self.coords.value(self.start_offset + i)
     }
@@ -93,15 +96,18 @@ impl<'a> LineStringTrait for &'a LineString<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.coords.dim().into()
     }
 
+    #[inline]
     fn num_coords(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
         self.coords.value(self.start_offset + i)
     }

--- a/rust/geoarrow/src/scalar/multilinestring/scalar.rs
+++ b/rust/geoarrow/src/scalar/multilinestring/scalar.rs
@@ -80,15 +80,18 @@ impl<'a> MultiLineStringTrait for MultiLineString<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.coords.dim().into()
     }
 
+    #[inline]
     fn num_line_strings(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_> {
         LineString::new(self.coords, self.ring_offsets, self.start_offset + i)
     }
@@ -101,15 +104,18 @@ impl<'a> MultiLineStringTrait for &'a MultiLineString<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.coords.dim().into()
     }
 
+    #[inline]
     fn num_line_strings(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_> {
         LineString::new(self.coords, self.ring_offsets, self.start_offset + i)
     }

--- a/rust/geoarrow/src/scalar/multipoint/scalar.rs
+++ b/rust/geoarrow/src/scalar/multipoint/scalar.rs
@@ -74,6 +74,7 @@ impl<'a> MultiPointTrait for MultiPoint<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self.coords.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
@@ -81,11 +82,13 @@ impl<'a> MultiPointTrait for MultiPoint<'a> {
         }
     }
 
+    #[inline]
     fn num_points(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_> {
         Point::new(self.coords, self.start_offset + i)
     }
@@ -98,6 +101,7 @@ impl<'a> MultiPointTrait for &'a MultiPoint<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self.coords.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
@@ -105,11 +109,13 @@ impl<'a> MultiPointTrait for &'a MultiPoint<'a> {
         }
     }
 
+    #[inline]
     fn num_points(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_> {
         Point::new(self.coords, self.start_offset + i)
     }

--- a/rust/geoarrow/src/scalar/multipolygon/scalar.rs
+++ b/rust/geoarrow/src/scalar/multipolygon/scalar.rs
@@ -93,6 +93,7 @@ impl<'a> MultiPolygonTrait for MultiPolygon<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self.coords.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
@@ -100,11 +101,13 @@ impl<'a> MultiPolygonTrait for MultiPolygon<'a> {
         }
     }
 
+    #[inline]
     fn num_polygons(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
         Polygon::new(
             self.coords,
@@ -122,6 +125,7 @@ impl<'a> MultiPolygonTrait for &'a MultiPolygon<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self.coords.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
@@ -129,11 +133,13 @@ impl<'a> MultiPolygonTrait for &'a MultiPolygon<'a> {
         }
     }
 
+    #[inline]
     fn num_polygons(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start
     }
 
+    #[inline]
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
         Polygon::new(
             self.coords,

--- a/rust/geoarrow/src/scalar/point/scalar.rs
+++ b/rust/geoarrow/src/scalar/point/scalar.rs
@@ -50,10 +50,12 @@ impl<'a> PointTrait for Point<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.coords.dim().into()
     }
 
+    #[inline]
     fn coord(&self) -> Option<Self::CoordType<'_>> {
         let coord = self.coords.value(self.geom_index);
         if coord.is_nan() {
@@ -71,10 +73,12 @@ impl<'a> PointTrait for &Point<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.coords.dim().into()
     }
 
+    #[inline]
     fn coord(&self) -> Option<Self::CoordType<'_>> {
         let coord = self.coords.value(self.geom_index);
         if coord.is_nan() {
@@ -106,6 +110,7 @@ impl From<Point<'_>> for geo::Geometry {
 impl RTreeObject for Point<'_> {
     type Envelope = AABB<[f64; 2]>;
 
+    #[inline]
     fn envelope(&self) -> Self::Envelope {
         let (lower, upper) = bounding_rect_point(self);
         AABB::from_corners(lower, upper)
@@ -113,6 +118,7 @@ impl RTreeObject for Point<'_> {
 }
 
 impl<G: PointTrait<T = f64>> PartialEq<G> for Point<'_> {
+    #[inline]
     fn eq(&self, other: &G) -> bool {
         point_eq(self, other)
     }

--- a/rust/geoarrow/src/scalar/polygon/scalar.rs
+++ b/rust/geoarrow/src/scalar/polygon/scalar.rs
@@ -81,6 +81,7 @@ impl<'a> PolygonTrait for Polygon<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self.coords.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
@@ -88,6 +89,7 @@ impl<'a> PolygonTrait for Polygon<'a> {
         }
     }
 
+    #[inline]
     fn exterior(&self) -> Option<Self::RingType<'_>> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         if start == end {
@@ -97,11 +99,13 @@ impl<'a> PolygonTrait for Polygon<'a> {
         }
     }
 
+    #[inline]
     fn num_interiors(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start - 1
     }
 
+    #[inline]
     unsafe fn interior_unchecked(&self, i: usize) -> Self::RingType<'_> {
         LineString::new(self.coords, self.ring_offsets, self.start_offset + 1 + i)
     }
@@ -114,6 +118,7 @@ impl<'a> PolygonTrait for &'a Polygon<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         match self.coords.dim() {
             Dimension::XY => geo_traits::Dimensions::Xy,
@@ -121,6 +126,7 @@ impl<'a> PolygonTrait for &'a Polygon<'a> {
         }
     }
 
+    #[inline]
     fn exterior(&self) -> Option<Self::RingType<'_>> {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         if start == end {
@@ -130,11 +136,13 @@ impl<'a> PolygonTrait for &'a Polygon<'a> {
         }
     }
 
+    #[inline]
     fn num_interiors(&self) -> usize {
         let (start, end) = self.geom_offsets.start_end(self.geom_index);
         end - start - 1
     }
 
+    #[inline]
     unsafe fn interior_unchecked(&self, i: usize) -> Self::RingType<'_> {
         LineString::new(self.coords, self.ring_offsets, self.start_offset + 1 + i)
     }

--- a/rust/geoarrow/src/scalar/rect/scalar.rs
+++ b/rust/geoarrow/src/scalar/rect/scalar.rs
@@ -54,7 +54,6 @@ impl NativeScalar for Rect<'_> {
     }
 }
 
-// TODO: support 3d rects
 impl<'a> RectTrait for Rect<'a> {
     type T = f64;
     type CoordType<'b>
@@ -62,14 +61,40 @@ impl<'a> RectTrait for Rect<'a> {
     where
         Self: 'b;
 
+    #[inline]
     fn dim(&self) -> geo_traits::Dimensions {
         self.lower.dim.into()
     }
 
+    #[inline]
     fn min(&self) -> Self::CoordType<'_> {
         self.lower.value(self.geom_index)
     }
 
+    #[inline]
+    fn max(&self) -> Self::CoordType<'_> {
+        self.upper.value(self.geom_index)
+    }
+}
+
+impl<'a> RectTrait for &'a Rect<'a> {
+    type T = f64;
+    type CoordType<'b>
+        = SeparatedCoord<'a>
+    where
+        Self: 'b;
+
+    #[inline]
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.lower.dim.into()
+    }
+
+    #[inline]
+    fn min(&self) -> Self::CoordType<'_> {
+        self.lower.value(self.geom_index)
+    }
+
+    #[inline]
     fn max(&self) -> Self::CoordType<'_> {
         self.upper.value(self.geom_index)
     }


### PR DESCRIPTION
I'm not sure why but this is slower:

```
test result: ok. 0 passed; 0 failed; 151 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/area.rs (target/release/deps/area-cf15bfea0dae142a)
Gnuplot not found, using plotters backend
area                    time:   [44.285 µs 44.397 µs 44.528 µs]
                        change: [+2.0141% +2.4655% +2.8707%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

     Running benches/from_geo.rs (target/release/deps/from_geo-67203421b5fdfb3e)
Gnuplot not found, using plotters backend
Benchmarking convert Vec<geo::Polygon> to PolygonArray: Collecting 100 samples in estimated 5.0965 convert Vec<geo::Polygon> to PolygonArray
                        time:   [28.326 µs 29.114 µs 30.107 µs]
                        change: [+7.3703% +12.343% +19.090%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 17 outliers among 100 measurements (17.00%)
  7 (7.00%) high mild
  10 (10.00%) high severe

     Running benches/geos_buffer.rs (target/release/deps/geos_buffer-fbc4c07a923c4c34)
Gnuplot not found, using plotters backend
buffer                  time:   [429.97 ms 432.93 ms 435.80 ms]
                        change: [-3.3956% -0.8337% +0.9899%] (p = 0.59 > 0.05)
                        No change in performance detected.

     Running benches/nybb.rs (target/release/deps/nybb-960ce5d69e6f00fe)
Gnuplot not found, using plotters backend
to geo                  time:   [151.96 µs 159.24 µs 167.86 µs]
                        change: [+3.4297% +6.5207% +10.545%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe

Benchmarking euclidean distance to scalar point: Collecting 100 samples in estimated 5.6645 s (10k euclidean distance to scalar point
                        time:   [544.17 µs 549.39 µs 555.31 µs]
                        change: [-7.3267% -6.4507% -5.5305%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

     Running benches/translate.rs (target/release/deps/translate-88d735e3c44565a9)
Gnuplot not found, using plotters backend
translate PolygonArray  time:   [93.005 µs 93.547 µs 94.188 µs]
                        change: [+5.1751% +6.2173% +7.2280%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```