### PR TITLE
geoarrow-schema crate, plus implementation of upstream ExtensionType trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "54.1.0"
+version = "54.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105f01ec0090259e9a33a9263ec18ff223ab91a0ea9fbc18042f7e38005142f6"
+checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -1893,6 +1893,17 @@ dependencies = [
  "tokio",
  "wkb",
  "wkt 0.12.0",
+]
+
+[[package]]
+name = "geoarrow-schema"
+version = "0.1.0-dev"
+dependencies = [
+ "arrow-schema",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,7 +1903,6 @@ dependencies = [
  "geo-traits",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,13 @@ exclude = ["js"]
 resolver = "2"
 
 [workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/geoarrow/geoarrow-rs"
+
+[workspace.dependencies]
+arrow-schema = "54.3.1"
+geo-traits = "0.2.0"
+serde = "1"
+serde_json = "1"
+thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["rust/geoarrow", "rust/geodatafusion"]
+members = ["rust/geoarrow", "rust/geoarrow-schema", "rust/geodatafusion"]
 exclude = ["js"]
 resolver = "2"
 

--- a/rust/geoarrow-schema/Cargo.toml
+++ b/rust/geoarrow-schema/Cargo.toml
@@ -1,0 +1,19 @@
+
+[package]
+name = "geoarrow-schema"
+version = "0.1.0-dev"
+authors = ["Kyle Barron <kylebarron2@gmail.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/geoarrow/geoarrow-rs"
+description = "Rust implementation of GeoArrow"
+categories = ["science::geo"]
+rust-version = "1.82"
+
+
+[dependencies]
+arrow-schema = "54.3.1"
+geo-traits = "0.2.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"

--- a/rust/geoarrow-schema/Cargo.toml
+++ b/rust/geoarrow-schema/Cargo.toml
@@ -3,17 +3,17 @@
 name = "geoarrow-schema"
 version = "0.1.0-dev"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/geoarrow/geoarrow-rs"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Rust implementation of GeoArrow"
 categories = ["science::geo"]
 rust-version = "1.82"
 
 
 [dependencies]
-arrow-schema = "54.3.1"
-geo-traits = "0.2.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "1"
+arrow-schema = { workspace = true }
+geo-traits = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/rust/geoarrow-schema/Cargo.toml
+++ b/rust/geoarrow-schema/Cargo.toml
@@ -16,4 +16,3 @@ arrow-schema = { workspace = true }
 geo-traits = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-thiserror = { workspace = true }

--- a/rust/geoarrow-schema/README.md
+++ b/rust/geoarrow-schema/README.md
@@ -1,0 +1,1 @@
+# geoarrow-schema

--- a/rust/geoarrow-schema/src/coord_type.rs
+++ b/rust/geoarrow-schema/src/coord_type.rs
@@ -3,10 +3,9 @@
 /// GeoArrow permits coordinate types to either be `Interleaved`, where the X and Y coordinates are
 /// in a single buffer as XYXYXY or `Separated`, where the X and Y coordinates are in multiple
 /// buffers as XXXX and YYYY.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CoordType {
     /// Interleaved coordinates.
-    #[default]
     Interleaved,
 
     /// Separated coordinates.

--- a/rust/geoarrow-schema/src/coord_type.rs
+++ b/rust/geoarrow-schema/src/coord_type.rs
@@ -1,0 +1,14 @@
+/// The permitted GeoArrow coordinate representations.
+///
+/// GeoArrow permits coordinate types to either be `Interleaved`, where the X and Y coordinates are
+/// in a single buffer as XYXYXY or `Separated`, where the X and Y coordinates are in multiple
+/// buffers as XXXX and YYYY.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CoordType {
+    /// Interleaved coordinates.
+    #[default]
+    Interleaved,
+
+    /// Separated coordinates.
+    Separated,
+}

--- a/rust/geoarrow-schema/src/crs.rs
+++ b/rust/geoarrow-schema/src/crs.rs
@@ -1,0 +1,100 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Crs {
+    /// One of:
+    ///
+    /// - A JSON object describing the coordinate reference system (CRS)
+    ///   using [PROJJSON](https://proj.org/specifications/projjson.html).
+    /// - A string containing a serialized CRS representation. This option
+    ///   is intended as a fallback for producers (e.g., database drivers or
+    ///   file readers) that are provided a CRS in some form but do not have the
+    ///   means to convert it to PROJJSON.
+    /// - Omitted, indicating that the producer does not have any information about
+    ///   the CRS.
+    ///
+    /// For maximum compatibility, producers should write PROJJSON where possible.
+    /// Note that regardless of the axis order specified by the CRS, axis order will be interpreted
+    /// [GeoPackage WKB binary encoding](https://www.geopackage.org/spec130/index.html#gpb_format):
+    /// axis order is always (longitude, latitude) and (easting, northing)
+    /// regardless of the the axis order encoded in the CRS specification.
+    crs: Option<Value>,
+
+    /// An optional string disambiguating the value of the `crs` field.
+    ///
+    /// The `"crs_type"` should be omitted if the producer cannot guarantee the validity
+    /// of any of the above values (e.g., if it just serialized a CRS object
+    /// specifically into one of these representations).
+    crs_type: Option<CrsType>,
+}
+
+impl Crs {
+    /// Construct from a PROJJSON object.
+    ///
+    /// Note that `value` should be a _parsed_ JSON object; this should not contain
+    /// `Value::String`.
+    pub fn from_projjson(value: Value) -> Self {
+        Self {
+            crs: Some(value),
+            crs_type: Some(CrsType::Projjson),
+        }
+    }
+
+    /// Construct from a WKT:2019 string.
+    pub fn from_wkt2_2019(value: String) -> Self {
+        Self {
+            crs: Some(Value::String(value)),
+            crs_type: Some(CrsType::Wkt2_2019),
+        }
+    }
+
+    /// Construct from an opaque string.
+    pub fn from_unknown_crs_type(value: String) -> Self {
+        Self {
+            crs: Some(Value::String(value)),
+            crs_type: None,
+        }
+    }
+
+    /// Construct from an authority:code string.
+    pub fn from_authority_code(value: String) -> Self {
+        assert!(value.contains(':'), "':' should be authority:code CRS");
+        Self {
+            crs: Some(Value::String(value)),
+            crs_type: Some(CrsType::AuthorityCode),
+        }
+    }
+
+    /// Return `true` if we should include a CRS key in the GeoArrow metadata
+    pub(crate) fn should_serialize(&self) -> bool {
+        self.crs.is_some()
+    }
+}
+
+/// An optional string disambiguating the value of the `crs` field.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum CrsType {
+    /// Indicates that the `"crs"` field was written as
+    /// [PROJJSON](https://proj.org/specifications/projjson.html).
+    #[serde(rename = "projjson")]
+    Projjson,
+
+    /// Indicates that the `"crs"` field was written as
+    /// [WKT2:2019](https://www.ogc.org/publications/standard/wkt-crs/).
+    #[serde(rename = "wkt2:2019")]
+    Wkt2_2019,
+
+    /// Indicates that the `"crs"` field contains an identifier
+    /// in the form `AUTHORITY:CODE`. This should only be used as a last resort
+    /// (i.e., producers should prefer writing a complete description of the CRS).
+    #[serde(rename = "authority_code")]
+    AuthorityCode,
+
+    /// Indicates that the `"crs"` field contains an opaque identifier
+    /// that requires the consumer to communicate with the producer outside of
+    /// this metadata. This should only be used as a last resort for database
+    /// drivers or readers that have no other option.
+    #[serde(rename = "srid")]
+    Srid,
+}

--- a/rust/geoarrow-schema/src/crs.rs
+++ b/rust/geoarrow-schema/src/crs.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Crs {
     /// One of:
     ///
@@ -73,7 +73,7 @@ impl Crs {
 }
 
 /// An optional string disambiguating the value of the `crs` field.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum CrsType {
     /// Indicates that the `"crs"` field was written as
     /// [PROJJSON](https://proj.org/specifications/projjson.html).

--- a/rust/geoarrow-schema/src/crs.rs
+++ b/rust/geoarrow-schema/src/crs.rs
@@ -26,6 +26,7 @@ pub struct Crs {
     /// The `"crs_type"` should be omitted if the producer cannot guarantee the validity
     /// of any of the above values (e.g., if it just serialized a CRS object
     /// specifically into one of these representations).
+    #[serde(skip_serializing_if = "Option::is_none")]
     crs_type: Option<CrsType>,
 }
 

--- a/rust/geoarrow-schema/src/dimension.rs
+++ b/rust/geoarrow-schema/src/dimension.rs
@@ -51,6 +51,16 @@ impl Dimension {
             );
         }
     }
+
+    /// Returns the number of dimensions.
+    pub fn size(&self) -> usize {
+        match self {
+            Dimension::XY => 2,
+            Dimension::XYZ => 3,
+            Dimension::XYM => 3,
+            Dimension::XYZM => 4,
+        }
+    }
 }
 
 impl From<Dimension> for geo_traits::Dimensions {

--- a/rust/geoarrow-schema/src/dimension.rs
+++ b/rust/geoarrow-schema/src/dimension.rs
@@ -83,7 +83,9 @@ impl TryFrom<geo_traits::Dimensions> for Dimension {
             geo_traits::Dimensions::Xy | geo_traits::Dimensions::Unknown(2) => Ok(Dimension::XY),
             geo_traits::Dimensions::Xyz | geo_traits::Dimensions::Unknown(3) => Ok(Dimension::XYZ),
             geo_traits::Dimensions::Xym => Ok(Dimension::XYM),
-            geo_traits::Dimensions::Xyzm => Ok(Dimension::XYZM),
+            geo_traits::Dimensions::Xyzm | geo_traits::Dimensions::Unknown(4) => {
+                Ok(Dimension::XYZM)
+            }
             _ => Err(ArrowError::SchemaError(format!(
                 "Unsupported dimension {:?}",
                 value

--- a/rust/geoarrow-schema/src/dimension.rs
+++ b/rust/geoarrow-schema/src/dimension.rs
@@ -5,12 +5,6 @@ use arrow_schema::{ArrowError, Field, Fields};
 /// The dimension of the geometry array.
 ///
 /// [Dimension] implements [TryFrom] for integers:
-///
-/// ```
-/// use geoarrow::datatypes::Dimension;
-///
-/// assert_eq!(Dimension::try_from(2).unwrap(), Dimension::XY);
-/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Dimension {
     /// Two-dimensional.

--- a/rust/geoarrow-schema/src/dimension.rs
+++ b/rust/geoarrow-schema/src/dimension.rs
@@ -1,0 +1,89 @@
+use std::collections::HashSet;
+
+use arrow_schema::{ArrowError, Field, Fields};
+
+/// The dimension of the geometry array.
+///
+/// [Dimension] implements [TryFrom] for integers:
+///
+/// ```
+/// use geoarrow::datatypes::Dimension;
+///
+/// assert_eq!(Dimension::try_from(2).unwrap(), Dimension::XY);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Dimension {
+    /// Two-dimensional.
+    XY,
+
+    /// Three-dimensional.
+    XYZ,
+
+    /// XYM (2D with measure).
+    XYM,
+
+    /// XYZM (3D with measure).
+    XYZM,
+}
+
+impl Dimension {
+    pub(crate) fn from_interleaved_field(field: &Field) -> Self {
+        match field.name().as_str() {
+            "xy" => Dimension::XY,
+            "xyz" => Dimension::XYZ,
+            "xym" => Dimension::XYM,
+            "xyzm" => Dimension::XYZM,
+            _ => panic!("Invalid interleaved field name: {}", field.name()),
+        }
+    }
+
+    pub(crate) fn from_separated_field(fields: &Fields) -> Self {
+        if fields.len() == 2 {
+            Self::XY
+        } else if fields.len() == 3 {
+            let field_names: HashSet<&str> =
+                HashSet::from_iter(fields.iter().map(|f| f.name().as_str()));
+            if field_names.contains("m") {
+                Self::XYM
+            } else {
+                Self::XYZ
+            }
+        } else if fields.len() == 4 {
+            Self::XYZM
+        } else {
+            panic!(
+                "Invalid number of fields for separated coordinates: {}",
+                fields.len()
+            );
+        }
+    }
+}
+
+impl From<Dimension> for geo_traits::Dimensions {
+    fn from(value: Dimension) -> Self {
+        match value {
+            Dimension::XY => geo_traits::Dimensions::Xy,
+            Dimension::XYZ => geo_traits::Dimensions::Xyz,
+            Dimension::XYM => geo_traits::Dimensions::Xym,
+            Dimension::XYZM => geo_traits::Dimensions::Xyzm,
+        }
+    }
+}
+
+impl TryFrom<geo_traits::Dimensions> for Dimension {
+    // TODO: switch to our own error
+    type Error = ArrowError;
+
+    fn try_from(value: geo_traits::Dimensions) -> std::result::Result<Self, Self::Error> {
+        match value {
+            geo_traits::Dimensions::Xy | geo_traits::Dimensions::Unknown(2) => Ok(Dimension::XY),
+            geo_traits::Dimensions::Xyz | geo_traits::Dimensions::Unknown(3) => Ok(Dimension::XYZ),
+            geo_traits::Dimensions::Xym => Ok(Dimension::XYM),
+            geo_traits::Dimensions::Xyzm => Ok(Dimension::XYZM),
+            _ => Err(ArrowError::SchemaError(format!(
+                "Unsupported dimension {:?}",
+                value
+            ))),
+        }
+    }
+}

--- a/rust/geoarrow-schema/src/edges.rs
+++ b/rust/geoarrow-schema/src/edges.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+/// If present, instructs consumers that edges follow a spherical path rather than a planar one. If
+/// this value is omitted, edges will be interpreted as planar.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Edges {
+    /// Follow a spherical path rather than a planar.
+    ///
+    /// See [the geoarrow
+    /// specification](https://github.com/geoarrow/geoarrow/blob/main/extension-types.md#extension-metadata)
+    /// for more information about how `edges` should be used.
+    #[serde(rename = "spherical")]
+    Spherical,
+}

--- a/rust/geoarrow-schema/src/edges.rs
+++ b/rust/geoarrow-schema/src/edges.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// If present, instructs consumers that edges follow a spherical path rather than a planar one. If
 /// this value is omitted, edges will be interpreted as planar.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Edges {
     /// Follow a spherical path rather than a planar.
     ///

--- a/rust/geoarrow-schema/src/lib.rs
+++ b/rust/geoarrow-schema/src/lib.rs
@@ -1,0 +1,14 @@
+mod coord_type;
+mod crs;
+mod dimension;
+mod edges;
+mod metadata;
+mod r#type;
+
+pub use coord_type::CoordType;
+pub use dimension::Dimension;
+pub use metadata::Metadata;
+pub use r#type::{
+    BoxType, GeometryCollectionType, GeometryType, LineStringType, MultiLineStringType,
+    MultiPointType, MultiPolygonType, PointType, PolygonType, WkbType, WktType,
+};

--- a/rust/geoarrow-schema/src/lib.rs
+++ b/rust/geoarrow-schema/src/lib.rs
@@ -6,7 +6,9 @@ mod metadata;
 mod r#type;
 
 pub use coord_type::CoordType;
+pub use crs::{Crs, CrsType};
 pub use dimension::Dimension;
+pub use edges::Edges;
 pub use metadata::Metadata;
 pub use r#type::{
     BoxType, GeometryCollectionType, GeometryType, LineStringType, MultiLineStringType,

--- a/rust/geoarrow-schema/src/metadata.rs
+++ b/rust/geoarrow-schema/src/metadata.rs
@@ -1,0 +1,51 @@
+use arrow_schema::ArrowError;
+use serde::{Deserialize, Serialize};
+
+use crate::crs::Crs;
+use crate::edges::Edges;
+
+/// A GeoArrow metadata object following the extension metadata [defined by the GeoArrow
+/// specification](https://geoarrow.org/extension-types).
+///
+/// This is serialized to JSON when a [`geoarrow`](self) array is exported to an [`arrow`] array and
+/// deserialized when imported from an [`arrow`] array.
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Metadata {
+    // Raise the underlying crs fields to this level.
+    // https://serde.rs/attr-flatten.html
+    #[serde(flatten)]
+    crs: Crs,
+
+    /// If present, instructs consumers that edges follow a spherical path rather than a planar
+    /// one. If this value is omitted, edges will be interpreted as planar.
+    pub edges: Option<Edges>,
+}
+
+impl Metadata {
+    /// Creates a new [`Metadata`] object.
+    pub fn new(crs: Crs, edges: Option<Edges>) -> Self {
+        Self { crs, edges }
+    }
+
+    /// Returns true if the metadata should be serialized.
+    fn should_serialize(&self) -> bool {
+        self.crs.should_serialize() || self.edges.is_some()
+    }
+
+    pub(crate) fn serialize(&self) -> Option<String> {
+        if self.should_serialize() {
+            Some(serde_json::to_string(&self).unwrap())
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn deserialize(metadata: Option<&str>) -> Result<Self, ArrowError> {
+        if let Some(ext_meta) = metadata {
+            Ok(serde_json::from_str(ext_meta)
+                .map_err(|err| ArrowError::ExternalError(Box::new(err)))?)
+        } else {
+            Ok(Default::default())
+        }
+    }
+}

--- a/rust/geoarrow-schema/src/metadata.rs
+++ b/rust/geoarrow-schema/src/metadata.rs
@@ -27,13 +27,8 @@ impl Metadata {
         Self { crs, edges }
     }
 
-    /// Returns true if the metadata should be serialized.
-    fn should_serialize(&self) -> bool {
-        self.crs.should_serialize() || self.edges.is_some()
-    }
-
     pub(crate) fn serialize(&self) -> Option<String> {
-        if self.should_serialize() {
+        if self.crs.should_serialize() || self.edges.is_some() {
             Some(serde_json::to_string(&self).unwrap())
         } else {
             None

--- a/rust/geoarrow-schema/src/metadata.rs
+++ b/rust/geoarrow-schema/src/metadata.rs
@@ -9,7 +9,7 @@ use crate::edges::Edges;
 ///
 /// This is serialized to JSON when a [`geoarrow`](self) array is exported to an [`arrow`] array and
 /// deserialized when imported from an [`arrow`] array.
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Metadata {
     // Raise the underlying crs fields to this level.
     // https://serde.rs/attr-flatten.html

--- a/rust/geoarrow-schema/src/metadata.rs
+++ b/rust/geoarrow-schema/src/metadata.rs
@@ -1,8 +1,7 @@
 use arrow_schema::ArrowError;
 use serde::{Deserialize, Serialize};
 
-use crate::crs::Crs;
-use crate::edges::Edges;
+use crate::{Crs, Edges};
 
 /// A GeoArrow metadata object following the extension metadata [defined by the GeoArrow
 /// specification](https://geoarrow.org/extension-types).
@@ -18,6 +17,7 @@ pub struct Metadata {
 
     /// If present, instructs consumers that edges follow a spherical path rather than a planar
     /// one. If this value is omitted, edges will be interpreted as planar.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub edges: Option<Edges>,
 }
 
@@ -47,5 +47,73 @@ impl Metadata {
         } else {
             Ok(Default::default())
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use serde_json::Value;
+
+    use super::*;
+
+    const EPSG_4326_WKT: &str = r#"GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]"#;
+
+    const EPSG_4326_PROJJSON: &str = r#"{"$schema":"https://proj.org/schemas/v0.7/projjson.schema.json","type":"GeographicCRS","name":"WGS 84","datum_ensemble":{"name":"World Geodetic System 1984 ensemble","members":[{"name":"World Geodetic System 1984 (Transit)","id":{"authority":"EPSG","code":1166}},{"name":"World Geodetic System 1984 (G730)","id":{"authority":"EPSG","code":1152}},{"name":"World Geodetic System 1984 (G873)","id":{"authority":"EPSG","code":1153}},{"name":"World Geodetic System 1984 (G1150)","id":{"authority":"EPSG","code":1154}},{"name":"World Geodetic System 1984 (G1674)","id":{"authority":"EPSG","code":1155}},{"name":"World Geodetic System 1984 (G1762)","id":{"authority":"EPSG","code":1156}},{"name":"World Geodetic System 1984 (G2139)","id":{"authority":"EPSG","code":1309}}],"ellipsoid":{"name":"WGS 84","semi_major_axis":6378137,"inverse_flattening":298.257223563},"accuracy":"2.0","id":{"authority":"EPSG","code":6326}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]},"scope":"Horizontal component of 3D system.","area":"World.","bbox":{"south_latitude":-90,"west_longitude":-180,"north_latitude":90,"east_longitude":180},"id":{"authority":"EPSG","code":4326}}"#;
+
+    #[test]
+    fn test_crs_authority_code() {
+        let crs = Crs::from_authority_code("EPSG:4326".to_string());
+        let metadata = Metadata::new(crs, Some(Edges::Spherical));
+
+        let expected = r#"{"crs":"EPSG:4326","crs_type":"authority_code","edges":"spherical"}"#;
+        assert_eq!(metadata.serialize().as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn test_crs_authority_code_no_edges() {
+        let crs = Crs::from_authority_code("EPSG:4326".to_string());
+        let metadata = Metadata::new(crs, None);
+
+        let expected = r#"{"crs":"EPSG:4326","crs_type":"authority_code"}"#;
+        assert_eq!(metadata.serialize().as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn test_crs_wkt() {
+        let crs = Crs::from_wkt2_2019(EPSG_4326_WKT.to_string());
+        let metadata = Metadata::new(crs, None);
+
+        let expected = r#"{"crs":"GEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],CS[ellipsoidal,2],AXIS[\"geodetic latitude (Lat)\",north,ORDER[1],ANGLEUNIT[\"degree\",0.0174532925199433]],AXIS[\"geodetic longitude (Lon)\",east,ORDER[2],ANGLEUNIT[\"degree\",0.0174532925199433]],USAGE[SCOPE[\"Horizontal component of 3D system.\"],AREA[\"World.\"],BBOX[-90,-180,90,180]],ID[\"EPSG\",4326]]","crs_type":"wkt2:2019"}"#;
+
+        assert_eq!(metadata.serialize().as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn test_projjson() {
+        let crs = Crs::from_projjson(Value::from_str(EPSG_4326_PROJJSON).unwrap());
+        let metadata = Metadata::new(crs, None);
+
+        let expected = r#"{"crs":{"$schema":"https://proj.org/schemas/v0.7/projjson.schema.json","type":"GeographicCRS","name":"WGS 84","datum_ensemble":{"name":"World Geodetic System 1984 ensemble","members":[{"name":"World Geodetic System 1984 (Transit)","id":{"authority":"EPSG","code":1166}},{"name":"World Geodetic System 1984 (G730)","id":{"authority":"EPSG","code":1152}},{"name":"World Geodetic System 1984 (G873)","id":{"authority":"EPSG","code":1153}},{"name":"World Geodetic System 1984 (G1150)","id":{"authority":"EPSG","code":1154}},{"name":"World Geodetic System 1984 (G1674)","id":{"authority":"EPSG","code":1155}},{"name":"World Geodetic System 1984 (G1762)","id":{"authority":"EPSG","code":1156}},{"name":"World Geodetic System 1984 (G2139)","id":{"authority":"EPSG","code":1309}}],"ellipsoid":{"name":"WGS 84","semi_major_axis":6378137,"inverse_flattening":298.257223563},"accuracy":"2.0","id":{"authority":"EPSG","code":6326}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]},"scope":"Horizontal component of 3D system.","area":"World.","bbox":{"south_latitude":-90,"west_longitude":-180,"north_latitude":90,"east_longitude":180},"id":{"authority":"EPSG","code":4326}},"crs_type":"projjson"}"#;
+        assert_eq!(
+            Value::from_str(&metadata.serialize().unwrap()).unwrap(),
+            Value::from_str(expected).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_unknown_crs() {
+        let crs = Crs::from_unknown_crs_type("CRS".to_string());
+        let metadata = Metadata::new(crs, None);
+
+        let expected = r#"{"crs":"CRS"}"#;
+        assert_eq!(metadata.serialize().as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn test_empty_metadata() {
+        let metadata = Metadata::default();
+        assert_eq!(metadata.serialize().as_deref(), None);
     }
 }

--- a/rust/geoarrow-schema/src/metadata.rs
+++ b/rust/geoarrow-schema/src/metadata.rs
@@ -68,7 +68,13 @@ mod test {
         let metadata = Metadata::new(crs, Some(Edges::Spherical));
 
         let expected = r#"{"crs":"EPSG:4326","crs_type":"authority_code","edges":"spherical"}"#;
-        assert_eq!(metadata.serialize().as_deref(), Some(expected));
+        let serialized = metadata.serialize();
+        assert_eq!(serialized.as_deref(), Some(expected));
+
+        assert_eq!(
+            metadata,
+            Metadata::deserialize(serialized.as_deref()).unwrap()
+        );
     }
 
     #[test]
@@ -77,7 +83,14 @@ mod test {
         let metadata = Metadata::new(crs, None);
 
         let expected = r#"{"crs":"EPSG:4326","crs_type":"authority_code"}"#;
-        assert_eq!(metadata.serialize().as_deref(), Some(expected));
+
+        let serialized = metadata.serialize();
+        assert_eq!(serialized.as_deref(), Some(expected));
+
+        assert_eq!(
+            metadata,
+            Metadata::deserialize(serialized.as_deref()).unwrap()
+        );
     }
 
     #[test]
@@ -87,7 +100,13 @@ mod test {
 
         let expected = r#"{"crs":"GEOGCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\",MEMBER[\"World Geodetic System 1984 (Transit)\"],MEMBER[\"World Geodetic System 1984 (G730)\"],MEMBER[\"World Geodetic System 1984 (G873)\"],MEMBER[\"World Geodetic System 1984 (G1150)\"],MEMBER[\"World Geodetic System 1984 (G1674)\"],MEMBER[\"World Geodetic System 1984 (G1762)\"],MEMBER[\"World Geodetic System 1984 (G2139)\"],ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],ENSEMBLEACCURACY[2.0]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],CS[ellipsoidal,2],AXIS[\"geodetic latitude (Lat)\",north,ORDER[1],ANGLEUNIT[\"degree\",0.0174532925199433]],AXIS[\"geodetic longitude (Lon)\",east,ORDER[2],ANGLEUNIT[\"degree\",0.0174532925199433]],USAGE[SCOPE[\"Horizontal component of 3D system.\"],AREA[\"World.\"],BBOX[-90,-180,90,180]],ID[\"EPSG\",4326]]","crs_type":"wkt2:2019"}"#;
 
-        assert_eq!(metadata.serialize().as_deref(), Some(expected));
+        let serialized = metadata.serialize();
+        assert_eq!(serialized.as_deref(), Some(expected));
+
+        assert_eq!(
+            metadata,
+            Metadata::deserialize(serialized.as_deref()).unwrap()
+        );
     }
 
     #[test]
@@ -96,9 +115,18 @@ mod test {
         let metadata = Metadata::new(crs, None);
 
         let expected = r#"{"crs":{"$schema":"https://proj.org/schemas/v0.7/projjson.schema.json","type":"GeographicCRS","name":"WGS 84","datum_ensemble":{"name":"World Geodetic System 1984 ensemble","members":[{"name":"World Geodetic System 1984 (Transit)","id":{"authority":"EPSG","code":1166}},{"name":"World Geodetic System 1984 (G730)","id":{"authority":"EPSG","code":1152}},{"name":"World Geodetic System 1984 (G873)","id":{"authority":"EPSG","code":1153}},{"name":"World Geodetic System 1984 (G1150)","id":{"authority":"EPSG","code":1154}},{"name":"World Geodetic System 1984 (G1674)","id":{"authority":"EPSG","code":1155}},{"name":"World Geodetic System 1984 (G1762)","id":{"authority":"EPSG","code":1156}},{"name":"World Geodetic System 1984 (G2139)","id":{"authority":"EPSG","code":1309}}],"ellipsoid":{"name":"WGS 84","semi_major_axis":6378137,"inverse_flattening":298.257223563},"accuracy":"2.0","id":{"authority":"EPSG","code":6326}},"coordinate_system":{"subtype":"ellipsoidal","axis":[{"name":"Geodetic latitude","abbreviation":"Lat","direction":"north","unit":"degree"},{"name":"Geodetic longitude","abbreviation":"Lon","direction":"east","unit":"degree"}]},"scope":"Horizontal component of 3D system.","area":"World.","bbox":{"south_latitude":-90,"west_longitude":-180,"north_latitude":90,"east_longitude":180},"id":{"authority":"EPSG","code":4326}},"crs_type":"projjson"}"#;
+
+        let serialized = metadata.serialize();
+
+        // We use Value for equality checking because JSON string formatting is different
         assert_eq!(
-            Value::from_str(&metadata.serialize().unwrap()).unwrap(),
+            Value::from_str(serialized.as_deref().unwrap()).unwrap(),
             Value::from_str(expected).unwrap()
+        );
+
+        assert_eq!(
+            metadata,
+            Metadata::deserialize(serialized.as_deref()).unwrap()
         );
     }
 
@@ -108,12 +136,25 @@ mod test {
         let metadata = Metadata::new(crs, None);
 
         let expected = r#"{"crs":"CRS"}"#;
-        assert_eq!(metadata.serialize().as_deref(), Some(expected));
+
+        let serialized = metadata.serialize();
+        assert_eq!(serialized.as_deref(), Some(expected));
+
+        assert_eq!(
+            metadata,
+            Metadata::deserialize(serialized.as_deref()).unwrap()
+        );
     }
 
     #[test]
     fn test_empty_metadata() {
         let metadata = Metadata::default();
-        assert_eq!(metadata.serialize().as_deref(), None);
+        let serialized = metadata.serialize();
+        assert_eq!(serialized.as_deref(), None);
+
+        assert_eq!(
+            metadata,
+            Metadata::deserialize(serialized.as_deref()).unwrap()
+        );
     }
 }

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -63,13 +63,34 @@ macro_rules! define_basic_type {
     };
 }
 
-define_basic_type!(PointType);
-define_basic_type!(LineStringType);
-define_basic_type!(PolygonType);
-define_basic_type!(MultiPointType);
-define_basic_type!(MultiLineStringType);
-define_basic_type!(MultiPolygonType);
-define_basic_type!(GeometryCollectionType);
+define_basic_type!(
+    /// A type representing a Point geometry, implementing the [`ExtensionType`] trait.
+    PointType
+);
+define_basic_type!(
+    /// A type representing a LineString geometry, implementing the [`ExtensionType`] trait.
+    LineStringType
+);
+define_basic_type!(
+    /// A type representing a Polygon geometry, implementing the [`ExtensionType`] trait.
+    PolygonType
+);
+define_basic_type!(
+    /// A type representing a MultiPoint geometry, implementing the [`ExtensionType`] trait.
+    MultiPointType
+);
+define_basic_type!(
+    /// A type representing a MultiLineString geometry, implementing the [`ExtensionType`] trait.
+    MultiLineStringType
+);
+define_basic_type!(
+    /// A type representing a MultiPolygon geometry, implementing the [`ExtensionType`] trait.
+    MultiPolygonType
+);
+define_basic_type!(
+    /// A type representing a GeometryCollection geometry, implementing the [`ExtensionType`] trait.
+    GeometryCollectionType
+);
 
 impl PointType {
     /// Convert to the corresponding [`DataType`].
@@ -621,6 +642,63 @@ impl GeometryCollectionType {
     /// Convert to the corresponding [`DataType`].
     ///
     /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    ///
+    /// use arrow_schema::{DataType, Field, UnionFields, UnionMode};
+    /// use geoarrow_schema::{
+    ///     CoordType, Dimension, GeometryCollectionType, LineStringType, Metadata, MultiLineStringType,
+    ///     MultiPointType, MultiPolygonType, PointType, PolygonType,
+    /// };
+    ///
+    /// let coord_type = CoordType::Interleaved;
+    /// let dim = Dimension::XY;
+    /// let metadata = Arc::new(Metadata::default());
+    /// let geom_type = GeometryCollectionType::new(coord_type, dim, metadata.clone());
+    ///
+    /// let fields = vec![
+    ///     Field::new(
+    ///         "Point",
+    ///         PointType::new(coord_type, dim, metadata.clone()).data_type(),
+    ///         true,
+    ///     ),
+    ///     Field::new(
+    ///         "LineString",
+    ///         LineStringType::new(coord_type, dim, metadata.clone()).data_type(),
+    ///         true,
+    ///     ),
+    ///     Field::new(
+    ///         "Polygon",
+    ///         PolygonType::new(coord_type, dim, metadata.clone()).data_type(),
+    ///         true,
+    ///     ),
+    ///     Field::new(
+    ///         "MultiPoint",
+    ///         MultiPointType::new(coord_type, dim, metadata.clone()).data_type(),
+    ///         true,
+    ///     ),
+    ///     Field::new(
+    ///         "MultiLineString",
+    ///         MultiLineStringType::new(coord_type, dim, metadata.clone()).data_type(),
+    ///         true,
+    ///     ),
+    ///     Field::new(
+    ///         "MultiPolygon",
+    ///         MultiPolygonType::new(coord_type, dim, metadata.clone()).data_type(),
+    ///         true,
+    ///     ),
+    /// ];
+    /// let type_ids = vec![1, 2, 3, 4, 5, 6];
+    ///
+    /// let union_fields = UnionFields::new(type_ids, fields);
+    /// let union_data_type = DataType::Union(union_fields, UnionMode::Dense);
+    ///
+    /// let geometries_field = Field::new("geometries", union_data_type, false).into();
+    /// let expected_type = DataType::List(geometries_field);
+    ///
+    /// assert_eq!(geom_type.data_type(), expected_type);
+    /// ```
     pub fn data_type(&self) -> DataType {
         let geometries_field = Field::new(
             "geometries",
@@ -1464,5 +1542,12 @@ mod test {
 
         let expected = r#"{"crs":"EPSG:4326","crs_type":"authority_code","edges":"spherical"}"#;
         assert_eq!(type_.serialize_metadata().as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn geometry_data_type() {
+        let typ =
+            GeometryCollectionType::new(CoordType::Interleaved, Dimension::XY, Default::default());
+        dbg!(typ.data_type());
     }
 }

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1388,9 +1388,9 @@ impl WktType {
     ///
     /// ```
     /// use arrow_schema::DataType;
-    /// use geoarrow_schema::WkbType;
+    /// use geoarrow_schema::WktType;
     ///
-    /// let geom_type = WkbType::new(Default::default());
+    /// let geom_type = WktType::new(Default::default());
     ///
     /// assert_eq!(geom_type.data_type(false), DataType::Utf8);
     /// ```

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -17,6 +17,7 @@ macro_rules! define_basic_type {
         }
 
         impl $struct_name {
+            /// Construct a new type from parts.
             pub fn new(coord_type: CoordType, dim: Dimension, metadata: Arc<Metadata>) -> Self {
                 Self {
                     coord_type,
@@ -25,26 +26,32 @@ macro_rules! define_basic_type {
                 }
             }
 
+            /// Change the underlying [`CoordType`]
             pub fn with_coord_type(self, coord_type: CoordType) -> Self {
                 Self { coord_type, ..self }
             }
 
+            /// Change the underlying [`Dimension`]
             pub fn with_dimension(self, dim: Dimension) -> Self {
                 Self { dim, ..self }
             }
 
+            /// Change the underlying [`Metadata`]
             pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
                 Self { metadata, ..self }
             }
 
+            /// Retrieve the underlying [`CoordType`]
             pub fn coord_type(&self) -> CoordType {
                 self.coord_type
             }
 
+            /// Retrieve the underlying [`Dimension`]
             pub fn dimension(&self) -> Dimension {
                 self.dim
             }
 
+            /// Retrieve the underlying [`Metadata`]
             pub fn metadata(&self) -> &Metadata {
                 &self.metadata
             }
@@ -61,6 +68,9 @@ define_basic_type!(MultiPolygonType);
 define_basic_type!(GeometryCollectionType);
 
 impl PointType {
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         coord_type_to_data_type(self.coord_type, self.dim)
     }
@@ -127,6 +137,9 @@ fn parse_point(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowErro
 }
 
 impl LineStringType {
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
         let vertices_field = Field::new("vertices", coords_type, false).into();
@@ -190,6 +203,9 @@ fn parse_linestring(data_type: &DataType) -> Result<(CoordType, Dimension), Arro
 }
 
 impl PolygonType {
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
         let vertices_field = Field::new("vertices", coords_type, false);
@@ -263,6 +279,9 @@ fn parse_polygon(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowEr
 }
 
 impl MultiPointType {
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
         let vertices_field = Field::new("points", coords_type, false).into();
@@ -325,6 +344,9 @@ fn parse_multipoint(data_type: &DataType) -> Result<(CoordType, Dimension), Arro
 }
 
 impl MultiLineStringType {
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
         let vertices_field = Field::new("vertices", coords_type, false);
@@ -398,6 +420,9 @@ fn parse_multilinestring(data_type: &DataType) -> Result<(CoordType, Dimension),
 }
 
 impl MultiPolygonType {
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
         let vertices_field = Field::new("vertices", coords_type, false);
@@ -482,6 +507,9 @@ fn parse_multipolygon(data_type: &DataType) -> Result<(CoordType, Dimension), Ar
 }
 
 impl GeometryCollectionType {
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         let geometries_field = Field::new(
             "geometries",
@@ -696,14 +724,37 @@ pub struct GeometryType {
 }
 
 impl GeometryType {
+    /// Construct a new type from parts.
+    pub fn new(coord_type: CoordType, metadata: Arc<Metadata>) -> Self {
+        Self {
+            coord_type,
+            metadata,
+        }
+    }
+
+    /// Change the underlying [`CoordType`]
     pub fn with_coord_type(self, coord_type: CoordType) -> Self {
         Self { coord_type, ..self }
     }
 
+    /// Change the underlying [`Metadata`]
     pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
         Self { metadata, ..self }
     }
 
+    /// Retrieve the underlying [`CoordType`]
+    pub fn coord_type(&self) -> CoordType {
+        self.coord_type
+    }
+
+    /// Retrieve the underlying [`Metadata`]
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         let mut fields = vec![];
         let type_ids = vec![
@@ -882,14 +933,34 @@ pub struct BoxType {
 }
 
 impl BoxType {
+    /// Construct a new type from parts.
+    pub fn new(dim: Dimension, metadata: Arc<Metadata>) -> Self {
+        Self { dim, metadata }
+    }
+
+    /// Change the underlying [`Dimension`]
     pub fn with_dimension(self, dim: Dimension) -> Self {
         Self { dim, ..self }
     }
 
+    /// Change the underlying [`Metadata`]
     pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
         Self { metadata, ..self }
     }
 
+    /// Retrieve the underlying [`CoordType`]
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
+    /// Retrieve the underlying [`Metadata`]
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self) -> DataType {
         let values_fields = match self.dim {
             Dimension::XY => {
@@ -1008,10 +1079,24 @@ pub struct WkbType {
 }
 
 impl WkbType {
+    /// Construct a new type from parts.
+    pub fn new(metadata: Arc<Metadata>) -> Self {
+        Self { metadata }
+    }
+
+    /// Change the underlying [`Metadata`]
     pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
         Self { metadata }
     }
 
+    /// Retrieve the underlying [`Metadata`]
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self, large: bool) -> DataType {
         if large {
             DataType::LargeBinary
@@ -1062,10 +1147,24 @@ pub struct WktType {
 }
 
 impl WktType {
+    /// Construct a new type from parts.
+    pub fn new(metadata: Arc<Metadata>) -> Self {
+        Self { metadata }
+    }
+
+    /// Change the underlying [`Metadata`]
     pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
         Self { metadata }
     }
 
+    /// Retrieve the underlying [`Metadata`]
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    /// Convert to the corresponding [`DataType`].
+    ///
+    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
     pub fn data_type(&self, large: bool) -> DataType {
         if large {
             DataType::LargeUtf8

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -6,6 +6,7 @@ use arrow_schema::{ArrowError, DataType};
 use crate::metadata::Metadata;
 use crate::{CoordType, Dimension};
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PointType {
     coord_type: CoordType,
     dim: Dimension,
@@ -72,6 +73,7 @@ fn parse_point(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowErro
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct LineStringType {
     coord_type: CoordType,
     dim: Dimension,
@@ -133,6 +135,7 @@ fn parse_linestring(data_type: &DataType) -> Result<(CoordType, Dimension), Arro
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PolygonType {
     coord_type: CoordType,
     dim: Dimension,
@@ -203,6 +206,7 @@ fn parse_polygon(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowEr
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MultiPointType {
     coord_type: CoordType,
     dim: Dimension,
@@ -263,6 +267,7 @@ fn parse_multipoint(data_type: &DataType) -> Result<(CoordType, Dimension), Arro
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MultiLineStringType {
     coord_type: CoordType,
     dim: Dimension,
@@ -333,6 +338,7 @@ fn parse_multilinestring(data_type: &DataType) -> Result<(CoordType, Dimension),
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MultiPolygonType {
     coord_type: CoordType,
     dim: Dimension,
@@ -413,6 +419,7 @@ fn parse_multipolygon(data_type: &DataType) -> Result<(CoordType, Dimension), Ar
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GeometryCollectionType {
     coord_type: CoordType,
     dim: Dimension,
@@ -548,6 +555,7 @@ fn parse_geometry_collection(data_type: &DataType) -> Result<(CoordType, Dimensi
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GeometryType {
     coord_type: CoordType,
     metadata: Metadata,
@@ -651,6 +659,7 @@ fn parse_geometry(data_type: &DataType) -> Result<CoordType, ArrowError> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BoxType {
     dim: Dimension,
     metadata: Metadata,
@@ -718,6 +727,7 @@ fn parse_box(data_type: &DataType) -> Result<Dimension, ArrowError> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WkbType {
     metadata: Metadata,
 }
@@ -755,6 +765,7 @@ impl ExtensionType for WkbType {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WktType {
     metadata: Metadata,
 }

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1,16 +1,69 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use arrow_schema::extension::ExtensionType;
-use arrow_schema::{ArrowError, DataType};
+use arrow_schema::{ArrowError, DataType, Field, UnionFields, UnionMode};
 
 use crate::metadata::Metadata;
 use crate::{CoordType, Dimension};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct PointType {
-    coord_type: CoordType,
-    dim: Dimension,
-    metadata: Metadata,
+macro_rules! define_basic_type {
+    ($struct_name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $struct_name {
+            coord_type: CoordType,
+            dim: Dimension,
+            metadata: Arc<Metadata>,
+        }
+
+        impl $struct_name {
+            pub fn new(coord_type: CoordType, dim: Dimension, metadata: Arc<Metadata>) -> Self {
+                Self {
+                    coord_type,
+                    dim,
+                    metadata,
+                }
+            }
+
+            pub fn with_coord_type(self, coord_type: CoordType) -> Self {
+                Self { coord_type, ..self }
+            }
+
+            pub fn with_dimension(self, dim: Dimension) -> Self {
+                Self { dim, ..self }
+            }
+
+            pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
+                Self { metadata, ..self }
+            }
+
+            pub fn coord_type(&self) -> CoordType {
+                self.coord_type
+            }
+
+            pub fn dimension(&self) -> Dimension {
+                self.dim
+            }
+
+            pub fn metadata(&self) -> &Metadata {
+                &self.metadata
+            }
+        }
+    };
+}
+
+define_basic_type!(PointType);
+define_basic_type!(LineStringType);
+define_basic_type!(PolygonType);
+define_basic_type!(MultiPointType);
+define_basic_type!(MultiLineStringType);
+define_basic_type!(MultiPolygonType);
+define_basic_type!(GeometryCollectionType);
+
+impl PointType {
+    pub fn data_type(&self) -> DataType {
+        coord_type_to_data_type(self.coord_type, self.dim)
+    }
 }
 
 impl ExtensionType for PointType {
@@ -52,7 +105,7 @@ impl ExtensionType for PointType {
         Ok(Self {
             coord_type,
             dim,
-            metadata,
+            metadata: Arc::new(metadata),
         })
     }
 }
@@ -73,11 +126,12 @@ fn parse_point(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowErro
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct LineStringType {
-    coord_type: CoordType,
-    dim: Dimension,
-    metadata: Metadata,
+impl LineStringType {
+    pub fn data_type(&self) -> DataType {
+        let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
+        let vertices_field = Field::new("vertices", coords_type, false).into();
+        DataType::List(vertices_field)
+    }
 }
 
 impl ExtensionType for LineStringType {
@@ -119,7 +173,7 @@ impl ExtensionType for LineStringType {
         Ok(Self {
             coord_type,
             dim,
-            metadata,
+            metadata: Arc::new(metadata),
         })
     }
 }
@@ -135,11 +189,13 @@ fn parse_linestring(data_type: &DataType) -> Result<(CoordType, Dimension), Arro
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct PolygonType {
-    coord_type: CoordType,
-    dim: Dimension,
-    metadata: Metadata,
+impl PolygonType {
+    pub fn data_type(&self) -> DataType {
+        let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
+        let vertices_field = Field::new("vertices", coords_type, false);
+        let rings_field = Field::new_list("rings", vertices_field, false).into();
+        DataType::List(rings_field)
+    }
 }
 
 impl ExtensionType for PolygonType {
@@ -181,7 +237,7 @@ impl ExtensionType for PolygonType {
         Ok(Self {
             coord_type,
             dim,
-            metadata,
+            metadata: Arc::new(metadata),
         })
     }
 }
@@ -206,11 +262,12 @@ fn parse_polygon(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowEr
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MultiPointType {
-    coord_type: CoordType,
-    dim: Dimension,
-    metadata: Metadata,
+impl MultiPointType {
+    pub fn data_type(&self) -> DataType {
+        let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
+        let vertices_field = Field::new("points", coords_type, false).into();
+        DataType::List(vertices_field)
+    }
 }
 
 impl ExtensionType for MultiPointType {
@@ -252,7 +309,7 @@ impl ExtensionType for MultiPointType {
         Ok(Self {
             coord_type,
             dim,
-            metadata,
+            metadata: Arc::new(metadata),
         })
     }
 }
@@ -267,11 +324,13 @@ fn parse_multipoint(data_type: &DataType) -> Result<(CoordType, Dimension), Arro
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MultiLineStringType {
-    coord_type: CoordType,
-    dim: Dimension,
-    metadata: Metadata,
+impl MultiLineStringType {
+    pub fn data_type(&self) -> DataType {
+        let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
+        let vertices_field = Field::new("vertices", coords_type, false);
+        let linestrings_field = Field::new_list("linestrings", vertices_field, false).into();
+        DataType::List(linestrings_field)
+    }
 }
 
 impl ExtensionType for MultiLineStringType {
@@ -313,7 +372,7 @@ impl ExtensionType for MultiLineStringType {
         Ok(Self {
             coord_type,
             dim,
-            metadata,
+            metadata: Arc::new(metadata),
         })
     }
 }
@@ -338,11 +397,14 @@ fn parse_multilinestring(data_type: &DataType) -> Result<(CoordType, Dimension),
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MultiPolygonType {
-    coord_type: CoordType,
-    dim: Dimension,
-    metadata: Metadata,
+impl MultiPolygonType {
+    pub fn data_type(&self) -> DataType {
+        let coords_type = coord_type_to_data_type(self.coord_type, self.dim);
+        let vertices_field = Field::new("vertices", coords_type, false);
+        let rings_field = Field::new_list("rings", vertices_field, false);
+        let polygons_field = Field::new_list("polygons", rings_field, false).into();
+        DataType::List(polygons_field)
+    }
 }
 
 impl ExtensionType for MultiPolygonType {
@@ -384,7 +446,7 @@ impl ExtensionType for MultiPolygonType {
         Ok(Self {
             coord_type,
             dim,
-            metadata,
+            metadata: Arc::new(metadata),
         })
     }
 }
@@ -419,11 +481,83 @@ fn parse_multipolygon(data_type: &DataType) -> Result<(CoordType, Dimension), Ar
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct GeometryCollectionType {
-    coord_type: CoordType,
-    dim: Dimension,
-    metadata: Metadata,
+impl GeometryCollectionType {
+    pub fn data_type(&self) -> DataType {
+        let geometries_field = Field::new(
+            "geometries",
+            mixed_data_type(self.coord_type, self.dim),
+            false,
+        )
+        .into();
+        DataType::List(geometries_field)
+    }
+}
+
+fn mixed_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
+    let mut fields = vec![];
+    let mut type_ids = vec![];
+
+    match dim {
+        Dimension::XY => type_ids.extend([1, 2, 3, 4, 5, 6]),
+        Dimension::XYZ => type_ids.extend([11, 12, 13, 14, 15, 16]),
+        Dimension::XYM => type_ids.extend([21, 22, 23, 24, 25, 26]),
+        Dimension::XYZM => type_ids.extend([31, 32, 33, 34, 35, 36]),
+    }
+
+    // Note: we manually construct the fields because these fields shouldn't have their own
+    // GeoArrow extension metadata
+    macro_rules! push_field {
+        ($field_name:literal, $geom_type:ident) => {{
+            fields.push(Field::new(
+                $field_name,
+                $geom_type {
+                    coord_type,
+                    dim,
+                    metadata: Metadata::default().into(),
+                }
+                .data_type(),
+                true,
+            ));
+        }};
+    }
+
+    match dim {
+        Dimension::XY => {
+            push_field!("Point", PointType);
+            push_field!("LineString", LineStringType);
+            push_field!("Polygon", PolygonType);
+            push_field!("MultiPoint", MultiPointType);
+            push_field!("MultiLineString", MultiLineStringType);
+            push_field!("MultiPolygon", MultiPolygonType);
+        }
+        Dimension::XYZ => {
+            push_field!("Point Z", PointType);
+            push_field!("LineString Z", LineStringType);
+            push_field!("Polygon Z", PolygonType);
+            push_field!("MultiPoint Z", MultiPointType);
+            push_field!("MultiLineString Z", MultiLineStringType);
+            push_field!("MultiPolygon Z", MultiPolygonType);
+        }
+        Dimension::XYM => {
+            push_field!("Point M", PointType);
+            push_field!("LineString M", LineStringType);
+            push_field!("Polygon M", PolygonType);
+            push_field!("MultiPoint M", MultiPointType);
+            push_field!("MultiLineString M", MultiLineStringType);
+            push_field!("MultiPolygon M", MultiPolygonType);
+        }
+        Dimension::XYZM => {
+            push_field!("Point ZM", PointType);
+            push_field!("LineString ZM", LineStringType);
+            push_field!("Polygon ZM", PolygonType);
+            push_field!("MultiPoint ZM", MultiPointType);
+            push_field!("MultiLineString ZM", MultiLineStringType);
+            push_field!("MultiPolygon ZM", MultiPolygonType);
+        }
+    }
+
+    let union_fields = UnionFields::new(type_ids, fields);
+    DataType::Union(union_fields, UnionMode::Dense)
 }
 
 impl ExtensionType for GeometryCollectionType {
@@ -465,7 +599,7 @@ impl ExtensionType for GeometryCollectionType {
         Ok(Self {
             coord_type,
             dim,
-            metadata,
+            metadata: Arc::new(metadata),
         })
     }
 }
@@ -558,7 +692,89 @@ fn parse_geometry_collection(data_type: &DataType) -> Result<(CoordType, Dimensi
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GeometryType {
     coord_type: CoordType,
-    metadata: Metadata,
+    metadata: Arc<Metadata>,
+}
+
+impl GeometryType {
+    pub fn with_coord_type(self, coord_type: CoordType) -> Self {
+        Self { coord_type, ..self }
+    }
+
+    pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
+        Self { metadata, ..self }
+    }
+
+    pub fn data_type(&self) -> DataType {
+        let mut fields = vec![];
+        let type_ids = vec![
+            1, 2, 3, 4, 5, 6, 7, 11, 12, 13, 14, 15, 16, 17, 21, 22, 23, 24, 25, 26, 27, 31, 32,
+            33, 34, 35, 36, 37,
+        ];
+
+        // Note: we manually construct the fields because these fields shouldn't have their own
+        // GeoArrow extension metadata
+        macro_rules! push_field {
+            ($field_name:literal, $geom_type:ident, $dim:path) => {{
+                fields.push(Field::new(
+                    $field_name,
+                    $geom_type {
+                        coord_type: self.coord_type,
+                        dim: $dim,
+                        metadata: Metadata::default().into(),
+                    }
+                    .data_type(),
+                    true,
+                ));
+            }};
+        }
+
+        push_field!("Point", PointType, Dimension::XY);
+        push_field!("LineString", LineStringType, Dimension::XY);
+        push_field!("Polygon", PolygonType, Dimension::XY);
+        push_field!("MultiPoint", MultiPointType, Dimension::XY);
+        push_field!("MultiLineString", MultiLineStringType, Dimension::XY);
+        push_field!("MultiPolygon", MultiPolygonType, Dimension::XY);
+        push_field!("GeometryCollection", GeometryCollectionType, Dimension::XY);
+
+        push_field!("Point Z", PointType, Dimension::XYZ);
+        push_field!("LineString Z", LineStringType, Dimension::XYZ);
+        push_field!("Polygon Z", PolygonType, Dimension::XYZ);
+        push_field!("MultiPoint Z", MultiPointType, Dimension::XYZ);
+        push_field!("MultiLineString Z", MultiLineStringType, Dimension::XYZ);
+        push_field!("MultiPolygon Z", MultiPolygonType, Dimension::XYZ);
+        push_field!(
+            "GeometryCollection Z",
+            GeometryCollectionType,
+            Dimension::XYZ
+        );
+
+        push_field!("Point M", PointType, Dimension::XYM);
+        push_field!("LineString M", LineStringType, Dimension::XYM);
+        push_field!("Polygon M", PolygonType, Dimension::XYM);
+        push_field!("MultiPoint M", MultiPointType, Dimension::XYM);
+        push_field!("MultiLineString M", MultiLineStringType, Dimension::XYM);
+        push_field!("MultiPolygon M", MultiPolygonType, Dimension::XYM);
+        push_field!(
+            "GeometryCollection M",
+            GeometryCollectionType,
+            Dimension::XYM
+        );
+
+        push_field!("Point ZM", PointType, Dimension::XYZM);
+        push_field!("LineString ZM", LineStringType, Dimension::XYZM);
+        push_field!("Polygon ZM", PolygonType, Dimension::XYZM);
+        push_field!("MultiPoint ZM", MultiPointType, Dimension::XYZM);
+        push_field!("MultiLineString ZM", MultiLineStringType, Dimension::XYZM);
+        push_field!("MultiPolygon ZM", MultiPolygonType, Dimension::XYZM);
+        push_field!(
+            "GeometryCollection ZM",
+            GeometryCollectionType,
+            Dimension::XYZM
+        );
+
+        let union_fields = UnionFields::new(type_ids, fields);
+        DataType::Union(union_fields, UnionMode::Dense)
+    }
 }
 
 impl ExtensionType for GeometryType {
@@ -593,7 +809,7 @@ impl ExtensionType for GeometryType {
         let coord_type = parse_geometry(data_type)?;
         Ok(Self {
             coord_type,
-            metadata,
+            metadata: Arc::new(metadata),
         })
     }
 }
@@ -662,7 +878,63 @@ fn parse_geometry(data_type: &DataType) -> Result<CoordType, ArrowError> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BoxType {
     dim: Dimension,
-    metadata: Metadata,
+    metadata: Arc<Metadata>,
+}
+
+impl BoxType {
+    pub fn with_dimension(self, dim: Dimension) -> Self {
+        Self { dim, ..self }
+    }
+
+    pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
+        Self { metadata, ..self }
+    }
+
+    pub fn data_type(&self) -> DataType {
+        let values_fields = match self.dim {
+            Dimension::XY => {
+                vec![
+                    Field::new("xmin", DataType::Float64, false),
+                    Field::new("ymin", DataType::Float64, false),
+                    Field::new("xmax", DataType::Float64, false),
+                    Field::new("ymax", DataType::Float64, false),
+                ]
+            }
+            Dimension::XYZ => {
+                vec![
+                    Field::new("xmin", DataType::Float64, false),
+                    Field::new("ymin", DataType::Float64, false),
+                    Field::new("zmin", DataType::Float64, false),
+                    Field::new("xmax", DataType::Float64, false),
+                    Field::new("ymax", DataType::Float64, false),
+                    Field::new("zmax", DataType::Float64, false),
+                ]
+            }
+            Dimension::XYM => {
+                vec![
+                    Field::new("xmin", DataType::Float64, false),
+                    Field::new("ymin", DataType::Float64, false),
+                    Field::new("mmin", DataType::Float64, false),
+                    Field::new("xmax", DataType::Float64, false),
+                    Field::new("ymax", DataType::Float64, false),
+                    Field::new("mmax", DataType::Float64, false),
+                ]
+            }
+            Dimension::XYZM => {
+                vec![
+                    Field::new("xmin", DataType::Float64, false),
+                    Field::new("ymin", DataType::Float64, false),
+                    Field::new("zmin", DataType::Float64, false),
+                    Field::new("mmin", DataType::Float64, false),
+                    Field::new("xmax", DataType::Float64, false),
+                    Field::new("ymax", DataType::Float64, false),
+                    Field::new("zmax", DataType::Float64, false),
+                    Field::new("mmax", DataType::Float64, false),
+                ]
+            }
+        };
+        DataType::Struct(values_fields.into())
+    }
 }
 
 impl ExtensionType for BoxType {
@@ -695,7 +967,10 @@ impl ExtensionType for BoxType {
 
     fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
         let dim = parse_box(data_type)?;
-        Ok(Self { dim, metadata })
+        Ok(Self {
+            dim,
+            metadata: Arc::new(metadata),
+        })
     }
 }
 
@@ -729,7 +1004,21 @@ fn parse_box(data_type: &DataType) -> Result<Dimension, ArrowError> {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WkbType {
-    metadata: Metadata,
+    metadata: Arc<Metadata>,
+}
+
+impl WkbType {
+    pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
+        Self { metadata }
+    }
+
+    pub fn data_type(&self, large: bool) -> DataType {
+        if large {
+            DataType::LargeBinary
+        } else {
+            DataType::Binary
+        }
+    }
 }
 
 impl ExtensionType for WkbType {
@@ -759,7 +1048,9 @@ impl ExtensionType for WkbType {
     }
 
     fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
-        let wkb = Self { metadata };
+        let wkb = Self {
+            metadata: Arc::new(metadata),
+        };
         wkb.supports_data_type(data_type)?;
         Ok(wkb)
     }
@@ -767,7 +1058,21 @@ impl ExtensionType for WkbType {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WktType {
-    metadata: Metadata,
+    metadata: Arc<Metadata>,
+}
+
+impl WktType {
+    pub fn with_metadata(self, metadata: Arc<Metadata>) -> Self {
+        Self { metadata }
+    }
+
+    pub fn data_type(&self, large: bool) -> DataType {
+        if large {
+            DataType::LargeUtf8
+        } else {
+            DataType::Utf8
+        }
+    }
 }
 
 impl ExtensionType for WktType {
@@ -797,9 +1102,64 @@ impl ExtensionType for WktType {
     }
 
     fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
-        let wkb = Self { metadata };
+        let wkb = Self {
+            metadata: Arc::new(metadata),
+        };
         wkb.supports_data_type(data_type)?;
         Ok(wkb)
+    }
+}
+
+fn coord_type_to_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
+    match (coord_type, dim) {
+        (CoordType::Interleaved, Dimension::XY) => {
+            let values_field = Field::new("xy", DataType::Float64, false);
+            DataType::FixedSizeList(Arc::new(values_field), 2)
+        }
+        (CoordType::Interleaved, Dimension::XYZ) => {
+            let values_field = Field::new("xyz", DataType::Float64, false);
+            DataType::FixedSizeList(Arc::new(values_field), 3)
+        }
+        (CoordType::Interleaved, Dimension::XYM) => {
+            let values_field = Field::new("xym", DataType::Float64, false);
+            DataType::FixedSizeList(Arc::new(values_field), 3)
+        }
+        (CoordType::Interleaved, Dimension::XYZM) => {
+            let values_field = Field::new("xyzm", DataType::Float64, false);
+            DataType::FixedSizeList(Arc::new(values_field), 4)
+        }
+        (CoordType::Separated, Dimension::XY) => {
+            let values_fields = vec![
+                Field::new("x", DataType::Float64, false),
+                Field::new("y", DataType::Float64, false),
+            ];
+            DataType::Struct(values_fields.into())
+        }
+        (CoordType::Separated, Dimension::XYZ) => {
+            let values_fields = vec![
+                Field::new("x", DataType::Float64, false),
+                Field::new("y", DataType::Float64, false),
+                Field::new("z", DataType::Float64, false),
+            ];
+            DataType::Struct(values_fields.into())
+        }
+        (CoordType::Separated, Dimension::XYM) => {
+            let values_fields = vec![
+                Field::new("x", DataType::Float64, false),
+                Field::new("y", DataType::Float64, false),
+                Field::new("m", DataType::Float64, false),
+            ];
+            DataType::Struct(values_fields.into())
+        }
+        (CoordType::Separated, Dimension::XYZM) => {
+            let values_fields = vec![
+                Field::new("x", DataType::Float64, false),
+                Field::new("y", DataType::Float64, false),
+                Field::new("z", DataType::Float64, false),
+                Field::new("m", DataType::Float64, false),
+            ];
+            DataType::Struct(values_fields.into())
+        }
     }
 }
 

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1,0 +1,891 @@
+use std::collections::HashSet;
+
+use arrow_schema::extension::ExtensionType;
+use arrow_schema::{ArrowError, DataType};
+
+use crate::metadata::Metadata;
+use crate::{CoordType, Dimension};
+
+pub struct PointType {
+    coord_type: CoordType,
+    dim: Dimension,
+    metadata: Metadata,
+}
+
+impl ExtensionType for PointType {
+    const NAME: &'static str = "geoarrow.point";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let (coord_type, dim) = parse_point_data_type(data_type)?;
+        if coord_type != self.coord_type {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected coordinate type {:?}, but got {:?}",
+                self.coord_type, coord_type
+            )));
+        }
+        if dim != self.dim {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected dimension {:?}, but got {:?}",
+                self.dim, dim
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let (coord_type, dim) = parse_point_data_type(data_type)?;
+        Ok(Self {
+            coord_type,
+            dim,
+            metadata,
+        })
+    }
+}
+
+fn parse_point_data_type(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowError> {
+    match data_type {
+        DataType::FixedSizeList(inner_field, _list_size) => Ok((
+            CoordType::Interleaved,
+            Dimension::from_interleaved_field(inner_field),
+        )),
+        DataType::Struct(struct_fields) => Ok((
+            CoordType::Separated,
+            Dimension::from_separated_field(struct_fields),
+        )),
+        dt => Err(ArrowError::SchemaError(format!(
+            "Unexpected data type {dt}"
+        ))),
+    }
+}
+
+pub struct LineStringType {
+    coord_type: CoordType,
+    dim: Dimension,
+    metadata: Metadata,
+}
+
+impl ExtensionType for LineStringType {
+    const NAME: &'static str = "geoarrow.linestring";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let (coord_type, dim) = parse_linestring(data_type)?;
+        if coord_type != self.coord_type {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected coordinate type {:?}, but got {:?}",
+                self.coord_type, coord_type
+            )));
+        }
+        if dim != self.dim {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected dimension {:?}, but got {:?}",
+                self.dim, dim
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let (coord_type, dim) = parse_linestring(data_type)?;
+        Ok(Self {
+            coord_type,
+            dim,
+            metadata,
+        })
+    }
+}
+
+fn parse_linestring(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowError> {
+    match data_type {
+        DataType::List(inner_field) | DataType::LargeList(inner_field) => {
+            parse_point_data_type(inner_field.data_type())
+        }
+        dt => Err(ArrowError::SchemaError(format!(
+            "Unexpected data type {dt}"
+        ))),
+    }
+}
+
+pub struct PolygonType {
+    coord_type: CoordType,
+    dim: Dimension,
+    metadata: Metadata,
+}
+
+impl ExtensionType for PolygonType {
+    const NAME: &'static str = "geoarrow.polygon";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let (coord_type, dim) = parse_polygon(data_type)?;
+        if coord_type != self.coord_type {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected coordinate type {:?}, but got {:?}",
+                self.coord_type, coord_type
+            )));
+        }
+        if dim != self.dim {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected dimension {:?}, but got {:?}",
+                self.dim, dim
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let (coord_type, dim) = parse_polygon(data_type)?;
+        Ok(Self {
+            coord_type,
+            dim,
+            metadata,
+        })
+    }
+}
+
+fn parse_polygon(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowError> {
+    match data_type {
+        DataType::List(inner1) => match inner1.data_type() {
+            DataType::List(inner2) => parse_point_data_type(inner2.data_type()),
+            _ => panic!(),
+        },
+        DataType::LargeList(inner1) => match inner1.data_type() {
+            DataType::LargeList(inner2) => parse_point_data_type(inner2.data_type()),
+            _ => panic!(),
+        },
+        dt => Err(ArrowError::SchemaError(format!(
+            "Unexpected data type {dt}"
+        ))),
+    }
+}
+
+pub struct MultiPointType {
+    coord_type: CoordType,
+    dim: Dimension,
+    metadata: Metadata,
+}
+
+impl ExtensionType for MultiPointType {
+    const NAME: &'static str = "geoarrow.multipoint";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let (coord_type, dim) = parse_multipoint_data_type(data_type)?;
+        if coord_type != self.coord_type {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected coordinate type {:?}, but got {:?}",
+                self.coord_type, coord_type
+            )));
+        }
+        if dim != self.dim {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected dimension {:?}, but got {:?}",
+                self.dim, dim
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let (coord_type, dim) = parse_multipoint_data_type(data_type)?;
+        Ok(Self {
+            coord_type,
+            dim,
+            metadata,
+        })
+    }
+}
+
+fn parse_multipoint_data_type(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowError> {
+    match data_type {
+        DataType::List(inner_field) => parse_point_data_type(inner_field.data_type()),
+        DataType::LargeList(inner_field) => parse_point_data_type(inner_field.data_type()),
+        dt => Err(ArrowError::SchemaError(format!(
+            "Unexpected data type {dt}"
+        ))),
+    }
+}
+
+pub struct MultiLineStringType {
+    coord_type: CoordType,
+    dim: Dimension,
+    metadata: Metadata,
+}
+
+impl ExtensionType for MultiLineStringType {
+    const NAME: &'static str = "geoarrow.multilinestring";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let (coord_type, dim) = parse_multilinestring(data_type)?;
+        if coord_type != self.coord_type {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected coordinate type {:?}, but got {:?}",
+                self.coord_type, coord_type
+            )));
+        }
+        if dim != self.dim {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected dimension {:?}, but got {:?}",
+                self.dim, dim
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let (coord_type, dim) = parse_multilinestring(data_type)?;
+        Ok(Self {
+            coord_type,
+            dim,
+            metadata,
+        })
+    }
+}
+
+fn parse_multilinestring(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowError> {
+    match data_type {
+        DataType::List(inner1) => match inner1.data_type() {
+            DataType::List(inner2) => parse_point_data_type(inner2.data_type()),
+            _ => panic!(),
+        },
+        DataType::LargeList(inner1) => match inner1.data_type() {
+            DataType::LargeList(inner2) => parse_point_data_type(inner2.data_type()),
+            _ => panic!(),
+        },
+        dt => Err(ArrowError::SchemaError(format!(
+            "Unexpected data type {dt}"
+        ))),
+    }
+}
+
+pub struct MultiPolygonType {
+    coord_type: CoordType,
+    dim: Dimension,
+    metadata: Metadata,
+}
+
+impl ExtensionType for MultiPolygonType {
+    const NAME: &'static str = "geoarrow.multipolygon";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let (coord_type, dim) = parse_multipolygon(data_type)?;
+        if coord_type != self.coord_type {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected coordinate type {:?}, but got {:?}",
+                self.coord_type, coord_type
+            )));
+        }
+        if dim != self.dim {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected dimension {:?}, but got {:?}",
+                self.dim, dim
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let (coord_type, dim) = parse_multipolygon(data_type)?;
+        Ok(Self {
+            coord_type,
+            dim,
+            metadata,
+        })
+    }
+}
+
+fn parse_multipolygon(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowError> {
+    match data_type {
+        DataType::List(inner1) => match inner1.data_type() {
+            DataType::List(inner2) => match inner2.data_type() {
+                DataType::List(inner3) => parse_point_data_type(inner3.data_type()),
+                _ => panic!(),
+            },
+            _ => panic!(),
+        },
+        DataType::LargeList(inner1) => match inner1.data_type() {
+            DataType::LargeList(inner2) => match inner2.data_type() {
+                DataType::LargeList(inner3) => parse_point_data_type(inner3.data_type()),
+                _ => panic!(),
+            },
+            _ => panic!(),
+        },
+        dt => Err(ArrowError::SchemaError(format!(
+            "Unexpected data type {dt}"
+        ))),
+    }
+}
+
+pub struct GeometryCollectionType {
+    coord_type: CoordType,
+    dim: Dimension,
+    metadata: Metadata,
+}
+
+impl ExtensionType for GeometryCollectionType {
+    const NAME: &'static str = "geoarrow.geometrycollection";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let (coord_type, dim) = parse_geometry_collection(data_type)?;
+        if coord_type != self.coord_type {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected coordinate type {:?}, but got {:?}",
+                self.coord_type, coord_type
+            )));
+        }
+        if dim != self.dim {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected dimension {:?}, but got {:?}",
+                self.dim, dim
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let (coord_type, dim) = parse_geometry_collection(data_type)?;
+        Ok(Self {
+            coord_type,
+            dim,
+            metadata,
+        })
+    }
+}
+
+fn parse_mixed(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowError> {
+    match data_type {
+        DataType::Union(fields, _) => {
+            let mut coord_types: HashSet<CoordType> = HashSet::new();
+            let mut dimensions: HashSet<Dimension> = HashSet::new();
+            fields.iter().try_for_each(|(type_id, field)| {
+                match type_id {
+                    1 => {
+                        let (ct, dim) = parse_point_data_type(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XY));
+                        dimensions.insert(dim);
+                    }
+                    2 => {
+                        let (ct, dim) = parse_linestring(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XY));
+                        dimensions.insert(dim);
+                    }
+                    3 => {
+                        let (ct, dim) = parse_polygon(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XY));
+                        dimensions.insert(dim);
+                    }
+                    4 => {
+                        let (ct, dim) = parse_multipoint_data_type(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XY));
+                        dimensions.insert(dim);
+                    }
+                    5 => {
+                        let (ct, dim) = parse_multilinestring(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XY));
+                        dimensions.insert(dim);
+                    }
+                    6 => {
+                        let (ct, dim) = parse_multipolygon(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XY));
+                        dimensions.insert(dim);
+                    }
+                    11 => {
+                        let (ct, dim) = parse_point_data_type(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XYZ));
+                        dimensions.insert(dim);
+                    }
+                    12 => {
+                        let (ct, dim) = parse_linestring(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XYZ));
+                        dimensions.insert(dim);
+                    }
+                    13 => {
+                        let (ct, dim) = parse_polygon(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XYZ));
+                        dimensions.insert(dim);
+                    }
+                    14 => {
+                        let (ct, dim) = parse_multipoint_data_type(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XYZ));
+                        dimensions.insert(dim);
+                    }
+                    15 => {
+                        let (ct, dim) = parse_multilinestring(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XYZ));
+                        dimensions.insert(dim);
+                    }
+                    16 => {
+                        let (ct, dim) = parse_multipolygon(field.data_type())?;
+                        coord_types.insert(ct);
+                        assert!(matches!(dim, Dimension::XYZ));
+                        dimensions.insert(dim);
+                    }
+                    id => panic!("unexpected type id {}", id),
+                };
+                Ok::<_, ArrowError>(())
+            })?;
+
+            if coord_types.len() > 1 {
+                return Err(ArrowError::SchemaError(
+                    "Multi coord types in union".to_string(),
+                ));
+            }
+            if dimensions.len() > 1 {
+                return Err(ArrowError::SchemaError(
+                    "Multi dimensions types in union".to_string(),
+                ));
+            }
+
+            let coord_type = coord_types.drain().next().unwrap();
+            let dimension = dimensions.drain().next().unwrap();
+            Ok((coord_type, dimension))
+        }
+        _ => panic!("Unexpected data type"),
+    }
+}
+
+fn parse_geometry_collection(data_type: &DataType) -> Result<(CoordType, Dimension), ArrowError> {
+    // We need to parse the _inner_ type of the geometry collection as a union so that we can check
+    // what coordinate type it's using.
+    match data_type {
+        DataType::List(inner_field) | DataType::LargeList(inner_field) => {
+            parse_mixed(inner_field.data_type())
+        }
+        _ => panic!(),
+    }
+}
+
+pub struct GeometryType {
+    coord_type: CoordType,
+    metadata: Metadata,
+}
+
+impl ExtensionType for GeometryType {
+    const NAME: &'static str = "geoarrow.geometry";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let coord_type = parse_geometry(data_type)?;
+        if coord_type != self.coord_type {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected coordinate type {:?}, but got {:?}",
+                self.coord_type, coord_type
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let coord_type = parse_geometry(data_type)?;
+        Ok(Self {
+            coord_type,
+            metadata,
+        })
+    }
+}
+
+fn parse_geometry(data_type: &DataType) -> Result<CoordType, ArrowError> {
+    if let DataType::Union(fields, _mode) = field.data_type() {
+        let mut coord_types: HashSet<CoordType> = HashSet::new();
+
+        fields.iter().try_for_each(|(type_id, field)| {
+            match type_id {
+                1 => match parse_point(field)? {
+                    NativeType::Point(ct, Dimension::XY) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                2 => match parse_linestring(field)? {
+                    NativeType::LineString(ct, Dimension::XY) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                3 => match parse_polygon(field)? {
+                    NativeType::Polygon(ct, Dimension::XY) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                4 => match parse_multi_point(field)? {
+                    NativeType::MultiPoint(ct, Dimension::XY) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                5 => match parse_multi_linestring(field)? {
+                    NativeType::MultiLineString(ct, Dimension::XY) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                6 => match parse_multi_polygon(field)? {
+                    NativeType::MultiPolygon(ct, Dimension::XY) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                7 => match parse_geometry_collection(field)? {
+                    NativeType::GeometryCollection(ct, Dimension::XY) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                11 => match parse_point(field)? {
+                    NativeType::Point(ct, Dimension::XYZ) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                12 => match parse_linestring(field)? {
+                    NativeType::LineString(ct, Dimension::XYZ) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                13 => match parse_polygon(field)? {
+                    NativeType::Polygon(ct, Dimension::XYZ) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                14 => match parse_multi_point(field)? {
+                    NativeType::MultiPoint(ct, Dimension::XYZ) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                15 => match parse_multi_linestring(field)? {
+                    NativeType::MultiLineString(ct, Dimension::XYZ) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                16 => match parse_multi_polygon(field)? {
+                    NativeType::MultiPolygon(ct, Dimension::XYZ) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                17 => match parse_geometry_collection(field)? {
+                    NativeType::GeometryCollection(ct, Dimension::XYZ) => {
+                        coord_types.insert(ct);
+                    }
+                    _ => unreachable!(),
+                },
+                id => panic!("unexpected type id {}", id),
+            };
+            Ok::<_, GeoArrowError>(())
+        })?;
+
+        if coord_types.len() > 1 {
+            return Err(GeoArrowError::General(
+                "Multi coord types in union".to_string(),
+            ));
+        }
+
+        let coord_type = coord_types.drain().next().unwrap();
+        Ok(NativeType::Geometry(coord_type))
+    } else {
+        Err(GeoArrowError::General("Expected union type".to_string()))
+    }
+}
+
+pub struct BoxType {
+    dim: Dimension,
+    metadata: Metadata,
+}
+
+impl ExtensionType for BoxType {
+    const NAME: &'static str = "geoarrow.box";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        let dim = parse_rect(data_type)?;
+        if dim != self.dim {
+            return Err(ArrowError::SchemaError(format!(
+                "Expected dimension {:?}, but got {:?}",
+                self.dim, dim
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let dim = parse_rect(data_type)?;
+        Ok(Self { dim, metadata })
+    }
+}
+
+fn parse_rect(data_type: &DataType) -> Result<Dimension, ArrowError> {
+    // TODO: check child names for higher dimensions
+    match data_type {
+        DataType::Struct(struct_fields) => match struct_fields.len() {
+            4 => Ok(Dimension::XY),
+            6 => Ok(Dimension::XYZ),
+            _ => panic!("unexpected number of struct fields"),
+        },
+        _ => panic!("unexpected data type parsing rect"),
+    }
+}
+
+pub struct WkbType {
+    metadata: Metadata,
+}
+
+impl ExtensionType for WkbType {
+    const NAME: &'static str = "geoarrow.wkb";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        match data_type {
+            DataType::Binary | DataType::LargeBinary => Ok(()),
+            dt => Err(ArrowError::SchemaError(format!(
+                "Unexpected data type {dt}"
+            ))),
+        }
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let wkb = Self { metadata };
+        wkb.supports_data_type(data_type)?;
+        Ok(wkb)
+    }
+}
+
+pub struct WktType {
+    metadata: Metadata,
+}
+
+impl ExtensionType for WktType {
+    const NAME: &'static str = "geoarrow.wkt";
+
+    type Metadata = Metadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.metadata
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        self.metadata.serialize()
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        Metadata::deserialize(metadata)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        match data_type {
+            DataType::Utf8 | DataType::LargeUtf8 => Ok(()),
+            dt => Err(ArrowError::SchemaError(format!(
+                "Unexpected data type {dt}"
+            ))),
+        }
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let wkb = Self { metadata };
+        wkb.supports_data_type(data_type)?;
+        Ok(wkb)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use crate::crs::Crs;
+    use crate::edges::Edges;
+
+    use super::*;
+    use arrow_schema::DataType;
+    use arrow_schema::Field;
+
+    #[test]
+    fn test_point_interleaved_xy() {
+        let data_type =
+            DataType::FixedSizeList(Arc::new(Field::new("xy", DataType::Float64, false)), 2);
+        let metadata = Metadata::default();
+        let type_ = PointType::try_new(&data_type, metadata).unwrap();
+
+        assert_eq!(type_.coord_type, CoordType::Interleaved);
+        assert_eq!(type_.dim, Dimension::XY);
+        assert_eq!(type_.serialize_metadata(), None);
+    }
+
+    #[test]
+    fn test_point_separated_xyz() {
+        let data_type = DataType::Struct(
+            vec![
+                Field::new("x", DataType::Float64, false),
+                Field::new("y", DataType::Float64, false),
+                Field::new("z", DataType::Float64, false),
+            ]
+            .into(),
+        );
+        let metadata = Metadata::default();
+        let type_ = PointType::try_new(&data_type, metadata).unwrap();
+
+        assert_eq!(type_.coord_type, CoordType::Separated);
+        assert_eq!(type_.dim, Dimension::XYZ);
+        assert_eq!(type_.serialize_metadata(), None);
+    }
+
+    #[test]
+    fn test_point_metadata() {
+        let data_type =
+            DataType::FixedSizeList(Arc::new(Field::new("xy", DataType::Float64, false)), 2);
+        let crs = Crs::from_authority_code("EPSG:4326".to_string());
+        let metadata = Metadata::new(crs, Some(Edges::Spherical));
+        let type_ = PointType::try_new(&data_type, metadata).unwrap();
+
+        let expected = r#"{"crs":"EPSG:4326","crs_type":"authority_code","edges":"spherical"}"#;
+        assert_eq!(type_.serialize_metadata().as_deref(), Some(expected));
+    }
+}

--- a/rust/geoarrow/src/array/metadata.rs
+++ b/rust/geoarrow/src/array/metadata.rs
@@ -16,7 +16,7 @@ pub enum Edges {
     ///
     /// See [the geoarrow
     /// specification](https://github.com/geoarrow/geoarrow/blob/main/extension-types.md#extension-metadata)
-    /// for more information aobut how `edges` should be used.
+    /// for more information about how `edges` should be used.
     #[serde(rename = "spherical")]
     Spherical,
 }


### PR DESCRIPTION
### Change list

- Add new `geoarrow_schema` crate
- Move `CoordType`, `Dimension`, `Crs`, `Edges`, `Metadata`, to new crate.
- Add tests for metadata serialization and deserialization
- Add new geometry-type-specific structs: BoxType, GeometryCollectionType, GeometryType, LineStringType, MultiLineStringType, MultiPointType, MultiPolygonType, PointType, PolygonType, WkbType, WktType
- Implement the upstream [`ExtensionType`](https://docs.rs/arrow-schema/latest/arrow_schema/extension/trait.ExtensionType.html) trait for each of these new structs.


Closes https://github.com/geoarrow/geoarrow-rs/issues/987

cc @paleolimbot 

Will probably leave for future PRs integrating this into existing `geoarrow` code because it'll require changing our current use of `NativeType` (see #1016 draft)