### PR TITLE
Add round trip `geo` and `arrow` tests for each array type

### DIFF
--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -239,18 +239,8 @@ impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryCollectionType)>
 
 impl PartialEq for GeometryCollectionArray {
     fn eq(&self, other: &Self) -> bool {
-        if self.validity != other.validity {
-            return false;
-        }
-
-        if !offset_buffer_eq(&self.geom_offsets, &other.geom_offsets) {
-            return false;
-        }
-
-        if self.array != other.array {
-            return false;
-        }
-
-        true
+        self.validity == other.validity
+            && offset_buffer_eq(&self.geom_offsets, &other.geom_offsets)
+            && self.array != other.array
     }
 }

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -241,6 +241,6 @@ impl PartialEq for GeometryCollectionArray {
     fn eq(&self, other: &Self) -> bool {
         self.validity == other.validity
             && offset_buffer_eq(&self.geom_offsets, &other.geom_offsets)
-            && self.array != other.array
+            && self.array == other.array
     }
 }

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -285,84 +285,68 @@ impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, LineStringType)> for LineStringAr
 
 impl PartialEq for LineStringArray {
     fn eq(&self, other: &Self) -> bool {
-        if self.validity != other.validity {
-            return false;
-        }
-
-        if !offset_buffer_eq(&self.geom_offsets, &other.geom_offsets) {
-            return false;
-        }
-
-        if self.coords != other.coords {
-            return false;
-        }
-
-        true
+        self.validity == other.validity
+            && offset_buffer_eq(&self.geom_offsets, &other.geom_offsets)
+            && self.coords != other.coords
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::test::linestring::{ls0, ls1};
+#[cfg(test)]
+mod test {
+    use geo_traits::to_geo::ToGeoLineString;
+    use geoarrow_schema::{CoordType, Dimension};
 
-//     use super::*;
+    use crate::test::linestring;
 
-//     // #[test]
-//     // fn geo_roundtrip_accurate() {
-//     //     let arr: LineStringArray = (vec![ls0(), ls1()].as_slice(), Dimension::XY).into();
-//     //     assert_eq!(arr.value_as_geo(0), ls0());
-//     //     assert_eq!(arr.value_as_geo(1), ls1());
-//     // }
+    use super::*;
 
-//     // #[test]
-//     // fn geo_roundtrip_accurate_option_vec() {
-//     //     let arr: LineStringArray = (vec![Some(ls0()), Some(ls1()), None], Dimension::XY).into();
-//     //     assert_eq!(arr.get_as_geo(0), Some(ls0()));
-//     //     assert_eq!(arr.get_as_geo(1), Some(ls1()));
-//     //     assert_eq!(arr.get_as_geo(2), None);
-//     // }
+    #[test]
+    fn geo_round_trip() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geoms = [Some(linestring::ls0()), None, Some(linestring::ls1()), None];
+            let typ = LineStringType::new(coord_type, Dimension::XY, Default::default());
+            let geo_arr = LineStringBuilder::from_nullable_line_strings(&geoms, typ).finish();
 
-//     // #[test]
-//     // fn rstar_integration() {
-//     //     let arr: LineStringArray = (vec![ls0(), ls1()].as_slice(), Dimension::XY).into();
-//     //     let tree = arr.rstar_tree();
+            for (i, g) in geo_arr.iter().enumerate() {
+                assert_eq!(geoms[i], g.transpose().unwrap().map(|g| g.to_line_string()));
+            }
 
-//     //     let search_box = AABB::from_corners([3.5, 5.5], [4.5, 6.5]);
-//     //     let results: Vec<&crate::scalar::LineString> =
-//     //         tree.locate_in_envelope_intersecting(&search_box).collect();
+            // Test sliced
+            for (i, g) in geo_arr.slice(2, 2).iter().enumerate() {
+                assert_eq!(
+                    geoms[i + 2],
+                    g.transpose().unwrap().map(|g| g.to_line_string())
+                );
+            }
+        }
+    }
 
-//     //     assert_eq!(results.len(), 1);
-//     //     assert_eq!(
-//     //         results[0].geom_index, 1,
-//     //         "The second element in the LineStringArray should be found"
-//     //     );
-//     // }
+    #[test]
+    fn try_from_arrow() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geo_arr = linestring::ls_array(coord_type);
 
-//     #[test]
-//     fn slice() {
-//         let arr: LineStringArray = (vec![ls0(), ls1()].as_slice(), Dimension::XY).into();
-//         let sliced = arr.slice(1, 1);
-//         assert_eq!(sliced.len(), 1);
-//         assert_eq!(sliced.get_as_geo(0), Some(ls1()));
-//     }
+            let ext_type = geo_arr.ext_type().clone();
+            let field = ext_type.to_field("geometry", true);
 
-//     // #[test]
-//     // fn parse_wkb_geoarrow_interleaved_example() {
-//     //     let linestring_arr = example_linestring_interleaved();
+            let arrow_arr = geo_arr.to_array_ref();
 
-//     //     let wkb_arr = example_linestring_wkb();
-//     //     let parsed_linestring_arr: LineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
+            let geo_arr2: LineStringArray = (arrow_arr.as_ref(), ext_type).try_into().unwrap();
+            let geo_arr3: LineStringArray = (arrow_arr.as_ref(), &field).try_into().unwrap();
 
-//     //     assert_eq!(linestring_arr, parsed_linestring_arr);
-//     // }
+            assert_eq!(geo_arr, geo_arr2);
+            assert_eq!(geo_arr, geo_arr3);
+        }
+    }
 
