### PR TITLE
Add `geoarrow-test` subcrate with WKT data from geoarrow-data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
 name = "geoarrow-test"
 version = "0.1.0-dev"
 dependencies = [
+ "geo 0.30.0",
  "geo-traits",
  "geo-types",
  "geoarrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "wkb",
- "wkt 0.12.0",
+ "wkt 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1353,7 +1353,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "wkb",
- "wkt 0.12.0",
+ "wkt 0.12.0 (git+https://github.com/georust/wkt?rev=270ffe0eaf5ba5255c364dbade39c451562a9e9b)",
 ]
 
 [[package]]
@@ -1364,6 +1364,17 @@ dependencies = [
  "geo-traits",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "geoarrow-test"
+version = "0.1.0-dev"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "geoarrow-array",
+ "geoarrow-schema",
+ "wkt 0.12.0 (git+https://github.com/georust/wkt?rev=270ffe0eaf5ba5255c364dbade39c451562a9e9b)",
 ]
 
 [[package]]
@@ -4536,6 +4547,18 @@ name = "wkt"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c591649bd1c9d4e28459758bbb5fb5c0edc7a67060b52422f4761c94ffe961"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wkt"
+version = "0.12.0"
+source = "git+https://github.com/georust/wkt?rev=270ffe0eaf5ba5255c364dbade39c451562a9e9b#270ffe0eaf5ba5255c364dbade39c451562a9e9b"
 dependencies = [
  "geo-traits",
  "geo-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "rust/geoarrow",
     "rust/geoarrow-array",
     "rust/geoarrow-schema",
+    "rust/geoarrow-test",
     # Comment out until datafusion 47 release so that the workspace can upgrade
     # to arrow 55
     # "rust/geodatafusion",
@@ -29,6 +30,7 @@ geo-traits = "0.2.0"
 geo-types = "0.7.16"
 geoarrow-array = { path = "rust/geoarrow-array" }
 geoarrow-schema = { path = "rust/geoarrow-schema" }
+geoarrow-test = { path = "rust/geoarrow-test" }
 geozero = "0.14"
 num-traits = "0.2.19"
 object_store = "0.12"
@@ -39,4 +41,5 @@ serde_json = "1"
 thiserror = "1"
 # to include https://github.com/georust/wkb/pull/53
 wkb = { git = "https://github.com/georust/wkb", rev = "5a2027995997017bcd531e6be7e5cf126db1d4c1" }
-wkt = "0.12"
+# https://github.com/georust/wkt/pull/137
+wkt = { git = "https://github.com/georust/wkt", rev = "270ffe0eaf5ba5255c364dbade39c451562a9e9b" }

--- a/rust/geoarrow-test/Cargo.toml
+++ b/rust/geoarrow-test/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "geoarrow-test"
+version = "0.1.0-dev"
+authors = ["Kyle Barron <kylebarron2@gmail.com>"]
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "Rust implementation of GeoArrow"
+categories = ["science::geo"]
+rust-version = { workspace = true }
+
+[dependencies]
+geo-traits = { workspace = true }
+geo-types = { workspace = true }
+geoarrow-array = { workspace = true }
+geoarrow-schema = { workspace = true }
+wkt = { workspace = true }

--- a/rust/geoarrow-test/Cargo.toml
+++ b/rust/geoarrow-test/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["science::geo"]
 rust-version = { workspace = true }
 
 [dependencies]
+geo = { workspace = true }
 geo-traits = { workspace = true }
 geo-types = { workspace = true }
 geoarrow-array = { workspace = true }

--- a/rust/geoarrow-test/README.md
+++ b/rust/geoarrow-test/README.md
@@ -1,0 +1,3 @@
+# geoarrow-test
+
+Test data for geoarrow-rs.

--- a/rust/geoarrow-test/src/geometry.rs
+++ b/rust/geoarrow-test/src/geometry.rs
@@ -1,0 +1,21 @@
+use geo::Convert;
+use geo_traits::to_geo::ToGeoGeometry;
+use geoarrow_array::array::GeometryArray;
+use geoarrow_array::builder::GeometryBuilder;
+use geoarrow_schema::{CoordType, GeometryType};
+
+use crate::raw;
+
+pub fn geoms() -> Vec<Option<geo_types::Geometry>> {
+    raw::geometry::geoms()
+        .iter()
+        .map(|g| g.as_ref().map(|g| g.to_geometry().convert()))
+        .collect()
+}
+
+pub fn array(coord_type: CoordType, prefer_multi: bool) -> GeometryArray {
+    let typ = GeometryType::new(coord_type, Default::default());
+    GeometryBuilder::from_nullable_geometries(&geoms(), typ, prefer_multi)
+        .unwrap()
+        .finish()
+}

--- a/rust/geoarrow-test/src/geometrycollection.rs
+++ b/rust/geoarrow-test/src/geometrycollection.rs
@@ -1,0 +1,38 @@
+use geo::Convert;
+use geo_traits::to_geo::ToGeoGeometryCollection;
+use geoarrow_array::array::GeometryCollectionArray;
+use geoarrow_array::builder::GeometryCollectionBuilder;
+use geoarrow_schema::{CoordType, Dimension, GeometryCollectionType};
+
+use crate::raw;
+
+macro_rules! impl_mod {
+    ($mod_name:ident, $dim:expr) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn geoms() -> Vec<Option<geo_types::GeometryCollection>> {
+                raw::geometrycollection::$mod_name::geoms()
+                    .iter()
+                    .map(|g| g.as_ref().map(|g| g.to_geometry_collection().convert()))
+                    .collect()
+            }
+
+            pub fn array(coord_type: CoordType, prefer_multi: bool) -> GeometryCollectionArray {
+                let typ = GeometryCollectionType::new(coord_type, $dim, Default::default());
+                GeometryCollectionBuilder::from_nullable_geometry_collections(
+                    &geoms(),
+                    typ,
+                    prefer_multi,
+                )
+                .unwrap()
+                .finish()
+            }
+        }
+    };
+}
+
+impl_mod!(xy, Dimension::XY);
+impl_mod!(xyz, Dimension::XYZ);
+impl_mod!(xym, Dimension::XYM);
+impl_mod!(xyzm, Dimension::XYZM);

