### PR TITLE
Implement From<GeoArrowError> for ArrowError

### DIFF
--- a/rust/geoarrow-array/src/error.rs
+++ b/rust/geoarrow-array/src/error.rs
@@ -54,3 +54,14 @@ pub enum GeoArrowError {
 
 /// Crate-specific result type.
 pub type Result<T> = std::result::Result<T, GeoArrowError>;
+
+impl From<GeoArrowError> for ArrowError {
+    /// Many APIs where we pass in a callback into the Arrow crate require the returned error type
+    /// to be ArrowError, so implementing this `From` makes the conversion less verbose there.
+    fn from(err: GeoArrowError) -> Self {
+        match err {
+            GeoArrowError::Arrow(err) => err,
+            _ => ArrowError::ExternalError(Box::new(err)),
+        }
+    }
+}

--- a/rust/geoarrow/src/error.rs
+++ b/rust/geoarrow/src/error.rs
@@ -102,3 +102,12 @@ pub enum GeoArrowError {
 
 /// Crate-specific result type.
 pub type Result<T> = std::result::Result<T, GeoArrowError>;
+
+impl From<GeoArrowError> for ArrowError {
+    fn from(err: GeoArrowError) -> Self {
+        match err {
+            GeoArrowError::Arrow(err) => err,
+            _ => ArrowError::ExternalError(Box::new(err)),
+        }
+    }
+}

--- a/rust/geoarrow/src/io/flatgeobuf/reader/sync.rs
+++ b/rust/geoarrow/src/io/flatgeobuf/reader/sync.rs
@@ -312,9 +312,7 @@ impl<R: Read> Iterator for FlatGeobufReader<R, NotSeekable> {
     type Item = std::result::Result<RecordBatch, ArrowError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.process_batch()
-            .map_err(|err| ArrowError::ExternalError(Box::new(err)))
-            .transpose()
+        self.process_batch().map_err(|err| err.into()).transpose()
     }
 }
 
@@ -334,9 +332,7 @@ impl<R: Read + Seek> Iterator for FlatGeobufReader<R, Seekable> {
     type Item = std::result::Result<RecordBatch, ArrowError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.process_batch()
-            .map_err(|err| ArrowError::ExternalError(Box::new(err)))
-            .transpose()
+        self.process_batch().map_err(|err| err.into()).transpose()
     }
 }
 

--- a/rust/geoarrow/src/io/parquet/reader/spatial_filter.rs
+++ b/rust/geoarrow/src/io/parquet/reader/spatial_filter.rs
@@ -6,7 +6,6 @@ use arrow::compute::kernels::cmp::{gt_eq, lt_eq};
 use arrow::datatypes::{Float32Type, Float64Type};
 use arrow_array::{Array, Float32Array, Float64Array, Scalar};
 use arrow_buffer::ScalarBuffer;
-use arrow_schema::ArrowError;
 use geo::{CoordNum, Rect, coord};
 use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::{
@@ -220,13 +219,8 @@ fn construct_native_predicate(
         let array = batch.column(0);
         let field = batch.schema_ref().field(0);
         let nulls = array.nulls();
-        let geo_arr = NativeArrayDyn::from_arrow_array(array, field)
-            .map_err(|err| ArrowError::ExternalError(Box::new(err)))?
-            .into_inner();
-        let rect_arr = geo_arr
-            .as_ref()
-            .bounding_rect()
-            .map_err(|err| ArrowError::ExternalError(Box::new(err)))?;
+        let geo_arr = NativeArrayDyn::from_arrow_array(array, field)?.into_inner();
+        let rect_arr = geo_arr.as_ref().bounding_rect()?;
 
         let xmin_col = Float64Array::new(rect_arr.lower().buffers[0].clone(), nulls.cloned());
         let ymin_col = Float64Array::new(rect_arr.lower().buffers[1].clone(), nulls.cloned());


### PR DESCRIPTION
Closes #1039 

Many APIs where we pass in a callback into the Arrow crate require the returned error type to be ArrowError, so implementing this `From` makes the conversion less verbose there.
