### PR TITLE
Fix stack overflow when converting `GeometryCollection` scalar to geo

### DIFF
--- a/rust/geoarrow/src/algorithm/geo/bounding_rect.rs
+++ b/rust/geoarrow/src/algorithm/geo/bounding_rect.rs
@@ -142,3 +142,31 @@ impl BoundingRect for &dyn ChunkedNativeArray {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use geo::point;
+
+    use crate::array::{GeometryCollectionArray, PointArray};
+    use crate::datatypes::Dimension;
+    use crate::ArrayBase;
+
+    #[test]
+    fn stack_overflow_repro_issue_979() {
+        let points: Vec<geo::Point<f64>> = vec![
+            point! {x: -104.991, y: 39.7392},
+            point! {x: -73.7897, y: 40.7379},
+        ];
+        let point_array: PointArray = (points.as_slice(), Dimension::XY).into();
+        assert!(point_array.is_valid(0));
+        assert!(point_array.is_valid(1));
+        let _ = point_array.bounding_rect();
+
+        let gc_array: GeometryCollectionArray = point_array.into();
+        assert!(gc_array.is_valid(0));
+        assert!(gc_array.is_valid(1));
+        let _ = gc_array.bounding_rect();
+    }
+}


### PR DESCRIPTION
As described in a contained comment:

We can't implement both
```
impl From<GeometryCollection<'_>> for geo::GeometryCollection
```
and
```
impl From<GeometryCollection<'_>> for geo::Geometry
```
because of this problematic blanket impl
(https://github.com/georust/geo/blob/ef55eabe9029b27f753d4c40db9f656e3670202e/geo-types/src/geometry/geometry_collection.rs#L113-L120).

Thus we need to choose either one or the other to implement.

If we implemented only `for geo::Geometry`, then the default blanket impl for
`geo::GeometryCollection` would be **wrong** because it would doubly-nest the
`GeometryCollection`:

```rs
GeometryCollection(
    [
        GeometryCollection(
            GeometryCollection(
                [
                    Point(
                        Point(
                            Coord {
                                x: 0.0,
                                y: 0.0,
                            },
                        ),
                    ),
                ],
            ),
        ),
    ],
)
```

Therefore we must implement only `for geo::GeometryCollection`

Closes #979