--- a/rust/geoarrow-test/src/lib.rs
+++ b/rust/geoarrow-test/src/lib.rs
@@ -1,0 +1,11 @@
+//! Test data for GeoArrow
+
+pub mod geometry;
+pub mod geometrycollection;
+pub mod linestring;
+pub mod multilinestring;
+pub mod multipoint;
+pub mod multipolygon;
+pub mod point;
+pub mod polygon;
+pub(crate) mod raw;

--- a/rust/geoarrow-test/src/linestring.rs
+++ b/rust/geoarrow-test/src/linestring.rs
@@ -1,0 +1,32 @@
+use geo::Convert;
+use geo_traits::to_geo::ToGeoLineString;
+use geoarrow_array::array::LineStringArray;
+use geoarrow_array::builder::LineStringBuilder;
+use geoarrow_schema::{CoordType, Dimension, LineStringType};
+
+use crate::raw;
+
+macro_rules! impl_mod {
+    ($mod_name:ident, $dim:expr) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn geoms() -> Vec<Option<geo_types::LineString>> {
+                raw::linestring::$mod_name::geoms()
+                    .iter()
+                    .map(|g| g.as_ref().map(|g| g.to_line_string().convert()))
+                    .collect()
+            }
+
+            pub fn array(coord_type: CoordType) -> LineStringArray {
+                let typ = LineStringType::new(coord_type, $dim, Default::default());
+                LineStringBuilder::from_nullable_line_strings(&geoms(), typ).finish()
+            }
+        }
+    };
+}
+
+impl_mod!(xy, Dimension::XY);
+impl_mod!(xyz, Dimension::XYZ);
+impl_mod!(xym, Dimension::XYM);
+impl_mod!(xyzm, Dimension::XYZM);

--- a/rust/geoarrow-test/src/multilinestring.rs
+++ b/rust/geoarrow-test/src/multilinestring.rs
@@ -1,0 +1,32 @@
+use geo::Convert;
+use geo_traits::to_geo::ToGeoMultiLineString;
+use geoarrow_array::array::MultiLineStringArray;
+use geoarrow_array::builder::MultiLineStringBuilder;
+use geoarrow_schema::{CoordType, Dimension, MultiLineStringType};
+
+use crate::raw;
+
+macro_rules! impl_mod {
+    ($mod_name:ident, $dim:expr) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn geoms() -> Vec<Option<geo_types::MultiLineString>> {
+                raw::multilinestring::$mod_name::geoms()
+                    .iter()
+                    .map(|g| g.as_ref().map(|g| g.to_multi_line_string().convert()))
+                    .collect()
+            }
+
+            pub fn array(coord_type: CoordType) -> MultiLineStringArray {
+                let typ = MultiLineStringType::new(coord_type, $dim, Default::default());
+                MultiLineStringBuilder::from_nullable_multi_line_strings(&geoms(), typ).finish()
+            }
+        }
+    };
+}
+
+impl_mod!(xy, Dimension::XY);
+impl_mod!(xyz, Dimension::XYZ);
+impl_mod!(xym, Dimension::XYM);
+impl_mod!(xyzm, Dimension::XYZM);

--- a/rust/geoarrow-test/src/multipoint.rs
+++ b/rust/geoarrow-test/src/multipoint.rs
@@ -1,0 +1,32 @@
+use geo::Convert;
+use geo_traits::to_geo::ToGeoMultiPoint;
+use geoarrow_array::array::MultiPointArray;
+use geoarrow_array::builder::MultiPointBuilder;
+use geoarrow_schema::{CoordType, Dimension, MultiPointType};
+
+use crate::raw;
+
+macro_rules! impl_mod {
+    ($mod_name:ident, $dim:expr) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn geoms() -> Vec<Option<geo_types::MultiPoint>> {
+                raw::multipoint::$mod_name::geoms()
+                    .iter()
+                    .map(|g| g.as_ref().map(|g| g.to_multi_point().convert()))
+                    .collect()
+            }
+
+            pub fn array(coord_type: CoordType) -> MultiPointArray {
+                let typ = MultiPointType::new(coord_type, $dim, Default::default());
+                MultiPointBuilder::from_nullable_multi_points(&geoms(), typ).finish()
+            }
+        }
+    };
+}
+
+impl_mod!(xy, Dimension::XY);
+impl_mod!(xyz, Dimension::XYZ);
+impl_mod!(xym, Dimension::XYM);
+impl_mod!(xyzm, Dimension::XYZM);

