### PR TITLE
Finish title-casing WKB-related concepts

### DIFF
--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -17,7 +17,7 @@ use crate::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 
 /// An immutable array of WKB geometries.
 ///
-/// This is semantically equivalent to `Vec<Option<WKB>>` due to the internal validity bitmap.
+/// This is semantically equivalent to `Vec<Option<Wkb>>` due to the internal validity bitmap.
 ///
 /// This array implements [`SerializedArray`], not [`NativeArray`]. This means that you'll need to
 /// parse the `WkbArray` into a native-typed GeoArrow array (such as

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -230,13 +230,13 @@ impl TryFrom<WkbArray<i64>> for WkbArray<i32> {
 #[cfg(test)]
 mod test {
     use crate::GeoArrowArray;
-    use crate::builder::WKBBuilder;
+    use crate::builder::WkbBuilder;
     use crate::test::point;
 
     use super::*;
 
     fn wkb_data<O: OffsetSizeTrait>() -> WkbArray<O> {
-        let mut builder = WKBBuilder::new(WkbType::new(Default::default()));
+        let mut builder = WkbBuilder::new(WkbType::new(Default::default()));
         builder.push_point(Some(&point::p0()));
         builder.push_point(Some(&point::p1()));
         builder.push_point(Some(&point::p2()));

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -9,7 +9,7 @@ use arrow_schema::{DataType, Field};
 use geoarrow_schema::{Metadata, WkbType};
 use wkb::reader::Wkb;
 
-use crate::capacity::WKBCapacity;
+use crate::capacity::WkbCapacity;
 use crate::datatypes::GeoArrowType;
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
@@ -46,8 +46,8 @@ impl<O: OffsetSizeTrait> WkbArray<O> {
     }
 
     /// The lengths of each buffer contained in this array.
-    pub fn buffer_lengths(&self) -> WKBCapacity {
-        WKBCapacity::new(
+    pub fn buffer_lengths(&self) -> WkbCapacity {
+        WkbCapacity::new(
             self.array.offsets().last().unwrap().to_usize().unwrap(),
             self.len(),
         )

--- a/rust/geoarrow-array/src/builder/mod.rs
+++ b/rust/geoarrow-array/src/builder/mod.rs
@@ -26,4 +26,4 @@ pub(crate) use offsets::OffsetsBuilder;
 pub use point::PointBuilder;
 pub use polygon::PolygonBuilder;
 pub use rect::RectBuilder;
-pub use wkb::WKBBuilder;
+pub use wkb::WkbBuilder;

--- a/rust/geoarrow-array/src/builder/wkb.rs
+++ b/rust/geoarrow-array/src/builder/wkb.rs
@@ -12,7 +12,7 @@ use wkb::writer::{
 };
 
 use crate::array::WkbArray;
-use crate::capacity::WKBCapacity;
+use crate::capacity::WkbCapacity;
 
 /// The GeoArrow equivalent to `Vec<Option<WKB>>`: a mutable collection of WKB buffers.
 ///
@@ -27,7 +27,7 @@ impl<O: OffsetSizeTrait> WKBBuilder<O> {
     }
 
     /// Initializes a new [`WKBBuilder`] with a pre-allocated capacity of slots and values.
-    pub fn with_capacity(typ: WkbType, capacity: WKBCapacity) -> Self {
+    pub fn with_capacity(typ: WkbType, capacity: WkbCapacity) -> Self {
         Self(
             GenericBinaryBuilder::with_capacity(
                 capacity.offsets_capacity,
@@ -43,13 +43,13 @@ impl<O: OffsetSizeTrait> WKBBuilder<O> {
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = f64> + 'a)>>,
         typ: WkbType,
     ) -> Self {
-        let counter = WKBCapacity::from_geometries(geoms);
+        let counter = WkbCapacity::from_geometries(geoms);
         Self::with_capacity(typ, counter)
     }
 
     // Upstream APIs don't exist for this yet. To implement this without upstream changes, we could
     // change to using manual `Vec`'s ourselves
-    // pub fn reserve(&mut self, capacity: WKBCapacity) {
+    // pub fn reserve(&mut self, capacity: WkbCapacity) {
     // }
 
     /// Push a Point onto the end of this builder

--- a/rust/geoarrow-array/src/builder/wkb.rs
+++ b/rust/geoarrow-array/src/builder/wkb.rs
@@ -16,17 +16,17 @@ use crate::capacity::WkbCapacity;
 
 /// The GeoArrow equivalent to `Vec<Option<WKB>>`: a mutable collection of WKB buffers.
 ///
-/// Converting a [`WKBBuilder`] into a [`WkbArray`] is `O(1)`.
+/// Converting a [`WkbBuilder`] into a [`WkbArray`] is `O(1)`.
 #[derive(Debug)]
-pub struct WKBBuilder<O: OffsetSizeTrait>(GenericBinaryBuilder<O>, WkbType);
+pub struct WkbBuilder<O: OffsetSizeTrait>(GenericBinaryBuilder<O>, WkbType);
 
-impl<O: OffsetSizeTrait> WKBBuilder<O> {
-    /// Creates a new empty [`WKBBuilder`].
+impl<O: OffsetSizeTrait> WkbBuilder<O> {
+    /// Creates a new empty [`WkbBuilder`].
     pub fn new(typ: WkbType) -> Self {
         Self::with_capacity(typ, Default::default())
     }
 
-    /// Initializes a new [`WKBBuilder`] with a pre-allocated capacity of slots and values.
+    /// Initializes a new [`WkbBuilder`] with a pre-allocated capacity of slots and values.
     pub fn with_capacity(typ: WkbType, capacity: WkbCapacity) -> Self {
         Self(
             GenericBinaryBuilder::with_capacity(
@@ -37,7 +37,7 @@ impl<O: OffsetSizeTrait> WKBBuilder<O> {
         )
     }
 
-    /// Creates a new empty [`WKBBuilder`] with a capacity inferred by the provided geometry
+    /// Creates a new empty [`WkbBuilder`] with a capacity inferred by the provided geometry
     /// iterator.
     pub fn with_capacity_from_iter<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = f64> + 'a)>>,

--- a/rust/geoarrow-array/src/builder/wkb.rs
+++ b/rust/geoarrow-array/src/builder/wkb.rs
@@ -14,7 +14,7 @@ use wkb::writer::{
 use crate::array::WkbArray;
 use crate::capacity::WkbCapacity;
 
-/// The GeoArrow equivalent to `Vec<Option<WKB>>`: a mutable collection of WKB buffers.
+/// The GeoArrow equivalent to `Vec<Option<Wkb>>`: a mutable collection of Wkb buffers.
 ///
 /// Converting a [`WkbBuilder`] into a [`WkbArray`] is `O(1)`.
 #[derive(Debug)]

--- a/rust/geoarrow-array/src/capacity/mod.rs
+++ b/rust/geoarrow-array/src/capacity/mod.rs
@@ -31,4 +31,4 @@ pub use multipoint::MultiPointCapacity;
 pub use multipolygon::MultiPolygonCapacity;
 pub use point::PointCapacity;
 pub use polygon::PolygonCapacity;
-pub use wkb::WKBCapacity;
+pub use wkb::WkbCapacity;

--- a/rust/geoarrow-array/src/capacity/wkb.rs
+++ b/rust/geoarrow-array/src/capacity/wkb.rs
@@ -15,12 +15,12 @@ use wkb::writer::{
 ///
 /// This can be used to reduce allocations by allocating once for exactly the array size you need.
 #[derive(Debug, Clone, Copy)]
-pub struct WKBCapacity {
+pub struct WkbCapacity {
     pub(crate) buffer_capacity: usize,
     pub(crate) offsets_capacity: usize,
 }
 
-impl WKBCapacity {
+impl WkbCapacity {
     /// Create a new capacity with known sizes.
     pub fn new(buffer_capacity: usize, offsets_capacity: usize) -> Self {
         Self {
@@ -244,13 +244,13 @@ impl WKBCapacity {
     }
 }
 
-impl Default for WKBCapacity {
+impl Default for WkbCapacity {
     fn default() -> Self {
         Self::new_empty()
     }
 }
 
-impl Add for WKBCapacity {
+impl Add for WkbCapacity {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -389,7 +389,7 @@ mod test {
     use geoarrow_schema::WkbType;
 
     use crate::array::WkbArray;
-    use crate::builder::WKBBuilder;
+    use crate::builder::WkbBuilder;
     use crate::error::Result;
     use crate::{ArrayAccessor, GeoArrowArray};
 
@@ -408,6 +408,6 @@ mod test {
             .collect::<std::result::Result<Vec<_>, _>>()
             .unwrap();
         let wkb_type = WkbType::new(Default::default());
-        Ok(WKBBuilder::from_nullable_geometries(geoms.as_slice(), wkb_type).finish())
+        Ok(WkbBuilder::from_nullable_geometries(geoms.as_slice(), wkb_type).finish())
     }
 }

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -22,58 +22,43 @@ use crate::error::{GeoArrowError, Result};
 /// This type uniquely identifies the physical buffer layout of each geometry array type.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum GeoArrowType {
-    /// Represents a [PointArray][crate::array::PointArray] or
-    /// [ChunkedPointArray][crate::chunked_array::ChunkedPointArray].
+    /// Represents a [PointArray][crate::array::PointArray].
     Point(PointType),
 
-    /// Represents a [LineStringArray][crate::array::LineStringArray] or
-    /// [ChunkedLineStringArray][crate::chunked_array::ChunkedLineStringArray] with `i32` offsets.
+    /// Represents a [LineStringArray][crate::array::LineStringArray].
     LineString(LineStringType),
 
-    /// Represents a [PolygonArray][crate::array::PolygonArray] or
-    /// [ChunkedPolygonArray][crate::chunked_array::ChunkedPolygonArray] with `i32` offsets.
+    /// Represents a [PolygonArray][crate::array::PolygonArray].
     Polygon(PolygonType),
 
-    /// Represents a [MultiPointArray][crate::array::MultiPointArray] or
-    /// [ChunkedMultiPointArray][crate::chunked_array::ChunkedMultiPointArray] with `i32` offsets.
+    /// Represents a [MultiPointArray][crate::array::MultiPointArray].
     MultiPoint(MultiPointType),
 
-    /// Represents a [MultiLineStringArray][crate::array::MultiLineStringArray] or
-    /// [ChunkedMultiLineStringArray][crate::chunked_array::ChunkedMultiLineStringArray] with `i32`
-    /// offsets.
+    /// Represents a [MultiLineStringArray][crate::array::MultiLineStringArray].
     MultiLineString(MultiLineStringType),
 
-    /// Represents a [MultiPolygonArray][crate::array::MultiPolygonArray] or
-    /// [ChunkedMultiPolygonArray][crate::chunked_array::ChunkedMultiPolygonArray] with `i32`
-    /// offsets.
+    /// Represents a [MultiPolygonArray][crate::array::MultiPolygonArray].
     MultiPolygon(MultiPolygonType),
 
-    /// Represents a [GeometryCollectionArray][crate::array::GeometryCollectionArray] or
-    /// [ChunkedGeometryCollectionArray][crate::chunked_array::ChunkedGeometryCollectionArray] with
-    /// `i32` offsets.
+    /// Represents a [GeometryCollectionArray][crate::array::GeometryCollectionArray].
     GeometryCollection(GeometryCollectionType),
 
-    /// Represents a [RectArray][crate::array::RectArray] or
-    /// [ChunkedRectArray][crate::chunked_array::ChunkedRectArray].
+    /// Represents a [RectArray][crate::array::RectArray].
     Rect(BoxType),
 
     /// Represents a mixed geometry array of unknown types or dimensions
     Geometry(GeometryType),
 
-    /// Represents a [WkbArray][crate::array::WkbArray] or
-    /// [ChunkedWKBArray][crate::chunked_array::ChunkedWKBArray] with `i32` offsets.
+    /// Represents a [WkbArray][crate::array::WkbArray] with `i32` offsets.
     Wkb(WkbType),
 
-    /// Represents a [WkbArray][crate::array::WkbArray] or
-    /// [ChunkedWKBArray][crate::chunked_array::ChunkedWKBArray] with `i64` offsets.
+    /// Represents a [WkbArray][crate::array::WkbArray] with `i64` offsets.
     LargeWkb(WkbType),
 
-    /// Represents a [WktArray][crate::array::WktArray] or
-    /// [ChunkedWKTArray][crate::chunked_array::ChunkedWKTArray] with `i32` offsets.
+    /// Represents a [WktArray][crate::array::WktArray] with `i32` offsets.
     Wkt(WktType),
 
-    /// Represents a [WktArray][crate::array::WktArray] or
-    /// [ChunkedWKTArray][crate::chunked_array::ChunkedWKTArray] with `i64` offsets.
+    /// Represents a [WktArray][crate::array::WktArray] with `i64` offsets.
     LargeWkt(WktType),
 }
 


### PR DESCRIPTION
Follow up from https://github.com/geoarrow/geoarrow-rs/pull/1032, where I missed `WKBCapacity` -> `WkbCapacity` and `WKBBuilder` -> `WkbBuilder`.

Also cleans up docstrings in the `GeoArrowType` enum.