### PR TITLE
Bump GEOS to 10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -1895,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "geos"
-version = "9.1.1"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d199db00644057267a8a68ee72df92aa59a32036b487b2a2b76fd0b3fca32b"
+checksum = "0473e63acafe4109b096ab8c1e6b8151e1cb25397811525779a9bc7187382a7b"
 dependencies = [
  "c_vec",
  "geos-sys",

--- a/rust/geoarrow/Cargo.toml
+++ b/rust/geoarrow/Cargo.toml
@@ -19,7 +19,7 @@ flatgeobuf_async = [
   "dep:bytes",
   "dep:http-range-client",
   "dep:object_store",
-  "dep:futures"
+  "dep:futures",
 ]
 gdal = ["dep:gdal"]
 geos = ["dep:geos"]
@@ -67,7 +67,7 @@ gdal = { version = "0.17", optional = true }
 geo = "0.29.3"
 geo-index = "0.1.1"
 geo-traits = "0.2"
-geos = { version = "9.1.1", features = ["v3_10_0"], optional = true }
+geos = { version = "10", features = ["v3_10_0"], optional = true }
 geozero = { version = "0.14", features = ["with-wkb"] }
 half = { version = "2.4.1" }
 http-range-client = { version = "0.9", optional = true, default-features = false }


### PR DESCRIPTION
GEOS v9 was yanked. We can't run `cargo update` until we bump GEOS to `10`