--- a/rust/geoarrow-test/src/multipolygon.rs
+++ b/rust/geoarrow-test/src/multipolygon.rs
@@ -1,0 +1,32 @@
+use geo::Convert;
+use geo_traits::to_geo::ToGeoMultiPolygon;
+use geoarrow_array::array::MultiPolygonArray;
+use geoarrow_array::builder::MultiPolygonBuilder;
+use geoarrow_schema::{CoordType, Dimension, MultiPolygonType};
+
+use crate::raw;
+
+macro_rules! impl_mod {
+    ($mod_name:ident, $dim:expr) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn geoms() -> Vec<Option<geo_types::MultiPolygon>> {
+                raw::multipolygon::$mod_name::geoms()
+                    .iter()
+                    .map(|g| g.as_ref().map(|g| g.to_multi_polygon().convert()))
+                    .collect()
+            }
+
+            pub fn array(coord_type: CoordType) -> MultiPolygonArray {
+                let typ = MultiPolygonType::new(coord_type, $dim, Default::default());
+                MultiPolygonBuilder::from_nullable_multi_polygons(&geoms(), typ).finish()
+            }
+        }
+    };
+}
+
+impl_mod!(xy, Dimension::XY);
+impl_mod!(xyz, Dimension::XYZ);
+impl_mod!(xym, Dimension::XYM);
+impl_mod!(xyzm, Dimension::XYZM);

--- a/rust/geoarrow-test/src/point.rs
+++ b/rust/geoarrow-test/src/point.rs
@@ -1,0 +1,32 @@
+use geo::Convert;
+use geo_traits::to_geo::ToGeoPoint;
+use geoarrow_array::array::PointArray;
+use geoarrow_array::builder::PointBuilder;
+use geoarrow_schema::{CoordType, Dimension, PointType};
+
+use crate::raw;
+
+macro_rules! impl_mod {
+    ($mod_name:ident, $dim:expr) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn geoms() -> Vec<Option<geo_types::Point>> {
+                raw::point::$mod_name::geoms()
+                    .iter()
+                    .map(|g| g.as_ref().map(|g| g.to_point().convert()))
+                    .collect()
+            }
+
+            pub fn array(coord_type: CoordType) -> PointArray {
+                let typ = PointType::new(coord_type, $dim, Default::default());
+                PointBuilder::from_nullable_points(geoms().iter().map(|x| x.as_ref()), typ).finish()
+            }
+        }
+    };
+}
+
+impl_mod!(xy, Dimension::XY);
+impl_mod!(xyz, Dimension::XYZ);
+impl_mod!(xym, Dimension::XYM);
+impl_mod!(xyzm, Dimension::XYZM);

--- a/rust/geoarrow-test/src/polygon.rs
+++ b/rust/geoarrow-test/src/polygon.rs
@@ -1,0 +1,32 @@
+use geo::Convert;
+use geo_traits::to_geo::ToGeoPolygon;
+use geoarrow_array::array::PolygonArray;
+use geoarrow_array::builder::PolygonBuilder;
+use geoarrow_schema::{CoordType, Dimension, PolygonType};
+
+use crate::raw;
+
+macro_rules! impl_mod {
+    ($mod_name:ident, $dim:expr) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub fn geoms() -> Vec<Option<geo_types::Polygon>> {
+                raw::polygon::$mod_name::geoms()
+                    .iter()
+                    .map(|g| g.as_ref().map(|g| g.to_polygon().convert()))
+                    .collect()
+            }
+
+            pub fn array(coord_type: CoordType) -> PolygonArray {
+                let typ = PolygonType::new(coord_type, $dim, Default::default());
+                PolygonBuilder::from_nullable_polygons(&geoms(), typ).finish()
+            }
+        }
+    };
+}
+
+impl_mod!(xy, Dimension::XY);
+impl_mod!(xyz, Dimension::XYZ);
+impl_mod!(xym, Dimension::XYM);
+impl_mod!(xyzm, Dimension::XYZM);

--- a/rust/geoarrow-test/src/raw/geometry.rs
+++ b/rust/geoarrow-test/src/raw/geometry.rs
@@ -1,10 +1,7 @@
 use wkt::wkt;
 
-pub mod xy {
-    use super::*;
-
-    pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
-        vec![
+pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
+    vec![
             Some(wkt! { POINT (30 10) }.into()),
             Some(wkt! { LINESTRING (30 10, 10 30, 40 40) }.into()),
             Some(wkt! { POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)) }.into()),
@@ -14,15 +11,8 @@ pub mod xy {
             Some(wkt! { GEOMETRYCOLLECTION (POINT (30 10), LINESTRING (30 10, 10 30, 40 40), POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)), MULTIPOINT (30 10), MULTILINESTRING ((30 10, 10 30, 40 40)), MULTIPOLYGON (((30 10, 40 40, 20 40, 10 20, 30 10)))) }.into()),
             None,
             Some(wkt! { GEOMETRYCOLLECTION EMPTY }.into()),
-        ]
-    }
-}
 
-pub mod xyz {
-    use super::*;
-
-    pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
-        vec![
+            // Z
             Some(wkt! { POINT Z (30 10 40) }.into()),
             Some(wkt! { LINESTRING Z (30 10 40, 10 30 40, 40 40 80) }.into()),
             Some(wkt! { POLYGON Z ((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)) }.into()),
@@ -32,15 +22,8 @@ pub mod xyz {
             Some(wkt! { GEOMETRYCOLLECTION Z (POINT Z (30 10 40), LINESTRING Z (30 10 40, 10 30 40, 40 40 80), POLYGON Z ((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)), MULTIPOINT Z (30 10 40), MULTILINESTRING Z ((30 10 40, 10 30 40, 40 40 80)), MULTIPOLYGON Z (((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)))) }.into()),
             None,
             Some(wkt! { GEOMETRYCOLLECTION Z EMPTY }.into()),
-        ]
-    }
-}
 
