### PR TITLE
Updated `geoarrow_schema` crate documentation

### DIFF
--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -587,14 +587,12 @@ impl GeoArrowArray for GeometryArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         // Note that `type_ids` is sliced as usual, and thus always has the correct length.
         self.type_ids.len()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         None

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -119,13 +119,11 @@ impl GeoArrowArray for GeometryCollectionArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -171,13 +171,11 @@ impl GeoArrowArray for LineStringArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()

--- a/rust/geoarrow-array/src/array/mixed.rs
+++ b/rust/geoarrow-array/src/array/mixed.rs
@@ -465,7 +465,6 @@ impl MixedGeometryArray {
         Arc::new(UnionArray::from(self))
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         // Note that `type_ids` is sliced as usual, and thus always has the correct length.

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -190,13 +190,11 @@ impl GeoArrowArray for MultiLineStringArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -174,13 +174,11 @@ impl GeoArrowArray for MultiPointArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -243,13 +243,11 @@ impl GeoArrowArray for MultiPolygonArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()

--- a/rust/geoarrow-array/src/array/point.rs
+++ b/rust/geoarrow-array/src/array/point.rs
@@ -128,13 +128,11 @@ impl GeoArrowArray for PointArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.coords.len()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -194,13 +194,11 @@ impl GeoArrowArray for PolygonArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()

--- a/rust/geoarrow-array/src/array/rect.rs
+++ b/rust/geoarrow-array/src/array/rect.rs
@@ -101,13 +101,11 @@ impl GeoArrowArray for RectArray {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.lower.len()
     }
 
-    /// Returns the optional validity.
     #[inline]
     fn nulls(&self) -> Option<&NullBuffer> {
         self.validity.as_ref()

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -97,7 +97,6 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WkbArray<O> {
     }
 
     fn into_array_ref(self) -> ArrayRef {
-        // Recreate a BinaryArray so that we can force it to have geoarrow.wkb extension type
         Arc::new(self.into_arrow())
     }
 
@@ -105,13 +104,11 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WkbArray<O> {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.array.len()
     }
 
-    /// Returns the optional validity.
     fn nulls(&self) -> Option<&NullBuffer> {
         self.array.nulls()
     }

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -79,7 +79,6 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
     }
 
     fn into_array_ref(self) -> ArrayRef {
-        // Recreate a BinaryArray so that we can force it to have geoarrow.wkb extension type
         Arc::new(self.into_arrow())
     }
 
@@ -87,13 +86,11 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
         self.clone().into_array_ref()
     }
 
-    /// Returns the number of geometries in this array
     #[inline]
     fn len(&self) -> usize {
         self.array.len()
     }
 
-    /// Returns the optional validity.
     fn nulls(&self) -> Option<&NullBuffer> {
         self.array.nulls()
     }

