### PR TITLE
frozen pyclasses

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -330,18 +330,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -722,7 +722,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "flatgeobuf"
 version = "4.5.0"
-source = "git+https://github.com/kylebarron/flatgeobuf?rev=06e987d6d3d73edb95124a14cdaab9ee8e6e57ac#06e987d6d3d73edb95124a14cdaab9ee8e6e57ac"
+source = "git+https://github.com/flatgeobuf/flatgeobuf?rev=f7563617549f8ab0c111e83ee423996f100ddb0c#f7563617549f8ab0c111e83ee423996f100ddb0c"
 dependencies = [
  "byteorder",
  "bytes",
@@ -949,7 +949,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1390,8 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-client"
-version = "0.8.0"
-source = "git+https://github.com/pka/http-range-client?rev=5699e32fafc416ce683bfbf1d179f80b0b6549a3#5699e32fafc416ce683bfbf1d179f80b0b6549a3"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b0cb8b2a6444be75e1bb3bfa79911cae70865df20a36d7c70945273b13b641"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1652,7 +1653,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2151,7 +2152,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2181,15 +2182,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
+checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
+ "httparse",
  "humantime",
  "hyper",
  "itertools 0.13.0",
@@ -2322,9 +2324,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2332,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2342,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
@@ -2352,31 +2354,31 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2570,7 +2572,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2583,7 +2585,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2611,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
  "serde",
@@ -2673,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2785,9 +2787,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2819,6 +2821,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3082,22 +3085,22 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3174,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -3211,7 +3214,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3514,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3540,7 +3543,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3551,12 +3554,13 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -3588,7 +3592,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3599,7 +3603,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3690,7 +3694,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3745,6 +3749,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3770,7 +3795,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -3948,7 +3973,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -3983,7 +4008,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4241,9 +4266,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]
@@ -4317,7 +4342,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -4339,7 +4364,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -4359,7 +4384,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -4388,7 +4413,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.95",
 ]
 
 [[package]]

--- a/python/geoarrow-io/src/io/parquet/async.rs
+++ b/python/geoarrow-io/src/io/parquet/async.rs
@@ -79,7 +79,7 @@ async fn read_parquet_async_inner(
 }
 
 /// Reader interface for a single Parquet file.