-pub mod xym {
-    use super::*;
-
-    pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
-        vec![
+            // M
             Some(wkt! { POINT M (30 10 300) }.into()),
             Some(wkt! { LINESTRING M (30 10 300, 10 30 300, 40 40 1600) }.into()),
             Some(wkt! { POLYGON M ((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)) }.into()),
@@ -50,15 +33,8 @@ pub mod xym {
             Some(wkt! { GEOMETRYCOLLECTION M (POINT M (30 10 300), LINESTRING M (30 10 300, 10 30 300, 40 40 1600), POLYGON M ((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)), MULTIPOINT M (30 10 300), MULTILINESTRING M ((30 10 300, 10 30 300, 40 40 1600)), MULTIPOLYGON M (((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)))) }.into()),
             None,
             Some(wkt! { GEOMETRYCOLLECTION M EMPTY }.into()),
-        ]
-    }
-}
 
-pub mod xyzm {
-    use super::*;
-
-    pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
-        vec![
+            // ZM
             Some(wkt! { POINT ZM (30 10 40 300) }.into()),
             Some(wkt! { LINESTRING ZM (30 10 40 300, 10 30 40 300, 40 40 80 1600) }.into()),
             Some(wkt! { POLYGON ZM ((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300)) }.into()),
@@ -69,5 +45,4 @@ pub mod xyzm {
             None,
             Some(wkt! { GEOMETRYCOLLECTION ZM EMPTY }.into()),
         ]
-    }
 }

--- a/rust/geoarrow-test/src/raw/geometry.rs
+++ b/rust/geoarrow-test/src/raw/geometry.rs
@@ -1,0 +1,73 @@
+use wkt::wkt;
+
+pub mod xy {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
+        vec![
+            Some(wkt! { POINT (30 10) }.into()),
+            Some(wkt! { LINESTRING (30 10, 10 30, 40 40) }.into()),
+            Some(wkt! { POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)) }.into()),
+            Some(wkt! { MULTIPOINT (30 10) }.into()),
+            Some(wkt! { MULTILINESTRING ((30 10, 10 30, 40 40)) }.into()),
+            Some(wkt! { MULTIPOLYGON (((30 10, 40 40, 20 40, 10 20, 30 10))) }.into()),
+            Some(wkt! { GEOMETRYCOLLECTION (POINT (30 10), LINESTRING (30 10, 10 30, 40 40), POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)), MULTIPOINT (30 10), MULTILINESTRING ((30 10, 10 30, 40 40)), MULTIPOLYGON (((30 10, 40 40, 20 40, 10 20, 30 10)))) }.into()),
+            None,
+            Some(wkt! { GEOMETRYCOLLECTION EMPTY }.into()),
+        ]
+    }
+}
+
+pub mod xyz {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
+        vec![
+            Some(wkt! { POINT Z (30 10 40) }.into()),
+            Some(wkt! { LINESTRING Z (30 10 40, 10 30 40, 40 40 80) }.into()),
+            Some(wkt! { POLYGON Z ((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)) }.into()),
+            Some(wkt! { MULTIPOINT Z (30 10 40) }.into()),
+            Some(wkt! { MULTILINESTRING Z ((30 10 40, 10 30 40, 40 40 80)) }.into()),
+            Some(wkt! { MULTIPOLYGON Z (((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40))) }.into()),
+            Some(wkt! { GEOMETRYCOLLECTION Z (POINT Z (30 10 40), LINESTRING Z (30 10 40, 10 30 40, 40 40 80), POLYGON Z ((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)), MULTIPOINT Z (30 10 40), MULTILINESTRING Z ((30 10 40, 10 30 40, 40 40 80)), MULTIPOLYGON Z (((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)))) }.into()),
+            None,
+            Some(wkt! { GEOMETRYCOLLECTION Z EMPTY }.into()),
+        ]
+    }
+}
+
+pub mod xym {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
+        vec![
+            Some(wkt! { POINT M (30 10 300) }.into()),
+            Some(wkt! { LINESTRING M (30 10 300, 10 30 300, 40 40 1600) }.into()),
+            Some(wkt! { POLYGON M ((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)) }.into()),
+            Some(wkt! { MULTIPOINT M (30 10 300) }.into()),
+            Some(wkt! { MULTILINESTRING M ((30 10 300, 10 30 300, 40 40 1600)) }.into()),
+            Some(wkt! { MULTIPOLYGON M (((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300))) }.into()),
+            Some(wkt! { GEOMETRYCOLLECTION M (POINT M (30 10 300), LINESTRING M (30 10 300, 10 30 300, 40 40 1600), POLYGON M ((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)), MULTIPOINT M (30 10 300), MULTILINESTRING M ((30 10 300, 10 30 300, 40 40 1600)), MULTIPOLYGON M (((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)))) }.into()),
+            None,
+            Some(wkt! { GEOMETRYCOLLECTION M EMPTY }.into()),
+        ]
+    }
+}
+
+pub mod xyzm {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::Wkt<i32>>> {
+        vec![
+            Some(wkt! { POINT ZM (30 10 40 300) }.into()),
+            Some(wkt! { LINESTRING ZM (30 10 40 300, 10 30 40 300, 40 40 80 1600) }.into()),
+            Some(wkt! { POLYGON ZM ((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300)) }.into()),
+            Some(wkt! { MULTIPOINT ZM (30 10 40 300) }.into()),
+            Some(wkt! { MULTILINESTRING ZM ((30 10 40 300, 10 30 40 300, 40 40 80 1600)) }.into()),
+            Some(wkt! { MULTIPOLYGON ZM (((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300))) }.into()),
+            Some(wkt! { GEOMETRYCOLLECTION ZM (POINT ZM (30 10 40 300), LINESTRING ZM (30 10 40 300, 10 30 40 300, 40 40 80 1600), POLYGON ZM ((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300)), MULTIPOINT ZM (30 10 40 300), MULTILINESTRING ZM ((30 10 40 300, 10 30 40 300, 40 40 80 1600)), MULTIPOLYGON ZM (((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300)))) }.into() ),
+            None,
+            Some(wkt! { GEOMETRYCOLLECTION ZM EMPTY }.into()),
+        ]
+    }
+}

