### PR TITLE
Rename `WKBArray` to `WkbArray` and `WKTArray` to `WktArray`

### DIFF
--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -930,10 +930,10 @@ impl TryFrom<(&dyn Array, &Field)> for GeometryArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, GeometryType)> for GeometryArray {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryType)> for GeometryArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, GeometryType)) -> Result<Self> {
+    fn try_from(value: (WkbArray<O>, GeometryType)) -> Result<Self> {
         let mut_arr: GeometryBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{GeometryCollectionType, Metadata};
 
-use crate::array::{MixedGeometryArray, WKBArray};
+use crate::array::{MixedGeometryArray, WkbArray};
 use crate::builder::GeometryCollectionBuilder;
 use crate::capacity::GeometryCollectionCapacity;
 use crate::datatypes::GeoArrowType;
@@ -228,12 +228,12 @@ impl TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, GeometryCollectionType)>
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryCollectionType)>
     for GeometryCollectionArray
 {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, GeometryCollectionType)) -> Result<Self> {
+    fn try_from(value: (WkbArray<O>, GeometryCollectionType)) -> Result<Self> {
         let mut_arr: GeometryCollectionBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::array::{CoordBuffer, WKBArray};
+use crate::array::{CoordBuffer, WkbArray};
 use crate::builder::LineStringBuilder;
 use crate::capacity::LineStringCapacity;
 use crate::datatypes::GeoArrowType;
@@ -276,10 +276,10 @@ impl TryFrom<(&dyn Array, &Field)> for LineStringArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, LineStringType)> for LineStringArray {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, LineStringType)> for LineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, LineStringType)) -> Result<Self> {
+    fn try_from(value: (WkbArray<O>, LineStringType)) -> Result<Self> {
         let mut_arr: LineStringBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/mixed.rs
+++ b/rust/geoarrow-array/src/array/mixed.rs
@@ -13,7 +13,7 @@ use geoarrow_schema::{
 use crate::ArrayAccessor;
 use crate::array::{
     LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray,
-    PolygonArray, WKBArray,
+    PolygonArray, WkbArray,
 };
 use crate::builder::{
     LineStringBuilder, MixedGeometryBuilder, MultiLineStringBuilder, MultiPointBuilder,
@@ -685,10 +685,10 @@ impl TryFrom<(&dyn Array, Dimension, CoordType)> for MixedGeometryArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MixedGeometryArray {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, Dimension)> for MixedGeometryArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, Dimension)) -> Result<Self> {
+    fn try_from(value: (WkbArray<O>, Dimension)) -> Result<Self> {
         let mut_arr: MixedGeometryBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -27,8 +27,8 @@ pub use multipolygon::MultiPolygonArray;
 pub use point::PointArray;
 pub use polygon::PolygonArray;
 pub use rect::RectArray;
-pub use wkb::WKBArray;
-pub use wkt::WKTArray;
+pub use wkb::WkbArray;
+pub use wkt::WktArray;
 
 use std::sync::Arc;
 
@@ -52,10 +52,10 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
         GeometryCollection(_) => Arc::new(GeometryCollectionArray::try_from((array, field))?),
         Rect(_) => Arc::new(RectArray::try_from((array, field))?),
         Geometry(_) => Arc::new(GeometryArray::try_from((array, field))?),
-        WKB(_) => Arc::new(WKBArray::<i32>::try_from((array, field))?),
-        LargeWKB(_) => Arc::new(WKBArray::<i64>::try_from((array, field))?),
-        WKT(_) => Arc::new(WKTArray::<i32>::try_from((array, field))?),
-        LargeWKT(_) => Arc::new(WKTArray::<i64>::try_from((array, field))?),
+        WKB(_) => Arc::new(WkbArray::<i32>::try_from((array, field))?),
+        LargeWKB(_) => Arc::new(WkbArray::<i64>::try_from((array, field))?),
+        WKT(_) => Arc::new(WktArray::<i32>::try_from((array, field))?),
+        LargeWKT(_) => Arc::new(WktArray::<i64>::try_from((array, field))?),
     };
     Ok(result)
 }

--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -52,10 +52,10 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
         GeometryCollection(_) => Arc::new(GeometryCollectionArray::try_from((array, field))?),
         Rect(_) => Arc::new(RectArray::try_from((array, field))?),
         Geometry(_) => Arc::new(GeometryArray::try_from((array, field))?),
-        WKB(_) => Arc::new(WkbArray::<i32>::try_from((array, field))?),
-        LargeWKB(_) => Arc::new(WkbArray::<i64>::try_from((array, field))?),
-        WKT(_) => Arc::new(WktArray::<i32>::try_from((array, field))?),
-        LargeWKT(_) => Arc::new(WktArray::<i64>::try_from((array, field))?),
+        Wkb(_) => Arc::new(WkbArray::<i32>::try_from((array, field))?),
+        LargeWkb(_) => Arc::new(WkbArray::<i64>::try_from((array, field))?),
+        Wkt(_) => Arc::new(WktArray::<i32>::try_from((array, field))?),
+        LargeWkt(_) => Arc::new(WktArray::<i64>::try_from((array, field))?),
     };
     Ok(result)
 }

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{Metadata, MultiLineStringType};
 
-use crate::array::{CoordBuffer, LineStringArray, WKBArray};
+use crate::array::{CoordBuffer, LineStringArray, WkbArray};
 use crate::builder::MultiLineStringBuilder;
 use crate::capacity::MultiLineStringCapacity;
 use crate::datatypes::GeoArrowType;
