### PR TITLE
Update existing pyo3-geoarrow code and move to `rust/pyo3-geoarrow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ version = "0.1.0-dev"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
+ "arrow-cast",
  "arrow-schema",
  "geo 0.30.0",
  "geoarrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2301,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,6 +2325,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -2340,6 +2365,21 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -2468,6 +2508,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "numpy"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cfbf3f0feededcaa4d289fe3079b03659e85c5b5a177f4ba6fb01ab4fb3e39"
+dependencies = [
+ "half",
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "pyo3-build-config",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -2765,6 +2822,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +2903,109 @@ dependencies = [
  "flate2",
  "pkg-config",
  "tar",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+dependencies = [
+ "cfg-if",
+ "chrono",
+ "chrono-tz",
+ "indexmap",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-arrow"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b01260f3000b917a5514025b46abc264d10b2e603d7563b3f287eae176206b9"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "half",
+ "indexmap",
+ "numpy",
+ "pyo3",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-geoarrow"
+version = "0.1.0-dev"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "geo 0.30.0",
+ "geoarrow-array",
+ "geoarrow-schema",
+ "indexmap",
+ "pyo3",
+ "pyo3-arrow",
+ "serde_json",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2933,6 +3108,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3771,6 +3952,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4101,6 +4288,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [workspace]
 members = [
-    "rust/geoarrow",
     "rust/geoarrow-array",
     "rust/geoarrow-geoparquet",
     "rust/geoarrow-schema",
     "rust/geoarrow-test",
+    "rust/geoarrow",
+    "rust/pyo3-geoarrow",
     # Comment out until datafusion 47 release so that the workspace can upgrade
     # to arrow 55
     # "rust/geodatafusion",
@@ -42,13 +43,19 @@ geoarrow-geoparquet = { path = "rust/geoarrow-geoparquet" }
 geoarrow-schema = { path = "rust/geoarrow-schema" }
 geoarrow-test = { path = "rust/geoarrow-test" }
 geozero = "0.14"
+indexmap = "2.5.0"
 num-traits = "0.2.19"
+numpy = "0.24"
 object_store = "0.12"
 parquet = { version = "55", default-features = false }
+pyo3 = "0.24"
+pyo3-arrow = "0.9"
+pyo3-geoarrow = { path = "rust/pyo3-geoarrow" }
 rstar = "0.12.2"
 serde = "1"
 serde_json = "1"
 thiserror = "1"
+url = "2.5"
 # to include https://github.com/georust/wkb/pull/53
 wkb = { git = "https://github.com/georust/wkb", rev = "5a2027995997017bcd531e6be7e5cf126db1d4c1" }
 # https://github.com/georust/wkt/pull/137

--- a/python/geoarrow-core/python/geoarrow/rust/core/enums.py
+++ b/python/geoarrow-core/python/geoarrow/rust/core/enums.py
@@ -1,14 +1,7 @@
-from enum import Enum, auto
+from enum import Enum, IntEnum
 
 
 class StrEnum(str, Enum):
-    def __new__(cls, value, *args, **kwargs):
-        if not isinstance(value, (str, auto)):
-            raise TypeError(
-                f"Values of StrEnums must be strings: {value!r} is a {type(value)}"
-            )
-        return super().__new__(cls, value, *args, **kwargs)
-
     def __str__(self):
         return str(self.value)
 
@@ -47,3 +40,32 @@ class Dimension(StrEnum):
     XYZM = "xyzm"
     """Four dimensions, X, Y, Z, and M
     """
+
+
+class GeometryType(IntEnum):
+    GEOMETRY = 0
+    """Unknown geometry type."""
+
+    POINT = 1
+    """Point geometry type."""
+
+    LINESTRING = 2
+    """Linestring geometry type."""
+
+    POLYGON = 3
+    """Polygon geometry type."""
+
+    MULTIPOINT = 4
+    """Multipoint geometry type."""
+
+    MULTILINESTRING = 5
+    """Multilinestring geometry type."""
+
+    MULTIPOLYGON = 6
+    """Multipolygon geometry type."""
+
+    GEOMETRYCOLLECTION = 7
+    """Geometrycollection geometry type."""
+
+    BOX = 990
+    """Box geometry type."""

--- a/rust/geoarrow-array/src/crs.rs
+++ b/rust/geoarrow-array/src/crs.rs
@@ -1,0 +1,77 @@
+//! Defines CRS transforms used for writing GeoArrow data to file formats that require different
+//! CRS representations.
+
+// Note, this module is in geoarrow-array, not geoarrow-schema because it needs access to
+// `GeoArrowError`.
+
+use std::fmt::Debug;
+
+use geoarrow_schema::{Crs, CrsType};
+use serde_json::Value;
+
+use crate::error::{GeoArrowError, Result};
+
+/// CRS transforms used for writing GeoArrow data to file formats that require different CRS
+/// representations.
+pub trait CRSTransform: Debug {
+    /// Convert the CRS contained in this Metadata to a PROJJSON object.
+    ///
+    /// Users should prefer calling `extract_projjson`, which will first unwrap the underlying
+    /// array metadata if it's already PROJJSON.
+    fn _convert_to_projjson(&self, crs: &Crs) -> Result<Option<Value>>;
+
+    /// Convert the CRS contained in this Metadata to a WKT string.
+    ///
+    /// Users should prefer calling `extract_wkt`, which will first unwrap the underlying
+    /// array metadata if it's already PROJJSON.
+    fn _convert_to_wkt(&self, crs: &Crs) -> Result<Option<String>>;
+
+    /// Extract PROJJSON from the provided metadata.
+    ///
+    /// If the CRS is already stored as PROJJSON, this will return that. Otherwise it will call
+    /// [`Self::_convert_to_projjson`].
+    fn extract_projjson(&self, crs: &Crs) -> Result<Option<Value>> {
+        match crs.crs_type() {
+            Some(CrsType::Projjson) => Ok(crs.crs_value().cloned()),
+            _ => self._convert_to_projjson(crs),
+        }
+    }
+
+    /// Extract WKT from the provided metadata.
+    ///
+    /// If the CRS is already stored as WKT, this will return that. Otherwise it will call
+    /// [`Self::_convert_to_wkt`].
+    fn extract_wkt(&self, crs: &Crs) -> Result<Option<String>> {
+        if let (Some(crs), Some(crs_type)) = (crs.crs_value(), crs.crs_type()) {
+            if crs_type == CrsType::Wkt2_2019 {
+                if let Value::String(inner) = crs {
+                    return Ok::<_, GeoArrowError>(Some(inner.clone()));
+                }
+            }
+        }
+
+        self._convert_to_wkt(crs)
+    }
+}
+
+/// A default implementation for [CRSTransform] which does not do any CRS conversion.
+///
+/// Instead of raising an error, this will **silently drop any CRS information when writing data**.
+#[derive(Debug, Clone, Default)]
+pub struct DefaultCRSTransform {}
+
+impl CRSTransform for DefaultCRSTransform {
+    fn _convert_to_projjson(&self, _crs: &Crs) -> Result<Option<Value>> {
+        // Unable to convert CRS to PROJJSON
+        // So we proceed with missing CRS
+        // TODO: we should probably log this.
+        Ok(None)
+    }
+
+    fn _convert_to_wkt(&self, _crs: &Crs) -> Result<Option<String>> {
+        // Unable to convert CRS to WKT
+        // So we proceed with missing CRS
+        // TODO: we should probably log this.
+        Ok(None)
+    }
+}

--- a/rust/geoarrow-array/src/lib.rs
+++ b/rust/geoarrow-array/src/lib.rs
@@ -6,6 +6,7 @@ pub mod array;
 pub mod builder;
 pub mod capacity;
 pub mod cast;
+pub mod crs;
 mod datatypes;
 mod eq;
 pub mod error;

--- a/rust/pyo3-geoarrow/Cargo.toml
+++ b/rust/pyo3-geoarrow/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 arrow-array = { workspace = true }
+arrow-cast = { workspace = true }
 arrow-buffer = { workspace = true }
 arrow-schema = { workspace = true }
 geo = { workspace = true }

--- a/rust/pyo3-geoarrow/Cargo.toml
+++ b/rust/pyo3-geoarrow/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "pyo3-geoarrow"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+description = "GeoArrow integration for pyo3."
+readme = "README.md"
+repository = { workspace = true }
+license = { workspace = true }
+keywords = ["python", "arrow"]
+categories = []
+rust-version = { workspace = true }
+
+[dependencies]
+arrow-array = { workspace = true }
+arrow-buffer = { workspace = true }
+arrow-schema = { workspace = true }
+geo = { workspace = true }
+geoarrow-array = { workspace = true }
+geoarrow-schema = { workspace = true }
+indexmap = { workspace = true }
+pyo3 = { workspace = true, features = ["chrono", "indexmap"] }
+pyo3-arrow = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+
+[lib]
+crate-type = ["rlib"]

--- a/rust/pyo3-geoarrow/src/array.rs
+++ b/rust/pyo3-geoarrow/src/array.rs
@@ -1,0 +1,175 @@
+use std::sync::Arc;
+
+use geoarrow_array::array::from_arrow_array;
+// use geoarrow::ArrayBase;
+// use geoarrow::NativeArray;
+// use geoarrow::error::GeoArrowError;
+// use geoarrow::scalar::GeometryScalar;
+// use geoarrow::trait_::NativeArrayRef;
+use geoarrow_array::GeoArrowArray;
+// use geozero::ProcessToJson;
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyTuple, PyType};
+use pyo3_arrow::PyArray;
+use pyo3_arrow::ffi::to_array_pycapsules;
+
+use crate::PyGeoArrowType;
+use crate::error::{PyGeoArrowError, PyGeoArrowResult};
+
+#[pyclass(
+    module = "geoarrow.rust.core",
+    name = "GeoArrowArray",
+    subclass,
+    frozen
+)]
+pub struct PyGeoArrowArray(Arc<dyn GeoArrowArray>);
+
+impl PyGeoArrowArray {
+    pub fn new(array: Arc<dyn GeoArrowArray>) -> Self {
+        Self(array)
+    }
+
+    /// Import from raw Arrow capsules
+    pub fn from_arrow_pycapsule(
+        schema_capsule: &Bound<PyCapsule>,
+        array_capsule: &Bound<PyCapsule>,
+    ) -> PyGeoArrowResult<Self> {
+        PyArray::from_arrow_pycapsule(schema_capsule, array_capsule)?.try_into()
+    }
+
+    pub fn into_inner(self) -> Arc<dyn GeoArrowArray> {
+        self.0
+    }
+
+    /// Export to a geoarrow.rust.core.NativeArray.
+    ///
+    /// This requires that you depend on geoarrow-rust-core from your Python package.
+    pub fn to_geoarrow<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let geoarrow_mod = py.import(intern!(py, "geoarrow.rust.core"))?;
+        geoarrow_mod
+            .getattr(intern!(py, "NativeArray"))?
+            .call_method1(
+                intern!(py, "from_arrow_pycapsule"),
+                self.__arrow_c_array__(py, None)?,
+            )
+    }
+}
+
+#[pymethods]
+impl PyGeoArrowArray {
+    #[new]
+    fn py_new(data: &Bound<PyAny>) -> PyResult<Self> {
+        data.extract()
+    }
+
+    #[pyo3(signature = (requested_schema=None))]
+    fn __arrow_c_array__<'py>(
+        &'py self,
+        py: Python<'py>,
+        requested_schema: Option<Bound<'py, PyCapsule>>,
+    ) -> PyGeoArrowResult<Bound<'py, PyTuple>> {
+        let field = Arc::new(self.0.data_type().to_field("", true));
+        let array = self.0.to_array_ref();
+        Ok(to_array_pycapsules(py, field, &array, requested_schema)?)
+    }
+
+    // /// Check for equality with other object.
+    // fn __eq__(&self, other: &PyGeoArrowArray) -> bool {
+    //     self.0 == other.0
+    // }
+
+    // #[getter]
+    // fn __geo_interface__<'py>(&'py self, py: Python<'py>) -> PyGeoArrowResult<Bound<'py, PyAny>> {
+    //     // Note: We create a Table out of this array so that each row can be its own Feature in a
+    //     // FeatureCollection
+
+    //     let field = self.0.extension_field();
+    //     let geometry = self.0.to_array_ref();
+    //     let schema = Arc::new(Schema::new(vec![field]));
+    //     let batch = RecordBatch::try_new(schema.clone(), vec![geometry])?;
+
+    //     let mut table = geoarrow::table::Table::try_new(vec![batch], schema)?;
+    //     let json_string = table.to_json().map_err(GeoArrowError::GeozeroError)?;
+
+    //     let json_mod = py.import(intern!(py, "json"))?;
+    //     let args = (json_string,);
+    //     Ok(json_mod.call_method1(intern!(py, "loads"), args)?)
+    // }
+
+    // fn __getitem__(&self, i: isize) -> PyGeoArrowResult<Option<PyGeometry>> {
+    //     // Handle negative indexes from the end
+    //     let i = if i < 0 {
+    //         let i = self.0.len() as isize + i;
+    //         if i < 0 {
+    //             return Err(PyIndexError::new_err("Index out of range").into());
+    //         }
+    //         i as usize
+    //     } else {
+    //         i as usize
+    //     };
+    //     if i >= self.0.len() {
+    //         return Err(PyIndexError::new_err("Index out of range").into());
+    //     }
+
+    //     Ok(Some(PyGeometry(
+    //         GeometryScalar::try_new(self.0.slice(i, 1)).unwrap(),
+    //     )))
+    // }
+
+    fn __len__(&self) -> usize {
+        self.0.len()
+    }
+
+    fn __repr__(&self) -> String {
+        "geoarrow.rust.core.NativeArray".to_string()
+    }
+
+    #[classmethod]
+    fn from_arrow(_cls: &Bound<PyType>, data: Self) -> Self {
+        data
+    }
+
+    #[classmethod]
+    #[pyo3(name = "from_arrow_pycapsule")]
+    fn from_arrow_pycapsule_py(
+        _cls: &Bound<PyType>,
+        schema_capsule: &Bound<PyCapsule>,
+        array_capsule: &Bound<PyCapsule>,
+    ) -> PyGeoArrowResult<Self> {
+        Self::from_arrow_pycapsule(schema_capsule, array_capsule)
+    }
+
+    #[getter]
+    fn r#type(&self) -> PyGeoArrowType {
+        self.0.data_type().into()
+    }
+}
+
+impl From<Arc<dyn GeoArrowArray>> for PyGeoArrowArray {
+    fn from(value: Arc<dyn GeoArrowArray>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PyGeoArrowArray> for Arc<dyn GeoArrowArray> {
+    fn from(value: PyGeoArrowArray) -> Self {
+        value.0
+    }
+}
+
+impl<'a> FromPyObject<'a> for PyGeoArrowArray {
+    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+        Ok(ob.extract::<PyArray>()?.try_into()?)
+    }
+}
+
+impl TryFrom<PyArray> for PyGeoArrowArray {
+    type Error = PyGeoArrowError;
+
+    fn try_from(value: PyArray) -> Result<Self, Self::Error> {
+        let (array, field) = value.into_inner();
+        let geo_arr = from_arrow_array(&array, &field)?;
+        Ok(Self(geo_arr))
+    }
+}

--- a/rust/pyo3-geoarrow/src/chunked_array.rs
+++ b/rust/pyo3-geoarrow/src/chunked_array.rs
@@ -1,0 +1,164 @@
+use std::sync::Arc;
+
+use geoarrow_array::array::from_arrow_array;
+use geoarrow_array::{GeoArrowArray, GeoArrowType};
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyTuple, PyType};
+use pyo3_arrow::PyChunkedArray;
+use pyo3_arrow::ffi::{ArrayIterator, to_stream_pycapsule};
+use pyo3_arrow::input::AnyArray;
+
+use crate::error::{PyGeoArrowError, PyGeoArrowResult};
+use crate::{PyGeoArrowArray, PyGeoArrowType};
+
+#[pyclass(
+    module = "geoarrow.rust.core",
+    name = "ChunkedGeoArrowArray",
+    subclass,
+    frozen
+)]
+pub struct PyChunkedGeoArrowArray {
+    chunks: Vec<Arc<dyn GeoArrowArray>>,
+    data_type: GeoArrowType,
+}
+
+impl PyChunkedGeoArrowArray {
+    pub fn new(chunks: Vec<Arc<dyn GeoArrowArray>>, data_type: GeoArrowType) -> Self {
+        // TODO: validate all chunks have the same data type
+        Self { chunks, data_type }
+    }
+
+    /// Import from a raw Arrow C Stream capsule
+    pub fn from_arrow_pycapsule(capsule: &Bound<PyCapsule>) -> PyGeoArrowResult<Self> {
+        PyChunkedArray::from_arrow_pycapsule(capsule)?.try_into()
+    }
+
+    /// Export to a geoarrow.rust.core.GeometryArray.
+    ///
+    /// This requires that you depend on geoarrow-rust-core from your Python package.
+    pub fn to_geoarrow<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let geoarrow_mod = py.import(intern!(py, "geoarrow.rust.core"))?;
+        geoarrow_mod
+            .getattr(intern!(py, "ChunkedGeoArrowArray"))?
+            .call_method1(
+                intern!(py, "from_arrow_pycapsule"),
+                PyTuple::new(py, vec![self.__arrow_c_stream__(py, None)?])?,
+            )
+    }
+}
+
+#[pymethods]
+impl PyChunkedGeoArrowArray {
+    #[pyo3(signature = (requested_schema=None))]
+    fn __arrow_c_stream__<'py>(
+        &self,
+        py: Python<'py>,
+        requested_schema: Option<Bound<'py, PyCapsule>>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let field = Arc::new(self.data_type.to_field("", true));
+        let arrow_chunks = self
+            .chunks
+            .iter()
+            .map(|x| x.to_array_ref())
+            .collect::<Vec<_>>();
+
+        let array_reader = Box::new(ArrayIterator::new(arrow_chunks.into_iter().map(Ok), field));
+        Ok(to_stream_pycapsule(py, array_reader, requested_schema)?)
+    }
+
+    // /// Check for equality with other object.
+    // fn __eq__(&self, _other: &PyNativeArray) -> bool {
+    //     self.0 == other.0
+    // }
+
+    // fn __getitem__(&self, i: isize) -> PyGeoArrowResult<Option<PyGeometry>> {
+    //     // Handle negative indexes from the end
+    //     let i = if i < 0 {
+    //         let i = self.__len__() as isize + i;
+    //         if i < 0 {
+    //             return Err(PyIndexError::new_err("Index out of range").into());
+    //         }
+    //         i as usize
+    //     } else {
+    //         i as usize
+    //     };
+    //     if i >= self.0.len() {
+    //         return Err(PyIndexError::new_err("Index out of range").into());
+    //     }
+
+    //     let sliced = self.0.slice(i, 1)?;
+    //     let geom_chunks = sliced.geometry_chunks();
+    //     assert_eq!(geom_chunks.len(), 1);
+    //     Ok(Some(PyGeometry(
+    //         GeometryScalar::try_new(geom_chunks[0].clone()).unwrap(),
+    //     )))
+    // }
+
+    fn __len__(&self) -> usize {
+        self.chunks.iter().fold(0, |acc, arr| acc + arr.len())
+    }
+
+    fn __repr__(&self) -> String {
+        // self.0.to_string()
+        "geoarrow.rust.core.ChunkedGeometryArray".to_string()
+    }
+
+    #[classmethod]
+    pub fn from_arrow(_cls: &Bound<PyType>, data: Self) -> Self {
+        data
+    }
+
+    #[classmethod]
+    #[pyo3(name = "from_arrow_pycapsule")]
+    fn from_arrow_pycapsule_py(
+        _cls: &Bound<PyType>,
+        capsule: &Bound<PyCapsule>,
+    ) -> PyGeoArrowResult<Self> {
+        Self::from_arrow_pycapsule(capsule)
+    }
+
+    fn num_chunks(&self) -> usize {
+        self.chunks.len()
+    }
+
+    fn chunk(&self, i: usize) -> PyGeoArrowArray {
+        PyGeoArrowArray::new(self.chunks[i].clone())
+    }
+
+    fn chunks(&self) -> Vec<PyGeoArrowArray> {
+        self.chunks
+            .iter()
+            .map(|chunk| PyGeoArrowArray::new(chunk.clone()))
+            .collect()
+    }
+
+    #[getter]
+    fn r#type(&self) -> PyGeoArrowType {
+        self.data_type.clone().into()
+    }
+}
+
+impl<'a> FromPyObject<'a> for PyChunkedGeoArrowArray {
+    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+        let chunked_array = ob.extract::<AnyArray>()?.into_chunked_array()?;
+        chunked_array.try_into().map_err(PyErr::from)
+    }
+}
+
+impl TryFrom<PyChunkedArray> for PyChunkedGeoArrowArray {
+    type Error = PyGeoArrowError;
+
+    fn try_from(value: PyChunkedArray) -> Result<Self, Self::Error> {
+        let (chunks, field) = value.into_inner();
+        let geo_chunks = chunks
+            .iter()
+            .map(|array| from_arrow_array(&array, &field))
+            .collect::<Result<Vec<_>, _>>()?;
+        let geo_data_type = GeoArrowType::try_from(field.as_ref())?;
+        Ok(Self {
+            chunks: geo_chunks,
+            data_type: geo_data_type,
+        })
+    }
+}

--- a/rust/pyo3-geoarrow/src/coord_buffer.rs
+++ b/rust/pyo3-geoarrow/src/coord_buffer.rs
@@ -1,0 +1,163 @@
+use arrow_array::Array;
+use arrow_array::cast::AsArray;
+use arrow_array::types::Float64Type;
+use arrow_buffer::ScalarBuffer;
+use arrow_schema::DataType;
+use geoarrow_array::array::{CoordBuffer, InterleavedCoordBuffer, SeparatedCoordBuffer};
+use geoarrow_schema::Dimension;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyList, PyTuple};
+use pyo3_arrow::PyArray;
+
+pub struct PyCoordBuffer(CoordBuffer);
+
+impl PyCoordBuffer {
+    pub fn into_inner(self) -> CoordBuffer {
+        self.0
+    }
+}
+
+impl<'py> FromPyObject<'py> for PyCoordBuffer {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if ob.is_instance_of::<PyTuple>() || ob.is_instance_of::<PyList>() {
+            let arrays = ob.extract::<Vec<PyArray>>()?;
+
+            if arrays.len() < 2 || arrays.len() > 3 {
+                return Err(PyValueError::new_err(format!(
+                    "Expected 2 or 3 arrays for each dimension, got {}.",
+                    arrays.len()
+                )));
+            }
+
+            let x = arrays[0].array();
+            let y = arrays[1].array();
+
+            if !matches!(x.data_type(), DataType::Float64) {
+                return Err(PyValueError::new_err(format!(
+                    "Expected x to be float64 data type, got {}",
+                    x.data_type()
+                )));
+            }
+
+            if !matches!(y.data_type(), DataType::Float64) {
+                return Err(PyValueError::new_err(format!(
+                    "Expected y to be float64 data type, got {}",
+                    y.data_type()
+                )));
+            }
+
+            let x = x.as_primitive::<Float64Type>();
+            let y = y.as_primitive::<Float64Type>();
+
+            if x.null_count() != 0 {
+                return Err(PyValueError::new_err(format!(
+                    "Cannot construct point array with null values. The 'x' array has {} null values",
+                    x.null_count()
+                )));
+            }
+
+            if y.null_count() != 0 {
+                return Err(PyValueError::new_err(format!(
+                    "Cannot construct point array with null values. The 'y' array has {} null values",
+                    y.null_count()
+                )));
+            }
+
+            let x = x.values();
+            let y = y.values();
+
+            if let Some(z) = arrays.get(2) {
+                if !matches!(z.field().data_type(), DataType::Float64) {
+                    return Err(PyValueError::new_err(format!(
+                        "Expected z to be float64 data type, got {}",
+                        z.field().data_type()
+                    )));
+                }
+
+                let z = z.array().as_primitive::<Float64Type>();
+
+                if z.null_count() != 0 {
+                    return Err(PyValueError::new_err(format!(
+                        "Cannot construct point array with null values. The 'z' array has {} null values",
+                        z.null_count()
+                    )));
+                }
+
+                let z = z.values();
+
+                Ok(Self(
+                    SeparatedCoordBuffer::new(
+                        [x.clone(), y.clone(), z.clone(), ScalarBuffer::from(vec![])],
+                        Dimension::XYZ,
+                    )
+                    .into(),
+                ))
+            } else {
+                Ok(Self(
+                    SeparatedCoordBuffer::new(
+                        [
+                            x.clone(),
+                            y.clone(),
+                            ScalarBuffer::from(vec![]),
+                            ScalarBuffer::from(vec![]),
+                        ],
+                        Dimension::XY,
+                    )
+                    .into(),
+                ))
+            }
+        } else {
+            let coords = ob.extract::<PyArray>()?;
+
+            match coords.field().data_type() {
+                DataType::FixedSizeList(inner_field, list_size) => {
+                    if !matches!(inner_field.data_type(), DataType::Float64) {
+                        return Err(PyValueError::new_err(format!(
+                            "Expected the inner field of coords to be float64 data type, got {}",
+                            inner_field.data_type()
+                        )));
+                    }
+
+                    let coords = coords.as_ref().as_fixed_size_list();
+
+                    if coords.null_count() != 0 {
+                        return Err(PyValueError::new_err(format!(
+                            "Cannot have null values in coordinate fixed size list array. {} null values present.",
+                            coords.null_count()
+                        )));
+                    }
+
+                    let values = coords.values();
+                    let values = values.as_primitive::<Float64Type>();
+
+                    if values.null_count() != 0 {
+                        return Err(PyValueError::new_err(format!(
+                            "Cannot construct point array with null values in the inner buffer of the coordinate array. The values of the fixed size list array array has {} null values",
+                            values.null_count()
+                        )));
+                    }
+
+                    match list_size {
+                        2 => Ok(Self(
+                            InterleavedCoordBuffer::new(values.values().clone(), Dimension::XY)
+                                .into(),
+                        )),
+                        3 => Ok(Self(
+                            InterleavedCoordBuffer::new(values.values().clone(), Dimension::XYZ)
+                                .into(),
+                        )),
+                        _ => Err(PyValueError::new_err(format!(
+                            "Unsupported fixed size list size {}",
+                            list_size
+                        ))),
+                    }
+                }
+                dt => Err(PyValueError::new_err(format!(
+                    "Expected coords to be FixedSizeList data type, got {}",
+                    dt
+                ))),
+            }
+        }
+    }
+}

--- a/rust/pyo3-geoarrow/src/coord_type.rs
+++ b/rust/pyo3-geoarrow/src/coord_type.rs
@@ -1,0 +1,54 @@
+use geoarrow_schema::CoordType;
+use pyo3::exceptions::PyValueError;
+use pyo3::intern;
+use pyo3::prelude::*;
+
+#[derive(Debug, Clone, Copy)]
+pub enum PyCoordType {
+    Interleaved,
+    Separated,
+}
+
+impl<'a> FromPyObject<'a> for PyCoordType {
+    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+        let s: String = ob.extract()?;
+        match s.to_lowercase().as_str() {
+            "interleaved" => Ok(Self::Interleaved),
+            "separated" => Ok(Self::Separated),
+            _ => Err(PyValueError::new_err("Unexpected coord type")),
+        }
+    }
+}
+
+impl From<PyCoordType> for CoordType {
+    fn from(value: PyCoordType) -> Self {
+        match value {
+            PyCoordType::Interleaved => Self::Interleaved,
+            PyCoordType::Separated => Self::Separated,
+        }
+    }
+}
+
+impl From<CoordType> for PyCoordType {
+    fn from(value: CoordType) -> Self {
+        match value {
+            CoordType::Interleaved => Self::Interleaved,
+            CoordType::Separated => Self::Separated,
+        }
+    }
+}
+
+impl<'py> IntoPyObject<'py> for PyCoordType {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let enums_mod = py.import(intern!(py, "geoarrow.rust.core.enums"))?;
+        let enum_cls = enums_mod.getattr(intern!(py, "CoordType"))?;
+        match self {
+            Self::Interleaved => enum_cls.getattr(intern!(py, "Interleaved")),
+            Self::Separated => enum_cls.getattr(intern!(py, "Separated")),
+        }
+    }
+}

--- a/rust/pyo3-geoarrow/src/crs.rs
+++ b/rust/pyo3-geoarrow/src/crs.rs
@@ -1,0 +1,164 @@
+use geoarrow_array::crs::CRSTransform;
+use geoarrow_array::error::GeoArrowError;
+use geoarrow_schema::{Crs, CrsType, Metadata};
+use pyo3::exceptions::PyValueError;
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
+use pyo3::types::PyTuple;
+use serde_json::Value;
+
+use crate::error::PyGeoArrowResult;
+
+/// A wrapper around the CRS functionality contained within [Metadata] to integrate with
+/// `pyproj` Python APIs.
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Clone, Debug)]
+pub struct PyCrs(Metadata);
+
+impl<'py> FromPyObject<'py> for PyCrs {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let py = ob.py();
+        let pyproj = py.import(intern!(py, "pyproj"))?;
+        let crs_class = pyproj.getattr(intern!(py, "CRS"))?;
+
+        let mut ob = ob.clone();
+
+        // If the input is not a pyproj.CRS, call pyproj.CRS.from_user_input on it
+        if !ob.is_instance(&crs_class)? {
+            let args = PyTuple::new(py, vec![ob])?;
+            ob = crs_class.call_method1(intern!(py, "from_user_input"), args)?;
+        }
+
+        let projjson_string = ob
+            .call_method0(intern!(py, "to_json"))?
+            .extract::<String>()?;
+        let projjson_value = serde_json::from_str(&projjson_string)
+            .map_err(|err| PyValueError::new_err(err.to_string()))?;
+
+        let crs = Crs::from_projjson(projjson_value);
+        Ok(Self(Metadata::new(crs, None)))
+    }
+}
+
+impl PyCrs {
+    pub fn from_projjson(value: Value) -> Self {
+        let crs = Crs::from_projjson(value);
+        Self(Metadata::new(crs, None))
+    }
+
+    #[allow(dead_code)]
+    pub fn into_inner(self) -> Metadata {
+        self.0
+    }
+
+    /// Export the embedded CRS to a `pyproj.CRS` or None
+    pub fn to_pyproj(&self, py: Python) -> PyGeoArrowResult<PyObject> {
+        let pyproj = py.import(intern!(py, "pyproj"))?;
+        let crs_class = pyproj.getattr(intern!(py, "CRS"))?;
+
+        let crs_obj = match self.0.crs().crs_type() {
+            Some(CrsType::Projjson) => {
+                let args = PyTuple::new(
+                    py,
+                    vec![serde_json::to_string(
+                        &self.0.crs().crs_value().as_ref().unwrap(),
+                    )?],
+                )?;
+                crs_class.call_method1(intern!(py, "from_json"), args)?
+            }
+            Some(CrsType::AuthorityCode) => match self.0.crs().crs_value().as_ref().unwrap() {
+                Value::String(value) => {
+                    let (authority, code) =
+                        value.split_once(':').expect("expected : in authority code");
+                    let args = PyTuple::new(py, vec![authority, code])?;
+                    crs_class.call_method1(intern!(py, "from_json"), args)?
+                }
+                _ => panic!("Expected string value"),
+            },
+            Some(CrsType::Wkt2_2019) => match self.0.crs().crs_value().as_ref().unwrap() {
+                Value::String(value) => {
+                    let args = PyTuple::new(py, vec![value])?;
+                    crs_class.call_method1(intern!(py, "from_wkt"), args)?
+                }
+                _ => panic!("Expected string value"),
+            },
+            _ => match self.0.crs().crs_value().as_ref() {
+                None => py.None().into_bound(py),
+                Some(Value::String(value)) => {
+                    let args = PyTuple::new(py, vec![value])?;
+                    crs_class.call_method1(intern!(py, "from_user_input"), args)?
+                }
+                _ => panic!("Expected missing CRS or string value"),
+            },
+        };
+        Ok(crs_obj.into())
+    }
+
+    pub fn to_projjson(&self, py: Python) -> PyResult<Option<Value>> {
+        let pyproj_crs = self.to_pyproj(py)?;
+        if pyproj_crs.is_none(py) {
+            Ok(None)
+        } else {
+            let projjson_str = pyproj_crs
+                .call_method0(py, intern!(py, "to_json"))?
+                .extract::<PyBackedStr>(py)?;
+
+            let projjson_value: Value = serde_json::from_str(&projjson_str)
+                .map_err(|err| PyValueError::new_err(err.to_string()))?;
+            Ok(Some(projjson_value))
+        }
+    }
+
+    pub fn to_wkt(&self, py: Python) -> PyResult<Option<String>> {
+        let pyproj_crs = self.to_pyproj(py)?;
+        if pyproj_crs.is_none(py) {
+            Ok(None)
+        } else {
+            let args = PyTuple::new(py, vec![intern!(py, "WKT2_2019")])?;
+            let wkt_str = pyproj_crs
+                .call_method1(py, intern!(py, "to_wkt"), args)?
+                .extract::<String>(py)?;
+
+            Ok(Some(wkt_str))
+        }
+    }
+}
+
+impl From<Crs> for PyCrs {
+    fn from(value: Crs) -> Self {
+        Self(Metadata::new(value, None))
+    }
+}
+
+/// An implementation of [CRSTransform] using pyproj.
+#[derive(Debug)]
+pub struct PyprojCRSTransform {}
+
+impl PyprojCRSTransform {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for PyprojCRSTransform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CRSTransform for PyprojCRSTransform {
+    fn _convert_to_projjson(&self, crs: &Crs) -> geoarrow_array::error::Result<Option<Value>> {
+        let crs = PyCrs::from(crs.clone());
+        let projjson = Python::with_gil(|py| crs.to_projjson(py))
+            .map_err(|err| GeoArrowError::General(err.to_string()))?;
+        Ok(projjson)
+    }
+
+    fn _convert_to_wkt(&self, crs: &Crs) -> geoarrow_array::error::Result<Option<String>> {
+        let crs = PyCrs::from(crs.clone());
+        let wkt = Python::with_gil(|py| crs.to_wkt(py))
+            .map_err(|err| GeoArrowError::General(err.to_string()))?;
+        Ok(wkt)
+    }
+}

--- a/rust/pyo3-geoarrow/src/data_type.rs
+++ b/rust/pyo3-geoarrow/src/data_type.rs
@@ -1,0 +1,165 @@
+use crate::error::{PyGeoArrowError, PyGeoArrowResult};
+use crate::{PyCoordType, PyDimension};
+
+use geoarrow_array::GeoArrowType;
+use geoarrow_schema::{
+    BoxType, GeometryCollectionType, GeometryType, LineStringType, MultiLineStringType,
+    MultiPointType, MultiPolygonType, PointType, PolygonType, WkbType, WktType,
+};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyType};
+use pyo3_arrow::PyField;
+use pyo3_arrow::ffi::to_schema_pycapsule;
+
+#[pyclass(module = "geoarrow.rust.core", name = "GeoArrowType", subclass, frozen)]
+pub struct PyGeoArrowType(pub(crate) GeoArrowType);
+
+impl PyGeoArrowType {
+    pub fn new(data_type: GeoArrowType) -> Self {
+        Self(data_type)
+    }
+
+    /// Import from a raw Arrow C Schema capsules
+    pub fn from_arrow_pycapsule(capsule: &Bound<PyCapsule>) -> PyGeoArrowResult<Self> {
+        PyField::from_arrow_pycapsule(capsule)?.try_into()
+    }
+
+    pub fn into_inner(self) -> GeoArrowType {
+        self.0
+    }
+}
+
+#[allow(non_snake_case)]
+#[pymethods]
+impl PyGeoArrowType {
+    #[new]
+    #[pyo3(signature = (r#type, dimension=None, coord_type=None))]
+    fn py_new(
+        r#type: &str,
+        dimension: Option<PyDimension>,
+        coord_type: Option<PyCoordType>,
+    ) -> PyResult<Self> {
+        match r#type.to_lowercase().as_str() {
+            "point" => Ok(Self(GeoArrowType::Point(PointType::new(
+                coord_type.unwrap().into(),
+                dimension.unwrap().into(),
+                Default::default(),
+            )))),
+            "linestring" => Ok(Self(GeoArrowType::LineString(LineStringType::new(
+                coord_type.unwrap().into(),
+                dimension.unwrap().into(),
+                Default::default(),
+            )))),
+            "polygon" => Ok(Self(GeoArrowType::Polygon(PolygonType::new(
+                coord_type.unwrap().into(),
+                dimension.unwrap().into(),
+                Default::default(),
+            )))),
+            "multipoint" => Ok(Self(GeoArrowType::MultiPoint(MultiPointType::new(
+                coord_type.unwrap().into(),
+                dimension.unwrap().into(),
+                Default::default(),
+            )))),
+            "multilinestring" => Ok(Self(GeoArrowType::MultiLineString(
+                MultiLineStringType::new(
+                    coord_type.unwrap().into(),
+                    dimension.unwrap().into(),
+                    Default::default(),
+                ),
+            ))),
+            "multipolygon" => Ok(Self(GeoArrowType::MultiPolygon(MultiPolygonType::new(
+                coord_type.unwrap().into(),
+                dimension.unwrap().into(),
+                Default::default(),
+            )))),
+            "geometry" => Ok(Self(GeoArrowType::Geometry(GeometryType::new(
+                coord_type.unwrap().into(),
+                Default::default(),
+            )))),
+            "geometrycollection" => Ok(Self(GeoArrowType::GeometryCollection(
+                GeometryCollectionType::new(
+                    coord_type.unwrap().into(),
+                    dimension.unwrap().into(),
+                    Default::default(),
+                ),
+            ))),
+            "box" | "rect" => Ok(Self(GeoArrowType::Rect(BoxType::new(
+                dimension.unwrap().into(),
+                Default::default(),
+            )))),
+            "wkb" => Ok(Self(GeoArrowType::Wkb(WkbType::new(Default::default())))),
+            "wkt" => Ok(Self(GeoArrowType::Wkt(WktType::new(Default::default())))),
+            _ => Err(PyValueError::new_err("Unknown geometry type input")),
+        }
+    }
+
+    #[allow(unused_variables)]
+    fn __arrow_c_schema__<'py>(
+        &'py self,
+        py: Python<'py>,
+    ) -> PyGeoArrowResult<Bound<'py, PyCapsule>> {
+        let field = self.0.to_field("", true);
+        Ok(to_schema_pycapsule(py, field)?)
+    }
+
+    /// Check for equality with other object.
+    fn __eq__(&self, other: &PyGeoArrowType) -> bool {
+        self.0 == other.0
+    }
+
+    fn __repr__(&self) -> String {
+        // TODO: implement Display for GeoArrowType
+        format!("geoarrow.rust.core.GeoArrowType({:?})", self.0)
+    }
+
+    #[classmethod]
+    fn from_arrow(_cls: &Bound<PyType>, data: Self) -> Self {
+        data
+    }
+
+    #[classmethod]
+    #[pyo3(name = "from_arrow_pycapsule")]
+    fn from_arrow_pycapsule_py(
+        _cls: &Bound<PyType>,
+        capsule: &Bound<PyCapsule>,
+    ) -> PyGeoArrowResult<Self> {
+        Self::from_arrow_pycapsule(capsule)
+    }
+
+    #[getter]
+    fn coord_type(&self) -> Option<PyCoordType> {
+        self.0.coord_type().map(|c| c.into())
+    }
+
+    #[getter]
+    fn dimension(&self) -> Option<PyDimension> {
+        self.0.dimension().map(|d| d.into())
+    }
+}
+
+impl From<GeoArrowType> for PyGeoArrowType {
+    fn from(value: GeoArrowType) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PyGeoArrowType> for GeoArrowType {
+    fn from(value: PyGeoArrowType) -> Self {
+        value.0
+    }
+}
+
+impl<'a> FromPyObject<'a> for PyGeoArrowType {
+    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+        ob.extract::<PyField>()?.try_into().map_err(PyErr::from)
+    }
+}
+
+impl TryFrom<PyField> for PyGeoArrowType {
+    type Error = PyGeoArrowError;
+
+    fn try_from(value: PyField) -> Result<Self, Self::Error> {
+        Ok(Self(value.into_inner().as_ref().try_into()?))
+    }
+}

--- a/rust/pyo3-geoarrow/src/dimension.rs
+++ b/rust/pyo3-geoarrow/src/dimension.rs
@@ -1,0 +1,65 @@
+use geoarrow_schema::Dimension;
+use pyo3::exceptions::PyValueError;
+use pyo3::intern;
+use pyo3::prelude::*;
+
+#[derive(Debug, Clone, Copy)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum PyDimension {
+    XY,
+    XYZ,
+    XYM,
+    XYZM,
+}
+
+impl<'a> FromPyObject<'a> for PyDimension {
+    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+        let s: String = ob.extract()?;
+        match s.to_lowercase().as_str() {
+            "xy" => Ok(Self::XY),
+            "xyz" => Ok(Self::XYZ),
+            "xym" => Ok(Self::XYM),
+            "xyzm" => Ok(Self::XYZM),
+            _ => Err(PyValueError::new_err("Unexpected dimension")),
+        }
+    }
+}
+
+impl From<PyDimension> for Dimension {
+    fn from(value: PyDimension) -> Self {
+        match value {
+            PyDimension::XY => Self::XY,
+            PyDimension::XYZ => Self::XYZ,
+            PyDimension::XYM => Self::XYM,
+            PyDimension::XYZM => Self::XYZM,
+        }
+    }
+}
+
+impl From<Dimension> for PyDimension {
+    fn from(value: Dimension) -> Self {
+        match value {
+            Dimension::XY => Self::XY,
+            Dimension::XYZ => Self::XYZ,
+            Dimension::XYM => Self::XYM,
+            Dimension::XYZM => Self::XYZM,
+        }
+    }
+}
+
+impl<'py> IntoPyObject<'py> for PyDimension {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let enums_mod = py.import(intern!(py, "geoarrow.rust.core.enums"))?;
+        let enum_cls = enums_mod.getattr(intern!(py, "Dimension"))?;
+        match self {
+            Self::XY => enum_cls.getattr(intern!(py, "XY")),
+            Self::XYZ => enum_cls.getattr(intern!(py, "XYZ")),
+            Self::XYM => enum_cls.getattr(intern!(py, "XYM")),
+            Self::XYZM => enum_cls.getattr(intern!(py, "XYZM")),
+        }
+    }
+}

--- a/rust/pyo3-geoarrow/src/error.rs
+++ b/rust/pyo3-geoarrow/src/error.rs
@@ -1,0 +1,72 @@
+use pyo3::exceptions::{PyException, PyTypeError, PyValueError};
+use pyo3::prelude::*;
+
+pub enum PyGeoArrowError {
+    GeoArrowError(geoarrow_array::error::GeoArrowError),
+    PyErr(PyErr),
+    PyArrowError(pyo3_arrow::error::PyArrowError),
+    SerdeJsonError(serde_json::Error),
+    UrlParseError(url::ParseError),
+}
+
+impl From<PyGeoArrowError> for PyErr {
+    fn from(error: PyGeoArrowError) -> Self {
+        match error {
+            PyGeoArrowError::GeoArrowError(err) => PyException::new_err(err.to_string()),
+            PyGeoArrowError::PyErr(err) => err,
+            PyGeoArrowError::PyArrowError(err) => err.into(),
+            PyGeoArrowError::SerdeJsonError(err) => PyException::new_err(err.to_string()),
+            PyGeoArrowError::UrlParseError(err) => PyException::new_err(err.to_string()),
+        }
+    }
+}
+
+impl From<geoarrow_array::error::GeoArrowError> for PyGeoArrowError {
+    fn from(other: geoarrow_array::error::GeoArrowError) -> Self {
+        Self::GeoArrowError(other)
+    }
+}
+
+impl From<pyo3_arrow::error::PyArrowError> for PyGeoArrowError {
+    fn from(other: pyo3_arrow::error::PyArrowError) -> Self {
+        Self::PyArrowError(other)
+    }
+}
+
+impl From<serde_json::Error> for PyGeoArrowError {
+    fn from(other: serde_json::Error) -> Self {
+        Self::SerdeJsonError(other)
+    }
+}
+
+impl From<url::ParseError> for PyGeoArrowError {
+    fn from(other: url::ParseError) -> Self {
+        Self::UrlParseError(other)
+    }
+}
+
+impl From<Bound<'_, PyTypeError>> for PyGeoArrowError {
+    fn from(other: Bound<'_, PyTypeError>) -> Self {
+        Self::PyErr((other).into())
+    }
+}
+
+impl From<Bound<'_, PyValueError>> for PyGeoArrowError {
+    fn from(other: Bound<'_, PyValueError>) -> Self {
+        Self::PyErr((other).into())
+    }
+}
+
+impl From<PyErr> for PyGeoArrowError {
+    fn from(other: PyErr) -> Self {
+        Self::PyErr(other)
+    }
+}
+
+impl From<arrow_schema::ArrowError> for PyGeoArrowError {
+    fn from(value: arrow_schema::ArrowError) -> Self {
+        PyGeoArrowError::GeoArrowError(value.into())
+    }
+}
+
+pub type PyGeoArrowResult<T> = Result<T, PyGeoArrowError>;

--- a/rust/pyo3-geoarrow/src/ffi/from_python/mod.rs
+++ b/rust/pyo3-geoarrow/src/ffi/from_python/mod.rs
@@ -1,0 +1,1 @@
+pub mod scalar;

--- a/rust/pyo3-geoarrow/src/ffi/from_python/mod.rs
+++ b/rust/pyo3-geoarrow/src/ffi/from_python/mod.rs
@@ -1,1 +1,1 @@
-pub mod scalar;
+// pub mod scalar;

--- a/rust/pyo3-geoarrow/src/ffi/from_python/scalar.rs
+++ b/rust/pyo3-geoarrow/src/ffi/from_python/scalar.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use crate::array::*;
+use crate::scalar::*;
+use geoarrow::io::geozero::ToGeometryArray;
+use geoarrow::scalar::GeometryScalar;
+use geozero::geojson::GeoJsonString;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
+use pyo3::{intern, PyAny, PyResult};
+
+impl<'a> FromPyObject<'a> for PyGeometry {
+    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+        let py = ob.py();
+        // TODO: direct shapely conversion not via __geo_interface__
+        if let Ok(geo_arr) = ob.extract::<PyNativeArray>() {
+            let scalar = GeometryScalar::try_new(geo_arr.0.into_inner()).unwrap();
+            Ok(PyGeometry::new(scalar))
+        } else if ob.hasattr(intern!(py, "__geo_interface__"))? {
+            let json_string = call_geo_interface(py, ob)?;
+
+            // Parse GeoJSON to geometry scalar
+            let reader = GeoJsonString(json_string);
+
+            // TODO: use ToGeometry directly in the future?
+            let arr = reader
+                .to_geometry_array()
+                .map_err(|err| PyValueError::new_err(err.to_string()))?;
+            Ok(Self(
+                GeometryScalar::try_new(Arc::new(arr))
+                    .map_err(|err| PyValueError::new_err(err.to_string()))?,
+            ))
+        } else {
+            Err(PyValueError::new_err(
+                "Expected input to have __arrow_c_array__ or __geo_interface__ dunder methods",
+            ))
+        }
+    }
+}
+
+/// Access Python `__geo_interface__` attribute and encode to JSON string
+fn call_geo_interface(py: Python, ob: &Bound<PyAny>) -> PyResult<String> {
+    let py_obj = ob.getattr("__geo_interface__")?;
+
+    // Import JSON module
+    let json_mod = py.import(intern!(py, "json"))?;
+
+    // Prepare json.dumps call
+    let args = (py_obj,);
+    let separators = PyTuple::new(py, vec![',', ':'])?;
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("separators", separators)?;
+
+    // Call json.dumps
+    let json_dumped = json_mod.call_method(intern!(py, "dumps"), args, Some(&kwargs))?;
+    json_dumped.extract()
+}

--- a/rust/pyo3-geoarrow/src/ffi/mod.rs
+++ b/rust/pyo3-geoarrow/src/ffi/mod.rs
@@ -1,0 +1,3 @@
+//! Arrow FFI via the C Data Interface and the Arrow PyCapsule Interface.
+
+pub mod from_python;

--- a/rust/pyo3-geoarrow/src/lib.rs
+++ b/rust/pyo3-geoarrow/src/lib.rs
@@ -8,10 +8,10 @@ mod dimension;
 mod error;
 mod ffi;
 mod offset_buffer;
-mod scalar;
+// mod scalar;
 
 pub use array::PyGeoArrowArray;
-pub use chunked_array::PyChunkedNativeArray;
+pub use chunked_array::PyChunkedGeoArrowArray;
 pub use coord_buffer::PyCoordBuffer;
 pub use coord_type::PyCoordType;
 pub use crs::{PyCrs, PyprojCRSTransform};
@@ -19,4 +19,4 @@ pub use data_type::PyGeoArrowType;
 pub use dimension::PyDimension;
 pub use error::{PyGeoArrowError, PyGeoArrowResult};
 pub use offset_buffer::PyOffsetBuffer;
-pub use scalar::PyGeometry;
+// pub use scalar::PyGeometry;

--- a/rust/pyo3-geoarrow/src/lib.rs
+++ b/rust/pyo3-geoarrow/src/lib.rs
@@ -1,0 +1,22 @@
+mod array;
+mod chunked_array;
+mod coord_buffer;
+mod coord_type;
+mod crs;
+mod data_type;
+mod dimension;
+mod error;
+mod ffi;
+mod offset_buffer;
+mod scalar;
+
+pub use array::PyGeoArrowArray;
+pub use chunked_array::PyChunkedNativeArray;
+pub use coord_buffer::PyCoordBuffer;
+pub use coord_type::PyCoordType;
+pub use crs::{PyCrs, PyprojCRSTransform};
+pub use data_type::PyGeoArrowType;
+pub use dimension::PyDimension;
+pub use error::{PyGeoArrowError, PyGeoArrowResult};
+pub use offset_buffer::PyOffsetBuffer;
+pub use scalar::PyGeometry;

--- a/rust/pyo3-geoarrow/src/offset_buffer.rs
+++ b/rust/pyo3-geoarrow/src/offset_buffer.rs
@@ -1,0 +1,33 @@
+use arrow_array::cast::AsArray;
+use arrow_array::types::Int32Type;
+use arrow_buffer::OffsetBuffer;
+use arrow_cast::cast;
+use arrow_schema::DataType;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3_arrow::PyArray;
+
+use crate::PyGeoArrowError;
+
+pub struct PyOffsetBuffer(OffsetBuffer<i32>);
+
+impl PyOffsetBuffer {
+    pub fn into_inner(self) -> OffsetBuffer<i32> {
+        self.0
+    }
+}
+
+impl<'py> FromPyObject<'py> for PyOffsetBuffer {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let ob = ob.extract::<PyArray>()?;
+        if ob.array().null_count() != 0 {
+            return Err(PyValueError::new_err(format!(
+                "Cannot construct offset buffer with nulls. Got {} nulls.",
+                ob.array().null_count()
+            )));
+        }
+        let offsets = cast(ob.as_ref(), &DataType::Int32).map_err(PyGeoArrowError::from)?;
+        let offsets = offsets.as_ref().as_primitive::<Int32Type>();
+        Ok(Self(OffsetBuffer::new(offsets.values().clone())))
+    }
+}

--- a/rust/pyo3-geoarrow/src/scalar.rs
+++ b/rust/pyo3-geoarrow/src/scalar.rs
@@ -1,0 +1,126 @@
+use geoarrow::algorithm::native::bounding_rect::bounding_rect_geometry;
+use geoarrow::error::GeoArrowError;
+use geoarrow::scalar::GeometryScalar;
+use geoarrow::NativeArray;
+use geozero::svg::SvgWriter;
+use geozero::{FeatureProcessor, GeozeroGeometry, ToJson};
+use pyo3::exceptions::PyIOError;
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyTuple};
+use pyo3_arrow::ffi::to_array_pycapsules;
+
+use crate::error::PyGeoArrowResult;
+
+/// This is modeled as a geospatial array of length 1
+#[pyclass(module = "geoarrow.rust.core", name = "Geometry", subclass, frozen)]
+pub struct PyGeometry(pub(crate) GeometryScalar);
+
+impl PyGeometry {
+    pub fn new(array: GeometryScalar) -> Self {
+        Self(array)
+    }
+
+    pub fn inner(&self) -> &GeometryScalar {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> GeometryScalar {
+        self.0
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn as_ref(&self) -> &dyn NativeArray {
+        self.0.inner().as_ref()
+    }
+
+    pub fn to_geo_point(&self) -> PyGeoArrowResult<geo::Point> {
+        Ok(self.inner().to_geo_point()?)
+    }
+
+    pub fn to_geo_line_string(&self) -> PyGeoArrowResult<geo::LineString> {
+        Ok(self.inner().to_geo_line_string()?)
+    }
+
+    pub fn to_geo(&self) -> geo::Geometry {
+        self.inner().to_geo()
+    }
+}
+
+#[pymethods]
+impl PyGeometry {
+    #[pyo3(signature = (requested_schema=None))]
+    fn __arrow_c_array__<'py>(
+        &'py self,
+        py: Python<'py>,
+        requested_schema: Option<Bound<'py, PyCapsule>>,
+    ) -> PyGeoArrowResult<Bound<'py, PyTuple>> {
+        let geo_arr = self.0.inner();
+        let field = geo_arr.extension_field();
+        let array = geo_arr.to_array_ref();
+        Ok(to_array_pycapsules(py, field, &array, requested_schema)?)
+    }
+
+    // /// Check for equality with other object.
+    // fn __eq__(&self, _other: &PyGeometry) -> bool {
+    //     // self.0 == other.0
+    // }
+
+    #[getter]
+    fn __geo_interface__<'py>(&'py self, py: Python<'py>) -> PyGeoArrowResult<Bound<'py, PyAny>> {
+        let json_string = self.0.to_json().map_err(GeoArrowError::GeozeroError)?;
+        let json_mod = py.import(intern!(py, "json"))?;
+        Ok(json_mod.call_method1(intern!(py, "loads"), (json_string,))?)
+    }
+
+    fn _repr_svg_(&self) -> PyGeoArrowResult<String> {
+        let scalar = self.0.to_geo();
+        let ([mut min_x, mut min_y], [mut max_x, mut max_y]) = bounding_rect_geometry(&scalar);
+
+        let mut svg_data = Vec::new();
+        // Passing `true` to `invert_y` is necessary to match Shapely's _repr_svg_
+        let mut svg = SvgWriter::new(&mut svg_data, true);
+
+        // Expand box by 10% for readability
+        min_x -= (max_x - min_x) * 0.05;
+        min_y -= (max_y - min_y) * 0.05;
+        max_x += (max_x - min_x) * 0.05;
+        max_y += (max_y - min_y) * 0.05;
+
+        svg.set_dimensions(min_x, min_y, max_x, max_y, 100, 100);
+
+        // This sequence is necessary so that the SvgWriter writes the header. See
+        // https://github.com/georust/geozero/blob/6c820ad7a0cac8c864058c783f548407427712d3/geozero/src/svg/mod.rs#L51-L58
+        svg.dataset_begin(None)
+            .map_err(GeoArrowError::GeozeroError)?;
+        svg.feature_begin(0).map_err(GeoArrowError::GeozeroError)?;
+        scalar
+            .process_geom(&mut svg)
+            .map_err(GeoArrowError::GeozeroError)?;
+        svg.feature_end(0).map_err(GeoArrowError::GeozeroError)?;
+        svg.dataset_end().map_err(GeoArrowError::GeozeroError)?;
+
+        let string =
+            String::from_utf8(svg_data).map_err(|err| PyIOError::new_err(err.to_string()))?;
+        Ok(string)
+    }
+
+    fn __repr__(&self) -> PyGeoArrowResult<String> {
+        Ok("geoarrow.rust.core.Geometry".to_string())
+        // todo!()
+        // let scalar = <$geoarrow_scalar>::from(&self.0);
+        // Ok(scalar.to_string())
+    }
+}
+
+impl From<GeometryScalar> for PyGeometry {
+    fn from(value: GeometryScalar) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PyGeometry> for GeometryScalar {
+    fn from(value: PyGeometry) -> Self {
+        value.0
+    }
+}


### PR DESCRIPTION
### Change list

- Add `rust/pyo3-geoarrow` directory and module
- This can be a module in the main `rust` monorepo crates, because it doesn't rely on the Python interpreter at all; it just relies on the `pyo3` dependency.
- `GeoArrowArray` is the Python-facing array type that stores all geometry array types, including WKB and WKT arrays
- `GeoArrowType` stores extension type information and metadata.