--- a/rust/geoarrow-test/src/raw/geometrycollection.rs
+++ b/rust/geoarrow-test/src/raw/geometrycollection.rs
@@ -1,0 +1,109 @@
+use wkt::wkt;
+
+pub mod xy {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::GeometryCollection<i32>>> {
+        vec![
+            Some(wkt! { GEOMETRYCOLLECTION (POINT (30 10)) }),
+            Some(wkt! { GEOMETRYCOLLECTION (LINESTRING (30 10, 10 30, 40 40)) }),
+            Some(wkt! { GEOMETRYCOLLECTION (POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))) }),
+            Some(wkt! { GEOMETRYCOLLECTION (MULTIPOINT (30 10)) }),
+            Some(wkt! { GEOMETRYCOLLECTION (MULTILINESTRING ((30 10, 10 30, 40 40))) }),
+            Some(
+                wkt! { GEOMETRYCOLLECTION (MULTIPOLYGON (((30 10, 40 40, 20 40, 10 20, 30 10)))) },
+            ),
+            Some(
+                wkt! { GEOMETRYCOLLECTION (POINT (30 10), LINESTRING (30 10, 10 30, 40 40), POLYGON ((30
+                10, 40 40, 20 40, 10 20, 30 10)), MULTIPOINT (30 10), MULTILINESTRING ((30 10,
+                10 30, 40 40)), MULTIPOLYGON (((30 10, 40 40, 20 40, 10 20, 30 10)))) },
+            ),
+            None,
+            Some(wkt! { GEOMETRYCOLLECTION EMPTY }),
+        ]
+    }
+}
+
+pub mod xyz {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::GeometryCollection<i32>>> {
+        vec![
+            Some(wkt! { GEOMETRYCOLLECTION Z (POINT Z (30 10 40)) }),
+            Some(wkt! { GEOMETRYCOLLECTION Z (LINESTRING Z (30 10 40, 10 30 40, 40 40 80)) }),
+            Some(
+                wkt! { GEOMETRYCOLLECTION Z (POLYGON Z ((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40))) },
+            ),
+            Some(wkt! { GEOMETRYCOLLECTION Z (MULTIPOINT Z (30 10 40)) }),
+            Some(
+                wkt! { GEOMETRYCOLLECTION Z (MULTILINESTRING Z ((30 10 40, 10 30 40, 40 40 80))) },
+            ),
+            Some(
+                wkt! { GEOMETRYCOLLECTION Z (MULTIPOLYGON Z (((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)))) },
+            ),
+            Some(
+                wkt! { GEOMETRYCOLLECTION Z (POINT Z (30 10 40), LINESTRING Z (30 10 40, 10 30 40, 40 40 80), POLYGON Z ((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)), MULTIPOINT Z (30 10 40), MULTILINESTRING Z ((30 10 40, 10 30 40, 40 40 80)), MULTIPOLYGON Z (((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)))) },
+            ),
+            None,
+            Some(wkt! { GEOMETRYCOLLECTION Z EMPTY }),
+        ]
+    }
+}
+
+pub mod xym {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::GeometryCollection<i32>>> {
+        vec![
+            Some(wkt! { GEOMETRYCOLLECTION M (POINT M (30 10 300)) }),
+            Some(wkt! { GEOMETRYCOLLECTION M (LINESTRING M (30 10 300, 10 30 300, 40 40 1600)) }),
+            Some(
+                wkt! { GEOMETRYCOLLECTION M (POLYGON M ((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300))) },
+            ),
+            Some(wkt! { GEOMETRYCOLLECTION M (MULTIPOINT M (30 10 300)) }),
+            Some(
+                wkt! { GEOMETRYCOLLECTION M (MULTILINESTRING M ((30 10 300, 10 30 300, 40 40 1600))) },
+            ),
+            Some(
+                wkt! { GEOMETRYCOLLECTION M (MULTIPOLYGON M (((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)))) },
+            ),
+            Some(
+                wkt! { GEOMETRYCOLLECTION M (POINT M (30 10 300), LINESTRING M (30 10 300, 10 30 300, 40 40 1600), POLYGON M ((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)), MULTIPOINT M (30 10 300), MULTILINESTRING M ((30 10 300, 10 30 300, 40 40 1600)), MULTIPOLYGON M (((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)))) },
+            ),
+            None,
+            Some(wkt! { GEOMETRYCOLLECTION M EMPTY }),
+        ]
+    }
+}
+
+pub mod xyzm {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::GeometryCollection<i32>>> {
+        vec![
+            Some(wkt! { GEOMETRYCOLLECTION ZM (POINT ZM (30 10 40 300)) }),
+            Some(
+                wkt! { GEOMETRYCOLLECTION ZM (LINESTRING ZM (30 10 40 300, 10 30 40 300, 40 40 80 1600)) },
+            ),
+            Some(
+                wkt! { GEOMETRYCOLLECTION ZM (POLYGON ZM ((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300))) },
+            ),
+            Some(wkt! { GEOMETRYCOLLECTION ZM (MULTIPOINT ZM (30 10 40 300)) }),
+            Some(
+                wkt! { GEOMETRYCOLLECTION ZM (MULTILINESTRING ZM ((30 10 40 300, 10 30 40 300, 40 40 80 1600))) },
+            ),
+            Some(
+                wkt! { GEOMETRYCOLLECTION ZM (MULTIPOLYGON ZM (((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300)))) },
+            ),
+            Some(
+                wkt! { GEOMETRYCOLLECTION ZM (POINT ZM (30 10 40 300), LINESTRING ZM (30 10 40 300, 10
+                30 40 300, 40 40 80 1600), POLYGON ZM ((30 10 40 300, 40 40 80 1600, 20 40 60 800,
+                10 20 30 200, 30 10 40 300)), MULTIPOINT ZM (30 10 40 300), MULTILINESTRING ZM
+                ((30 10 40 300, 10 30 40 300, 40 40 80 1600)), MULTIPOLYGON ZM (((30 10 40 300,
+                40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300)))) },
+            ),
+            None,
+            Some(wkt! { GEOMETRYCOLLECTION ZM EMPTY }),
+        ]
+    }
+}