-#[pyclass(module = "geoarrow.rust.io._io")]
+#[pyclass(module = "geoarrow.rust.io._io", frozen)]
 pub struct ParquetFile {
     object_meta: object_store::ObjectMeta,
     geoparquet_meta: GeoParquetReaderMetadata,
@@ -323,7 +323,7 @@ async fn fetch_arrow_metadata_objects(
 
 /// Encapsulates details of reading a complete Parquet dataset possibly consisting of multiple
 /// files and partitions in subdirectories.
-#[pyclass(module = "geoarrow.rust.io._io")]
+#[pyclass(module = "geoarrow.rust.io._io", frozen)]
 pub struct ParquetDataset {
     meta: GeoParquetDatasetMetadata,
     // metas: HashMap<object_store::path::Path, Vec<(ParquetObjectReader, GeoParquetReaderMetadata)>>,

--- a/python/geoarrow-io/src/io/parquet/sync.rs
+++ b/python/geoarrow-io/src/io/parquet/sync.rs
@@ -133,7 +133,7 @@ pub fn write_parquet(
     Ok(())
 }
 
-#[pyclass(module = "geoarrow.rust.io._io")]
+#[pyclass(module = "geoarrow.rust.io._io", frozen)]
 pub struct ParquetWriter {
     file: Mutex<Option<_GeoParquetWriter<FileWriter>>>,
 }
@@ -155,7 +155,7 @@ impl ParquetWriter {
 
     pub fn __enter__(&self) {}
 
-    pub fn write_batch(&mut self, batch: PyRecordBatch) -> PyGeoArrowResult<()> {
+    pub fn write_batch(&self, batch: PyRecordBatch) -> PyGeoArrowResult<()> {
         if let Some(file) = self.file.lock().unwrap().as_mut() {
             file.write_batch(batch.as_ref())?;
             Ok(())
@@ -164,7 +164,7 @@ impl ParquetWriter {
         }
     }
 
-    pub fn write_table(&mut self, table: AnyRecordBatch) -> PyGeoArrowResult<()> {
+    pub fn write_table(&self, table: AnyRecordBatch) -> PyGeoArrowResult<()> {
         if let Some(file) = self.file.lock().unwrap().as_mut() {
             for batch in table.into_reader()? {
                 file.write_batch(&batch?)?;
@@ -175,7 +175,7 @@ impl ParquetWriter {
         }
     }
 
-    pub fn close(&mut self) -> PyGeoArrowResult<()> {
+    pub fn close(&self) -> PyGeoArrowResult<()> {
         if let Some(file) = self.file.lock().unwrap().take() {
             file.finish()?;
             Ok(())
@@ -191,7 +191,7 @@ impl ParquetWriter {
     /// Exit the context manager
     #[allow(unused_variables)]
     pub fn __exit__(
-        &mut self,
+        &self,
         r#type: PyObject,
         value: PyObject,
         traceback: PyObject,

--- a/python/pyo3-geoarrow/src/array.rs
+++ b/python/pyo3-geoarrow/src/array.rs
@@ -19,7 +19,12 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 use pyo3_arrow::ffi::to_array_pycapsules;
 use pyo3_arrow::PyArray;
 
-#[pyclass(module = "geoarrow.rust.core._rust", name = "NativeArray", subclass)]
+#[pyclass(
+    module = "geoarrow.rust.core._rust",
+    name = "NativeArray",
+    subclass,
+    frozen
+)]
 pub struct PyNativeArray(pub(crate) NativeArrayDyn);
 
 impl PyNativeArray {
@@ -184,7 +189,8 @@ impl TryFrom<PyArray> for PyNativeArray {
 #[pyclass(
     module = "geoarrow.rust.core._rust",
     name = "SerializedArray",
-    subclass
+    subclass,
+    frozen
 )]
 pub struct PySerializedArray(pub(crate) SerializedArrayDyn);
 

--- a/python/pyo3-geoarrow/src/chunked_array.rs
+++ b/python/pyo3-geoarrow/src/chunked_array.rs
@@ -19,7 +19,8 @@ use crate::PyNativeType;
 #[pyclass(
     module = "geoarrow.rust.core._rust",
     name = "ChunkedNativeArray",
-    subclass
+    subclass,
+    frozen
 )]
 pub struct PyChunkedNativeArray(pub(crate) Arc<dyn ChunkedNativeArray>);
 

--- a/python/pyo3-geoarrow/src/data_type.rs
+++ b/python/pyo3-geoarrow/src/data_type.rs
@@ -10,7 +10,12 @@ use pyo3::types::{PyCapsule, PyType};
 use pyo3_arrow::ffi::to_schema_pycapsule;
 use pyo3_arrow::PyField;
 
-#[pyclass(module = "geoarrow.rust.core._rust", name = "NativeType", subclass)]
+#[pyclass(
+    module = "geoarrow.rust.core._rust",
+    name = "NativeType",
+    subclass,
+    frozen
+)]
 pub struct PyNativeType(pub(crate) NativeType);
 
 impl PyNativeType {
@@ -154,7 +159,12 @@ impl TryFrom<PyField> for PyNativeType {
     }
 }
 
-#[pyclass(module = "geoarrow.rust.core._rust", name = "SerializedType", subclass)]
+#[pyclass(
+    module = "geoarrow.rust.core._rust",
+    name = "SerializedType",
+    subclass,
+    frozen
+)]
 pub struct PySerializedType(pub(crate) SerializedType);
 
 impl PySerializedType {

--- a/python/pyo3-geoarrow/src/scalar.rs
+++ b/python/pyo3-geoarrow/src/scalar.rs
@@ -13,7 +13,12 @@ use pyo3_arrow::ffi::to_array_pycapsules;
 use crate::error::PyGeoArrowResult;
 
 /// This is modeled as a geospatial array of length 1
-#[pyclass(module = "geoarrow.rust.core._rust", name = "Geometry", subclass)]
+#[pyclass(
+    module = "geoarrow.rust.core._rust",
+    name = "Geometry",
+    subclass,
+    frozen
+)]
 pub struct PyGeometry(pub(crate) GeometryScalar);
 
 impl PyGeometry {


### PR DESCRIPTION
### Change list

- Add the [`frozen`](https://pyo3.rs/v0.23.3/class.html?highlight=frozen#frozen-classes-opting-out-of-interior-mutability) attribute to `#[pyclass]`. This should be a small performance improvement, and allows for accessing the interior of a class even without the GIL.

Ref https://github.com/developmentseed/obstore/pull/118