### PR TITLE
Simplify builder apis

### DIFF
--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -1,11 +1,14 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, OffsetSizeTrait, UnionArray};
 use arrow_buffer::{NullBuffer, ScalarBuffer};
 use arrow_schema::{DataType, Field, UnionMode};
-use geo_traits::GeometryTrait;
-use geoarrow_schema::{CoordType, Dimension, GeometryType, Metadata};
+use geoarrow_schema::{
+    CoordType, Dimension, GeometryCollectionType, GeometryType, LineStringType, Metadata,
+    MultiLineStringType, MultiPointType, MultiPolygonType, PointType, PolygonType,
+};
 
 use crate::array::*;
 use crate::builder::*;
@@ -660,10 +663,12 @@ impl IntoArrow for GeometryArray {
     }
 }
 
-impl TryFrom<&UnionArray> for GeometryArray {
+impl TryFrom<(&UnionArray, GeometryType)> for GeometryArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: &UnionArray) -> std::result::Result<Self, Self::Error> {
+    fn try_from(
+        (value, typ): (&UnionArray, GeometryType),
+    ) -> std::result::Result<Self, Self::Error> {
         let mut point_xy: Option<PointArray> = None;
         let mut line_string_xy: Option<LineStringArray> = None;
         let mut polygon_xy: Option<PolygonArray> = None;
@@ -680,6 +685,8 @@ impl TryFrom<&UnionArray> for GeometryArray {
         let mut mpolygon_xyz: Option<MultiPolygonArray> = None;
         let mut gc_xyz: Option<GeometryCollectionArray> = None;
 
+        let coord_type = typ.coord_type();
+
         match value.data_type() {
             DataType::Union(fields, mode) => {
                 if !matches!(mode, UnionMode::Dense) {
@@ -687,7 +694,7 @@ impl TryFrom<&UnionArray> for GeometryArray {
                 }
 
                 for (type_id, _field) in fields.iter() {
-                    let dimension = if type_id < 10 {
+                    let dim = if type_id < 10 {
                         Dimension::XY
                     } else if type_id < 20 {
                         Dimension::XYZ
@@ -701,98 +708,148 @@ impl TryFrom<&UnionArray> for GeometryArray {
                     match type_id {
                         1 => {
                             point_xy = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    PointType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         2 => {
                             line_string_xy = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    LineStringType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         3 => {
                             polygon_xy = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    PolygonType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         4 => {
                             mpoint_xy = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    MultiPointType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         5 => {
                             mline_string_xy = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    MultiLineStringType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         6 => {
                             mpolygon_xy = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    MultiPolygonType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         7 => {
                             gc_xy = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    GeometryCollectionType::new(
+                                        coord_type,
+                                        dim,
+                                        Default::default(),
+                                    ),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         11 => {
                             point_xyz = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    PointType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         12 => {
                             line_string_xyz = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    LineStringType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         13 => {
                             polygon_xyz = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    PolygonType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         14 => {
                             mpoint_xyz = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    MultiPointType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         15 => {
                             mline_string_xyz = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    MultiLineStringType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         16 => {
                             mpolygon_xyz = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    MultiPolygonType::new(coord_type, dim, Default::default()),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
                         }
                         17 => {
                             gc_xyz = Some(
-                                (value.child(type_id).as_ref(), dimension)
+                                (
+                                    value.child(type_id).as_ref(),
+                                    GeometryCollectionType::new(
+                                        coord_type,
+                                        dim,
+                                        Default::default(),
+                                    ),
+                                )
                                     .try_into()
                                     .unwrap(),
                             );
@@ -835,15 +892,12 @@ impl TryFrom<&UnionArray> for GeometryArray {
     }
 }
 
-impl TryFrom<&dyn Array> for GeometryArray {
+impl TryFrom<(&dyn Array, GeometryType)> for GeometryArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: &dyn Array) -> Result<Self> {
+    fn try_from((value, typ): (&dyn Array, GeometryType)) -> Result<Self> {
         match value.data_type() {
-            DataType::Union(_, _) => {
-                let downcasted = value.as_any().downcast_ref::<UnionArray>().unwrap();
-                downcasted.try_into()
-            }
+            DataType::Union(_, _) => (value.as_union(), typ).try_into(),
             _ => Err(GeoArrowError::General(format!(
                 "Unexpected type: {:?}",
                 value.data_type()
@@ -856,37 +910,17 @@ impl TryFrom<(&dyn Array, &Field)> for GeometryArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let mut arr: Self = arr.try_into()?;
-        let metadata = Arc::new(Metadata::try_from(field)?);
-        arr.data_type = arr.data_type.clone().with_metadata(metadata);
-        Ok(arr)
+        let typ = field.try_extension_type::<GeometryType>()?;
+        (arr, typ).try_into()
     }
 }
 
-impl<G: GeometryTrait<T = f64>> TryFrom<&[G]> for GeometryArray {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, GeometryType)> for GeometryArray {
     type Error = GeoArrowError;
 
-    fn try_from(geoms: &[G]) -> Result<Self> {
-        let mut_arr: GeometryBuilder = geoms.try_into()?;
-        Ok(mut_arr.into())
-    }
-}
-
-impl<G: GeometryTrait<T = f64>> TryFrom<Vec<Option<G>>> for GeometryArray {
-    type Error = GeoArrowError;
-
-    fn try_from(geoms: Vec<Option<G>>) -> Result<Self> {
-        let mut_arr: GeometryBuilder = geoms.try_into()?;
-        Ok(mut_arr.into())
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<WKBArray<O>> for GeometryArray {
-    type Error = GeoArrowError;
-
-    fn try_from(value: WKBArray<O>) -> Result<Self> {
+    fn try_from(value: (WKBArray<O>, GeometryType)) -> Result<Self> {
         let mut_arr: GeometryBuilder = value.try_into()?;
-        Ok(mut_arr.into())
+        Ok(mut_arr.finish())
     }
 }
 

--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -168,57 +168,71 @@ impl GeometryArray {
             type_ids,
             offsets,
             point_xy: point_xy.unwrap_or(
-                PointBuilder::new_with_options(XY, coord_type, Default::default()).finish(),
+                PointBuilder::new(PointType::new(coord_type, XY, Default::default())).finish(),
             ),
             line_string_xy: line_string_xy.unwrap_or(
-                LineStringBuilder::new_with_options(XY, coord_type, Default::default()).finish(),
-            ),
-            polygon_xy: polygon_xy.unwrap_or(
-                PolygonBuilder::new_with_options(XY, coord_type, Default::default()).finish(),
-            ),
-            mpoint_xy: mpoint_xy.unwrap_or(
-                MultiPointBuilder::new_with_options(XY, coord_type, Default::default()).finish(),
-            ),
-            mline_string_xy: mline_string_xy.unwrap_or(
-                MultiLineStringBuilder::new_with_options(XY, coord_type, Default::default())
+                LineStringBuilder::new(LineStringType::new(coord_type, XY, Default::default()))
                     .finish(),
             ),
+            polygon_xy: polygon_xy.unwrap_or(
+                PolygonBuilder::new(PolygonType::new(coord_type, XY, Default::default())).finish(),
+            ),
+            mpoint_xy: mpoint_xy.unwrap_or(
+                MultiPointBuilder::new(MultiPointType::new(coord_type, XY, Default::default()))
+                    .finish(),
+            ),
+            mline_string_xy: mline_string_xy.unwrap_or(
+                MultiLineStringBuilder::new(MultiLineStringType::new(
+                    coord_type,
+                    XY,
+                    Default::default(),
+                ))
+                .finish(),
+            ),
             mpolygon_xy: mpolygon_xy.unwrap_or(
-                MultiPolygonBuilder::new_with_options(XY, coord_type, Default::default()).finish(),
+                MultiPolygonBuilder::new(MultiPolygonType::new(coord_type, XY, Default::default()))
+                    .finish(),
             ),
             gc_xy: gc_xy.unwrap_or(
-                GeometryCollectionBuilder::new_with_options(
-                    XY,
-                    coord_type,
-                    Default::default(),
+                GeometryCollectionBuilder::new(
+                    GeometryCollectionType::new(coord_type, XY, Default::default()),
                     false,
                 )
                 .finish(),
             ),
             point_xyz: point_xyz.unwrap_or(
-                PointBuilder::new_with_options(XYZ, coord_type, Default::default()).finish(),
+                PointBuilder::new(PointType::new(coord_type, XYZ, Default::default())).finish(),
             ),
             line_string_xyz: line_string_xyz.unwrap_or(
-                LineStringBuilder::new_with_options(XYZ, coord_type, Default::default()).finish(),
-            ),
-            polygon_xyz: polygon_xyz.unwrap_or(
-                PolygonBuilder::new_with_options(XYZ, coord_type, Default::default()).finish(),
-            ),
-            mpoint_xyz: mpoint_xyz.unwrap_or(
-                MultiPointBuilder::new_with_options(XYZ, coord_type, Default::default()).finish(),
-            ),
-            mline_string_xyz: mline_string_xyz.unwrap_or(
-                MultiLineStringBuilder::new_with_options(XYZ, coord_type, Default::default())
+                LineStringBuilder::new(LineStringType::new(coord_type, XYZ, Default::default()))
                     .finish(),
             ),
+            polygon_xyz: polygon_xyz.unwrap_or(
+                PolygonBuilder::new(PolygonType::new(coord_type, XYZ, Default::default())).finish(),
+            ),
+            mpoint_xyz: mpoint_xyz.unwrap_or(
+                MultiPointBuilder::new(MultiPointType::new(coord_type, XYZ, Default::default()))
+                    .finish(),
+            ),
+            mline_string_xyz: mline_string_xyz.unwrap_or(
+                MultiLineStringBuilder::new(MultiLineStringType::new(
+                    coord_type,
+                    XYZ,
+                    Default::default(),
+                ))
+                .finish(),
+            ),
             mpolygon_xyz: mpolygon_xyz.unwrap_or(
-                MultiPolygonBuilder::new_with_options(XYZ, coord_type, Default::default()).finish(),
+                MultiPolygonBuilder::new(MultiPolygonType::new(
+                    coord_type,
+                    XYZ,
+                    Default::default(),
+                ))
+                .finish(),
             ),
             gc_xyz: gc_xyz.unwrap_or(
-                GeometryCollectionBuilder::new_with_options(
-                    XYZ,
-                    coord_type,
-                    Default::default(),
+                GeometryCollectionBuilder::new(
+                    GeometryCollectionType::new(coord_type, XYZ, Default::default()),
                     false,
                 )
                 .finish(),

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -4,8 +4,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
-use geo_traits::GeometryCollectionTrait;
-use geoarrow_schema::{Dimension, GeometryCollectionType, Metadata};
+use geoarrow_schema::{GeometryCollectionType, Metadata};
 
 use crate::array::{MixedGeometryArray, WKBArray};
 use crate::builder::GeometryCollectionBuilder;
@@ -225,28 +224,14 @@ impl TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray {
     }
 }
 
-impl<G: GeometryCollectionTrait<T = f64>> From<(&[G], Dimension)> for GeometryCollectionArray {
-    fn from(other: (&[G], Dimension)) -> Self {
-        let mut_arr: GeometryCollectionBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<G: GeometryCollectionTrait<T = f64>> From<(Vec<Option<G>>, Dimension)>
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, GeometryCollectionType)>
     for GeometryCollectionArray
 {
-    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
-        let mut_arr: GeometryCollectionBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for GeometryCollectionArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
+    fn try_from(value: (WKBArray<O>, GeometryCollectionType)) -> Result<Self> {
         let mut_arr: GeometryCollectionBuilder = value.try_into()?;
-        Ok(mut_arr.into())
+        Ok(mut_arr.finish())
     }
 }
 

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -167,11 +167,11 @@ impl IntoArrow for GeometryCollectionArray {
     }
 }
 
-impl TryFrom<(&GenericListArray<i32>, Dimension)> for GeometryCollectionArray {
+impl TryFrom<(&GenericListArray<i32>, GeometryCollectionType)> for GeometryCollectionArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&GenericListArray<i32>, Dimension)) -> Result<Self> {
-        let geoms: MixedGeometryArray = (value.values().as_ref(), dim).try_into()?;
+    fn try_from((value, typ): (&GenericListArray<i32>, GeometryCollectionType)) -> Result<Self> {
+        let geoms: MixedGeometryArray = (value.values().as_ref(), typ.dimension()).try_into()?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
@@ -179,16 +179,16 @@ impl TryFrom<(&GenericListArray<i32>, Dimension)> for GeometryCollectionArray {
             geoms,
             geom_offsets.clone(),
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&GenericListArray<i64>, Dimension)> for GeometryCollectionArray {
+impl TryFrom<(&GenericListArray<i64>, GeometryCollectionType)> for GeometryCollectionArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&GenericListArray<i64>, Dimension)) -> Result<Self> {
-        let geoms: MixedGeometryArray = (value.values().as_ref(), dim).try_into()?;
+    fn try_from((value, typ): (&GenericListArray<i64>, GeometryCollectionType)) -> Result<Self> {
+        let geoms: MixedGeometryArray = (value.values().as_ref(), typ.dimension()).try_into()?;
         let geom_offsets = offsets_buffer_i64_to_i32(value.offsets())?;
         let validity = value.nulls();
 
@@ -196,24 +196,18 @@ impl TryFrom<(&GenericListArray<i64>, Dimension)> for GeometryCollectionArray {
             geoms,
             geom_offsets,
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&dyn Array, Dimension)> for GeometryCollectionArray {
+impl TryFrom<(&dyn Array, GeometryCollectionType)> for GeometryCollectionArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&dyn Array, Dimension)) -> Result<Self> {
+    fn try_from((value, typ): (&dyn Array, GeometryCollectionType)) -> Result<Self> {
         match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_list::<i32>();
-                (downcasted, dim).try_into()
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_list::<i64>();
-                (downcasted, dim).try_into()
-            }
+            DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
+            DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
             _ => Err(GeoArrowError::General(format!(
                 "Unexpected type: {:?}",
                 value.data_type()
@@ -226,14 +220,8 @@ impl TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let geom_type = NativeType::try_from(field)?;
-        let dim = geom_type
-            .dimension()
-            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
-        let mut arr: Self = (arr, dim).try_into()?;
-        let metadata = Arc::new(Metadata::try_from(field)?);
-        arr.data_type = arr.data_type.clone().with_metadata(metadata);
-        Ok(arr)
+        let typ = field.try_extension_type::<GeometryCollectionType>()?;
+        (arr, typ).try_into()
     }
 }
 

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -170,7 +170,8 @@ impl TryFrom<(&GenericListArray<i32>, GeometryCollectionType)> for GeometryColle
     type Error = GeoArrowError;
 
     fn try_from((value, typ): (&GenericListArray<i32>, GeometryCollectionType)) -> Result<Self> {
-        let geoms: MixedGeometryArray = (value.values().as_ref(), typ.dimension()).try_into()?;
+        let geoms: MixedGeometryArray =
+            (value.values().as_ref(), typ.dimension(), typ.coord_type()).try_into()?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
@@ -187,7 +188,8 @@ impl TryFrom<(&GenericListArray<i64>, GeometryCollectionType)> for GeometryColle
     type Error = GeoArrowError;
 
     fn try_from((value, typ): (&GenericListArray<i64>, GeometryCollectionType)) -> Result<Self> {
-        let geoms: MixedGeometryArray = (value.values().as_ref(), typ.dimension()).try_into()?;
+        let geoms: MixedGeometryArray =
+            (value.values().as_ref(), typ.dimension(), typ.coord_type()).try_into()?;
         let geom_offsets = offsets_buffer_i64_to_i32(value.offsets())?;
         let validity = value.nulls();
 

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -222,11 +222,11 @@ impl IntoArrow for LineStringArray {
     }
 }
 
-impl TryFrom<(&GenericListArray<i32>, Dimension)> for LineStringArray {
+impl TryFrom<(&GenericListArray<i32>, LineStringType)> for LineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&GenericListArray<i32>, Dimension)) -> Result<Self> {
-        let coords = CoordBuffer::from_arrow(value.values().as_ref(), dim)?;
+    fn try_from((value, typ): (&GenericListArray<i32>, LineStringType)) -> Result<Self> {
+        let coords = CoordBuffer::from_arrow(value.values().as_ref(), typ.dimension())?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
@@ -234,16 +234,16 @@ impl TryFrom<(&GenericListArray<i32>, Dimension)> for LineStringArray {
             coords,
             geom_offsets.clone(),
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&GenericListArray<i64>, Dimension)> for LineStringArray {
+impl TryFrom<(&GenericListArray<i64>, LineStringType)> for LineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&GenericListArray<i64>, Dimension)) -> Result<Self> {
-        let coords = CoordBuffer::from_arrow(value.values().as_ref(), dim)?;
+    fn try_from((value, typ): (&GenericListArray<i64>, LineStringType)) -> Result<Self> {
+        let coords = CoordBuffer::from_arrow(value.values().as_ref(), typ.dimension())?;
         let geom_offsets = offsets_buffer_i64_to_i32(value.offsets())?;
         let validity = value.nulls();
 
@@ -251,23 +251,17 @@ impl TryFrom<(&GenericListArray<i64>, Dimension)> for LineStringArray {
             coords,
             geom_offsets,
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
-impl TryFrom<(&dyn Array, Dimension)> for LineStringArray {
+impl TryFrom<(&dyn Array, LineStringType)> for LineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&dyn Array, Dimension)) -> Result<Self> {
+    fn try_from((value, typ): (&dyn Array, LineStringType)) -> Result<Self> {
         match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_list::<i32>();
-                (downcasted, dim).try_into()
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_list::<i64>();
-                (downcasted, dim).try_into()
-            }
+            DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
+            DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
             _ => Err(GeoArrowError::General(format!(
                 "Unexpected type: {:?}",
                 value.data_type()
@@ -280,14 +274,8 @@ impl TryFrom<(&dyn Array, &Field)> for LineStringArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let geom_type = NativeType::try_from(field)?;
-        let dim = geom_type
-            .dimension()
-            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
-        let mut arr: Self = (arr, dim).try_into()?;
-        let metadata = Arc::new(Metadata::try_from(field)?);
-        arr.data_type = arr.data_type.clone().with_metadata(metadata);
-        Ok(arr)
+        let typ = field.try_extension_type::<LineStringType>()?;
+        (arr, typ).try_into()
     }
 }
 

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -14,8 +14,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
-use geo_traits::LineStringTrait;
-use geoarrow_schema::{Dimension, LineStringType, Metadata};
+use geoarrow_schema::{LineStringType, Metadata};
 
 /// An immutable array of LineString geometries using GeoArrow's in-memory representation.
 ///
@@ -279,26 +278,12 @@ impl TryFrom<(&dyn Array, &Field)> for LineStringArray {
     }
 }
 
-impl<G: LineStringTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for LineStringArray {
-    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
-        let mut_arr: LineStringBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<G: LineStringTrait<T = f64>> From<(&[G], Dimension)> for LineStringArray {
-    fn from(other: (&[G], Dimension)) -> Self {
-        let mut_arr: LineStringBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for LineStringArray {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, LineStringType)> for LineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
+    fn try_from(value: (WKBArray<O>, LineStringType)) -> Result<Self> {
         let mut_arr: LineStringBuilder = value.try_into()?;
-        Ok(mut_arr.into())
+        Ok(mut_arr.finish())
     }
 }
 

--- a/rust/geoarrow-array/src/array/mixed.rs
+++ b/rust/geoarrow-array/src/array/mixed.rs
@@ -635,29 +635,11 @@ impl TryFrom<(&dyn Array, Dimension)> for MixedGeometryArray {
     }
 }
 
-impl<G: GeometryTrait<T = f64>> TryFrom<(&[G], Dimension)> for MixedGeometryArray {
-    type Error = GeoArrowError;
-
-    fn try_from(geoms: (&[G], Dimension)) -> Result<Self> {
-        let mut_arr: MixedGeometryBuilder = geoms.try_into()?;
-        Ok(mut_arr.into())
-    }
-}
-
-impl<G: GeometryTrait<T = f64>> TryFrom<(Vec<Option<G>>, Dimension)> for MixedGeometryArray {
-    type Error = GeoArrowError;
-
-    fn try_from(geoms: (Vec<Option<G>>, Dimension)) -> Result<Self> {
-        let mut_arr: MixedGeometryBuilder = geoms.try_into()?;
-        Ok(mut_arr.into())
-    }
-}
-
 impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MixedGeometryArray {
     type Error = GeoArrowError;
 
     fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
         let mut_arr: MixedGeometryBuilder = value.try_into()?;
-        Ok(mut_arr.into())
+        Ok(mut_arr.finish())
     }
 }

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -245,10 +245,10 @@ impl IntoArrow for MultiLineStringArray {
     }
 }
 
-impl TryFrom<(&GenericListArray<i32>, Dimension)> for MultiLineStringArray {
+impl TryFrom<(&GenericListArray<i32>, MultiLineStringType)> for MultiLineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from((geom_array, dim): (&GenericListArray<i32>, Dimension)) -> Result<Self> {
+    fn try_from((geom_array, typ): (&GenericListArray<i32>, MultiLineStringType)) -> Result<Self> {
         let geom_offsets = geom_array.offsets();
         let validity = geom_array.nulls();
 
@@ -256,22 +256,22 @@ impl TryFrom<(&GenericListArray<i32>, Dimension)> for MultiLineStringArray {
         let rings_array = rings_dyn_array.as_list::<i32>();
 
         let ring_offsets = rings_array.offsets();
-        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), dim)?;
+        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), typ.dimension())?;
 
         Ok(Self::new(
             coords,
             geom_offsets.clone(),
             ring_offsets.clone(),
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&GenericListArray<i64>, Dimension)> for MultiLineStringArray {
+impl TryFrom<(&GenericListArray<i64>, MultiLineStringType)> for MultiLineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from((geom_array, dim): (&GenericListArray<i64>, Dimension)) -> Result<Self> {
+    fn try_from((geom_array, typ): (&GenericListArray<i64>, MultiLineStringType)) -> Result<Self> {
         let geom_offsets = offsets_buffer_i64_to_i32(geom_array.offsets())?;
         let validity = geom_array.nulls();
 
@@ -279,31 +279,25 @@ impl TryFrom<(&GenericListArray<i64>, Dimension)> for MultiLineStringArray {
         let rings_array = rings_dyn_array.as_list::<i64>();
 
         let ring_offsets = offsets_buffer_i64_to_i32(rings_array.offsets())?;
-        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), dim)?;
+        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), typ.dimension())?;
 
         Ok(Self::new(
             coords,
             geom_offsets.clone(),
             ring_offsets.clone(),
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&dyn Array, Dimension)> for MultiLineStringArray {
+impl TryFrom<(&dyn Array, MultiLineStringType)> for MultiLineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&dyn Array, Dimension)) -> Result<Self> {
+    fn try_from((value, typ): (&dyn Array, MultiLineStringType)) -> Result<Self> {
         match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_list::<i32>();
-                (downcasted, dim).try_into()
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_list::<i64>();
-                (downcasted, dim).try_into()
-            }
+            DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
+            DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
             _ => Err(GeoArrowError::General(format!(
                 "Unexpected type: {:?}",
                 value.data_type()
@@ -316,14 +310,8 @@ impl TryFrom<(&dyn Array, &Field)> for MultiLineStringArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let geom_type = NativeType::try_from(field)?;
-        let dim = geom_type
-            .dimension()
-            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
-        let mut arr: Self = (arr, dim).try_into()?;
-        let metadata = Arc::new(Metadata::try_from(field)?);
-        arr.data_type = arr.data_type.clone().with_metadata(metadata);
-        Ok(arr)
+        let typ = field.try_extension_type::<MultiLineStringType>()?;
+        (arr, typ).try_into()
     }
 }
 

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -222,11 +222,11 @@ impl IntoArrow for MultiPointArray {
     }
 }
 
-impl TryFrom<(&GenericListArray<i32>, Dimension)> for MultiPointArray {
+impl TryFrom<(&GenericListArray<i32>, MultiPointType)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&GenericListArray<i32>, Dimension)) -> Result<Self> {
-        let coords = CoordBuffer::from_arrow(value.values().as_ref(), dim)?;
+    fn try_from((value, typ): (&GenericListArray<i32>, MultiPointType)) -> Result<Self> {
+        let coords = CoordBuffer::from_arrow(value.values().as_ref(), typ.dimension())?;
         let geom_offsets = value.offsets();
         let validity = value.nulls();
 
@@ -234,16 +234,16 @@ impl TryFrom<(&GenericListArray<i32>, Dimension)> for MultiPointArray {
             coords,
             geom_offsets.clone(),
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&GenericListArray<i64>, Dimension)> for MultiPointArray {
+impl TryFrom<(&GenericListArray<i64>, MultiPointType)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&GenericListArray<i64>, Dimension)) -> Result<Self> {
-        let coords = CoordBuffer::from_arrow(value.values().as_ref(), dim)?;
+    fn try_from((value, typ): (&GenericListArray<i64>, MultiPointType)) -> Result<Self> {
+        let coords = CoordBuffer::from_arrow(value.values().as_ref(), typ.dimension())?;
         let geom_offsets = offsets_buffer_i64_to_i32(value.offsets())?;
         let validity = value.nulls();
 
@@ -251,24 +251,18 @@ impl TryFrom<(&GenericListArray<i64>, Dimension)> for MultiPointArray {
             coords,
             geom_offsets,
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&dyn Array, Dimension)> for MultiPointArray {
+impl TryFrom<(&dyn Array, MultiPointType)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&dyn Array, Dimension)) -> Result<Self> {
+    fn try_from((value, typ): (&dyn Array, MultiPointType)) -> Result<Self> {
         match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_list::<i32>();
-                (downcasted, dim).try_into()
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_list::<i64>();
-                (downcasted, dim).try_into()
-            }
+            DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
+            DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
             _ => Err(GeoArrowError::General(format!(
                 "Unexpected type: {:?}",
                 value.data_type()
@@ -281,14 +275,8 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPointArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let geom_type = NativeType::try_from(field)?;
-        let dim = geom_type
-            .dimension()
-            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
-        let mut arr: Self = (arr, dim).try_into()?;
-        let metadata = Arc::new(Metadata::try_from(field)?);
-        arr.data_type = arr.data_type.clone().with_metadata(metadata);
-        Ok(arr)
+        let typ = field.try_extension_type::<MultiPointType>()?;
+        (arr, typ).try_into()
     }
 }
 

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -4,8 +4,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
-use geo_traits::MultiPointTrait;
-use geoarrow_schema::{Dimension, Metadata, MultiPointType};
+use geoarrow_schema::{Metadata, MultiPointType};
 
 use crate::array::{CoordBuffer, LineStringArray, PointArray, WKBArray};
 use crate::builder::MultiPointBuilder;
@@ -280,26 +279,12 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPointArray {
     }
 }
 
-impl<G: MultiPointTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for MultiPointArray {
-    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
-        let mut_arr: MultiPointBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<G: MultiPointTrait<T = f64>> From<(&[G], Dimension)> for MultiPointArray {
-    fn from(other: (&[G], Dimension)) -> Self {
-        let mut_arr: MultiPointBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MultiPointArray {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiPointType)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
+    fn try_from(value: (WKBArray<O>, MultiPointType)) -> Result<Self> {
         let mut_arr: MultiPointBuilder = value.try_into()?;
-        Ok(mut_arr.into())
+        Ok(mut_arr.finish())
     }
 }
 

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -312,10 +312,10 @@ impl IntoArrow for MultiPolygonArray {
     }
 }
 
-impl TryFrom<(&GenericListArray<i32>, Dimension)> for MultiPolygonArray {
+impl TryFrom<(&GenericListArray<i32>, MultiPolygonType)> for MultiPolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from((geom_array, dim): (&GenericListArray<i32>, Dimension)) -> Result<Self> {
+    fn try_from((geom_array, typ): (&GenericListArray<i32>, MultiPolygonType)) -> Result<Self> {
         let geom_offsets = geom_array.offsets();
         let validity = geom_array.nulls();
 
@@ -327,7 +327,7 @@ impl TryFrom<(&GenericListArray<i32>, Dimension)> for MultiPolygonArray {
         let rings_array = rings_dyn_array.as_list::<i32>();
 
         let ring_offsets = rings_array.offsets();
-        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), dim)?;
+        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), typ.dimension())?;
 
         Ok(Self::new(
             coords,
@@ -335,15 +335,15 @@ impl TryFrom<(&GenericListArray<i32>, Dimension)> for MultiPolygonArray {
             polygon_offsets.clone(),
             ring_offsets.clone(),
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&GenericListArray<i64>, Dimension)> for MultiPolygonArray {
+impl TryFrom<(&GenericListArray<i64>, MultiPolygonType)> for MultiPolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from((geom_array, dim): (&GenericListArray<i64>, Dimension)) -> Result<Self> {
+    fn try_from((geom_array, typ): (&GenericListArray<i64>, MultiPolygonType)) -> Result<Self> {
         let geom_offsets = offsets_buffer_i64_to_i32(geom_array.offsets())?;
         let validity = geom_array.nulls();
 
@@ -355,7 +355,7 @@ impl TryFrom<(&GenericListArray<i64>, Dimension)> for MultiPolygonArray {
         let rings_array = rings_dyn_array.as_list::<i64>();
 
         let ring_offsets = offsets_buffer_i64_to_i32(rings_array.offsets())?;
-        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), dim)?;
+        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), typ.dimension())?;
 
         Ok(Self::new(
             coords,
@@ -363,24 +363,18 @@ impl TryFrom<(&GenericListArray<i64>, Dimension)> for MultiPolygonArray {
             polygon_offsets,
             ring_offsets,
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&dyn Array, Dimension)> for MultiPolygonArray {
+impl TryFrom<(&dyn Array, MultiPolygonType)> for MultiPolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&dyn Array, Dimension)) -> Result<Self> {
+    fn try_from((value, typ): (&dyn Array, MultiPolygonType)) -> Result<Self> {
         match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_list::<i32>();
-                (downcasted, dim).try_into()
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_list::<i64>();
-                (downcasted, dim).try_into()
-            }
+            DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
+            DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
             _ => Err(GeoArrowError::General(format!(
                 "Unexpected type: {:?}",
                 value.data_type()
@@ -393,14 +387,8 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPolygonArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let geom_type = NativeType::try_from(field)?;
-        let dim = geom_type
-            .dimension()
-            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
-        let mut arr: Self = (arr, dim).try_into()?;
-        let metadata = Arc::new(Metadata::try_from(field)?);
-        arr.data_type = arr.data_type.clone().with_metadata(metadata);
-        Ok(arr)
+        let typ = field.try_extension_type::<MultiPolygonType>()?;
+        (arr, typ).try_into()
     }
 }
 

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -4,8 +4,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
-use geo_traits::MultiPolygonTrait;
-use geoarrow_schema::{Dimension, Metadata, MultiPolygonType};
+use geoarrow_schema::{Metadata, MultiPolygonType};
 
 use crate::array::{CoordBuffer, PolygonArray, WKBArray};
 use crate::builder::MultiPolygonBuilder;
@@ -392,26 +391,12 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPolygonArray {
     }
 }
 
-impl<G: MultiPolygonTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for MultiPolygonArray {
-    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
-        let mut_arr: MultiPolygonBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<G: MultiPolygonTrait<T = f64>> From<(&[G], Dimension)> for MultiPolygonArray {
-    fn from(other: (&[G], Dimension)) -> Self {
-        let mut_arr: MultiPolygonBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MultiPolygonArray {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiPolygonType)> for MultiPolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
+    fn try_from(value: (WKBArray<O>, MultiPolygonType)) -> Result<Self> {
         let mut_arr: MultiPolygonBuilder = value.try_into()?;
-        Ok(mut_arr.into())
+        Ok(mut_arr.finish())
     }
 }
 

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -247,10 +247,10 @@ impl IntoArrow for PolygonArray {
     }
 }
 
-impl TryFrom<(&GenericListArray<i32>, Dimension)> for PolygonArray {
+impl TryFrom<(&GenericListArray<i32>, PolygonType)> for PolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from((geom_array, dim): (&GenericListArray<i32>, Dimension)) -> Result<Self> {
+    fn try_from((geom_array, typ): (&GenericListArray<i32>, PolygonType)) -> Result<Self> {
         let geom_offsets = geom_array.offsets();
         let validity = geom_array.nulls();
 
@@ -258,22 +258,22 @@ impl TryFrom<(&GenericListArray<i32>, Dimension)> for PolygonArray {
         let rings_array = rings_dyn_array.as_list::<i32>();
 
         let ring_offsets = rings_array.offsets();
-        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), dim)?;
+        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), typ.dimension())?;
 
         Ok(Self::new(
             coords,
             geom_offsets.clone(),
             ring_offsets.clone(),
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
 
-impl TryFrom<(&GenericListArray<i64>, Dimension)> for PolygonArray {
+impl TryFrom<(&GenericListArray<i64>, PolygonType)> for PolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from((geom_array, dim): (&GenericListArray<i64>, Dimension)) -> Result<Self> {
+    fn try_from((geom_array, typ): (&GenericListArray<i64>, PolygonType)) -> Result<Self> {
         let geom_offsets = offsets_buffer_i64_to_i32(geom_array.offsets())?;
         let validity = geom_array.nulls();
 
@@ -281,30 +281,24 @@ impl TryFrom<(&GenericListArray<i64>, Dimension)> for PolygonArray {
         let rings_array = rings_dyn_array.as_list::<i64>();
 
         let ring_offsets = offsets_buffer_i64_to_i32(rings_array.offsets())?;
-        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), dim)?;
+        let coords = CoordBuffer::from_arrow(rings_array.values().as_ref(), typ.dimension())?;
 
         Ok(Self::new(
             coords,
             geom_offsets,
             ring_offsets,
             validity.cloned(),
-            Default::default(),
+            typ.metadata().clone(),
         ))
     }
 }
-impl TryFrom<(&dyn Array, Dimension)> for PolygonArray {
+impl TryFrom<(&dyn Array, PolygonType)> for PolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (&dyn Array, Dimension)) -> Result<Self> {
+    fn try_from((value, typ): (&dyn Array, PolygonType)) -> Result<Self> {
         match value.data_type() {
-            DataType::List(_) => {
-                let downcasted = value.as_list::<i32>();
-                (downcasted, dim).try_into()
-            }
-            DataType::LargeList(_) => {
-                let downcasted = value.as_list::<i64>();
-                (downcasted, dim).try_into()
-            }
+            DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
+            DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
             _ => Err(GeoArrowError::General(format!(
                 "Unexpected type: {:?}",
                 value.data_type()
@@ -317,14 +311,8 @@ impl TryFrom<(&dyn Array, &Field)> for PolygonArray {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
-        let geom_type = NativeType::try_from(field)?;
-        let dim = geom_type
-            .dimension()
-            .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
-        let mut arr: Self = (arr, dim).try_into()?;
-        let metadata = Arc::new(Metadata::try_from(field)?);
-        arr.data_type = arr.data_type.clone().with_metadata(metadata);
-        Ok(arr)
+        let typ = field.try_extension_type::<PolygonType>()?;
+        (arr, typ).try_into()
     }
 }
 

--- a/rust/geoarrow-array/src/array/rect.rs
+++ b/rust/geoarrow-array/src/array/rect.rs
@@ -5,11 +5,9 @@ use arrow_array::types::Float64Type;
 use arrow_array::{Array, ArrayRef, StructArray};
 use arrow_buffer::{NullBuffer, ScalarBuffer};
 use arrow_schema::{DataType, Field};
-use geo_traits::RectTrait;
-use geoarrow_schema::{BoxType, Dimension, Metadata};
+use geoarrow_schema::{BoxType, Metadata};
 
 use crate::array::SeparatedCoordBuffer;
-use crate::builder::RectBuilder;
 use crate::datatypes::NativeType;
 use crate::error::GeoArrowError;
 use crate::scalar::Rect;
@@ -212,20 +210,6 @@ impl TryFrom<(&dyn Array, &Field)> for RectArray {
     }
 }
 
-impl<G: RectTrait<T = f64>> From<(&[G], Dimension)> for RectArray {
-    fn from(other: (&[G], Dimension)) -> Self {
-        let mut_arr: RectBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
-impl<G: RectTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for RectArray {
-    fn from(other: (Vec<Option<G>>, Dimension)) -> Self {
-        let mut_arr: RectBuilder = other.into();
-        mut_arr.into()
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -239,8 +223,8 @@ mod test {
             geo::coord! { x: 0.0, y: 5.0 },
             geo::coord! { x: 10.0, y: 15.0 },
         );
-        let mut builder =
-            RectBuilder::with_capacity_and_options(Dimension::XY, 1, Default::default());
+        let typ = BoxType::new(Dimension::XY, Default::default());
+        let mut builder = RectBuilder::with_capacity(typ, 1);
         builder.push_rect(Some(&rect));
         builder.push_min_max(&rect.min(), &rect.max());
         let rect_arr = builder.finish();

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -6,10 +6,8 @@ use arrow_array::{
 };
 use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field};
-use geo_traits::GeometryTrait;
 use geoarrow_schema::{CoordType, Metadata, WkbType};
 
-use crate::builder::WKBBuilder;
 use crate::capacity::WKBCapacity;
 use crate::datatypes::{NativeType, SerializedType};
 use crate::error::{GeoArrowError, Result};
@@ -247,23 +245,5 @@ impl TryFrom<WKBArray<i64>> for WKBArray<i32> {
             data_type: value.data_type,
             array,
         })
-    }
-}
-
-impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<&[G]> for WKBArray<O> {
-    type Error = GeoArrowError;
-
-    fn try_from(geoms: &[G]) -> Result<Self> {
-        let mut_arr: WKBBuilder<O> = geoms.try_into()?;
-        Ok(mut_arr.into())
-    }
-}
-
-impl<O: OffsetSizeTrait, G: GeometryTrait<T = f64>> TryFrom<Vec<Option<G>>> for WKBArray<O> {
-    type Error = GeoArrowError;
-
-    fn try_from(geoms: Vec<Option<G>>) -> Result<Self> {
-        let mut_arr: WKBBuilder<O> = geoms.try_into()?;
-        Ok(mut_arr.into())
     }
 }

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use arrow_array::OffsetSizeTrait;
 use geo_traits::*;
-use geoarrow_schema::{CoordType, Dimension, Metadata};
+use geoarrow_schema::{
+    CoordType, Dimension, LineStringType, Metadata, MultiLineStringType, MultiPointType,
+    MultiPolygonType, PointType, PolygonType,
+};
 
 use crate::array::{MixedGeometryArray, WKBArray};
 use crate::builder::{
@@ -62,7 +65,7 @@ pub struct MixedGeometryBuilder {
 
 impl<'a> MixedGeometryBuilder {
     /// Creates a new empty [`MixedGeometryBuilder`].
-    pub fn new(dim: Dimension) -> Self {
+    pub(crate) fn new(dim: Dimension) -> Self {
         Self::new_with_options(
             dim,
             CoordType::default_interleaved(),
@@ -71,7 +74,7 @@ impl<'a> MixedGeometryBuilder {
         )
     }
 
-    pub fn new_with_options(
+    pub(crate) fn new_with_options(
         dim: Dimension,
         coord_type: CoordType,
         metadata: Arc<Metadata>,
@@ -81,7 +84,7 @@ impl<'a> MixedGeometryBuilder {
     }
 
     /// Creates a new [`MixedGeometryBuilder`] with given capacity and no validity.
-    pub fn with_capacity(dim: Dimension, capacity: MixedCapacity) -> Self {
+    pub(crate) fn with_capacity(dim: Dimension, capacity: MixedCapacity) -> Self {
         Self::with_capacity_and_options(
             dim,
             capacity,
@@ -91,7 +94,7 @@ impl<'a> MixedGeometryBuilder {
         )
     }
 
-    pub fn with_capacity_and_options(
+    pub(crate) fn with_capacity_and_options(
         dim: Dimension,
         capacity: MixedCapacity,
         coord_type: CoordType,
@@ -103,48 +106,36 @@ impl<'a> MixedGeometryBuilder {
             metadata,
             dim,
             types: vec![],
-            points: PointBuilder::with_capacity_and_options(
-                dim,
+            points: PointBuilder::with_capacity(
+                PointType::new(coord_type, dim, Default::default()),
                 capacity.point,
-                coord_type,
-                Default::default(),
             ),
-            line_strings: LineStringBuilder::with_capacity_and_options(
-                dim,
+            line_strings: LineStringBuilder::with_capacity(
+                LineStringType::new(coord_type, dim, Default::default()),
                 capacity.line_string,
-                coord_type,
-                Default::default(),
             ),
-            polygons: PolygonBuilder::with_capacity_and_options(
-                dim,
+            polygons: PolygonBuilder::with_capacity(
+                PolygonType::new(coord_type, dim, Default::default()),
                 capacity.polygon,
-                coord_type,
-                Default::default(),
             ),
-            multi_points: MultiPointBuilder::with_capacity_and_options(
-                dim,
+            multi_points: MultiPointBuilder::with_capacity(
+                MultiPointType::new(coord_type, dim, Default::default()),
                 capacity.multi_point,
-                coord_type,
-                Default::default(),
             ),
-            multi_line_strings: MultiLineStringBuilder::with_capacity_and_options(
-                dim,
+            multi_line_strings: MultiLineStringBuilder::with_capacity(
+                MultiLineStringType::new(coord_type, dim, Default::default()),
                 capacity.multi_line_string,
-                coord_type,
-                Default::default(),
             ),
-            multi_polygons: MultiPolygonBuilder::with_capacity_and_options(
-                dim,
+            multi_polygons: MultiPolygonBuilder::with_capacity(
+                MultiPolygonType::new(coord_type, dim, Default::default()),
                 capacity.multi_polygon,
-                coord_type,
-                Default::default(),
             ),
             offsets: vec![],
             prefer_multi,
         }
     }
 
-    pub fn reserve(&mut self, capacity: MixedCapacity) {
+    pub(crate) fn reserve(&mut self, capacity: MixedCapacity) {
         let total_num_geoms = capacity.total_num_geoms();
         self.types.reserve(total_num_geoms);
         self.offsets.reserve(total_num_geoms);
@@ -156,7 +147,7 @@ impl<'a> MixedGeometryBuilder {
         self.multi_polygons.reserve(capacity.multi_polygon);
     }
 
-    pub fn reserve_exact(&mut self, capacity: MixedCapacity) {
+    pub(crate) fn reserve_exact(&mut self, capacity: MixedCapacity) {
         let total_num_geoms = capacity.total_num_geoms();
         self.types.reserve_exact(total_num_geoms);
         self.offsets.reserve_exact(total_num_geoms);
@@ -178,7 +169,7 @@ impl<'a> MixedGeometryBuilder {
     // ///
     // /// # Errors
     // ///
-    // pub fn try_new(
+    // pub(crate) fn try_new(
     //     coords: CoordBufferBuilder,
     //     geom_offsets: BufferBuilder<O>,
     //     ring_offsets: BufferBuilder<O>,
@@ -198,11 +189,21 @@ impl<'a> MixedGeometryBuilder {
     //     })
     // }
 
-    pub fn finish(self) -> MixedGeometryArray {
-        self.into()
+    pub(crate) fn finish(self) -> MixedGeometryArray {
+        MixedGeometryArray::new(
+            self.types.into(),
+            self.offsets.into(),
+            Some(self.points.finish()),
+            Some(self.line_strings.finish()),
+            Some(self.polygons.finish()),
+            Some(self.multi_points.finish()),
+            Some(self.multi_line_strings.finish()),
+            Some(self.multi_polygons.finish()),
+            self.metadata,
+        )
     }
 
-    pub fn with_capacity_from_iter(
+    pub(crate) fn with_capacity_from_iter(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
         dim: Dimension,
     ) -> Result<Self> {
@@ -215,7 +216,7 @@ impl<'a> MixedGeometryBuilder {
         )
     }
 
-    pub fn with_capacity_and_options_from_iter(
+    pub(crate) fn with_capacity_and_options_from_iter(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
         dim: Dimension,
         coord_type: CoordType,
@@ -232,7 +233,7 @@ impl<'a> MixedGeometryBuilder {
         ))
     }
 
-    pub fn reserve_from_iter(
+    pub(crate) fn reserve_from_iter(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
     ) -> Result<()> {
@@ -241,7 +242,7 @@ impl<'a> MixedGeometryBuilder {
         Ok(())
     }
 
-    pub fn reserve_exact_from_iter(
+    pub(crate) fn reserve_exact_from_iter(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
     ) -> Result<()> {
@@ -255,7 +256,7 @@ impl<'a> MixedGeometryBuilder {
     /// If `self.prefer_multi` is `true`, it will be stored in the `MultiPointBuilder` child
     /// array. Otherwise, it will be stored in the `PointBuilder` child array.
     #[inline]
-    pub fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
+    pub(crate) fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
         if self.prefer_multi {
             self.add_multi_point_type();
             self.multi_points.push_point(value)
@@ -285,7 +286,7 @@ impl<'a> MixedGeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_line_string(
+    pub(crate) fn push_line_string(
         &mut self,
         value: Option<&impl LineStringTrait<T = f64>>,
     ) -> Result<()> {
@@ -318,7 +319,10 @@ impl<'a> MixedGeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
+    pub(crate) fn push_polygon(
+        &mut self,
+        value: Option<&impl PolygonTrait<T = f64>>,
+    ) -> Result<()> {
         if self.prefer_multi {
             self.add_multi_polygon_type();
             self.multi_polygons.push_polygon(value)
@@ -344,7 +348,7 @@ impl<'a> MixedGeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_point(
+    pub(crate) fn push_multi_point(
         &mut self,
         value: Option<&impl MultiPointTrait<T = f64>>,
     ) -> Result<()> {
@@ -369,7 +373,7 @@ impl<'a> MixedGeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_line_string(
+    pub(crate) fn push_multi_line_string(
         &mut self,
         value: Option<&impl MultiLineStringTrait<T = f64>>,
     ) -> Result<()> {
@@ -394,7 +398,7 @@ impl<'a> MixedGeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_polygon(
+    pub(crate) fn push_multi_polygon(
         &mut self,
         value: Option<&impl MultiPolygonTrait<T = f64>>,
     ) -> Result<()> {
@@ -414,7 +418,10 @@ impl<'a> MixedGeometryBuilder {
     }
 
     #[inline]
-    pub fn push_geometry(&mut self, value: Option<&'a impl GeometryTrait<T = f64>>) -> Result<()> {
+    pub(crate) fn push_geometry(
+        &mut self,
+        value: Option<&'a impl GeometryTrait<T = f64>>,
+    ) -> Result<()> {
         use geo_traits::GeometryType::*;
 
         if let Some(geom) = value {
@@ -449,12 +456,12 @@ impl<'a> MixedGeometryBuilder {
     }
 
     #[inline]
-    pub fn push_null(&mut self) {
+    pub(crate) fn push_null(&mut self) {
         todo!("push null geometry")
     }
 
     /// Extend this builder with the given geometries
-    pub fn extend_from_iter(
+    pub(crate) fn extend_from_iter(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = f64> + 'a)>>,
     ) {
@@ -465,7 +472,7 @@ impl<'a> MixedGeometryBuilder {
     }
 
     /// Create this builder from a slice of Geometries.
-    pub fn from_geometries(
+    pub(crate) fn from_geometries(
         geoms: &[impl GeometryTrait<T = f64>],
         dim: Dimension,
         coord_type: CoordType,
@@ -484,7 +491,7 @@ impl<'a> MixedGeometryBuilder {
     }
 
     /// Create this builder from a slice of nullable Geometries.
-    pub fn from_nullable_geometries(
+    pub(crate) fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
         dim: Dimension,
         coord_type: CoordType,
@@ -514,50 +521,6 @@ impl<'a> MixedGeometryBuilder {
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
             .collect::<Result<Vec<_>>>()?;
         Self::from_nullable_geometries(&wkb_objects2, dim, coord_type, metadata, prefer_multi)
-    }
-}
-
-impl From<MixedGeometryBuilder> for MixedGeometryArray {
-    fn from(other: MixedGeometryBuilder) -> Self {
-        Self::new(
-            other.types.into(),
-            other.offsets.into(),
-            Some(other.points.into()),
-            Some(other.line_strings.into()),
-            Some(other.polygons.into()),
-            Some(other.multi_points.into()),
-            Some(other.multi_line_strings.into()),
-            Some(other.multi_polygons.into()),
-            other.metadata,
-        )
-    }
-}
-
-impl<G: GeometryTrait<T = f64>> TryFrom<(&[G], Dimension)> for MixedGeometryBuilder {
-    type Error = GeoArrowError;
-
-    fn try_from((geoms, dim): (&[G], Dimension)) -> Result<Self> {
-        Self::from_geometries(
-            geoms,
-            dim,
-            CoordType::default_interleaved(),
-            Default::default(),
-            true,
-        )
-    }
-}
-
-impl<G: GeometryTrait<T = f64>> TryFrom<(Vec<Option<G>>, Dimension)> for MixedGeometryBuilder {
-    type Error = GeoArrowError;
-
-    fn try_from((geoms, dim): (Vec<Option<G>>, Dimension)) -> Result<Self> {
-        Self::from_nullable_geometries(
-            &geoms,
-            dim,
-            CoordType::default_interleaved(),
-            Default::default(),
-            true,
-        )
     }
 }
 

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -1,3 +1,6 @@
+// TODO: remove unused methods
+#![allow(dead_code)]
+
 use std::sync::Arc;
 
 use arrow_array::OffsetSizeTrait;

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -33,13 +33,6 @@ pub struct MultiLineStringBuilder {
     pub(crate) validity: NullBufferBuilder,
 }
 
-pub type MultiLineStringInner = (
-    CoordBufferBuilder,
-    OffsetsBuilder<i32>,
-    OffsetsBuilder<i32>,
-    NullBufferBuilder,
-);
-
 impl MultiLineStringBuilder {
     /// Creates a new empty [`MultiLineStringBuilder`].
     pub fn new(typ: MultiLineStringType) -> Self {

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -1,16 +1,13 @@
-use std::sync::Arc;
-
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
-use geoarrow_schema::{CoordType, Dimension, Metadata};
+use geoarrow_schema::{CoordType, MultiPointType};
 
 use crate::capacity::MultiPointCapacity;
 // use super::array::check;
 use crate::array::{MultiPointArray, WKBArray};
 use crate::builder::{
-    CoordBufferBuilder, InterleavedCoordBufferBuilder, LineStringBuilder, OffsetsBuilder,
-    SeparatedCoordBufferBuilder,
+    CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::WKB;
@@ -21,7 +18,7 @@ use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
 /// Converting an [`MultiPointBuilder`] into a [`MultiPointArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct MultiPointBuilder {
-    metadata: Arc<Metadata>,
+    data_type: MultiPointType,
 
     coords: CoordBufferBuilder,
 
@@ -33,49 +30,31 @@ pub struct MultiPointBuilder {
 
 impl MultiPointBuilder {
     /// Creates a new empty [`MultiPointBuilder`].
-    pub fn new(dim: Dimension) -> Self {
-        Self::new_with_options(dim, CoordType::default_interleaved(), Default::default())
-    }
-
-    /// Creates a new [`MultiPointBuilder`] with options
-    pub fn new_with_options(
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-    ) -> Self {
-        Self::with_capacity_and_options(dim, Default::default(), coord_type, metadata)
+    pub fn new(typ: MultiPointType) -> Self {
+        Self::with_capacity(typ, Default::default())
     }
 
     /// Creates a new [`MultiPointBuilder`] with a capacity.
-    pub fn with_capacity(dim: Dimension, capacity: MultiPointCapacity) -> Self {
-        Self::with_capacity_and_options(
-            dim,
-            capacity,
-            CoordType::default_interleaved(),
-            Default::default(),
-        )
-    }
-
-    /// Creates a new [`MultiPointBuilder`] with capacity and options
-    pub fn with_capacity_and_options(
-        dim: Dimension,
-        capacity: MultiPointCapacity,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-    ) -> Self {
-        let coords = match coord_type {
-            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
-                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
-            ),
-            CoordType::Separated => CoordBufferBuilder::Separated(
-                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
-            ),
+    pub fn with_capacity(typ: MultiPointType, capacity: MultiPointCapacity) -> Self {
+        let coords = match typ.coord_type() {
+            CoordType::Interleaved => {
+                CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(
+                    capacity.coord_capacity,
+                    typ.dimension(),
+                ))
+            }
+            CoordType::Separated => {
+                CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(
+                    capacity.coord_capacity,
+                    typ.dimension(),
+                ))
+            }
         };
         Self {
             coords,
             geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity),
             validity: NullBufferBuilder::new(capacity.geom_capacity),
-            metadata,
+            data_type: typ,
         }
     }
 
@@ -105,70 +84,29 @@ impl MultiPointBuilder {
         self.geom_offsets.reserve_exact(capacity.geom_capacity);
     }
 
-    /// The canonical method to create a [`MultiPointBuilder`] out of its internal components.
-    ///
-    /// # Implementation
-    ///
-    /// This function is `O(1)`.
-    ///
-    /// # Errors
-    ///
-    /// This function errors iff:
-    ///
-    /// - if the validity is not `None` and its length is different from the number of geometries
-    /// - if the largest geometry offset does not match the number of coordinates
-    pub fn try_new(
-        coords: CoordBufferBuilder,
-        geom_offsets: OffsetsBuilder<i32>,
-        validity: NullBufferBuilder,
-        metadata: Arc<Metadata>,
-    ) -> Result<Self> {
-        // check(
-        //     &coords.clone().into(),
-        //     validity.as_ref().map(|x| x.len()),
-        //     &geom_offsets.clone().into(),
-        // )?;
-        Ok(Self {
-            coords,
-            geom_offsets,
-            validity,
-            metadata,
-        })
-    }
-
-    /// Extract the low-level APIs from the [`MultiPointBuilder`].
-    pub fn into_inner(self) -> (CoordBufferBuilder, OffsetsBuilder<i32>, NullBufferBuilder) {
-        (self.coords, self.geom_offsets, self.validity)
-    }
-
     /// Consume the builder and convert to an immutable [`MultiPointArray`]
-    pub fn finish(self) -> MultiPointArray {
-        self.into()
+    pub fn finish(mut self) -> MultiPointArray {
+        let validity = self.validity.finish();
+
+        // TODO: impl shrink_to_fit for all mutable -> * impls
+        // self.coords.shrink_to_fit();
+        self.geom_offsets.shrink_to_fit();
+
+        MultiPointArray::new(
+            self.coords.into(),
+            self.geom_offsets.into(),
+            validity,
+            self.data_type.metadata().clone(),
+        )
     }
 
     /// Creates a new builder with a capacity inferred by the provided iterator.
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-        dim: Dimension,
-    ) -> Self {
-        Self::with_capacity_and_options_from_iter(
-            geoms,
-            dim,
-            CoordType::default_interleaved(),
-            Default::default(),
-        )
-    }
-
-    /// Creates a new builder with the provided options and a capacity inferred by the provided
-    /// iterator.
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPointTrait + 'a)>>,
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPointType,
     ) -> Self {
         let counter = MultiPointCapacity::from_multi_points(geoms);
-        Self::with_capacity_and_options(dim, counter, coord_type, metadata)
+        Self::with_capacity(typ, counter)
     }
 
     /// Reserve more space in the underlying buffers with the capacity inferred from the provided
@@ -310,18 +248,8 @@ impl MultiPointBuilder {
     }
 
     /// Construct a new builder, pre-filling it with the provided geometries
-    pub fn from_multi_points(
-        geoms: &[impl MultiPointTrait<T = f64>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-    ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(Some),
-            dim,
-            coord_type,
-            metadata,
-        );
+    pub fn from_multi_points(geoms: &[impl MultiPointTrait<T = f64>], typ: MultiPointType) -> Self {
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(Some), typ);
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }
@@ -329,16 +257,9 @@ impl MultiPointBuilder {
     /// Construct a new builder, pre-filling it with the provided geometries
     pub fn from_nullable_multi_points(
         geoms: &[Option<impl MultiPointTrait<T = f64>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPointType,
     ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(|x| x.as_ref()),
-            dim,
-            coord_type,
-            metadata,
-        );
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(|x| x.as_ref()), typ);
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
     }
@@ -346,94 +267,31 @@ impl MultiPointBuilder {
     /// Construct a new builder, pre-filling it with the provided geometries
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPointType,
     ) -> Result<Self> {
         let capacity = MultiPointCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
-        let mut array = Self::with_capacity_and_options(dim, capacity, coord_type, metadata);
+        let mut array = Self::with_capacity(typ, capacity);
         array.extend_from_geometry_iter(geoms.iter().map(|x| x.as_ref()))?;
         Ok(array)
     }
     pub(crate) fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPointType,
     ) -> Result<Self> {
         let wkb_objects2 = wkb_objects
             .iter()
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(&wkb_objects2, dim, coord_type, metadata)
+        Self::from_nullable_geometries(&wkb_objects2, typ)
     }
 }
 
-impl From<MultiPointBuilder> for MultiPointArray {
-    fn from(mut other: MultiPointBuilder) -> Self {
-        let validity = other.validity.finish();
-
-        // TODO: impl shrink_to_fit for all mutable -> * impls
-        // other.coords.shrink_to_fit();
-        other.geom_offsets.shrink_to_fit();
-
-        Self::new(
-            other.coords.into(),
-            other.geom_offsets.into(),
-            validity,
-            other.metadata,
-        )
-    }
-}
-
-impl<G: MultiPointTrait<T = f64>> From<(&[G], Dimension)> for MultiPointBuilder {
-    fn from((geoms, dim): (&[G], Dimension)) -> Self {
-        Self::from_multi_points(
-            geoms,
-            dim,
-            CoordType::default_interleaved(),
-            Default::default(),
-        )
-    }
-}
-
-impl<G: MultiPointTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for MultiPointBuilder {
-    fn from((geoms, dim): (Vec<Option<G>>, Dimension)) -> Self {
-        Self::from_nullable_multi_points(
-            &geoms,
-            dim,
-            CoordType::default_interleaved(),
-            Default::default(),
-        )
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MultiPointBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiPointType)> for MultiPointBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (WKBArray<O>, Dimension)) -> Result<Self> {
-        let metadata = value.data_type.metadata().clone();
+    fn try_from((value, typ): (WKBArray<O>, MultiPointType)) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(
-            &wkb_objects,
-            dim,
-            CoordType::default_interleaved(),
-            metadata,
-        )
-    }
-}
-
-/// LineString and MultiPoint have the same layout, so enable conversions between the two to change
-/// the semantic type
-impl From<MultiPointBuilder> for LineStringBuilder {
-    fn from(value: MultiPointBuilder) -> Self {
-        Self::try_new(
-            value.coords,
-            value.geom_offsets,
-            value.validity,
-            value.metadata,
-        )
-        .unwrap()
+        Self::from_wkb(&wkb_objects, typ)
     }
 }
 

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -15,14 +15,6 @@ use crate::error::{GeoArrowError, Result};
 use crate::scalar::WKB;
 use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
 
-pub type MutableMultiPolygonParts = (
-    CoordBufferBuilder,
-    OffsetsBuilder<i32>,
-    OffsetsBuilder<i32>,
-    OffsetsBuilder<i32>,
-    NullBufferBuilder,
-);
-
 /// The GeoArrow equivalent to `Vec<Option<MultiPolygon>>`: a mutable collection of MultiPolygons.
 ///
 /// Converting an [`MultiPolygonBuilder`] into a [`MultiPolygonArray`] is `O(1)`.

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 use geo_traits::{
     CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait,
 };
-use geoarrow_schema::{CoordType, Dimension, Metadata};
+use geoarrow_schema::{CoordType, MultiPolygonType};
 
 use crate::capacity::MultiPolygonCapacity;
 // use super::array::check;
@@ -30,7 +28,7 @@ pub type MutableMultiPolygonParts = (
 /// Converting an [`MultiPolygonBuilder`] into a [`MultiPolygonArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct MultiPolygonBuilder {
-    metadata: Arc<Metadata>,
+    data_type: MultiPolygonType,
 
     pub(crate) coords: CoordBufferBuilder,
 
@@ -49,43 +47,25 @@ pub struct MultiPolygonBuilder {
 
 impl MultiPolygonBuilder {
     /// Creates a new empty [`MultiPolygonBuilder`].
-    pub fn new(dim: Dimension) -> Self {
-        Self::new_with_options(dim, CoordType::default_interleaved(), Default::default())
-    }
-
-    /// Creates a new empty [`MultiPolygonBuilder`] with the provided options.
-    pub fn new_with_options(
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-    ) -> Self {
-        Self::with_capacity_and_options(dim, Default::default(), coord_type, metadata)
+    pub fn new(typ: MultiPolygonType) -> Self {
+        Self::with_capacity(typ, Default::default())
     }
 
     /// Creates a new [`MultiPolygonBuilder`] with a capacity.
-    pub fn with_capacity(dim: Dimension, capacity: MultiPolygonCapacity) -> Self {
-        Self::with_capacity_and_options(
-            dim,
-            capacity,
-            CoordType::default_interleaved(),
-            Default::default(),
-        )
-    }
-
-    /// Creates a new empty [`MultiPolygonBuilder`] with the provided capacity and options.
-    pub fn with_capacity_and_options(
-        dim: Dimension,
-        capacity: MultiPolygonCapacity,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-    ) -> Self {
-        let coords = match coord_type {
-            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
-                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
-            ),
-            CoordType::Separated => CoordBufferBuilder::Separated(
-                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
-            ),
+    pub fn with_capacity(typ: MultiPolygonType, capacity: MultiPolygonCapacity) -> Self {
+        let coords = match typ.coord_type() {
+            CoordType::Interleaved => {
+                CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(
+                    capacity.coord_capacity,
+                    typ.dimension(),
+                ))
+            }
+            CoordType::Separated => {
+                CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(
+                    capacity.coord_capacity,
+                    typ.dimension(),
+                ))
+            }
         };
 
         Self {
@@ -94,7 +74,7 @@ impl MultiPolygonBuilder {
             polygon_offsets: OffsetsBuilder::with_capacity(capacity.polygon_capacity),
             ring_offsets: OffsetsBuilder::with_capacity(capacity.ring_capacity),
             validity: NullBufferBuilder::new(capacity.geom_capacity),
-            metadata,
+            data_type: typ,
         }
     }
 
@@ -129,83 +109,31 @@ impl MultiPolygonBuilder {
         self.geom_offsets.reserve_exact(additional.geom_capacity);
     }
 
-    /// The canonical method to create a [`MultiPolygonBuilder`] out of its internal
-    /// components.
-    ///
-    /// # Implementation
-    ///
-    /// This function is `O(1)`.
-    ///
-    /// # Errors
-    ///
-    /// - if the validity is not `None` and its length is different from the number of geometries
-    /// - if the largest ring offset does not match the number of coordinates
-    /// - if the largest polygon offset does not match the size of ring offsets
-    /// - if the largest geometry offset does not match the size of polygon offsets
-    pub fn try_new(
-        coords: CoordBufferBuilder,
-        geom_offsets: OffsetsBuilder<i32>,
-        polygon_offsets: OffsetsBuilder<i32>,
-        ring_offsets: OffsetsBuilder<i32>,
-        validity: NullBufferBuilder,
-        metadata: Arc<Metadata>,
-    ) -> Result<Self> {
-        // check(
-        //     &coords.clone().into(),
-        //     &geom_offsets.clone().into(),
-        //     &polygon_offsets.clone().into(),
-        //     &ring_offsets.clone().into(),
-        //     validity.as_ref().map(|x| x.len()),
-        // )?;
-        Ok(Self {
-            coords,
+    /// Consume the builder and convert to an immutable [`MultiPolygonArray`]
+    pub fn finish(mut self) -> MultiPolygonArray {
+        let validity = self.validity.finish();
+
+        let geom_offsets: OffsetBuffer<i32> = self.geom_offsets.into();
+        let polygon_offsets: OffsetBuffer<i32> = self.polygon_offsets.into();
+        let ring_offsets: OffsetBuffer<i32> = self.ring_offsets.into();
+
+        MultiPolygonArray::new(
+            self.coords.into(),
             geom_offsets,
             polygon_offsets,
             ring_offsets,
             validity,
-            metadata,
-        })
-    }
-
-    /// Extract the low-level APIs from the [`MultiPolygonBuilder`].
-    pub fn into_inner(self) -> MutableMultiPolygonParts {
-        (
-            self.coords,
-            self.geom_offsets,
-            self.polygon_offsets,
-            self.ring_offsets,
-            self.validity,
+            self.data_type.metadata().clone(),
         )
-    }
-
-    /// Consume the builder and convert to an immutable [`MultiPolygonArray`]
-    pub fn finish(self) -> MultiPolygonArray {
-        self.into()
     }
 
     /// Creates a new builder with a capacity inferred by the provided iterator.
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
-        dim: Dimension,
-    ) -> Self {
-        Self::with_capacity_and_options_from_iter(
-            geoms,
-            dim,
-            CoordType::default_interleaved(),
-            Default::default(),
-        )
-    }
-
-    /// Creates a new builder with the provided options and a capacity inferred by the provided
-    /// iterator.
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl MultiPolygonTrait + 'a)>>,
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPolygonType,
     ) -> Self {
         let capacity = MultiPolygonCapacity::from_multi_polygons(geoms);
-        Self::with_capacity_and_options(dim, capacity, coord_type, metadata)
+        Self::with_capacity(typ, capacity)
     }
 
     /// Reserve more space in the underlying buffers with the capacity inferred from the provided
@@ -431,16 +359,9 @@ impl MultiPolygonBuilder {
     /// Construct a new builder, pre-filling it with the provided geometries
     pub fn from_multi_polygons(
         geoms: &[impl MultiPolygonTrait<T = f64>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPolygonType,
     ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(Some),
-            dim,
-            coord_type,
-            metadata,
-        );
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(Some), typ);
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }
@@ -448,16 +369,9 @@ impl MultiPolygonBuilder {
     /// Construct a new builder, pre-filling it with the provided geometries
     pub fn from_nullable_multi_polygons(
         geoms: &[Option<impl MultiPolygonTrait<T = f64>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPolygonType,
     ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(|x| x.as_ref()),
-            dim,
-            coord_type,
-            metadata,
-        );
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(|x| x.as_ref()), typ);
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
     }
@@ -465,83 +379,32 @@ impl MultiPolygonBuilder {
     /// Construct a new builder, pre-filling it with the provided geometries
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPolygonType,
     ) -> Result<Self> {
         let capacity = MultiPolygonCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
-        let mut array = Self::with_capacity_and_options(dim, capacity, coord_type, metadata);
+        let mut array = Self::with_capacity(typ, capacity);
         array.extend_from_geometry_iter(geoms.iter().map(|x| x.as_ref()))?;
         Ok(array)
     }
 
     pub(crate) fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: MultiPolygonType,
     ) -> Result<Self> {
         let wkb_objects2 = wkb_objects
             .iter()
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(&wkb_objects2, dim, coord_type, metadata)
+        Self::from_nullable_geometries(&wkb_objects2, typ)
     }
 }
 
-impl From<MultiPolygonBuilder> for MultiPolygonArray {
-    fn from(mut other: MultiPolygonBuilder) -> Self {
-        let validity = other.validity.finish();
-
-        let geom_offsets: OffsetBuffer<i32> = other.geom_offsets.into();
-        let polygon_offsets: OffsetBuffer<i32> = other.polygon_offsets.into();
-        let ring_offsets: OffsetBuffer<i32> = other.ring_offsets.into();
-
-        Self::new(
-            other.coords.into(),
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
-            other.metadata,
-        )
-    }
-}
-
-impl<G: MultiPolygonTrait<T = f64>> From<(&[G], Dimension)> for MultiPolygonBuilder {
-    fn from((geoms, dim): (&[G], Dimension)) -> Self {
-        Self::from_multi_polygons(
-            geoms,
-            dim,
-            CoordType::default_interleaved(),
-            Default::default(),
-        )
-    }
-}
-
-impl<G: MultiPolygonTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for MultiPolygonBuilder {
-    fn from((geoms, dim): (Vec<Option<G>>, Dimension)) -> Self {
-        Self::from_nullable_multi_polygons(
-            &geoms,
-            dim,
-            CoordType::default_interleaved(),
-            Default::default(),
-        )
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MultiPolygonBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiPolygonType)> for MultiPolygonBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (WKBArray<O>, Dimension)) -> Result<Self> {
-        let metadata = value.data_type.metadata().clone();
+    fn try_from((value, typ): (WKBArray<O>, MultiPolygonType)) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(
-            &wkb_objects,
-            dim,
-            CoordType::default_interleaved(),
-            metadata,
-        )
+        Self::from_wkb(&wkb_objects, typ)
     }
 }
 

--- a/rust/geoarrow-array/src/builder/polygon.rs
+++ b/rust/geoarrow-array/src/builder/polygon.rs
@@ -1,17 +1,14 @@
-use std::sync::Arc;
-
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
 use geo_traits::{
     CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait,
     RectTrait,
 };
-use geoarrow_schema::{CoordType, Dimension, Metadata};
+use geoarrow_schema::{CoordType, PolygonType};
 
 use crate::array::{PolygonArray, WKBArray};
 use crate::builder::{
-    CoordBufferBuilder, InterleavedCoordBufferBuilder, MultiLineStringBuilder, OffsetsBuilder,
-    SeparatedCoordBufferBuilder,
+    CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::capacity::PolygonCapacity;
 use crate::error::{GeoArrowError, Result};
@@ -30,7 +27,7 @@ pub type MutablePolygonParts = (
 /// Converting an [`PolygonBuilder`] into a [`PolygonArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct PolygonBuilder {
-    metadata: Arc<Metadata>,
+    data_type: PolygonType,
 
     pub(crate) coords: CoordBufferBuilder,
 
@@ -46,45 +43,32 @@ pub struct PolygonBuilder {
 
 impl PolygonBuilder {
     /// Creates a new empty [`PolygonBuilder`].
-    pub fn new(dim: Dimension) -> Self {
-        Self::new_with_options(dim, CoordType::Interleaved, Default::default())
-    }
-
-    /// Creates a new empty [`PolygonBuilder`] with the provided options.
-    pub fn new_with_options(
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-    ) -> Self {
-        Self::with_capacity_and_options(dim, Default::default(), coord_type, metadata)
+    pub fn new(typ: PolygonType) -> Self {
+        Self::with_capacity(typ, Default::default())
     }
 
     /// Creates a new [`PolygonBuilder`] with given capacity and no validity.
-    pub fn with_capacity(dim: Dimension, capacity: PolygonCapacity) -> Self {
-        Self::with_capacity_and_options(dim, capacity, CoordType::Interleaved, Default::default())
-    }
-
-    /// Creates a new empty [`PolygonBuilder`] with the provided capacity and options.
-    pub fn with_capacity_and_options(
-        dim: Dimension,
-        capacity: PolygonCapacity,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-    ) -> Self {
-        let coords = match coord_type {
-            CoordType::Interleaved => CoordBufferBuilder::Interleaved(
-                InterleavedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
-            ),
-            CoordType::Separated => CoordBufferBuilder::Separated(
-                SeparatedCoordBufferBuilder::with_capacity(capacity.coord_capacity, dim),
-            ),
+    pub fn with_capacity(typ: PolygonType, capacity: PolygonCapacity) -> Self {
+        let coords = match typ.coord_type() {
+            CoordType::Interleaved => {
+                CoordBufferBuilder::Interleaved(InterleavedCoordBufferBuilder::with_capacity(
+                    capacity.coord_capacity,
+                    typ.dimension(),
+                ))
+            }
+            CoordType::Separated => {
+                CoordBufferBuilder::Separated(SeparatedCoordBufferBuilder::with_capacity(
+                    capacity.coord_capacity,
+                    typ.dimension(),
+                ))
+            }
         };
         Self {
             coords,
             geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity),
             ring_offsets: OffsetsBuilder::with_capacity(capacity.ring_capacity),
             validity: NullBufferBuilder::new(capacity.geom_capacity),
-            metadata,
+            data_type: typ,
         }
     }
 
@@ -136,39 +120,6 @@ impl PolygonBuilder {
         self.reserve_exact(counter)
     }
 
-    /// The canonical method to create a [`PolygonBuilder`] out of its internal components.
-    ///
-    /// # Implementation
-    ///
-    /// This function is `O(1)`.
-    ///
-    /// # Errors
-    ///
-    /// - if the validity is not `None` and its length is different from the number of geometries
-    /// - if the largest ring offset does not match the number of coordinates
-    /// - if the largest geometry offset does not match the size of ring offsets
-    pub fn try_new(
-        coords: CoordBufferBuilder,
-        geom_offsets: OffsetsBuilder<i32>,
-        ring_offsets: OffsetsBuilder<i32>,
-        validity: NullBufferBuilder,
-        metadata: Arc<Metadata>,
-    ) -> Result<Self> {
-        // check(
-        //     &coords.clone().into(),
-        //     &geom_offsets.clone().into(),
-        //     &ring_offsets.clone().into(),
-        //     validity.as_ref().map(|x| x.len()),
-        // )?;
-        Ok(Self {
-            coords,
-            geom_offsets,
-            ring_offsets,
-            validity,
-            metadata,
-        })
-    }
-
     /// Extract the low-level APIs from the [`PolygonBuilder`].
     pub fn into_inner(self) -> MutablePolygonParts {
         (
@@ -205,33 +156,28 @@ impl PolygonBuilder {
     }
 
     /// Consume the builder and convert to an immutable [`PolygonArray`]
-    pub fn finish(self) -> PolygonArray {
-        self.into()
+    pub fn finish(mut self) -> PolygonArray {
+        let validity = self.validity.finish();
+
+        let geom_offsets: OffsetBuffer<i32> = self.geom_offsets.into();
+        let ring_offsets: OffsetBuffer<i32> = self.ring_offsets.into();
+
+        PolygonArray::new(
+            self.coords.into(),
+            geom_offsets,
+            ring_offsets,
+            validity,
+            self.data_type.metadata().clone(),
+        )
     }
 
     /// Creates a new builder with a capacity inferred by the provided iterator.
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
-        dim: Dimension,
-    ) -> Self {
-        Self::with_capacity_and_options_from_iter(
-            geoms,
-            dim,
-            CoordType::Interleaved,
-            Default::default(),
-        )
-    }
-
-    /// Creates a new builder with the provided options and a capacity inferred by the provided
-    /// iterator.
-    pub fn with_capacity_and_options_from_iter<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl PolygonTrait + 'a)>>,
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: PolygonType,
     ) -> Self {
         let counter = PolygonCapacity::from_polygons(geoms);
-        Self::with_capacity_and_options(dim, counter, coord_type, metadata)
+        Self::with_capacity(typ, counter)
     }
 
     /// Add a new Polygon to the end of this array.
@@ -392,18 +338,8 @@ impl PolygonBuilder {
     }
 
     /// Construct a new builder, pre-filling it with the provided geometries
-    pub fn from_polygons(
-        geoms: &[impl PolygonTrait<T = f64>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-    ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(Some),
-            dim,
-            coord_type,
-            metadata,
-        );
+    pub fn from_polygons(geoms: &[impl PolygonTrait<T = f64>], typ: PolygonType) -> Self {
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(Some), typ);
         array.extend_from_iter(geoms.iter().map(Some));
         array
     }
@@ -411,16 +347,9 @@ impl PolygonBuilder {
     /// Construct a new builder, pre-filling it with the provided geometries
     pub fn from_nullable_polygons(
         geoms: &[Option<impl PolygonTrait<T = f64>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: PolygonType,
     ) -> Self {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter().map(|x| x.as_ref()),
-            dim,
-            coord_type,
-            metadata,
-        );
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(|x| x.as_ref()), typ);
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         array
     }
@@ -428,81 +357,32 @@ impl PolygonBuilder {
     /// Construct a new builder, pre-filling it with the provided geometries
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: PolygonType,
     ) -> Result<Self> {
         let capacity = PolygonCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
-        let mut array = Self::with_capacity_and_options(dim, capacity, coord_type, metadata);
+        let mut array = Self::with_capacity(typ, capacity);
         array.extend_from_geometry_iter(geoms.iter().map(|x| x.as_ref()))?;
         Ok(array)
     }
 
     pub(crate) fn from_wkb<W: OffsetSizeTrait>(
         wkb_objects: &[Option<WKB<'_, W>>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
+        typ: PolygonType,
     ) -> Result<Self> {
         let wkb_objects2 = wkb_objects
             .iter()
             .map(|maybe_wkb| maybe_wkb.as_ref().map(|wkb| wkb.parse()).transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(&wkb_objects2, dim, coord_type, metadata)
+        Self::from_nullable_geometries(&wkb_objects2, typ)
     }
 }
 
-impl From<PolygonBuilder> for PolygonArray {
-    fn from(mut other: PolygonBuilder) -> Self {
-        let validity = other.validity.finish();
-
-        let geom_offsets: OffsetBuffer<i32> = other.geom_offsets.into();
-        let ring_offsets: OffsetBuffer<i32> = other.ring_offsets.into();
-
-        Self::new(
-            other.coords.into(),
-            geom_offsets,
-            ring_offsets,
-            validity,
-            other.metadata,
-        )
-    }
-}
-
-impl<G: PolygonTrait<T = f64>> From<(&[G], Dimension)> for PolygonBuilder {
-    fn from((geoms, dim): (&[G], Dimension)) -> Self {
-        Self::from_polygons(geoms, dim, CoordType::Interleaved, Default::default())
-    }
-}
-
-impl<G: PolygonTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for PolygonBuilder {
-    fn from((geoms, dim): (Vec<Option<G>>, Dimension)) -> Self {
-        Self::from_nullable_polygons(&geoms, dim, CoordType::Interleaved, Default::default())
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for PolygonBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, PolygonType)> for PolygonBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (WKBArray<O>, Dimension)) -> Result<Self> {
-        let metadata = value.data_type.metadata().clone();
+    fn try_from((value, typ): (WKBArray<O>, PolygonType)) -> Result<Self> {
         let wkb_objects: Vec<Option<WKB<'_, O>>> = value.iter().collect();
-        Self::from_wkb(&wkb_objects, dim, CoordType::Interleaved, metadata)
-    }
-}
-
-/// Polygon and MultiLineString have the same layout, so enable conversions between the two to
-/// change the semantic type
-impl From<PolygonBuilder> for MultiLineStringBuilder {
-    fn from(value: PolygonBuilder) -> Self {
-        Self::try_new(
-            value.coords,
-            value.geom_offsets,
-            value.ring_offsets,
-            value.validity,
-            value.metadata,
-        )
-        .unwrap()
+        Self::from_wkb(&wkb_objects, typ)
     }
 }
 

--- a/rust/geoarrow-array/src/scalar/multilinestring.rs
+++ b/rust/geoarrow-array/src/scalar/multilinestring.rs
@@ -92,16 +92,25 @@ impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for MultiLineString<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::array::MultiLineStringArray;
+    use crate::builder::MultiLineStringBuilder;
     use crate::test::multilinestring::{ml0, ml1};
     use crate::trait_::ArrayAccessor;
-    use geoarrow_schema::Dimension;
+    use geoarrow_schema::{CoordType, Dimension, MultiLineStringType};
 
     /// Test Eq where the current index is true but another index is false
     #[test]
     fn test_eq_other_index_false() {
-        let arr1: MultiLineStringArray = (vec![ml0(), ml1()].as_slice(), Dimension::XY).into();
-        let arr2: MultiLineStringArray = (vec![ml0(), ml0()].as_slice(), Dimension::XY).into();
+        let typ =
+            MultiLineStringType::new(CoordType::Interleaved, Dimension::XY, Default::default());
+
+        let arr1 = MultiLineStringBuilder::from_multi_line_strings(
+            vec![ml0(), ml1()].as_slice(),
+            typ.clone(),
+        )
+        .finish();
+        let arr2 =
+            MultiLineStringBuilder::from_multi_line_strings(vec![ml0(), ml0()].as_slice(), typ)
+                .finish();
 
         assert_eq!(arr1.value(0), arr2.value(0));
         assert_ne!(arr1.value(1), arr2.value(1));

--- a/rust/geoarrow-array/src/test/linestring.rs
+++ b/rust/geoarrow-array/src/test/linestring.rs
@@ -1,5 +1,5 @@
 use geo::{line_string, LineString};
-use geoarrow_schema::{CoordType, Dimension};
+use geoarrow_schema::{CoordType, Dimension, LineStringType};
 
 use crate::array::LineStringArray;
 use crate::builder::LineStringBuilder;
@@ -21,11 +21,6 @@ pub(crate) fn ls1() -> LineString {
 #[allow(dead_code)]
 pub(crate) fn ls_array() -> LineStringArray {
     let geoms = vec![ls0(), ls1()];
-    LineStringBuilder::from_line_strings(
-        &geoms,
-        Dimension::XY,
-        CoordType::Interleaved,
-        Default::default(),
-    )
-    .finish()
+    let typ = LineStringType::new(CoordType::Interleaved, Dimension::XY, Default::default());
+    LineStringBuilder::from_line_strings(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/multilinestring.rs
+++ b/rust/geoarrow-array/src/test/multilinestring.rs
@@ -1,5 +1,5 @@
 use geo::{line_string, MultiLineString};
-use geoarrow_schema::{CoordType, Dimension};
+use geoarrow_schema::{CoordType, Dimension, MultiLineStringType};
 
 use crate::array::MultiLineStringArray;
 use crate::builder::MultiLineStringBuilder;
@@ -32,11 +32,6 @@ pub(crate) fn ml1() -> MultiLineString {
 
 pub(crate) fn ml_array() -> MultiLineStringArray {
     let geoms = vec![ml0(), ml1()];
-    MultiLineStringBuilder::from_multi_line_strings(
-        &geoms,
-        Dimension::XY,
-        CoordType::default_interleaved(),
-        Default::default(),
-    )
-    .finish()
+    let typ = MultiLineStringType::new(CoordType::Interleaved, Dimension::XY, Default::default());
+    MultiLineStringBuilder::from_multi_line_strings(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/multipoint.rs
+++ b/rust/geoarrow-array/src/test/multipoint.rs
@@ -2,7 +2,7 @@ use geo::{point, MultiPoint};
 
 use crate::array::MultiPointArray;
 use crate::builder::MultiPointBuilder;
-use geoarrow_schema::{CoordType, Dimension};
+use geoarrow_schema::{CoordType, Dimension, MultiPointType};
 
 pub(crate) fn mp0() -> MultiPoint {
     MultiPoint::new(vec![
@@ -28,11 +28,6 @@ pub(crate) fn mp1() -> MultiPoint {
 
 pub(crate) fn mp_array() -> MultiPointArray {
     let geoms = vec![mp0(), mp1()];
-    MultiPointBuilder::from_multi_points(
-        &geoms,
-        Dimension::XY,
-        CoordType::Interleaved,
-        Default::default(),
-    )
-    .finish()
+    let typ = MultiPointType::new(CoordType::Interleaved, Dimension::XY, Default::default());
+    MultiPointBuilder::from_multi_points(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/multipolygon.rs
+++ b/rust/geoarrow-array/src/test/multipolygon.rs
@@ -1,7 +1,8 @@
 use geo::{polygon, MultiPolygon};
 
 use crate::array::MultiPolygonArray;
-use geoarrow_schema::Dimension;
+use crate::builder::MultiPolygonBuilder;
+use geoarrow_schema::{CoordType, Dimension, MultiPolygonType};
 
 pub(crate) fn mp0() -> MultiPolygon {
     MultiPolygon::new(vec![
@@ -48,5 +49,7 @@ pub(crate) fn mp1() -> MultiPolygon {
 }
 
 pub(crate) fn mp_array() -> MultiPolygonArray {
-    (vec![mp0(), mp1()].as_slice(), Dimension::XY).into()
+    let geoms = vec![mp0(), mp1()];
+    let typ = MultiPolygonType::new(CoordType::Interleaved, Dimension::XY, Default::default());
+    MultiPolygonBuilder::from_multi_polygons(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/point.rs
+++ b/rust/geoarrow-array/src/test/point.rs
@@ -3,7 +3,7 @@ use geo::{point, Point};
 use crate::array::PointArray;
 use crate::builder::PointBuilder;
 use geo_traits::CoordTrait;
-use geoarrow_schema::{CoordType, Dimension};
+use geoarrow_schema::{CoordType, Dimension, PointType};
 
 pub(crate) fn p0() -> Point {
     point!(
@@ -25,13 +25,8 @@ pub(crate) fn p2() -> Point {
 
 pub(crate) fn point_array() -> PointArray {
     let geoms = [p0(), p1(), p2()];
-    PointBuilder::from_points(
-        geoms.iter(),
-        Dimension::XY,
-        CoordType::default_interleaved(),
-        Default::default(),
-    )
-    .finish()
+    let typ = PointType::new(CoordType::Interleaved, Dimension::XY, Default::default());
+    PointBuilder::from_points(geoms.iter(), typ).finish()
 }
 
 struct CoordZ {
@@ -66,7 +61,8 @@ impl CoordTrait for CoordZ {
 }
 
 pub(crate) fn point_z_array() -> PointArray {
-    let mut builder = PointBuilder::with_capacity(Dimension::XYZ, 3);
+    let typ = PointType::new(CoordType::Interleaved, Dimension::XYZ, Default::default());
+    let mut builder = PointBuilder::with_capacity(typ, 3);
     let coords = vec![
         CoordZ {
             x: 0.,

--- a/rust/geoarrow-array/src/test/polygon.rs
+++ b/rust/geoarrow-array/src/test/polygon.rs
@@ -1,5 +1,5 @@
 use geo::{polygon, Polygon};
-use geoarrow_schema::{CoordType, Dimension};
+use geoarrow_schema::{CoordType, Dimension, PolygonType};
 
 use crate::array::PolygonArray;
 use crate::builder::PolygonBuilder;
@@ -34,11 +34,6 @@ pub(crate) fn p1() -> Polygon {
 
 pub(crate) fn p_array() -> PolygonArray {
     let geoms = vec![p0(), p1()];
-    PolygonBuilder::from_polygons(
-        &geoms,
-        Dimension::XY,
-        CoordType::Interleaved,
-        Default::default(),
-    )
-    .finish()
+    let typ = PolygonType::new(CoordType::Interleaved, Dimension::XY, Default::default());
+    PolygonBuilder::from_polygons(&geoms, typ).finish()
 }


### PR DESCRIPTION
### Change list

#### Simplify builder constructors

So instead of both `new` and `new_with_options`

```rs
// OLD
impl LineStringBuilder {
	/// Creates a new empty [`LineStringBuilder`].
	pub fn new(dim: Dimension) -> Self;

	/// Creates a new empty [`LineStringBuilder`] with the provided options.
	pub fn new_with_options(
		dim: Dimension,
		coord_type: CoordType,
		metadata: Arc<Metadata>,
	) -> Self;
```

we now just have a `new` that takes in a relevant type

```rs
// NEW
impl LineStringBuilder {
	/// Creates a new empty [`LineStringBuilder`].
	pub fn new(typ: LineStringType) -> Self;
```

And similarly, instead of having with `with_capacity` and `with_capacity_with_options`, we now have just `with_capacity`.

This also simplifies the signature of APIs like

```rs
	pub fn from_line_strings(
		geoms: &[impl LineStringTrait<T = f64>],
		dim: Dimension,
		coord_type: CoordType,
		metadata: Arc<Metadata>,
	) -> Self;
``` 

which becomes

```rs
	pub fn from_line_strings(geoms: &[impl LineStringTrait<T = f64>], typ: LineStringType) -> Self;
```

#### Convert `From` impls that used to be in terms of `Dimension`, like

```rs
impl TryFrom<(&dyn Array, Dimension)> for LineStringArray
```

to be in terms of the relevant type instead

```rs
impl TryFrom<(&dyn Array, LineStringType)> for LineStringArray {
```

This ensures that the correct coord type and metadata is propagated, and we don't have to use `Default::default` on either of those.

- Remove `From` impls like

```rs
impl<G: LineStringTrait<T = f64>> From<(&[G], Dimension)> for LineStringBuilder {
```

and

```rs
impl<G: LineStringTrait<T = f64>> From<(Vec<Option<G>>, Dimension)> for LineStringBuilder {
```

For one, it was super awkward that in the non-nullable case we accept a slice but in the nullable case we only accepted a vec. We can't have both in terms of slices because that gives an overlapping trait error. Because G could be implemented in the future for `Option<G>` and Rust wouldn't know which trait to choose.

#### Remove `From<Builder> for Array`. Instead, have only the named method `finish()` which converts a builder to an array.

#### Remove conversions between e.g. `MultiLineStringArray` and `PolygonArray`, which have the same physical layout but different interpretations.

#### Better and more concise handling of field metadata using the new upstream extension APIs


```rs
// OLD
   fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
       let geom_type = NativeType::try_from(field)?;
       let dim = geom_type
           .dimension()
           .ok_or(GeoArrowError::General("Expected dimension".to_string()))?;
       let mut arr: Self = (arr, dim).try_into()?;
       let metadata = Arc::new(Metadata::try_from(field)?);
       arr.data_type = arr.data_type.clone().with_metadata(metadata);
       Ok(arr)
   }
```

```rs
// NEW
   fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
       let typ = field.try_extension_type::<GeometryCollectionType>()?;
       (arr, typ).try_into()
   }
```