--- a/rust/geoarrow-test/src/raw/linestring.rs
+++ b/rust/geoarrow-test/src/raw/linestring.rs
@@ -1,0 +1,53 @@
+use wkt::wkt;
+
+pub mod xy {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::LineString<i32>>> {
+        vec![
+            Some(wkt! { LINESTRING (30 10, 10 30, 40 40) }),
+            Some(wkt! { LINESTRING (40 20, 20 40, 50 50) }),
+            None,
+            Some(wkt! { LINESTRING EMPTY }),
+        ]
+    }
+}
+
+pub mod xyz {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::LineString<i32>>> {
+        vec![
+            Some(wkt! { LINESTRING Z (30 10 40, 10 30 40, 40 40 80) }),
+            Some(wkt! { LINESTRING Z (40 20 60, 20 40 60, 50 50 100) }),
+            None,
+            Some(wkt! { LINESTRING Z EMPTY }),
+        ]
+    }
+}
+
+pub mod xym {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::LineString<i32>>> {
+        vec![
+            Some(wkt! { LINESTRING M (30 10 300, 10 30 300, 40 40 1600) }),
+            Some(wkt! { LINESTRING M (40 20 800, 20 40 800, 50 50 2500) }),
+            None,
+            Some(wkt! { LINESTRING M EMPTY }),
+        ]
+    }
+}
+
+pub mod xyzm {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::LineString<i32>>> {
+        vec![
+            Some(wkt! { LINESTRING ZM (30 10 40 300, 10 30 40 300, 40 40 80 1600) }),
+            Some(wkt! { LINESTRING ZM (40 20 60 800, 20 40 60 800, 50 50 100 2500) }),
+            None,
+            Some(wkt! { LINESTRING ZM EMPTY }),
+        ]
+    }
+}

--- a/rust/geoarrow-test/src/raw/mod.rs
+++ b/rust/geoarrow-test/src/raw/mod.rs
@@ -1,0 +1,13 @@
+//! Raw test data, copied from geoarrow-data
+//!
+//! - https://github.com/geoarrow/geoarrow-data/blob/3feaaa0b56758e2b5d7afc1c44c6555cb589d295/example/example_src.yaml
+//! - https://github.com/geoarrow/geoarrow-data/blob/3feaaa0b56758e2b5d7afc1c44c6555cb589d295/example/example_src_generated.yaml
+
+pub(crate) mod geometry;
+pub(crate) mod geometrycollection;
+pub(crate) mod linestring;
+pub(crate) mod multilinestring;
+pub(crate) mod multipoint;
+pub(crate) mod multipolygon;
+pub(crate) mod point;
+pub(crate) mod polygon;