-//     // #[test]
-//     // fn parse_wkb_geoarrow_separated_example() {
-//     //     let linestring_arr = example_linestring_separated().into_coord_type(CoordType::Interleaved);
+    #[test]
+    fn partial_eq() {
+        let arr1 = linestring::ls_array(CoordType::Interleaved);
+        let arr2 = linestring::ls_array(CoordType::Separated);
+        assert_eq!(arr1, arr1);
+        assert_eq!(arr2, arr2);
+        assert_eq!(arr1, arr2);
 
-//     //     let wkb_arr = example_linestring_wkb();
-//     //     let parsed_linestring_arr: LineStringArray = (wkb_arr, Dimension::XY).try_into().unwrap();
-
-//     //     assert_eq!(linestring_arr, parsed_linestring_arr);
-//     // }
-// }
+        assert_ne!(arr1, arr2.slice(0, 2));
+    }
+}

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -287,7 +287,7 @@ impl PartialEq for LineStringArray {
     fn eq(&self, other: &Self) -> bool {
         self.validity == other.validity
             && offset_buffer_eq(&self.geom_offsets, &other.geom_offsets)
-            && self.coords != other.coords
+            && self.coords == other.coords
     }
 }
 

--- a/rust/geoarrow-array/src/array/mixed.rs
+++ b/rust/geoarrow-array/src/array/mixed.rs
@@ -58,7 +58,7 @@ use crate::trait_::GeoArrowArray;
 /// - 35: MultiLineString ZM
 /// - 36: MultiPolygon ZM
 /// - 37: GeometryCollection ZM
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct MixedGeometryArray {
     // We store the coord type and dimension separately because there's no NativeType::Mixed
     // variant
@@ -681,5 +681,21 @@ impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, Dimension)> for MixedGeometryArra
     fn try_from(value: (WkbArray<O>, Dimension)) -> Result<Self> {
         let mut_arr: MixedGeometryBuilder = value.try_into()?;
         Ok(mut_arr.finish())
+    }
+}
+
+impl PartialEq for MixedGeometryArray {
+    fn eq(&self, other: &Self) -> bool {
+        self.dim == other.dim
+            && self.metadata == other.metadata
+            && self.type_ids == other.type_ids
+            && self.offsets == other.offsets
+            && self.points == other.points
+            && self.line_strings == other.line_strings
+            && self.polygons == other.polygons
+            && self.multi_points == other.multi_points
+            && self.multi_line_strings == other.multi_line_strings
+            && self.multi_polygons == other.multi_polygons
+            && self.slice_offset == other.slice_offset
     }
 }

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -417,26 +417,78 @@ impl From<PolygonArray> for MultiPolygonArray {
 
 impl PartialEq for MultiPolygonArray {
     fn eq(&self, other: &Self) -> bool {
-        if self.validity != other.validity {
-            return false;
-        }
+        self.validity == other.validity
+            && offset_buffer_eq(&self.geom_offsets, &other.geom_offsets)
+            && offset_buffer_eq(&self.polygon_offsets, &other.polygon_offsets)
+            && offset_buffer_eq(&self.ring_offsets, &other.ring_offsets)
+            && self.coords == other.coords
+    }
+}
 
-        if !offset_buffer_eq(&self.geom_offsets, &other.geom_offsets) {
-            return false;
-        }
+#[cfg(test)]
+mod test {
+    use geo_traits::to_geo::ToGeoMultiPolygon;
+    use geoarrow_schema::{CoordType, Dimension};
 
-        if !offset_buffer_eq(&self.polygon_offsets, &other.polygon_offsets) {
-            return false;
-        }
+    use crate::test::multipolygon;
 
-        if !offset_buffer_eq(&self.ring_offsets, &other.ring_offsets) {
-            return false;
-        }
+    use super::*;
 
-        if self.coords != other.coords {
-            return false;
-        }
+    #[test]
+    fn geo_round_trip() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geoms = [
+                Some(multipolygon::mp0()),
+                None,
+                Some(multipolygon::mp1()),
+                None,
+            ];
+            let typ = MultiPolygonType::new(coord_type, Dimension::XY, Default::default());
+            let geo_arr = MultiPolygonBuilder::from_nullable_multi_polygons(&geoms, typ).finish();
 
-        true
+            for (i, g) in geo_arr.iter().enumerate() {
+                assert_eq!(
+                    geoms[i],
+                    g.transpose().unwrap().map(|g| g.to_multi_polygon())
+                );
+            }
+
+            // Test sliced
+            for (i, g) in geo_arr.slice(2, 2).iter().enumerate() {
+                assert_eq!(
+                    geoms[i + 2],
+                    g.transpose().unwrap().map(|g| g.to_multi_polygon())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn try_from_arrow() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geo_arr = multipolygon::mp_array(coord_type);
+
+            let ext_type = geo_arr.ext_type().clone();
+            let field = ext_type.to_field("geometry", true);
+
+            let arrow_arr = geo_arr.to_array_ref();
+
+            let geo_arr2: MultiPolygonArray = (arrow_arr.as_ref(), ext_type).try_into().unwrap();
+            let geo_arr3: MultiPolygonArray = (arrow_arr.as_ref(), &field).try_into().unwrap();
+
+            assert_eq!(geo_arr, geo_arr2);
+            assert_eq!(geo_arr, geo_arr3);
+        }
+    }
+
+    #[test]
+    fn partial_eq() {
+        let arr1 = multipolygon::mp_array(CoordType::Interleaved);
+        let arr2 = multipolygon::mp_array(CoordType::Separated);
+        assert_eq!(arr1, arr1);
+        assert_eq!(arr2, arr2);
+        assert_eq!(arr1, arr2);
+
+        assert_ne!(arr1, arr2.slice(0, 2));
     }
 }

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -360,22 +360,66 @@ impl From<RectArray> for PolygonArray {
 
 impl PartialEq for PolygonArray {
     fn eq(&self, other: &Self) -> bool {
-        if self.validity != other.validity {
-            return false;
-        }
+        self.validity == other.validity
+            && offset_buffer_eq(&self.geom_offsets, &other.geom_offsets)
+            && offset_buffer_eq(&self.ring_offsets, &other.ring_offsets)
+            && self.coords == other.coords
+    }
+}
 
-        if !offset_buffer_eq(&self.geom_offsets, &other.geom_offsets) {
-            return false;
-        }
+#[cfg(test)]
+mod test {
+    use geo_traits::to_geo::ToGeoPolygon;
+    use geoarrow_schema::{CoordType, Dimension};
 
-        if !offset_buffer_eq(&self.ring_offsets, &other.ring_offsets) {
-            return false;
-        }
+    use crate::test::polygon;
 
-        if self.coords != other.coords {
-            return false;
-        }
+    use super::*;
 
-        true
+    #[test]
+    fn geo_round_trip() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geoms = [Some(polygon::p0()), None, Some(polygon::p1()), None];
+            let typ = PolygonType::new(coord_type, Dimension::XY, Default::default());
+            let geo_arr = PolygonBuilder::from_nullable_polygons(&geoms, typ).finish();
+
+            for (i, g) in geo_arr.iter().enumerate() {
+                assert_eq!(geoms[i], g.transpose().unwrap().map(|g| g.to_polygon()));
+            }
+
+            // Test sliced
+            for (i, g) in geo_arr.slice(2, 2).iter().enumerate() {
+                assert_eq!(geoms[i + 2], g.transpose().unwrap().map(|g| g.to_polygon()));
+            }
+        }
+    }
+
+    #[test]
+    fn try_from_arrow() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geo_arr = polygon::p_array(coord_type);
+
+            let ext_type = geo_arr.ext_type().clone();
+            let field = ext_type.to_field("geometry", true);
+
+            let arrow_arr = geo_arr.to_array_ref();
+
+            let geo_arr2: PolygonArray = (arrow_arr.as_ref(), ext_type).try_into().unwrap();
+            let geo_arr3: PolygonArray = (arrow_arr.as_ref(), &field).try_into().unwrap();
+
+            assert_eq!(geo_arr, geo_arr2);
+            assert_eq!(geo_arr, geo_arr3);
+        }
+    }
+
+    #[test]
+    fn partial_eq() {
+        let arr1 = polygon::p_array(CoordType::Interleaved);
+        let arr2 = polygon::p_array(CoordType::Separated);
+        assert_eq!(arr1, arr1);
+        assert_eq!(arr2, arr2);
+        assert_eq!(arr1, arr2);
+
+        assert_ne!(arr1, arr2.slice(0, 2));
     }
 }

