### PR TITLE
Add `downcast_geometry_array` macro

### DIFF
--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -298,6 +298,27 @@ pub mod __private {
 /// iterate over the input values to compute that.
 ///
 /// ```
+/// # use arrow_array::Float64Array;
+/// # use arrow_array::builder::Float64Builder;
+/// # use geo::Area;
+/// # use geo_traits::to_geo::ToGeoGeometry;
+/// # use geoarrow_array::error::Result;
+/// # use geoarrow_array::{ArrayAccessor, GeoArrowType};
+/// #
+/// # fn impl_unsigned_area<'a>(array: &'a impl ArrayAccessor<'a>) -> Result<Float64Array> {
+/// #     let mut builder = Float64Builder::with_capacity(array.len());
+/// #
+/// #     for item in array.iter() {
+/// #         if let Some(geom) = item {
+/// #             builder.append_value(geom?.to_geometry().unsigned_area());
+/// #         } else {
+/// #             builder.append_null();
+/// #         }
+/// #     }
+/// #
+/// #     Ok(builder.finish())
+/// # }
+/// #
 /// fn impl_unsigned_area_specialized<'a>(array: &'a impl ArrayAccessor<'a>) -> Result<Float64Array> {
 ///     use GeoArrowType::*;
 ///     match array.data_type() {


### PR DESCRIPTION
I'm tired today and accidentally pushed to main in https://github.com/geoarrow/geoarrow-rs/commit/80e905b1086deb357ca69819b5740ebacc269714. (github branch protection settings are so weird. I can't push with `--force`, but I _can_ push without `--force`. I since turned on "do not allow bypassing these settings", which might help prevent this again in the future)

Then https://github.com/geoarrow/geoarrow-rs/pull/1030 auto-merged on top of it and I decided it wasn't worth the work to rewrite the history. This PR fixes the doctest from https://github.com/geoarrow/geoarrow-rs/commit/80e905b1086deb357ca69819b5740ebacc269714