--- a/rust/geoarrow-test/src/raw/multilinestring.rs
+++ b/rust/geoarrow-test/src/raw/multilinestring.rs
@@ -1,0 +1,59 @@
+use wkt::wkt;
+
+pub mod xy {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiLineString<i32>>> {
+        vec![
+            Some(wkt! { MULTILINESTRING ((30 10, 10 30, 40 40)) }),
+            Some(wkt! { MULTILINESTRING ((10 10, 20 20, 10 40), (40 40, 30 30, 40 20, 30 10)) }),
+            None,
+            Some(wkt! { MULTILINESTRING EMPTY }),
+        ]
+    }
+}
+
+pub mod xyz {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiLineString<i32>>> {
+        vec![
+            Some(wkt! { MULTILINESTRING Z ((30 10 40, 10 30 40, 40 40 80)) }),
+            Some(
+                wkt! { MULTILINESTRING Z ((10 10 20, 20 20 40, 10 40 50), (40 40 80, 30 30 60, 40 20 60, 30 10 40)) },
+            ),
+            None,
+            Some(wkt! { MULTILINESTRING Z EMPTY }),
+        ]
+    }
+}
+
+pub mod xym {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiLineString<i32>>> {
+        vec![
+            Some(wkt! { MULTILINESTRING M ((30 10 300, 10 30 300, 40 40 1600)) }),
+            Some(
+                wkt! { MULTILINESTRING M ((10 10 100, 20 20 400, 10 40 400), (40 40 1600, 30 30 900, 40 20 800, 30 10 300)) },
+            ),
+            None,
+            Some(wkt! { MULTILINESTRING M EMPTY }),
+        ]
+    }
+}
+
+pub mod xyzm {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiLineString<i32>>> {
+        vec![
+            Some(wkt! { MULTILINESTRING ZM ((30 10 40 300, 10 30 40 300, 40 40 80 1600)) }),
+            Some(
+                wkt! { MULTILINESTRING ZM ((10 10 20 100, 20 20 40 400, 10 40 50 400), (40 40 80 1600, 30 30 60 900, 40 20 60 800, 30 10 40 300)) },
+            ),
+            None,
+            Some(wkt! { MULTILINESTRING ZM EMPTY }),
+        ]
+    }
+}

--- a/rust/geoarrow-test/src/raw/multipoint.rs
+++ b/rust/geoarrow-test/src/raw/multipoint.rs
@@ -1,0 +1,53 @@
+use wkt::wkt;
+
+pub mod xy {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiPoint<i32>>> {
+        vec![
+            Some(wkt! { MULTIPOINT (30 10) }),
+            Some(wkt! { MULTIPOINT (10 40, 40 30, 20 20, 30 10) }),
+            None,
+            Some(wkt! { MULTIPOINT EMPTY }),
+        ]
+    }
+}
+
+pub mod xyz {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiPoint<i32>>> {
+        vec![
+            Some(wkt! { MULTIPOINT Z (30 10 40) }),
+            Some(wkt! { MULTIPOINT Z (10 40 50, 40 30 70, 20 20 40, 30 10 40) }),
+            None,
+            Some(wkt! { MULTIPOINT Z EMPTY }),
+        ]
+    }
+}
+
+pub mod xym {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiPoint<i32>>> {
+        vec![
+            Some(wkt! { MULTIPOINT M (30 10 300) }),
+            Some(wkt! { MULTIPOINT M (10 40 400, 40 30 1200, 20 20 400, 30 10 300) }),
+            None,
+            Some(wkt! { MULTIPOINT M EMPTY }),
+        ]
+    }
+}
+
+pub mod xyzm {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiPoint<i32>>> {
+        vec![
+            Some(wkt! { MULTIPOINT ZM (30 10 40 300) }),
+            Some(wkt! { MULTIPOINT ZM (10 40 50 400, 40 30 70 1200, 20 20 40 400, 30 10 40 300) }),
+            None,
+            Some(wkt! { MULTIPOINT ZM EMPTY }),
+        ]
+    }
+}

--- a/rust/geoarrow-test/src/raw/multipolygon.rs
+++ b/rust/geoarrow-test/src/raw/multipolygon.rs
@@ -1,0 +1,77 @@
+use wkt::wkt;
+
+pub mod xy {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiPolygon<i32>>> {
+        vec![
+            Some(wkt! { MULTIPOLYGON (((30 10, 40 40, 20 40, 10 20, 30 10))) }),
+            Some(
+                wkt! { MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5))) },
+            ),
+            Some(
+                wkt! { MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20))) },
+            ),
+            None,
+            Some(wkt! { MULTIPOLYGON EMPTY }),
+        ]
+    }
+}
+
+pub mod xyz {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiPolygon<i32>>> {
+        vec![
+            Some(wkt! { MULTIPOLYGON Z (((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40))) }),
+            Some(
+                wkt! { MULTIPOLYGON Z (((30 20 50, 45 40 85, 10 40 50, 30 20 50)), ((15 5 20, 40 10 50, 10 20 30, 5 10 15, 15 5 20))) },
+            ),
+            Some(
+                wkt! { MULTIPOLYGON Z (((40 40 80, 20 45 65, 45 30 75, 40 40 80)), ((20 35 55, 10 30 40, 10 10 20, 30 5 35, 45 20 65, 20 35 55), (30 20 50, 20 15 35, 20 25 45, 30 20 50))) },
+            ),
+            None,
+            Some(wkt! { MULTIPOLYGON Z EMPTY }),
+        ]
+    }
+}
+
+pub mod xym {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiPolygon<i32>>> {
+        vec![
+            Some(
+                wkt! { MULTIPOLYGON M (((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300))) },
+            ),
+            Some(
+                wkt! { MULTIPOLYGON M (((30 20 600, 45 40 1800, 10 40 400, 30 20 600)), ((15 5 75, 40 10 400, 10 20 200, 5 10 50, 15 5 75))) },
+            ),
+            Some(
+                wkt! { MULTIPOLYGON M (((40 40 1600, 20 45 900, 45 30 1350, 40 40 1600)), ((20 35 700, 10 30 300, 10 10 100, 30 5 150, 45 20 900, 20 35 700), (30 20 600, 20 15 300, 20 25 500, 30 20 600))) },
+            ),
+            None,
+            Some(wkt! { MULTIPOLYGON M EMPTY }),
+        ]
+    }
+}
+
+pub mod xyzm {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::MultiPolygon<i32>>> {
+        vec![
+            Some(
+                wkt! { MULTIPOLYGON ZM (((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300))) },
+            ),
+            Some(
+                wkt! { MULTIPOLYGON ZM (((30 20 50 600, 45 40 85 1800, 10 40 50 400, 30 20 50 600)), ((15 5 20 75, 40 10 50 400, 10 20 30 200, 5 10 15 50, 15 5 20 75))) },
+            ),
+            Some(
+                wkt! { MULTIPOLYGON ZM (((40 40 80 1600, 20 45 65 900, 45 30 75 1350, 40 40 80 1600)), ((20 35 55 700, 10 30 40 300, 10 10 20 100, 30 5 35 150, 45 20 65 900, 20 35 55 700), (30 20 50 600, 20 15 35 300, 20 25 45 500, 30 20 50 600))) },
+            ),
+            None,
+            Some(wkt! { MULTIPOLYGON ZM EMPTY }),
+        ]
+    }
+}