--- a/rust/geoarrow-array/src/array/rect.rs
+++ b/rust/geoarrow-array/src/array/rect.rs
@@ -25,7 +25,7 @@ use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
 /// `bounds()`.
 ///
 /// Internally this is implemented as a FixedSizeList, laid out as minx, miny, maxx, maxy.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct RectArray {
     pub(crate) data_type: BoxType,
 
@@ -211,33 +211,62 @@ impl TryFrom<(&dyn Array, &Field)> for RectArray {
     }
 }
 
+impl PartialEq for RectArray {
+    fn eq(&self, other: &Self) -> bool {
+        // A naive implementation of PartialEq would check for buffer equality. This won't always
+        // work for null elements where the actual value can be undefined and doesn't have to be
+        // equal. As such, it's simplest to reuse the upstream PartialEq impl, especially since
+        // RectArray only has one coordinate type.
+        self.clone().into_arrow() == other.clone().into_arrow()
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::builder::RectBuilder;
-    use crate::eq::rect_eq;
+    use geo_traits::to_geo::ToGeoRect;
     use geoarrow_schema::Dimension;
 
+    use crate::builder::RectBuilder;
+    use crate::test::rect;
+
+    use super::*;
+
     #[test]
-    fn rect_array_round_trip() {
-        let rect = geo_types::Rect::new(
-            geo_types::coord! { x: 0.0, y: 5.0 },
-            geo_types::coord! { x: 10.0, y: 15.0 },
-        );
+    fn geo_round_trip() {
+        let geoms = [Some(rect::r0()), None, Some(rect::r1()), None];
         let typ = BoxType::new(Dimension::XY, Default::default());
-        let mut builder = RectBuilder::with_capacity(typ, 1);
-        builder.push_rect(Some(&rect));
-        builder.push_min_max(&rect.min(), &rect.max());
-        let rect_arr = builder.finish();
+        let geo_arr =
+            RectBuilder::from_nullable_rects(geoms.iter().map(|x| x.as_ref()), typ).finish();
 
-        let arrow_arr = rect_arr.into_array_ref();
+        for (i, g) in geo_arr.iter().enumerate() {
+            assert_eq!(geoms[i], g.transpose().unwrap().map(|g| g.to_rect()));
+        }
 
-        let rect_arr_again = RectArray::try_from((
-            arrow_arr.as_ref(),
-            BoxType::new(Dimension::XY, Default::default()),
-        ))
-        .unwrap();
-        let rect_again = rect_arr_again.value(0).unwrap();
-        assert!(rect_eq(&rect, &rect_again));
+        // Test sliced
+        for (i, g) in geo_arr.slice(2, 2).iter().enumerate() {
+            assert_eq!(geoms[i + 2], g.transpose().unwrap().map(|g| g.to_rect()));
+        }
+    }
+
+    #[test]
+    fn try_from_arrow() {
+        let geo_arr = rect::r_array();
+
+        let ext_type = geo_arr.ext_type().clone();
+        let field = ext_type.to_field("geometry", true);
+
+        let arrow_arr = geo_arr.to_array_ref();
+
+        let geo_arr2: RectArray = (arrow_arr.as_ref(), ext_type).try_into().unwrap();
+        let geo_arr3: RectArray = (arrow_arr.as_ref(), &field).try_into().unwrap();
+
+        assert_eq!(geo_arr, geo_arr2);
+        assert_eq!(geo_arr, geo_arr3);
+    }
+
+    #[test]
+    fn partial_eq() {
+        let arr1 = rect::r_array();
+        assert_eq!(arr1, arr1);
     }
 }

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -384,12 +384,12 @@ mod test {
 
     #[test]
     fn native_type_round_trip() {
-        let point_array = crate::test::point::point_array();
+        let point_array = crate::test::point::point_array(CoordType::Interleaved);
         let field = point_array.data_type.to_field("geometry", true);
         let data_type: GeoArrowType = (&field).try_into().unwrap();
         assert_eq!(point_array.data_type(), data_type);
 
-        let ml_array = crate::test::multilinestring::ml_array();
+        let ml_array = crate::test::multilinestring::ml_array(CoordType::Interleaved);
         let field = ml_array.data_type.to_field("geometry", true);
         let data_type: GeoArrowType = (&field).try_into().unwrap();
         assert_eq!(ml_array.data_type(), data_type);

--- a/rust/geoarrow-array/src/scalar/coord/combined.rs
+++ b/rust/geoarrow-array/src/scalar/coord/combined.rs
@@ -1,5 +1,6 @@
 use geo_traits::CoordTrait;
 
+use crate::eq::coord_eq;
 use crate::scalar::{InterleavedCoord, SeparatedCoord};
 
 /// An Arrow equivalent of a Coord
@@ -25,19 +26,19 @@ impl Coord<'_> {
 
 impl PartialEq for Coord<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.x_y() == other.x_y()
+        coord_eq(self, other)
     }
 }
 
 impl PartialEq<InterleavedCoord<'_>> for Coord<'_> {
     fn eq(&self, other: &InterleavedCoord<'_>) -> bool {
-        self.x_y() == other.x_y()
+        coord_eq(self, other)
     }
 }
 
 impl PartialEq<SeparatedCoord<'_>> for Coord<'_> {
     fn eq(&self, other: &SeparatedCoord<'_>) -> bool {
-        self.x_y() == other.x_y()
+        coord_eq(self, other)
     }
 }
 

--- a/rust/geoarrow-array/src/scalar/specialization.rs
+++ b/rust/geoarrow-array/src/scalar/specialization.rs
@@ -1,4 +1,4 @@
-// Specialized implementations on each WKT concrete type.
+// Specialized implementations of GeometryTrait on each scalar type.
 
 use geo_traits::{
     GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,

--- a/rust/geoarrow-array/src/test/linestring.rs
+++ b/rust/geoarrow-array/src/test/linestring.rs
@@ -18,9 +18,8 @@ pub(crate) fn ls1() -> LineString {
     ]
 }
 
-#[allow(dead_code)]
-pub(crate) fn ls_array() -> LineStringArray {
-    let geoms = vec![ls0(), ls1()];
-    let typ = LineStringType::new(CoordType::Interleaved, Dimension::XY, Default::default());
-    LineStringBuilder::from_line_strings(&geoms, typ).finish()
+pub(crate) fn ls_array(coord_type: CoordType) -> LineStringArray {
+    let geoms = vec![Some(ls0()), None, Some(ls1()), None];
+    let typ = LineStringType::new(coord_type, Dimension::XY, Default::default());
+    LineStringBuilder::from_nullable_line_strings(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/mod.rs
+++ b/rust/geoarrow-array/src/test/mod.rs
@@ -7,3 +7,4 @@ pub mod multipolygon;
 pub mod point;
 pub mod polygon;
 pub mod properties;
+pub mod rect;

--- a/rust/geoarrow-array/src/test/multilinestring.rs
+++ b/rust/geoarrow-array/src/test/multilinestring.rs
@@ -30,8 +30,8 @@ pub(crate) fn ml1() -> MultiLineString {
     ])
 }
 
-pub(crate) fn ml_array() -> MultiLineStringArray {
-    let geoms = vec![ml0(), ml1()];
-    let typ = MultiLineStringType::new(CoordType::Interleaved, Dimension::XY, Default::default());
-    MultiLineStringBuilder::from_multi_line_strings(&geoms, typ).finish()
+pub(crate) fn ml_array(coord_type: CoordType) -> MultiLineStringArray {
+    let geoms = vec![Some(ml0()), None, Some(ml1()), None];
+    let typ = MultiLineStringType::new(coord_type, Dimension::XY, Default::default());
+    MultiLineStringBuilder::from_nullable_multi_line_strings(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/multipoint.rs
+++ b/rust/geoarrow-array/src/test/multipoint.rs
@@ -26,8 +26,8 @@ pub(crate) fn mp1() -> MultiPoint {
     ])
 }
 
-pub(crate) fn mp_array() -> MultiPointArray {
-    let geoms = vec![mp0(), mp1()];
-    let typ = MultiPointType::new(CoordType::Interleaved, Dimension::XY, Default::default());
-    MultiPointBuilder::from_multi_points(&geoms, typ).finish()
+pub(crate) fn mp_array(coord_type: CoordType) -> MultiPointArray {
+    let geoms = vec![Some(mp0()), None, Some(mp1()), None];
+    let typ = MultiPointType::new(coord_type, Dimension::XY, Default::default());
+    MultiPointBuilder::from_nullable_multi_points(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/multipolygon.rs
+++ b/rust/geoarrow-array/src/test/multipolygon.rs
@@ -48,8 +48,8 @@ pub(crate) fn mp1() -> MultiPolygon {
     ])
 }
 
-pub(crate) fn mp_array() -> MultiPolygonArray {
-    let geoms = vec![mp0(), mp1()];
-    let typ = MultiPolygonType::new(CoordType::Interleaved, Dimension::XY, Default::default());
-    MultiPolygonBuilder::from_multi_polygons(&geoms, typ).finish()
+pub(crate) fn mp_array(coord_type: CoordType) -> MultiPolygonArray {
+    let geoms = vec![Some(mp0()), None, Some(mp1()), None];
+    let typ = MultiPolygonType::new(coord_type, Dimension::XY, Default::default());
+    MultiPolygonBuilder::from_nullable_multi_polygons(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/point.rs
+++ b/rust/geoarrow-array/src/test/point.rs
@@ -1,8 +1,8 @@
+use geo::wkt;
 use geo_types::{Point, point};
 
 use crate::array::PointArray;
 use crate::builder::PointBuilder;
-use geo_traits::CoordTrait;
 use geoarrow_schema::{CoordType, Dimension, PointType};
 
 pub(crate) fn p0() -> Point {
@@ -23,65 +23,14 @@ pub(crate) fn p2() -> Point {
     )
 }
 
-pub(crate) fn point_array() -> PointArray {
-    let geoms = [p0(), p1(), p2()];
-    let typ = PointType::new(CoordType::Interleaved, Dimension::XY, Default::default());
-    PointBuilder::from_points(geoms.iter(), typ).finish()
-}
-
-struct CoordZ {
-    x: f64,
-    y: f64,
-    z: f64,
-}
-
-impl CoordTrait for CoordZ {
-    type T = f64;
-
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xyz
-    }
-
-    fn nth_or_panic(&self, n: usize) -> Self::T {
-        match n {
-            0 => self.x,
-            1 => self.y,
-            2 => self.z,
-            _ => panic!(),
-        }
-    }
-
-    fn x(&self) -> Self::T {
-        self.x
-    }
-
-    fn y(&self) -> Self::T {
-        self.y
+pub(crate) fn p3() -> Point {
+    wkt! {
+        POINT (30.0 10.0)
     }
 }
 
-pub(crate) fn point_z_array() -> PointArray {
-    let typ = PointType::new(CoordType::Interleaved, Dimension::XYZ, Default::default());
-    let mut builder = PointBuilder::with_capacity(typ, 3);
-    let coords = vec![
-        CoordZ {
-            x: 0.,
-            y: 1.,
-            z: 2.,
-        },
-        CoordZ {
-            x: 3.,
-            y: 4.,
-            z: 5.,
-        },
-        CoordZ {
-            x: 6.,
-            y: 7.,
-            z: 8.,
-        },
-    ];
-    for coord in &coords {
-        builder.push_coord(Some(coord));
-    }
-    builder.finish()
+pub(crate) fn point_array(coord_type: CoordType) -> PointArray {
+    let geoms = [Some(p0()), Some(p1()), None, Some(p2())];
+    let typ = PointType::new(coord_type, Dimension::XY, Default::default());
+    PointBuilder::from_nullable_points(geoms.iter().map(|x| x.as_ref()), typ).finish()
 }

--- a/rust/geoarrow-array/src/test/polygon.rs
+++ b/rust/geoarrow-array/src/test/polygon.rs
@@ -32,8 +32,8 @@ pub(crate) fn p1() -> Polygon {
     )
 }
 
-pub(crate) fn p_array() -> PolygonArray {
-    let geoms = vec![p0(), p1()];
-    let typ = PolygonType::new(CoordType::Interleaved, Dimension::XY, Default::default());
-    PolygonBuilder::from_polygons(&geoms, typ).finish()
+pub(crate) fn p_array(coord_type: CoordType) -> PolygonArray {
+    let geoms = vec![Some(p0()), None, Some(p1()), None];
+    let typ = PolygonType::new(coord_type, Dimension::XY, Default::default());
+    PolygonBuilder::from_nullable_polygons(&geoms, typ).finish()
 }

--- a/rust/geoarrow-array/src/test/rect.rs
+++ b/rust/geoarrow-array/src/test/rect.rs
@@ -1,0 +1,20 @@
+use geo::coord;
+use geo_types::Rect;
+
+use crate::array::RectArray;
+use crate::builder::RectBuilder;
+use geoarrow_schema::{BoxType, Dimension};
+
+pub(crate) fn r0() -> Rect {
+    Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. })
+}
+
+pub(crate) fn r1() -> Rect {
+    Rect::new(coord! { x: 100., y: 200. }, coord! { x: 300., y: 100. })
+}
+
+pub(crate) fn r_array() -> RectArray {
+    let geoms = [Some(r0()), None, Some(r1()), None];
+    let typ = BoxType::new(Dimension::XY, Default::default());
+    RectBuilder::from_nullable_rects(geoms.iter().map(|x| x.as_ref()), typ).finish()
+}


### PR DESCRIPTION
### Change list

- Adds tests for both interleaved and separated encoding to go from geo to geoarrow and back to geo and assert equality
- Adds tests for both interleaved and separated encoding to go from geoarrow to arrow and back
- Adds minimal `PartialEq` tests