### PR TITLE
Add `geo` round trip tests with null and empty geometries

### DIFF
--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -325,6 +325,21 @@ mod test {
     }
 
     #[test]
+    fn geo_round_trip2() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geo_arr = linestring::array(coord_type, Dimension::XY);
+            let geo_geoms = geo_arr
+                .iter()
+                .map(|x| x.transpose().unwrap().map(|g| g.to_line_string()))
+                .collect::<Vec<_>>();
+
+            let typ = LineStringType::new(coord_type, Dimension::XY, Default::default());
+            let geo_arr2 = LineStringBuilder::from_nullable_line_strings(&geo_geoms, typ).finish();
+            assert_eq!(geo_arr, geo_arr2);
+        }
+    }
+
+    #[test]
     fn try_from_arrow() {
         for coord_type in [CoordType::Interleaved, CoordType::Separated] {
             for dim in [

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -396,6 +396,22 @@ mod test {
     }
 
     #[test]
+    fn geo_round_trip2() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geo_arr = multilinestring::array(coord_type, Dimension::XY);
+            let geo_geoms = geo_arr
+                .iter()
+                .map(|x| x.transpose().unwrap().map(|g| g.to_multi_line_string()))
+                .collect::<Vec<_>>();
+
+            let typ = MultiLineStringType::new(coord_type, Dimension::XY, Default::default());
+            let geo_arr2 =
+                MultiLineStringBuilder::from_nullable_multi_line_strings(&geo_geoms, typ).finish();
+            assert_eq!(geo_arr, geo_arr2);
+        }
+    }
+
+    #[test]
     fn try_from_arrow() {
         for coord_type in [CoordType::Interleaved, CoordType::Separated] {
             for dim in [

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -346,6 +346,21 @@ mod test {
     }
 
     #[test]
+    fn geo_round_trip2() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geo_arr = multipoint::array(coord_type, Dimension::XY);
+            let geo_geoms = geo_arr
+                .iter()
+                .map(|x| x.transpose().unwrap().map(|g| g.to_multi_point()))
+                .collect::<Vec<_>>();
+
+            let typ = MultiPointType::new(coord_type, Dimension::XY, Default::default());
+            let geo_arr2 = MultiPointBuilder::from_nullable_multi_points(&geo_geoms, typ).finish();
+            assert_eq!(geo_arr, geo_arr2);
+        }
+    }
+
+    #[test]
     fn try_from_arrow() {
         for coord_type in [CoordType::Interleaved, CoordType::Separated] {
             for dim in [

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -477,6 +477,22 @@ mod test {
     }
 
     #[test]
+    fn geo_round_trip2() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geo_arr = multipolygon::array(coord_type, Dimension::XY);
+            let geo_geoms = geo_arr
+                .iter()
+                .map(|x| x.transpose().unwrap().map(|g| g.to_multi_polygon()))
+                .collect::<Vec<_>>();
+
+            let typ = MultiPolygonType::new(coord_type, Dimension::XY, Default::default());
+            let geo_arr2 =
+                MultiPolygonBuilder::from_nullable_multi_polygons(&geo_geoms, typ).finish();
+            assert_eq!(geo_arr, geo_arr2);
+        }
+    }
+
+    #[test]
     fn try_from_arrow() {
         for coord_type in [CoordType::Interleaved, CoordType::Separated] {
             for dim in [

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -407,6 +407,21 @@ mod test {
     }
 
     #[test]
+    fn geo_round_trip2() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            let geo_arr = polygon::array(coord_type, Dimension::XY);
+            let geo_geoms = geo_arr
+                .iter()
+                .map(|x| x.transpose().unwrap().map(|g| g.to_polygon()))
+                .collect::<Vec<_>>();
+
+            let typ = PolygonType::new(coord_type, Dimension::XY, Default::default());
+            let geo_arr2 = PolygonBuilder::from_nullable_polygons(&geo_geoms, typ).finish();
+            assert_eq!(geo_arr, geo_arr2);
+        }
+    }
+
+    #[test]
     fn try_from_arrow() {
         for coord_type in [CoordType::Interleaved, CoordType::Separated] {
             for dim in [


### PR DESCRIPTION
Note that we can't do this test with any array that has an empty point, because `geo`/`geo-types` don't support empty points.