--- a/rust/geoarrow-test/src/raw/point.rs
+++ b/rust/geoarrow-test/src/raw/point.rs
@@ -1,0 +1,53 @@
+use wkt::wkt;
+
+pub mod xy {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::Point<i32>>> {
+        vec![
+            Some(wkt! { POINT (30 10) }),
+            Some(wkt! { POINT (40 20) }),
+            None,
+            Some(wkt! { POINT EMPTY }),
+        ]
+    }
+}
+
+pub mod xyz {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::Point<i32>>> {
+        vec![
+            Some(wkt! { POINT Z (30 10 40) }),
+            Some(wkt! { POINT Z (40 20 60) }),
+            None,
+            Some(wkt! { POINT Z EMPTY }),
+        ]
+    }
+}
+
+pub mod xym {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::Point<i32>>> {
+        vec![
+            Some(wkt! { POINT M (30 10 300) }),
+            Some(wkt! { POINT M (40 20 800) }),
+            None,
+            Some(wkt! { POINT M EMPTY }),
+        ]
+    }
+}
+
+pub mod xyzm {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::Point<i32>>> {
+        vec![
+            Some(wkt! { POINT ZM (30 10 40 300) }),
+            Some(wkt! { POINT ZM (40 20 60 800) }),
+            None,
+            Some(wkt! { POINT ZM EMPTY }),
+        ]
+    }
+}

--- a/rust/geoarrow-test/src/raw/polygon.rs
+++ b/rust/geoarrow-test/src/raw/polygon.rs
@@ -1,0 +1,64 @@
+use wkt::wkt;
+
+pub mod xy {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::Polygon<i32>>> {
+        vec![
+            Some(wkt! { POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10)) }),
+            Some(
+                wkt! { POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30)) },
+            ),
+            None,
+            Some(wkt! { POLYGON EMPTY }),
+        ]
+    }
+}
+
+pub mod xyz {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::Polygon<i32>>> {
+        vec![
+            Some(wkt! { POLYGON Z ((30 10 40, 40 40 80, 20 40 60, 10 20 30, 30 10 40)) }),
+            Some(
+                wkt! { POLYGON Z ((35 10 45, 45 45 90, 15 40 55, 10 20 30, 35 10 45), (20 30 50, 35 35 70, 30 20 50, 20 30 50)) },
+            ),
+            None,
+            Some(wkt! { POLYGON Z EMPTY }),
+        ]
+    }
+}
+
+pub mod xym {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::Polygon<i32>>> {
+        vec![
+            Some(wkt! { POLYGON M ((30 10 300, 40 40 1600, 20 40 800, 10 20 200, 30 10 300)) }),
+            Some(
+                wkt! { POLYGON M ((35 10 350, 45 45 2025, 15 40 600, 10 20 200, 35 10 350), (20 30 600,
+                35 35 1225, 30 20 600, 20 30 600)) },
+            ),
+            None,
+            Some(wkt! { POLYGON M EMPTY }),
+        ]
+    }
+}
+
+pub mod xyzm {
+    use super::*;
+
+    pub fn geoms() -> Vec<Option<wkt::types::Polygon<i32>>> {
+        vec![
+            Some(
+                wkt! { POLYGON ZM ((30 10 40 300, 40 40 80 1600, 20 40 60 800, 10 20 30 200, 30 10 40 300)) },
+            ),
+            Some(
+                wkt! { POLYGON ZM ((35 10 45 350, 45 45 90 2025, 15 40 55 600, 10 20 30 200, 35 10 45 350), (20 30 50 600, 35 35 70 1225, 30 20 50 600, 20 30 50 600)) },
+            ),
+            None,
+            Some(wkt! { POLYGON ZM EMPTY }),
+        ]
+    }
+}


### PR DESCRIPTION
### Change list

- Includes copied in data from https://github.com/geoarrow/geoarrow-data/blob/3feaaa0b56758e2b5d7afc1c44c6555cb589d295/example/example_src.yaml and https://github.com/geoarrow/geoarrow-data/blob/3feaaa0b56758e2b5d7afc1c44c6555cb589d295/example/example_src_generated.yaml. By copying in the data, we can pass the WKT strings to the `wkt!` macro (https://github.com/georust/wkt/pull/137)
- It includes all geometry types except for `geometrycollection-nested`, which we leave for the future.
- This PR just defines the test data; it doesn't add it to any tests yet.

cc @paleolimbot 