--- a/rust/geoarrow-array/src/trait_.rs
+++ b/rust/geoarrow-array/src/trait_.rs
@@ -36,7 +36,7 @@ pub trait GeoArrowArray: Debug + Send + Sync {
     /// Prefer using [`AsGeoArrowArray`] instead of calling this method and manually downcasting.
     fn as_any(&self) -> &dyn Any;
 
-    /// Returns the [`NativeType`] of this array.
+    /// Returns the [`GeoArrowType`] of this array.
     ///
     /// # Examples
     ///

--- a/rust/geoarrow-schema/README.md
+++ b/rust/geoarrow-schema/README.md
@@ -1,1 +1,3 @@
 # geoarrow-schema
+
+GeoArrow geometry type and metadata definitions.

--- a/rust/geoarrow-schema/src/coord_type.rs
+++ b/rust/geoarrow-schema/src/coord_type.rs
@@ -1,8 +1,8 @@
 /// The permitted GeoArrow coordinate representations.
 ///
-/// GeoArrow permits coordinate types to either be `Interleaved`, where the X and Y coordinates are
-/// in a single buffer as XYXYXY or `Separated`, where the X and Y coordinates are in multiple
-/// buffers as XXXX and YYYY.
+/// GeoArrow permits coordinate types to either be "Interleaved", where the X and Y coordinates are
+/// in a single buffer as `XYXYXY` or "Separated", where the X and Y coordinates are in multiple
+/// buffers as `XXXX` and `YYYY`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CoordType {
     /// Interleaved coordinates.
@@ -16,7 +16,7 @@ pub enum CoordType {
 impl CoordType {
     /// Specify Interleaved as a "default".
     ///
-    /// There are discussions ongoing about whether `CoordType` should define a default value. This
+    /// There are discussions ongoing about whether `CoordType` should implement [Default]. This
     /// exists for places where we want to use a default value of `CoordType` without currently
     /// defining `Default` on `CoordType`.
     pub fn default_interleaved() -> Self {

--- a/rust/geoarrow-schema/src/crs.rs
+++ b/rust/geoarrow-schema/src/crs.rs
@@ -1,6 +1,26 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Coordinate Reference System information.
+///
+/// As of GeoArrow version 0.2, GeoArrow supports various CRS representations:
+///
+/// - A JSON object describing the coordinate reference system (CRS)
+///   using [PROJJSON](https://proj.org/specifications/projjson.html).
+/// - A string containing a serialized CRS representation. This option
+///   is intended as a fallback for producers (e.g., database drivers or
+///   file readers) that are provided a CRS in some form but do not have the
+///   means to convert it to PROJJSON.
+/// - Omitted, indicating that the producer does not have any information about
+///   the CRS.
+///
+/// For maximum compatibility, producers should write PROJJSON.
+///
+/// Note that regardless of the axis order specified by the CRS, axis order will be interpreted
+/// according to the wording in the [GeoPackage WKB binary
+/// encoding](https://www.geopackage.org/spec130/index.html#gpb_format): axis order is always
+/// (longitude, latitude) and (easting, northing) regardless of the the axis order encoded in the
+/// CRS specification.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Crs {
     /// One of:

--- a/rust/geoarrow-schema/src/edges.rs
+++ b/rust/geoarrow-schema/src/edges.rs
@@ -1,14 +1,74 @@
 use serde::{Deserialize, Serialize};
 
-/// If present, instructs consumers that edges follow a spherical path rather than a planar one. If
-/// this value is omitted, edges will be interpreted as planar.
+/// The edge interpretation between explicitly defined vertices.
+///
+/// This does not affect format conversions (e.g., parsing `geoarrow.wkb` as
+/// `geoarrow.linestring`), but does affect distance, intersection, bounding, overlay, length, and
+/// area calculations. The `edges` key must be omitted to indicate planar/linear edges or be one
+/// of:
+///
+/// If the `edges` key is omitted, edges will be interpreted following the language of
+/// [Simple features access](https://www.opengeospatial.org/standards/sfa):
+///
+/// > **simple feature** feature with all geometric attributes described piecewise
+/// > by straight line or planar interpolation between sets of points (Section 4.19).
+///
+/// If an implementation only has support for a single edge interpretation (e.g.,
+/// a library with only planar edge support), an array with a different edge type
+/// may be imported without losing information if the geometries in the array
+/// do not contain edges (e.g., `geoarrow.point`, `geoarrow.multipoint`, a
+/// `geoarrow.wkb`/`geoarrow.wkt` that only contains points and multipoints, or any
+/// array that only contains empty geometries). For arrays that contain edges,
+/// the error introduced by ignoring the original edge interpretation is similar to
+/// the error introduced by applying a coordinate transformation to vertices (which
+/// is usually small but may be large or create invalid geometries, particularly if
+/// vertices are not closely spaced). Ignoring the original edge interpretation will
+/// silently introduce invalid and/or misinterpreted geometries for any edge that crosses
+/// the antimeridian (i.e., longitude 180/-180) when translating from non-planar
+/// to planar edges.
+///
+/// Implementations may implicitly import arrays with an unsupported edge type if the
+/// arrays do not contain edges. Implementations may otherwise import arrays with an
+/// unsupported edge type with an explicit opt-in from a user or if accompanied
+/// by a prominent warning.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Edges {
-    /// Follow a spherical path rather than a planar.
+    /// Edges in the longitude-latitude dimensions follow a path calculated by
+    /// the fomula in Thomas, Paul D. Mathematical models for navigation systems. US Naval
+    /// Oceanographic Office, 1965 using the ellipsoid specified by the `"crs"`.
+    #[serde(rename = "andoyer")]
+    Andoyer,
+
+    /// Edges in the longitude-latitude dimensions follow a path calculated by the fomula in
+    /// [Karney, Charles FF. "Algorithms for geodesics." Journal of Geodesy 87 (2013):
+    /// 43-55](https://link.springer.com/content/pdf/10.1007/s00190-012-0578-z.pdf) and
+    /// [GeographicLib](https://geographiclib.sourceforge.io/) using the ellipsoid specified by the
+    /// `"crs"`. GeographicLib available via modern versions of PROJ.
+    #[serde(rename = "karney")]
+    Karney,
+
+    /// Edges in the longitude-latitude dimensions follow the
+    /// shortest distance between vertices approximated as the shortest distance
+    /// between the vertices on a perfect sphere. This edge interpretation is used by
+    /// [BigQuery Geography](https://cloud.google.com/bigquery/docs/geospatial-data#coordinate_systems_and_edges),
+    /// and [Snowflake Geography](https://docs.snowflake.com/en/sql-reference/data-types-geospatial).
     ///
-    /// See [the geoarrow
-    /// specification](https://github.com/geoarrow/geoarrow/blob/main/extension-types.md#extension-metadata)
-    /// for more information about how `edges` should be used.
+    /// A common library for interpreting edges in this way is
+    /// [Google's s2geometry](https://github.com/google/s2geometry); a common formula
+    /// for calculating distances along this trajectory is the
+    /// [Haversine Formula](https://en.wikipedia.org/wiki/Haversine_formula).
     #[serde(rename = "spherical")]
     Spherical,
+
+    /// Edges in the longitude-latitude dimensions follow a path calculated by
+    /// the fomula in Thomas, Paul D. Spheroidal geodesics, reference systems, & local geometry.
+    /// US Naval Oceanographic Office, 1970 using the ellipsoid specified by the `"crs"`.
+    #[serde(rename = "thomas")]
+    Thomas,
+
+    /// Edges in the longitude-latitude dimensions follow a path calculated
+    /// using [Vincenty's formula](https://en.wikipedia.org/wiki/Vincenty%27s_formulae) and
+    /// the ellipsoid specified by the `"crs"`.
+    #[serde(rename = "vincenty")]
+    Vincenty,
 }

--- a/rust/geoarrow-schema/src/lib.rs
+++ b/rust/geoarrow-schema/src/lib.rs
@@ -1,3 +1,7 @@
+//! GeoArrow geometry type and metadata definitions.
+
+#![warn(missing_docs)]
+
 mod coord_type;
 mod crs;
 mod dimension;

--- a/rust/geoarrow-schema/src/metadata.rs
+++ b/rust/geoarrow-schema/src/metadata.rs
@@ -4,11 +4,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Crs, Edges};
 
-/// A GeoArrow metadata object following the extension metadata [defined by the GeoArrow
+/// GeoArrow extension metadata.
+///
+/// This follows the extension metadata [defined by the GeoArrow
 /// specification](https://geoarrow.org/extension-types).
 ///
-/// This is serialized to JSON when a [`geoarrow`](self) array is exported to an [`arrow`] array and
-/// deserialized when imported from an [`arrow`] array.
+/// This is serialized to JSON when a [`geoarrow`](self) array is exported to an [`arrow`] array
+/// and deserialized when imported from an [`arrow`] array.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Metadata {
     // Raise the underlying crs fields to this level.
@@ -28,14 +30,19 @@ impl Metadata {
         Self { crs, edges }
     }
 
+    /// Expose the underlying Coordinate Reference System information.
     pub fn crs(&self) -> &Crs {
         &self.crs
     }
 
+    /// Expose the underlying edge interpolation
     pub fn edges(&self) -> Option<Edges> {
         self.edges
     }
 
+    /// Serialize this metadata to a string.
+    ///
+    /// If `None`, no extension metadata should be written.
     pub(crate) fn serialize(&self) -> Option<String> {
         if self.crs.should_serialize() || self.edges.is_some() {
             Some(serde_json::to_string(&self).unwrap())
@@ -44,6 +51,7 @@ impl Metadata {
         }
     }
 
+    /// Deserialize metadata from a string.
     pub(crate) fn deserialize<S: AsRef<str>>(metadata: Option<S>) -> Result<Self, ArrowError> {
         if let Some(ext_meta) = metadata {
             Ok(serde_json::from_str(ext_meta.as_ref())

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -69,31 +69,45 @@ macro_rules! define_basic_type {
 }
 
 define_basic_type!(
-    /// A type representing a Point geometry, implementing the [`ExtensionType`] trait.
+    /// A type representing a Point geometry.
+    ///
+    /// This implements the [`ExtensionType`] trait.
     PointType
 );
 define_basic_type!(
-    /// A type representing a LineString geometry, implementing the [`ExtensionType`] trait.
+    /// A type representing a LineString geometry.
+    ///
+    /// This implements the [`ExtensionType`] trait.
     LineStringType
 );
 define_basic_type!(
-    /// A type representing a Polygon geometry, implementing the [`ExtensionType`] trait.
+    /// A type representing a Polygon geometry.
+    ///
+    /// This implements the [`ExtensionType`] trait.
     PolygonType
 );
 define_basic_type!(
-    /// A type representing a MultiPoint geometry, implementing the [`ExtensionType`] trait.
+    /// A type representing a MultiPoint geometry.
+    ///
+    /// This implements the [`ExtensionType`] trait.
     MultiPointType
 );
 define_basic_type!(
-    /// A type representing a MultiLineString geometry, implementing the [`ExtensionType`] trait.
+    /// A type representing a MultiLineString geometry.
+    ///
+    /// This implements the [`ExtensionType`] trait.
     MultiLineStringType
 );
 define_basic_type!(
-    /// A type representing a MultiPolygon geometry, implementing the [`ExtensionType`] trait.
+    /// A type representing a MultiPolygon geometry.
+    ///
+    /// This implements the [`ExtensionType`] trait.
     MultiPolygonType
 );
 define_basic_type!(
-    /// A type representing a GeometryCollection geometry, implementing the [`ExtensionType`] trait.
+    /// A type representing a GeometryCollection geometry.
+    ///
+    /// This implements the [`ExtensionType`] trait.
     GeometryCollectionType
 );
 
@@ -912,6 +926,9 @@ fn parse_geometry_collection(data_type: &DataType) -> Result<(CoordType, Dimensi
     }
 }
 
+/// A type representing a geoarrow array of unknown geometry type and dimension.
+///
+/// This implements the [`ExtensionType`] trait.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GeometryType {
     coord_type: CoordType,
@@ -1130,6 +1147,9 @@ fn parse_geometry(data_type: &DataType) -> Result<CoordType, ArrowError> {
     }
 }
 
+/// A type representing a geoarrow "box" or "rect" array.
+///
+/// This implements the [`ExtensionType`] trait.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BoxType {
     dim: Dimension,
@@ -1307,6 +1327,9 @@ fn parse_box(data_type: &DataType) -> Result<Dimension, ArrowError> {
     }
 }
 
+/// A type representing a geoarrow WKB array.
+///
+/// This implements the [`ExtensionType`] trait.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WkbType {
     metadata: Arc<Metadata>,
@@ -1389,6 +1412,9 @@ impl ExtensionType for WkbType {
     }
 }
 
+/// A type representing a geoarrow WKT array.
+///
+/// This implements the [`ExtensionType`] trait.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WktType {
     metadata: Arc<Metadata>,

--- a/rust/geoarrow/src/io/parquet/writer/metadata.rs
+++ b/rust/geoarrow/src/io/parquet/writer/metadata.rs
@@ -125,8 +125,10 @@ impl ColumnInfo {
 
     /// Returns (column_name, column_metadata)
     pub fn finish(self) -> (String, GeoParquetColumnMetadata) {
-        let edges = self.edges.map(|edges| match edges {
-            Edges::Spherical => "spherical".to_string(),
+        let edges = self.edges.and_then(|edges| match edges {
+            Edges::Spherical => Some("spherical".to_string()),
+            // Other edge interpretations not supported in existing GeoParquet
+            _ => None,
         });
         let bbox = if let Some(bbox) = self.bbox {
             if let (Some(minz), Some(maxz)) = (bbox.minz(), bbox.maxz()) {


### PR DESCRIPTION
- Adds `#![warn(missing_docs)]` to `geoarrow_schema`.
- Updated to latest `Edges` variants
- Some drive by docs cleanups