### PR TITLE
Add functions to change coordinate type of a geometry array

### DIFF
--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -4,7 +4,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
-use geoarrow_schema::{GeometryCollectionType, Metadata};
+use geoarrow_schema::{CoordType, GeometryCollectionType, Metadata};
 
 use crate::array::{MixedGeometryArray, WkbArray};
 use crate::builder::GeometryCollectionBuilder;
@@ -75,19 +75,9 @@ impl GeometryCollectionArray {
     /// Slices this [`GeometryCollectionArray`] in place.
     ///
     /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
-    /// # Examples
-    /// ```ignore
-    /// use arrow::array::PrimitiveArray;
-    /// use arrow_array::types::Int32Type;
     ///
-    /// let array: PrimitiveArray<Int32Type> = PrimitiveArray::from(vec![1, 2, 3]);
-    /// assert_eq!(format!("{:?}", array), "PrimitiveArray<Int32>\n[\n  1,\n  2,\n  3,\n]");
-    /// let sliced = array.slice(1, 1);
-    /// assert_eq!(format!("{:?}", sliced), "PrimitiveArray<Int32>\n[\n  2,\n]");
+    /// This operation is `O(1)` as it amounts to increasing a few ref counts.
     ///
-    /// // note: `sliced` and `array` share the same memory region.
-    /// ```ignore
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
@@ -103,6 +93,17 @@ impl GeometryCollectionArray {
             geom_offsets: self.geom_offsets.slice(offset, length),
             validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
         }
+    }
+
+    /// Change the [`CoordType`] of this array.
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        let metadata = self.data_type.metadata().clone();
+        Self::new(
+            self.array.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.validity,
+            metadata,
+        )
     }
 }
 

--- a/rust/geoarrow-array/src/array/mixed.rs
+++ b/rust/geoarrow-array/src/array/mixed.rs
@@ -429,6 +429,21 @@ impl MixedGeometryArray {
         }
     }
 
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        let metadata = self.metadata;
+        Self::new(
+            self.type_ids,
+            self.offsets,
+            Some(self.points.into_coord_type(coord_type)),
+            Some(self.line_strings.into_coord_type(coord_type)),
+            Some(self.polygons.into_coord_type(coord_type)),
+            Some(self.multi_points.into_coord_type(coord_type)),
+            Some(self.multi_line_strings.into_coord_type(coord_type)),
+            Some(self.multi_polygons.into_coord_type(coord_type)),
+            metadata,
+        )
+    }
+
     pub fn contained_types(&self) -> HashSet<GeoArrowType> {
         let mut types = HashSet::new();
         if self.has_points() {

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -4,7 +4,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
-use geoarrow_schema::{Metadata, MultiLineStringType};
+use geoarrow_schema::{CoordType, Metadata, MultiLineStringType};
 
 use crate::array::{CoordBuffer, LineStringArray, WkbArray};
 use crate::builder::MultiLineStringBuilder;
@@ -174,6 +174,18 @@ impl MultiLineStringArray {
             ring_offsets: self.ring_offsets.clone(),
             validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
         }
+    }
+
+    /// Change the [`CoordType`] of this array.
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        let metadata = self.data_type.metadata().clone();
+        Self::new(
+            self.coords.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.ring_offsets,
+            self.validity,
+            metadata,
+        )
     }
 }
 

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -4,7 +4,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
-use geoarrow_schema::{Metadata, MultiPointType};
+use geoarrow_schema::{CoordType, Metadata, MultiPointType};
 
 use crate::array::{CoordBuffer, LineStringArray, PointArray, WkbArray};
 use crate::builder::MultiPointBuilder;
@@ -129,20 +129,13 @@ impl MultiPointArray {
     }
 
     /// Slices this [`MultiPointArray`] in place.
-    /// # Implementation
-    /// This operation is `O(1)` as it amounts to increase two ref counts.
-    /// # Examples
-    /// ```ignore
-    /// use arrow::array::PrimitiveArray;
-    /// use arrow_array::types::Int32Type;
     ///
-    /// let array: PrimitiveArray<Int32Type> = PrimitiveArray::from(vec![1, 2, 3]);
-    /// assert_eq!(format!("{:?}", array), "PrimitiveArray<Int32>\n[\n  1,\n  2,\n  3,\n]");
-    /// let sliced = array.slice(1, 1);
-    /// assert_eq!(format!("{:?}", sliced), "PrimitiveArray<Int32>\n[\n  2,\n]");
-    /// // note: `sliced` and `array` share the same memory region.
-    /// ```
+    /// # Implementation
+    ///
+    /// This operation is `O(1)` as it amounts to increasing a few ref counts.
+    ///
     /// # Panic
+    ///
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
@@ -158,6 +151,17 @@ impl MultiPointArray {
             geom_offsets: self.geom_offsets.slice(offset, length),
             validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
         }
+    }
+
+    /// Change the [`CoordType`] of this array.
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        let metadata = self.data_type.metadata().clone();
+        Self::new(
+            self.coords.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.validity,
+            metadata,
+        )
     }
 }
 

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -4,7 +4,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
-use geoarrow_schema::{Metadata, MultiPolygonType};
+use geoarrow_schema::{CoordType, Metadata, MultiPolygonType};
 
 use crate::array::{CoordBuffer, PolygonArray, WkbArray};
 use crate::builder::MultiPolygonBuilder;
@@ -227,6 +227,19 @@ impl MultiPolygonArray {
             ring_offsets: self.ring_offsets.clone(),
             validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
         }
+    }
+
+    /// Change the [`CoordType`] of this array.
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        let metadata = self.data_type.metadata().clone();
+        Self::new(
+            self.coords.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.polygon_offsets,
+            self.ring_offsets,
+            self.validity,
+            metadata,
+        )
     }
 }
 

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -179,6 +179,18 @@ impl PolygonArray {
             validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
         }
     }
+
+    /// Change the [`CoordType`] of this array.
+    pub fn into_coord_type(self, coord_type: CoordType) -> Self {
+        let metadata = self.data_type.metadata().clone();
+        Self::new(
+            self.coords.into_coord_type(coord_type),
+            self.geom_offsets,
+            self.ring_offsets,
+            self.validity,
+            metadata,
+        )
+    }
 }
 
 impl GeoArrowArray for PolygonArray {


### PR DESCRIPTION
### Change list

- Add `into_coord_type` to all native geoarrow array types that can have multiple coordinate types (excluding Rect, Wkt, Wkb)

For https://github.com/geoarrow/geoarrow-rs/pull/1024