@@ -317,10 +317,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiLineStringArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiLineStringType)> for MultiLineStringArray {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiLineStringType)> for MultiLineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, MultiLineStringType)) -> Result<Self> {
+    fn try_from(value: (WkbArray<O>, MultiLineStringType)) -> Result<Self> {
         let mut_arr: MultiLineStringBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{Metadata, MultiPointType};
 
-use crate::array::{CoordBuffer, LineStringArray, PointArray, WKBArray};
+use crate::array::{CoordBuffer, LineStringArray, PointArray, WkbArray};
 use crate::builder::MultiPointBuilder;
 use crate::capacity::MultiPointCapacity;
 use crate::datatypes::GeoArrowType;
@@ -277,10 +277,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPointArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiPointType)> for MultiPointArray {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPointType)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, MultiPointType)) -> Result<Self> {
+    fn try_from(value: (WkbArray<O>, MultiPointType)) -> Result<Self> {
         let mut_arr: MultiPointBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{Metadata, MultiPolygonType};
 
-use crate::array::{CoordBuffer, PolygonArray, WKBArray};
+use crate::array::{CoordBuffer, PolygonArray, WkbArray};
 use crate::builder::MultiPolygonBuilder;
 use crate::capacity::MultiPolygonCapacity;
 use crate::datatypes::GeoArrowType;
@@ -389,10 +389,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPolygonArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiPolygonType)> for MultiPolygonArray {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPolygonType)> for MultiPolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, MultiPolygonType)) -> Result<Self> {
+    fn try_from(value: (WkbArray<O>, MultiPolygonType)) -> Result<Self> {
         let mut_arr: MultiPolygonBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -7,7 +7,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, PolygonType};
 
-use crate::array::{CoordBuffer, RectArray, WKBArray};
+use crate::array::{CoordBuffer, RectArray, WkbArray};
 use crate::builder::PolygonBuilder;
 use crate::capacity::PolygonCapacity;
 use crate::datatypes::GeoArrowType;
@@ -320,10 +320,10 @@ impl TryFrom<(&dyn Array, &Field)> for PolygonArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, PolygonType)> for PolygonArray {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, PolygonType)> for PolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WKBArray<O>, PolygonType)) -> Result<Self> {
+    fn try_from(value: (WkbArray<O>, PolygonType)) -> Result<Self> {
         let mut_arr: PolygonBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -118,9 +118,9 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WkbArray<O> {
 
     fn data_type(&self) -> GeoArrowType {
         if O::IS_LARGE {
-            GeoArrowType::LargeWKB(self.data_type.clone())
+            GeoArrowType::LargeWkb(self.data_type.clone())
         } else {
-            GeoArrowType::WKB(self.data_type.clone())
+            GeoArrowType::Wkb(self.data_type.clone())
         }
     }
 

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -20,19 +20,19 @@ use crate::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 /// This is semantically equivalent to `Vec<Option<WKB>>` due to the internal validity bitmap.
 ///
 /// This array implements [`SerializedArray`], not [`NativeArray`]. This means that you'll need to
-/// parse the `WKBArray` into a native-typed GeoArrow array (such as
+/// parse the `WkbArray` into a native-typed GeoArrow array (such as
 /// [`GeometryArray`][crate::array::GeometryArray]) before using it for computations.
 ///
 /// Refer to [`crate::io::wkb`] for encoding and decoding this array to the native array types.
 #[derive(Debug, Clone, PartialEq)]
-pub struct WKBArray<O: OffsetSizeTrait> {
+pub struct WkbArray<O: OffsetSizeTrait> {
     pub(crate) data_type: WkbType,
     pub(crate) array: GenericBinaryArray<O>,
 }
 
 // Implement geometry accessors
-impl<O: OffsetSizeTrait> WKBArray<O> {
-    /// Create a new WKBArray from a BinaryArray
+impl<O: OffsetSizeTrait> WkbArray<O> {
+    /// Create a new WkbArray from a BinaryArray
     pub fn new(array: GenericBinaryArray<O>, metadata: Arc<Metadata>) -> Self {
         Self {
             data_type: WkbType::new(metadata),
@@ -45,7 +45,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
         self.len() == 0
     }
 
-    /// Infer the minimal NativeType that this WKBArray can be casted to.
+    /// Infer the minimal NativeType that this WkbArray can be casted to.
     #[allow(dead_code)]
     // TODO: is this obsolete with new from_wkb approach that uses downcasting?
     pub(crate) fn infer_geo_data_type(&self, _coord_type: CoordType) -> Result<GeoArrowType> {
@@ -68,7 +68,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 
-    /// Slices this [`WKBArray`] in place.
+    /// Slices this [`WkbArray`] in place.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
@@ -91,7 +91,7 @@ impl<O: OffsetSizeTrait> WKBArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeoArrowArray for WKBArray<O> {
+impl<O: OffsetSizeTrait> GeoArrowArray for WkbArray<O> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -129,7 +129,7 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WKBArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> ArrayAccessor<'a> for WKBArray<O> {
+impl<'a, O: OffsetSizeTrait> ArrayAccessor<'a> for WkbArray<O> {
     type Item = Wkb<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {
@@ -138,7 +138,7 @@ impl<'a, O: OffsetSizeTrait> ArrayAccessor<'a> for WKBArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for WKBArray<O> {
+impl<O: OffsetSizeTrait> IntoArrow for WkbArray<O> {
     type ArrowArray = GenericBinaryArray<O>;
     type ExtensionType = WkbType;
 
@@ -155,19 +155,19 @@ impl<O: OffsetSizeTrait> IntoArrow for WKBArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<(GenericBinaryArray<O>, WkbType)> for WKBArray<O> {
+impl<O: OffsetSizeTrait> From<(GenericBinaryArray<O>, WkbType)> for WkbArray<O> {
     fn from((value, typ): (GenericBinaryArray<O>, WkbType)) -> Self {
         Self::new(value, typ.metadata().clone())
     }
 }
 
-impl TryFrom<(&dyn Array, WkbType)> for WKBArray<i32> {
+impl TryFrom<(&dyn Array, WkbType)> for WkbArray<i32> {
     type Error = GeoArrowError;
     fn try_from((value, typ): (&dyn Array, WkbType)) -> Result<Self> {
         match value.data_type() {
             DataType::Binary => Ok((value.as_binary::<i32>().clone(), typ).into()),
             DataType::LargeBinary => {
-                let geom_array: WKBArray<i64> = (value.as_binary::<i64>().clone(), typ).into();
+                let geom_array: WkbArray<i64> = (value.as_binary::<i64>().clone(), typ).into();
                 geom_array.try_into()
             }
             _ => Err(GeoArrowError::General(format!(
@@ -178,12 +178,12 @@ impl TryFrom<(&dyn Array, WkbType)> for WKBArray<i32> {
     }
 }
 
-impl TryFrom<(&dyn Array, WkbType)> for WKBArray<i64> {
+impl TryFrom<(&dyn Array, WkbType)> for WkbArray<i64> {
     type Error = GeoArrowError;
     fn try_from((value, typ): (&dyn Array, WkbType)) -> Result<Self> {
         match value.data_type() {
             DataType::Binary => {
-                let geom_array: WKBArray<i32> = (value.as_binary::<i32>().clone(), typ).into();
+                let geom_array: WkbArray<i32> = (value.as_binary::<i32>().clone(), typ).into();
                 Ok(geom_array.into())
             }
             DataType::LargeBinary => Ok((value.as_binary::<i64>().clone(), typ).into()),
@@ -195,7 +195,7 @@ impl TryFrom<(&dyn Array, WkbType)> for WKBArray<i64> {
     }
 }
 
-impl TryFrom<(&dyn Array, &Field)> for WKBArray<i32> {
+impl TryFrom<(&dyn Array, &Field)> for WkbArray<i32> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -204,7 +204,7 @@ impl TryFrom<(&dyn Array, &Field)> for WKBArray<i32> {
     }
 }
 
-impl TryFrom<(&dyn Array, &Field)> for WKBArray<i64> {
+impl TryFrom<(&dyn Array, &Field)> for WkbArray<i64> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -213,8 +213,8 @@ impl TryFrom<(&dyn Array, &Field)> for WKBArray<i64> {
     }
 }
 
-impl From<WKBArray<i32>> for WKBArray<i64> {
-    fn from(value: WKBArray<i32>) -> Self {
+impl From<WkbArray<i32>> for WkbArray<i64> {
+    fn from(value: WkbArray<i32>) -> Self {
         let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
         let array = LargeBinaryArray::new(offsets_buffer_i32_to_i64(&offsets), values, nulls);
@@ -225,10 +225,10 @@ impl From<WKBArray<i32>> for WKBArray<i64> {
     }
 }
 
-impl TryFrom<WKBArray<i64>> for WKBArray<i32> {
+impl TryFrom<WkbArray<i64>> for WkbArray<i32> {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKBArray<i64>) -> Result<Self> {
+    fn try_from(value: WkbArray<i64>) -> Result<Self> {
         let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
         let array = BinaryArray::new(offsets_buffer_i64_to_i32(&offsets)?, values, nulls);
@@ -247,7 +247,7 @@ mod test {
 
     use super::*;
 
-    fn wkb_data<O: OffsetSizeTrait>() -> WKBArray<O> {
+    fn wkb_data<O: OffsetSizeTrait>() -> WkbArray<O> {
         let mut builder = WKBBuilder::new(WkbType::new(Default::default()));
         builder.push_point(Some(&point::p0()));
         builder.push_point(Some(&point::p1()));
@@ -260,7 +260,7 @@ mod test {
         let wkb_array = wkb_data::<i32>();
         let array = wkb_array.to_array_ref();
         let field = wkb_array.data_type.to_field("geometry", true, false);
-        let wkb_array_retour: WKBArray<i32> = (array.as_ref(), &field).try_into().unwrap();
+        let wkb_array_retour: WkbArray<i32> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
     }
@@ -270,7 +270,7 @@ mod test {
         let wkb_array = wkb_data::<i64>();
         let array = wkb_array.to_array_ref();
         let field = wkb_array.data_type.to_field("geometry", true, false);
-        let wkb_array_retour: WKBArray<i64> = (array.as_ref(), &field).try_into().unwrap();
+        let wkb_array_retour: WkbArray<i64> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
     }
@@ -278,8 +278,8 @@ mod test {
     #[test]
     fn convert_i32_to_i64() {
         let wkb_array = wkb_data::<i32>();
-        let wkb_array_i64: WKBArray<i64> = wkb_array.clone().into();
-        let wkb_array_i32: WKBArray<i32> = wkb_array_i64.clone().try_into().unwrap();
+        let wkb_array_i64: WkbArray<i64> = wkb_array.clone().into();
+        let wkb_array_i32: WkbArray<i32> = wkb_array_i64.clone().try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_i32);
     }
@@ -287,8 +287,8 @@ mod test {
     #[test]
     fn convert_i64_to_i32_to_i64() {
         let wkb_array = wkb_data::<i64>();
-        let wkb_array_i32: WKBArray<i32> = wkb_array.clone().try_into().unwrap();
-        let wkb_array_i64: WKBArray<i64> = wkb_array_i32.clone().into();
+        let wkb_array_i32: WkbArray<i32> = wkb_array.clone().try_into().unwrap();
+        let wkb_array_i64: WkbArray<i64> = wkb_array_i32.clone().into();
 
         assert_eq!(wkb_array, wkb_array_i64);
     }

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -100,9 +100,9 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
 
     fn data_type(&self) -> GeoArrowType {
         if O::IS_LARGE {
-            GeoArrowType::LargeWKT(self.data_type.clone())
+            GeoArrowType::LargeWkt(self.data_type.clone())
         } else {
-            GeoArrowType::WKT(self.data_type.clone())
+            GeoArrowType::Wkt(self.data_type.clone())
         }
     }
 

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -25,14 +25,14 @@ use crate::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 ///
 /// Refer to [`crate::io::wkt`] for encoding and decoding this array to the native array types.
 #[derive(Debug, Clone, PartialEq)]
-pub struct WKTArray<O: OffsetSizeTrait> {
+pub struct WktArray<O: OffsetSizeTrait> {
     pub(crate) data_type: WktType,
     pub(crate) array: GenericStringArray<O>,
 }
 
 // Implement geometry accessors
-impl<O: OffsetSizeTrait> WKTArray<O> {
-    /// Create a new WKTArray from a StringArray
+impl<O: OffsetSizeTrait> WktArray<O> {
+    /// Create a new WktArray from a StringArray
     pub fn new(array: GenericStringArray<O>, metadata: Arc<Metadata>) -> Self {
         Self {
             data_type: WktType::new(metadata),
@@ -50,7 +50,7 @@ impl<O: OffsetSizeTrait> WKTArray<O> {
         self.array
     }
 
-    /// Slices this [`WKBArray`] in place.
+    /// Slices this [`WkbArray`] in place.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
@@ -73,7 +73,7 @@ impl<O: OffsetSizeTrait> WKTArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeoArrowArray for WKTArray<O> {
+impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -111,7 +111,7 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WKTArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> ArrayAccessor<'a> for WKTArray<O> {
+impl<'a, O: OffsetSizeTrait> ArrayAccessor<'a> for WktArray<O> {
     type Item = Wkt<f64>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {
@@ -120,7 +120,7 @@ impl<'a, O: OffsetSizeTrait> ArrayAccessor<'a> for WKTArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for WKTArray<O> {
+impl<O: OffsetSizeTrait> IntoArrow for WktArray<O> {
     type ArrowArray = GenericStringArray<O>;
     type ExtensionType = WktType;
 
@@ -137,20 +137,20 @@ impl<O: OffsetSizeTrait> IntoArrow for WKTArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<(GenericStringArray<O>, WktType)> for WKTArray<O> {
+impl<O: OffsetSizeTrait> From<(GenericStringArray<O>, WktType)> for WktArray<O> {
     fn from((value, typ): (GenericStringArray<O>, WktType)) -> Self {
         Self::new(value, typ.metadata().clone())
     }
 }
 
-impl TryFrom<(&dyn Array, WktType)> for WKTArray<i32> {
+impl TryFrom<(&dyn Array, WktType)> for WktArray<i32> {
     type Error = GeoArrowError;
 
     fn try_from((value, typ): (&dyn Array, WktType)) -> Result<Self> {
         match value.data_type() {
             DataType::Utf8 => Ok((value.as_string::<i32>().clone(), typ).into()),
             DataType::LargeUtf8 => {
-                let geom_array: WKTArray<i64> = (value.as_string::<i64>().clone(), typ).into();
+                let geom_array: WktArray<i64> = (value.as_string::<i64>().clone(), typ).into();
                 geom_array.try_into()
             }
             _ => Err(GeoArrowError::General(format!(
@@ -161,13 +161,13 @@ impl TryFrom<(&dyn Array, WktType)> for WKTArray<i32> {
     }
 }
 
-impl TryFrom<(&dyn Array, WktType)> for WKTArray<i64> {
+impl TryFrom<(&dyn Array, WktType)> for WktArray<i64> {
     type Error = GeoArrowError;
 
     fn try_from((value, typ): (&dyn Array, WktType)) -> Result<Self> {
         match value.data_type() {
             DataType::Utf8 => {
-                let geom_array: WKTArray<i32> = (value.as_string::<i32>().clone(), typ).into();
+                let geom_array: WktArray<i32> = (value.as_string::<i32>().clone(), typ).into();
                 Ok(geom_array.into())
             }
             DataType::LargeUtf8 => Ok((value.as_string::<i64>().clone(), typ).into()),
@@ -179,7 +179,7 @@ impl TryFrom<(&dyn Array, WktType)> for WKTArray<i64> {
     }
 }
 
-impl TryFrom<(&dyn Array, &Field)> for WKTArray<i32> {
+impl TryFrom<(&dyn Array, &Field)> for WktArray<i32> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -188,7 +188,7 @@ impl TryFrom<(&dyn Array, &Field)> for WKTArray<i32> {
     }
 }
 
-impl TryFrom<(&dyn Array, &Field)> for WKTArray<i64> {
+impl TryFrom<(&dyn Array, &Field)> for WktArray<i64> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -197,8 +197,8 @@ impl TryFrom<(&dyn Array, &Field)> for WKTArray<i64> {
     }
 }
 
-impl From<WKTArray<i32>> for WKTArray<i64> {
-    fn from(value: WKTArray<i32>) -> Self {
+impl From<WktArray<i32>> for WktArray<i64> {
+    fn from(value: WktArray<i32>) -> Self {
         let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
         Self {
@@ -208,10 +208,10 @@ impl From<WKTArray<i32>> for WKTArray<i64> {
     }
 }
 
-impl TryFrom<WKTArray<i64>> for WKTArray<i32> {
+impl TryFrom<WktArray<i64>> for WktArray<i32> {
     type Error = GeoArrowError;
 
-    fn try_from(value: WKTArray<i64>) -> Result<Self> {
+    fn try_from(value: WktArray<i64>) -> Result<Self> {
         let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
         Ok(Self {
@@ -230,7 +230,7 @@ mod test {
 
     use super::*;
 
-    fn wkt_data<O: OffsetSizeTrait>() -> WKTArray<O> {
+    fn wkt_data<O: OffsetSizeTrait>() -> WktArray<O> {
         let mut builder = GenericStringBuilder::new();
 
         wkt::to_wkt::write_geometry(&mut builder, &point::p0()).unwrap();
@@ -242,7 +242,7 @@ mod test {
         wkt::to_wkt::write_geometry(&mut builder, &point::p2()).unwrap();
         builder.append_value("");
 
-        WKTArray::new(builder.finish(), Default::default())
+        WktArray::new(builder.finish(), Default::default())
     }
 
     #[test]
@@ -250,7 +250,7 @@ mod test {
         let wkb_array = wkt_data::<i32>();
         let array = wkb_array.to_array_ref();
         let field = wkb_array.data_type.to_field("geometry", true, false);
-        let wkb_array_retour: WKTArray<i32> = (array.as_ref(), &field).try_into().unwrap();
+        let wkb_array_retour: WktArray<i32> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
     }
@@ -260,7 +260,7 @@ mod test {
         let wkb_array = wkt_data::<i64>();
         let array = wkb_array.to_array_ref();
         let field = wkb_array.data_type.to_field("geometry", true, false);
-        let wkb_array_retour: WKTArray<i64> = (array.as_ref(), &field).try_into().unwrap();
+        let wkb_array_retour: WktArray<i64> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
     }
@@ -268,8 +268,8 @@ mod test {
     #[test]
     fn convert_i32_to_i64() {
         let wkb_array = wkt_data::<i32>();
-        let wkb_array_i64: WKTArray<i64> = wkb_array.clone().into();
-        let wkb_array_i32: WKTArray<i32> = wkb_array_i64.clone().try_into().unwrap();
+        let wkb_array_i64: WktArray<i64> = wkb_array.clone().into();
+        let wkb_array_i32: WktArray<i32> = wkb_array_i64.clone().try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_i32);
     }
@@ -277,8 +277,8 @@ mod test {
     #[test]
     fn convert_i64_to_i32_to_i64() {
         let wkb_array = wkt_data::<i64>();
-        let wkb_array_i32: WKTArray<i32> = wkb_array.clone().try_into().unwrap();
-        let wkb_array_i64: WKTArray<i64> = wkb_array_i32.clone().into();
+        let wkb_array_i32: WktArray<i32> = wkb_array.clone().try_into().unwrap();
+        let wkb_array_i64: WktArray<i64> = wkb_array_i32.clone().into();
 
         assert_eq!(wkb_array, wkb_array_i64);
     }

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -7,7 +7,7 @@ use geoarrow_schema::{
     MultiPointType, MultiPolygonType, PointType, PolygonType,
 };
 
-use crate::array::{GeometryArray, WKBArray};
+use crate::array::{GeometryArray, WkbArray};
 use crate::builder::{
     GeometryCollectionBuilder, LineStringBuilder, MultiLineStringBuilder, MultiPointBuilder,
     MultiPolygonBuilder, PointBuilder, PolygonBuilder,
@@ -890,16 +890,16 @@ impl<'a> GeometryBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, GeometryType)> for GeometryBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryType)> for GeometryBuilder {
     type Error = GeoArrowError;
 
     fn try_from(
-        (value, typ): (WKBArray<O>, GeometryType),
+        (value, typ): (WkbArray<O>, GeometryType),
     ) -> std::result::Result<Self, Self::Error> {
         assert_eq!(
             value.nulls().map_or(0, |validity| validity.null_count()),
             0,
-            "Parsing a WKBArray with null elements not supported",
+            "Parsing a WkbArray with null elements not supported",
         );
 
         let wkb_objects = value

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -6,7 +6,7 @@ use geo_traits::{
 };
 use geoarrow_schema::GeometryCollectionType;
 
-use crate::array::{GeometryCollectionArray, WKBArray};
+use crate::array::{GeometryCollectionArray, WkbArray};
 use crate::builder::mixed::DEFAULT_PREFER_MULTI;
 use crate::builder::{MixedGeometryBuilder, OffsetsBuilder};
 use crate::capacity::GeometryCollectionCapacity;
@@ -309,12 +309,12 @@ impl<'a> GeometryCollectionBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, GeometryCollectionType)>
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryCollectionType)>
     for GeometryCollectionBuilder
 {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WKBArray<O>, GeometryCollectionType)) -> Result<Self> {
+    fn try_from((value, typ): (WkbArray<O>, GeometryCollectionType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -3,7 +3,7 @@ use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
 use geoarrow_schema::{CoordType, LineStringType};
 
-use crate::array::{LineStringArray, WKBArray};
+use crate::array::{LineStringArray, WkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -243,10 +243,10 @@ impl LineStringBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, LineStringType)> for LineStringBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, LineStringType)> for LineStringBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WKBArray<O>, LineStringType)) -> Result<Self> {
+    fn try_from((value, typ): (WkbArray<O>, LineStringType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -10,7 +10,7 @@ use geoarrow_schema::{
     MultiPolygonType, PointType, PolygonType,
 };
 
-use crate::array::{MixedGeometryArray, WKBArray};
+use crate::array::{MixedGeometryArray, WkbArray};
 use crate::builder::{
     LineStringBuilder, MultiLineStringBuilder, MultiPointBuilder, MultiPolygonBuilder,
     PointBuilder, PolygonBuilder,
@@ -512,14 +512,14 @@ impl<'a> MixedGeometryBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, Dimension)> for MixedGeometryBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, Dimension)> for MixedGeometryBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, dim): (WKBArray<O>, Dimension)) -> std::result::Result<Self, Self::Error> {
+    fn try_from((value, dim): (WkbArray<O>, Dimension)) -> std::result::Result<Self, Self::Error> {
         assert_eq!(
             value.nulls().map_or(0, |validity| validity.null_count()),
             0,
-            "Parsing a WKBArray with null elements not supported",
+            "Parsing a WkbArray with null elements not supported",
         );
 
         let metadata = value.data_type.metadata().clone();

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -4,7 +4,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, Multi
 use geoarrow_schema::{CoordType, MultiLineStringType};
 // use super::array::check;
 
-use crate::array::{MultiLineStringArray, WKBArray};
+use crate::array::{MultiLineStringArray, WkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -357,10 +357,10 @@ impl MultiLineStringBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiLineStringType)> for MultiLineStringBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiLineStringType)> for MultiLineStringBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WKBArray<O>, MultiLineStringType)) -> Result<Self> {
+    fn try_from((value, typ): (WkbArray<O>, MultiLineStringType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -5,7 +5,7 @@ use geoarrow_schema::{CoordType, MultiPointType};
 
 use crate::capacity::MultiPointCapacity;
 // use super::array::check;
-use crate::array::{MultiPointArray, WKBArray};
+use crate::array::{MultiPointArray, WkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -275,10 +275,10 @@ impl MultiPointBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiPointType)> for MultiPointBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPointType)> for MultiPointBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WKBArray<O>, MultiPointType)) -> Result<Self> {
+    fn try_from((value, typ): (WkbArray<O>, MultiPointType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -7,7 +7,7 @@ use geoarrow_schema::{CoordType, MultiPolygonType};
 
 use crate::capacity::MultiPolygonCapacity;
 // use super::array::check;
-use crate::array::{MultiPolygonArray, WKBArray};
+use crate::array::{MultiPolygonArray, WkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -379,10 +379,10 @@ impl MultiPolygonBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, MultiPolygonType)> for MultiPolygonBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPolygonType)> for MultiPolygonBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WKBArray<O>, MultiPolygonType)) -> Result<Self> {
+    fn try_from((value, typ): (WkbArray<O>, MultiPolygonType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -4,7 +4,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, Point
 use geoarrow_schema::{CoordType, PointType};
 
 // use super::array::check;
-use crate::array::{PointArray, WKBArray};
+use crate::array::{PointArray, WkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder,
 };
@@ -222,10 +222,10 @@ impl PointBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, PointType)> for PointBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, PointType)> for PointBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WKBArray<O>, PointType)) -> Result<Self> {
+    fn try_from((value, typ): (WkbArray<O>, PointType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/polygon.rs
+++ b/rust/geoarrow-array/src/builder/polygon.rs
@@ -6,7 +6,7 @@ use geo_traits::{
 };
 use geoarrow_schema::{CoordType, PolygonType};
 
-use crate::array::{PolygonArray, WKBArray};
+use crate::array::{PolygonArray, WkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -365,10 +365,10 @@ impl PolygonBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WKBArray<O>, PolygonType)> for PolygonBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, PolygonType)> for PolygonBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WKBArray<O>, PolygonType)) -> Result<Self> {
+    fn try_from((value, typ): (WkbArray<O>, PolygonType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/wkb.rs
+++ b/rust/geoarrow-array/src/builder/wkb.rs
@@ -11,12 +11,12 @@ use wkb::writer::{
     write_multi_polygon, write_point, write_polygon,
 };
 
-use crate::array::WKBArray;
+use crate::array::WkbArray;
 use crate::capacity::WKBCapacity;
 
 /// The GeoArrow equivalent to `Vec<Option<WKB>>`: a mutable collection of WKB buffers.
 ///
-/// Converting a [`WKBBuilder`] into a [`WKBArray`] is `O(1)`.
+/// Converting a [`WKBBuilder`] into a [`WkbArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct WKBBuilder<O: OffsetSizeTrait>(GenericBinaryBuilder<O>, WkbType);
 
@@ -185,10 +185,10 @@ impl<O: OffsetSizeTrait> WKBBuilder<O> {
         array
     }
 
-    /// Consume this builder and convert to a [WKBArray].
+    /// Consume this builder and convert to a [WkbArray].
     ///
     /// This is `O(1)`.
-    pub fn finish(mut self) -> WKBArray<O> {
-        WKBArray::new(self.0.finish(), self.1.metadata().clone())
+    pub fn finish(mut self) -> WkbArray<O> {
+        WkbArray::new(self.0.finish(), self.1.metadata().clone())
     }
 }

--- a/rust/geoarrow-array/src/capacity/wkb.rs
+++ b/rust/geoarrow-array/src/capacity/wkb.rs
@@ -11,7 +11,7 @@ use wkb::writer::{
     multi_point_wkb_size, multi_polygon_wkb_size, point_wkb_size, polygon_wkb_size,
 };
 
-/// A counter for the buffer sizes of a [`WKBArray`][crate::array::WKBArray].
+/// A counter for the buffer sizes of a [`WkbArray`][crate::array::WkbArray].
 ///
 /// This can be used to reduce allocations by allocating once for exactly the array size you need.
 #[derive(Debug, Clone, Copy)]

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -120,21 +120,21 @@ pub trait AsGeoArrowArray {
         self.as_geometry_opt().unwrap()
     }
 
-    /// Downcast this to a [`WKBArray`] with `O` offsets returning `None` if not possible
-    fn as_wkb_opt<O: OffsetSizeTrait>(&self) -> Option<&WKBArray<O>>;
+    /// Downcast this to a [`WkbArray`] with `O` offsets returning `None` if not possible
+    fn as_wkb_opt<O: OffsetSizeTrait>(&self) -> Option<&WkbArray<O>>;
 
-    /// Downcast this to a [`WKBArray`] with `O` offsets panicking if not possible
+    /// Downcast this to a [`WkbArray`] with `O` offsets panicking if not possible
     #[inline]
-    fn as_wkb<O: OffsetSizeTrait>(&self) -> &WKBArray<O> {
+    fn as_wkb<O: OffsetSizeTrait>(&self) -> &WkbArray<O> {
         self.as_wkb_opt::<O>().unwrap()
     }
 
-    /// Downcast this to a [`WKTArray`] with `O` offsets returning `None` if not possible
-    fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WKTArray<O>>;
+    /// Downcast this to a [`WktArray`] with `O` offsets returning `None` if not possible
+    fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WktArray<O>>;
 
-    /// Downcast this to a [`WKTArray`] with `O` offsets panicking if not possible
+    /// Downcast this to a [`WktArray`] with `O` offsets panicking if not possible
     #[inline]
-    fn as_wkt<O: OffsetSizeTrait>(&self) -> &WKTArray<O> {
+    fn as_wkt<O: OffsetSizeTrait>(&self) -> &WktArray<O> {
         self.as_wkt_opt::<O>().unwrap()
     }
 }
@@ -187,13 +187,13 @@ impl AsGeoArrowArray for dyn GeoArrowArray + '_ {
     }
 
     #[inline]
-    fn as_wkb_opt<O: OffsetSizeTrait>(&self) -> Option<&WKBArray<O>> {
-        self.as_any().downcast_ref::<WKBArray<O>>()
+    fn as_wkb_opt<O: OffsetSizeTrait>(&self) -> Option<&WkbArray<O>> {
+        self.as_any().downcast_ref::<WkbArray<O>>()
     }
 
     #[inline]
-    fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WKTArray<O>> {
-        self.as_any().downcast_ref::<WKTArray<O>>()
+    fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WktArray<O>> {
+        self.as_any().downcast_ref::<WktArray<O>>()
     }
 }
 
@@ -244,13 +244,13 @@ impl AsGeoArrowArray for Arc<dyn GeoArrowArray> {
     }
 
     #[inline]
-    fn as_wkb_opt<O: OffsetSizeTrait>(&self) -> Option<&WKBArray<O>> {
-        self.as_any().downcast_ref::<WKBArray<O>>()
+    fn as_wkb_opt<O: OffsetSizeTrait>(&self) -> Option<&WkbArray<O>> {
+        self.as_any().downcast_ref::<WkbArray<O>>()
     }
 
     #[inline]
-    fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WKTArray<O>> {
-        self.as_any().downcast_ref::<WKTArray<O>>()
+    fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WktArray<O>> {
+        self.as_any().downcast_ref::<WktArray<O>>()
     }
 }
 
@@ -388,18 +388,18 @@ macro_rules! downcast_geoarrow_array {
 mod test {
     use geoarrow_schema::WkbType;
 
-    use crate::array::WKBArray;
+    use crate::array::WkbArray;
     use crate::builder::WKBBuilder;
     use crate::error::Result;
     use crate::{ArrayAccessor, GeoArrowArray};
 
     // Verify that this compiles with the macro
     #[allow(dead_code)]
-    fn to_wkb(arr: &dyn GeoArrowArray) -> Result<WKBArray<i32>> {
+    fn to_wkb(arr: &dyn GeoArrowArray) -> Result<WkbArray<i32>> {
         downcast_geoarrow_array!(arr, impl_to_wkb)
     }
 
-    fn impl_to_wkb<'a>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WKBArray<i32>> {
+    fn impl_to_wkb<'a>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WkbArray<i32>> {
         // let metadata = geo_arr.metadata().clone();
 
         let geoms = geo_arr

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -368,16 +368,16 @@ macro_rules! downcast_geoarrow_array {
             $crate::cast::__private::GeoArrowType::Rect(_) => {
                 $fn($crate::cast::AsGeoArrowArray::as_rect($array))
             }
-            $crate::cast::__private::GeoArrowType::WKB(_) => {
+            $crate::cast::__private::GeoArrowType::Wkb(_) => {
                 $fn($crate::cast::AsGeoArrowArray::as_wkb::<i32>($array))
             }
-            $crate::cast::__private::GeoArrowType::LargeWKB(_) => {
+            $crate::cast::__private::GeoArrowType::LargeWkb(_) => {
                 $fn($crate::cast::AsGeoArrowArray::as_wkb::<i64>($array))
             }
-            $crate::cast::__private::GeoArrowType::WKT(_) => {
+            $crate::cast::__private::GeoArrowType::Wkt(_) => {
                 $fn($crate::cast::AsGeoArrowArray::as_wkt::<i32>($array))
             }
-            $crate::cast::__private::GeoArrowType::LargeWKT(_) => {
+            $crate::cast::__private::GeoArrowType::LargeWkt(_) => {
                 $fn($crate::cast::AsGeoArrowArray::as_wkt::<i64>($array))
             }
         }

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -64,19 +64,19 @@ pub enum GeoArrowType {
 
     /// Represents a [WkbArray][crate::array::WkbArray] or
     /// [ChunkedWKBArray][crate::chunked_array::ChunkedWKBArray] with `i32` offsets.
-    WKB(WkbType),
+    Wkb(WkbType),
 
     /// Represents a [WkbArray][crate::array::WkbArray] or
     /// [ChunkedWKBArray][crate::chunked_array::ChunkedWKBArray] with `i64` offsets.
-    LargeWKB(WkbType),
+    LargeWkb(WkbType),
 
     /// Represents a [WktArray][crate::array::WktArray] or
     /// [ChunkedWKTArray][crate::chunked_array::ChunkedWKTArray] with `i32` offsets.
-    WKT(WktType),
+    Wkt(WktType),
 
     /// Represents a [WktArray][crate::array::WktArray] or
     /// [ChunkedWKTArray][crate::chunked_array::ChunkedWKTArray] with `i64` offsets.
-    LargeWKT(WktType),
+    LargeWkt(WktType),
 }
 
 impl From<GeoArrowType> for DataType {
@@ -101,7 +101,7 @@ impl GeoArrowType {
             GeometryCollection(t) => Some(t.coord_type()),
             Rect(_) => Some(CoordType::Separated),
             Geometry(t) => Some(t.coord_type()),
-            WKB(_) | LargeWKB(_) | WKT(_) | LargeWKT(_) => None,
+            Wkb(_) | LargeWkb(_) | Wkt(_) | LargeWkt(_) => None,
         }
     }
 
@@ -122,7 +122,7 @@ impl GeoArrowType {
             GeometryCollection(t) => Some(t.dimension()),
             Rect(t) => Some(t.dimension()),
             Geometry(_) => None,
-            WKB(_) | LargeWKB(_) | WKT(_) | LargeWKT(_) => None,
+            Wkb(_) | LargeWkb(_) | Wkt(_) | LargeWkt(_) => None,
         }
     }
 
@@ -139,8 +139,8 @@ impl GeoArrowType {
             GeometryCollection(t) => t.metadata(),
             Rect(t) => t.metadata(),
             Geometry(t) => t.metadata(),
-            WKB(t) | LargeWKB(t) => t.metadata(),
-            WKT(t) | LargeWKT(t) => t.metadata(),
+            Wkb(t) | LargeWkb(t) => t.metadata(),
+            Wkt(t) | LargeWkt(t) => t.metadata(),
         }
     }
     /// Converts a [`GeoArrowType`] into the relevant arrow [`DataType`].
@@ -169,10 +169,10 @@ impl GeoArrowType {
             GeometryCollection(t) => t.data_type(),
             Rect(t) => t.data_type(),
             Geometry(t) => t.data_type(),
-            WKB(t) => t.data_type(false),
-            LargeWKB(t) => t.data_type(true),
-            WKT(t) => t.data_type(false),
-            LargeWKT(t) => t.data_type(true),
+            Wkb(t) => t.data_type(false),
+            LargeWkb(t) => t.data_type(true),
+            Wkt(t) => t.data_type(false),
+            LargeWkt(t) => t.data_type(true),
         }
     }
 
@@ -202,10 +202,10 @@ impl GeoArrowType {
             GeometryCollection(t) => t.to_field(name, nullable),
             Rect(t) => t.to_field(name, nullable),
             Geometry(t) => t.to_field(name, nullable),
-            WKB(t) => t.to_field(name, nullable, false),
-            LargeWKB(t) => t.to_field(name, nullable, true),
-            WKT(t) => t.to_field(name, nullable, false),
-            LargeWKT(t) => t.to_field(name, nullable, true),
+            Wkb(t) => t.to_field(name, nullable, false),
+            LargeWkb(t) => t.to_field(name, nullable, true),
+            Wkt(t) => t.to_field(name, nullable, false),
+            LargeWkt(t) => t.to_field(name, nullable, true),
         }
     }
 
@@ -278,10 +278,10 @@ impl GeoArrowType {
             GeometryCollection(t) => GeometryCollection(t.with_metadata(meta)),
             Rect(t) => Rect(t.with_metadata(meta)),
             Geometry(t) => Geometry(t.with_metadata(meta)),
-            WKB(t) => WKB(t.with_metadata(meta)),
-            LargeWKB(t) => LargeWKB(t.with_metadata(meta)),
-            WKT(t) => WKT(t.with_metadata(meta)),
-            LargeWKT(t) => LargeWKT(t.with_metadata(meta)),
+            Wkb(t) => Wkb(t.with_metadata(meta)),
+            LargeWkb(t) => LargeWkb(t.with_metadata(meta)),
+            Wkt(t) => Wkt(t.with_metadata(meta)),
+            LargeWkt(t) => LargeWkt(t.with_metadata(meta)),
         }
     }
 }
@@ -321,8 +321,8 @@ impl TryFrom<&Field> for GeoArrowType {
                 BoxType::NAME => Rect(BoxType::try_new(field.data_type(), metadata)?),
                 GeometryType::NAME => Geometry(GeometryType::try_new(field.data_type(), metadata)?),
                 WkbType::NAME | "ogc.wkb" => match field.data_type() {
-                    DataType::Binary => WKB(WkbType::new(metadata.into())),
-                    DataType::LargeBinary => LargeWKB(WkbType::new(metadata.into())),
+                    DataType::Binary => Wkb(WkbType::new(metadata.into())),
+                    DataType::LargeBinary => LargeWkb(WkbType::new(metadata.into())),
                     _ => {
                         return Err(GeoArrowError::General(format!(
                             "Expected binary type for geoarrow.wkb, got '{}'",
@@ -331,8 +331,8 @@ impl TryFrom<&Field> for GeoArrowType {
                     }
                 },
                 WktType::NAME => match field.data_type() {
-                    DataType::Utf8 => WKT(WktType::new(metadata.into())),
-                    DataType::LargeUtf8 => LargeWKT(WktType::new(metadata.into())),
+                    DataType::Utf8 => Wkt(WktType::new(metadata.into())),
+                    DataType::LargeUtf8 => LargeWkt(WktType::new(metadata.into())),
                     _ => {
                         return Err(GeoArrowError::General(format!(
                             "Expected string type for geoarrow.wkt, got '{}'",
@@ -365,10 +365,10 @@ impl TryFrom<&Field> for GeoArrowType {
                     todo!("Restore parsing of FixedSizeList to PointType");
                     // GeoArrowType::Point(PointType::new(CoordType::Interleaved , (*list_size as usize).try_into()?, metadata) )
                 },
-                DataType::Binary => WKB(WkbType::new(metadata.into())),
-                DataType::LargeBinary => LargeWKB(WkbType::new(metadata.into())),
-                DataType::Utf8 => WKT(WktType::new(metadata.into())),
-                DataType::LargeUtf8 => LargeWKT(WktType::new(metadata.into())),
+                DataType::Binary => Wkb(WkbType::new(metadata.into())),
+                DataType::LargeBinary => LargeWkb(WkbType::new(metadata.into())),
+                DataType::Utf8 => Wkt(WktType::new(metadata.into())),
+                DataType::LargeUtf8 => LargeWkt(WktType::new(metadata.into())),
                 _ => return Err(GeoArrowError::General("Only FixedSizeList, Struct, Binary, LargeBinary, String, and LargeString arrays are unambigously typed for a GeoArrow type and can be used without extension metadata.".to_string())),
             };
             Ok(data_type)

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -62,19 +62,19 @@ pub enum GeoArrowType {
     /// Represents a mixed geometry array of unknown types or dimensions
     Geometry(GeometryType),
 
-    /// Represents a [WKBArray][crate::array::WKBArray] or
+    /// Represents a [WkbArray][crate::array::WkbArray] or
     /// [ChunkedWKBArray][crate::chunked_array::ChunkedWKBArray] with `i32` offsets.
     WKB(WkbType),
 
-    /// Represents a [WKBArray][crate::array::WKBArray] or
+    /// Represents a [WkbArray][crate::array::WkbArray] or
     /// [ChunkedWKBArray][crate::chunked_array::ChunkedWKBArray] with `i64` offsets.
     LargeWKB(WkbType),
 
-    /// Represents a [WKTArray][crate::array::WKTArray] or
+    /// Represents a [WktArray][crate::array::WktArray] or
     /// [ChunkedWKTArray][crate::chunked_array::ChunkedWKTArray] with `i32` offsets.
     WKT(WktType),
 
-    /// Represents a [WKTArray][crate::array::WKTArray] or
+    /// Represents a [WktArray][crate::array::WktArray] or
     /// [ChunkedWKTArray][crate::chunked_array::ChunkedWKTArray] with `i64` offsets.
     LargeWKT(WktType),
 }

--- a/rust/geoarrow-array/src/scalar/mod.rs
+++ b/rust/geoarrow-array/src/scalar/mod.rs
@@ -3,8 +3,8 @@
 //! For all "native" GeoArrow scalar types, (all types defined in this module) it is `O(1)` and
 //! allocation-free for any coordinate access.
 //!
-//! For "serialized" scalars emitted from the [`WKBArray`][crate::array::WKBArray] and
-//! [`WKTArray`][crate::array::WKTArray], there is an initial parsing step when accessing the
+//! For "serialized" scalars emitted from the [`WkbArray`][crate::array::WkbArray] and
+//! [`WktArray`][crate::array::WktArray], there is an initial parsing step when accessing the
 //! scalar from the [`ArrayAccessor`][crate::ArrayAccessor] trait.
 //!
 //! All scalars implement [`geo_traits`]. You can iterate through geometry parts directly using the

--- a/rust/geoarrow-array/src/trait_.rs
+++ b/rust/geoarrow-array/src/trait_.rs
@@ -234,13 +234,13 @@ pub trait GeoArrowArray: Debug + Send + Sync {
 /// Accessing a geometry from a "native" array, such as `PointArray`, `MultiPolygonArray` or
 /// `GeometryArray` will always be constant-time and zero-copy.
 ///
-/// Accessing a geometry from a "serialized" array such as `WKBArray` or `WKTArray` will trigger
-/// some amount of parsing. In the case of `WKBArray`, accessing an item will read the WKB header
+/// Accessing a geometry from a "serialized" array such as `WkbArray` or `WktArray` will trigger
+/// some amount of parsing. In the case of `WkbArray`, accessing an item will read the WKB header
 /// and scan the buffer if needed to find internal geometry offsets, but will not copy any internal
 /// coordinates. This allows for later access to be constant-time (though not necessarily
-/// zero-copy, since WKB is not byte-aligned). In the case of `WKTArray`, accessing a geometry will
+/// zero-copy, since WKB is not byte-aligned). In the case of `WktArray`, accessing a geometry will
 /// fully parse the WKT string and copy coordinates to a separate representation. This means that
-/// calling `.iter()` on a `WKTArray` will transparently fully parse every row.
+/// calling `.iter()` on a `WktArray` will transparently fully parse every row.
 ///
 /// # Validity
 ///


### PR DESCRIPTION
Changes list

- Rename `WKBArray` to `WkbArray` and `WKTArray` to `WktArray`
- Rename `GeoArrowType` enum variants `WKB` to `Wkb` and `WKT` to `Wkt`

This makes it consistent with other naming:

- `wkb::reader::Wkb`
- `wkt::Wkt`
- `geoarrow_schema::WkbType`
- `geoarrow_schema::WktType`