### PR TITLE
Updates AsyncGeoParquetWriter's inner writer trait bound

### DIFF
--- a/rust/geoarrow/Cargo.toml
+++ b/rust/geoarrow/Cargo.toml
@@ -30,7 +30,6 @@ parquet_async = [
   "parquet/async",
   "dep:async-stream",
   "dep:futures",
-  "dep:tokio",
 ]
 parquet_compression = [
   "parquet/snap",
@@ -96,7 +95,6 @@ sqlx = { version = "0.7", optional = true, default-features = false, features = 
   "tls-rustls",
 ] }
 thiserror = "1"
-tokio = { version = "1", default-features = false, optional = true }
 wkt = "0.12"
 wkb = "0.8"
 

--- a/rust/geoarrow/src/io/parquet/writer/async.rs
+++ b/rust/geoarrow/src/io/parquet/writer/async.rs
@@ -4,12 +4,12 @@ use crate::io::parquet::writer::metadata::GeoParquetMetadataBuilder;
 use crate::io::parquet::writer::options::GeoParquetWriterOptions;
 use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_schema::Schema;
+use parquet::arrow::async_writer::AsyncFileWriter;
 use parquet::arrow::AsyncArrowWriter;
 use parquet::file::metadata::KeyValue;
-use tokio::io::AsyncWrite;
 
 /// Write a [RecordBatchReader] to GeoParquet.
-pub async fn write_geoparquet_async<W: AsyncWrite + Unpin + Send>(
+pub async fn write_geoparquet_async<W: AsyncFileWriter>(
     stream: Box<dyn RecordBatchReader>,
     writer: W,
     options: &GeoParquetWriterOptions,
@@ -25,12 +25,12 @@ pub async fn write_geoparquet_async<W: AsyncWrite + Unpin + Send>(
 }
 
 /// An asynchronous GeoParquet file writer
-pub struct GeoParquetWriterAsync<W: AsyncWrite + Unpin + Send> {
+pub struct GeoParquetWriterAsync<W: AsyncFileWriter> {
     writer: AsyncArrowWriter<W>,
     metadata_builder: GeoParquetMetadataBuilder,
 }
 
-impl<W: AsyncWrite + Unpin + Send> GeoParquetWriterAsync<W> {
+impl<W: AsyncFileWriter> GeoParquetWriterAsync<W> {
     /// Construct a new [GeoParquetWriterAsync]
     pub fn try_new(writer: W, schema: &Schema, options: &GeoParquetWriterOptions) -> Result<Self> {
         let metadata_builder = GeoParquetMetadataBuilder::try_new(schema, options)?;


### PR DESCRIPTION
 - Updates the trait bound used by the AsyncGeoParquetWriter's inner writer with the upstream Arrow's AsyncFileWriter trait introduced in Arrow 52.0.0
 - This update allows the use of the ParquetObjectWriter introduced in Arrow 53.0.0