### PR TITLE
Add `geoarrow_array::cast::to_wkb`, `to_wkt` ,`from_wkb`, `from_wkt`

### DIFF
--- a/rust/geoarrow-array/src/array/mixed.rs
+++ b/rust/geoarrow-array/src/array/mixed.rs
@@ -493,7 +493,7 @@ impl MixedGeometryArray {
         let offset = self.offsets[index] as usize;
 
         let expect_msg = "native geometry value access should never error";
-        match type_id {
+        match type_id % 10 {
             1 => Geometry::Point(self.points.value(offset).expect(expect_msg)),
             2 => Geometry::LineString(self.line_strings.value(offset).expect(expect_msg)),
             3 => Geometry::Polygon(self.polygons.value(offset).expect(expect_msg)),
@@ -503,17 +503,6 @@ impl MixedGeometryArray {
             }
             6 => Geometry::MultiPolygon(self.multi_polygons.value(offset).expect(expect_msg)),
             7 => {
-                panic!("nested geometry collections not supported")
-            }
-            11 => Geometry::Point(self.points.value(offset).expect(expect_msg)),
-            12 => Geometry::LineString(self.line_strings.value(offset).expect(expect_msg)),
-            13 => Geometry::Polygon(self.polygons.value(offset).expect(expect_msg)),
-            14 => Geometry::MultiPoint(self.multi_points.value(offset).expect(expect_msg)),
-            15 => {
-                Geometry::MultiLineString(self.multi_line_strings.value(offset).expect(expect_msg))
-            }
-            16 => Geometry::MultiPolygon(self.multi_polygons.value(offset).expect(expect_msg)),
-            17 => {
                 panic!("nested geometry collections not supported")
             }
             _ => panic!("unknown type_id {}", type_id),

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -220,26 +220,16 @@ impl TryFrom<WktArray<i64>> for WktArray<i32> {
 
 #[cfg(test)]
 mod test {
-    use arrow_array::builder::GenericStringBuilder;
+    use geoarrow_schema::{CoordType, Dimension};
 
     use crate::GeoArrowArray;
+    use crate::cast::to_wkt;
     use crate::test::point;
 
     use super::*;
 
     fn wkt_data<O: OffsetSizeTrait>() -> WktArray<O> {
-        let mut builder = GenericStringBuilder::new();
-
-        wkt::to_wkt::write_geometry(&mut builder, &point::p0()).unwrap();
-        builder.append_value("");
-
-        wkt::to_wkt::write_geometry(&mut builder, &point::p1()).unwrap();
-        builder.append_value("");
-
-        wkt::to_wkt::write_geometry(&mut builder, &point::p2()).unwrap();
-        builder.append_value("");
-
-        WktArray::new(builder.finish(), Default::default())
+        to_wkt(&point::array(CoordType::Interleaved, Dimension::XY)).unwrap()
     }
 
     #[test]

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -459,7 +459,7 @@ fn impl_to_wkt<'a, O: OffsetSizeTrait>(geo_arr: &'a impl ArrayAccessor<'a>) -> R
     Ok(WktArray::new(builder.finish(), metadata))
 }
 
-/// Parse a [WkbArray] to a [GeoArrowArray] with the designated [GeoArrowType].
+/// Parse a [WktArray] to a [GeoArrowArray] with the designated [GeoArrowType].
 ///
 /// Note that the GeoArrow metadata on the new array is taken from `to_type` **not** the original
 /// array. Ensure you construct the [GeoArrowType] with the correct metadata.

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -855,35 +855,21 @@ mod test {
         }
     }
 
-    #[ignore = "nullability issues with geometry array?"]
     #[test]
     fn test_round_trip_wkb_geometry() {
-        // let arr = test::geometry::array(CoordType::Interleaved, true);
-        // for i in 0..arr.len() {
-        //     dbg!(arr.is_null(i));
-        // }
-        // // arr.is_null(i)
-        // dbg!(&arr.mpoints[0].validity);
-        // for coord_type in [
-        //     CoordType::Interleaved,
-        //     // CoordType::Separated
-        // ] {
-        //     for prefer_multi in [
-        //         false,
-        //         //  true
-        //     ] {
-        //         let arr = test::geometry::array(coord_type, prefer_multi);
-        //         dbg!(&arr.mpoints[0].validity);
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            for prefer_multi in [false, true] {
+                let arr = test::geometry::array(coord_type, prefer_multi);
 
-        //         // let wkb_arr = to_wkb::<i32>(&arr).unwrap();
-        //         // let arr2 = from_wkb(&wkb_arr, arr.data_type().clone(), prefer_multi).unwrap();
-        //         // assert_eq!(&arr, arr2.as_geometry());
+                let wkb_arr = to_wkb::<i32>(&arr).unwrap();
+                let arr2 = from_wkb(&wkb_arr, arr.data_type().clone(), prefer_multi).unwrap();
+                assert_eq!(&arr, arr2.as_geometry());
 
-        //         // let wkb_arr2 = to_wkb::<i64>(&arr).unwrap();
-        //         // let arr3 = from_wkb(&wkb_arr2, arr.data_type().clone(), prefer_multi).unwrap();
-        //         // assert_eq!(&arr, arr3.as_geometry());
-        //     }
-        // }
+                let wkb_arr2 = to_wkb::<i64>(&arr).unwrap();
+                let arr3 = from_wkb(&wkb_arr2, arr.data_type().clone(), prefer_multi).unwrap();
+                assert_eq!(&arr, arr3.as_geometry());
+            }
+        }
     }
 
     // Start WKT round trip tests
@@ -1039,6 +1025,23 @@ mod test {
                     let arr3 = from_wkt(&wkt_arr2, arr.data_type().clone(), prefer_multi).unwrap();
                     assert_eq!(&arr, arr3.as_geometry_collection());
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn test_round_trip_wkt_geometry() {
+        for coord_type in [CoordType::Interleaved, CoordType::Separated] {
+            for prefer_multi in [false, true] {
+                let arr = test::geometry::array(coord_type, prefer_multi);
+
+                let wkt_arr = to_wkt::<i32>(&arr).unwrap();
+                let arr2 = from_wkt(&wkt_arr, arr.data_type().clone(), prefer_multi).unwrap();
+                assert_eq!(&arr, arr2.as_geometry());
+
+                let wkt_arr2 = to_wkt::<i64>(&arr).unwrap();
+                let arr3 = from_wkt(&wkt_arr2, arr.data_type().clone(), prefer_multi).unwrap();
+                assert_eq!(&arr, arr3.as_geometry());
             }
         }
     }

--- a/rust/geoarrow-geoparquet/src/writer/encode.rs
+++ b/rust/geoarrow-geoparquet/src/writer/encode.rs
@@ -1,11 +1,10 @@
 use arrow_array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::Field;
-use geoarrow_array::array::{WkbArray, from_arrow_array};
-use geoarrow_array::builder::WkbBuilder;
-use geoarrow_array::cast::AsGeoArrowArray;
+use geoarrow_array::array::from_arrow_array;
+use geoarrow_array::cast::{AsGeoArrowArray, to_wkb};
 use geoarrow_array::error::Result;
-use geoarrow_array::{ArrayAccessor, GeoArrowArray, GeoArrowType};
-use geoarrow_schema::{CoordType, WkbType};
+use geoarrow_array::{GeoArrowArray, GeoArrowType};
+use geoarrow_schema::CoordType;
 
 use crate::metadata::GeoParquetColumnEncoding;
 use crate::total_bounds::{BoundingRect, total_bounds};
@@ -49,7 +48,7 @@ fn encode_column(
 
 /// Encode column as WKB
 fn encode_wkb_column(geo_arr: &dyn GeoArrowArray) -> Result<ArrayRef> {
-    Ok(to_wkb(geo_arr)?.to_array_ref())
+    Ok(to_wkb::<i32>(geo_arr)?.to_array_ref())
 }
 
 /// Encode column as GeoArrow.
@@ -76,35 +75,4 @@ fn encode_native_column(geo_arr: &dyn GeoArrowArray) -> ArrayRef {
         GeoArrowType::GeometryCollection(_) => impl_into_coord_type!(as_geometry_collection),
         _ => geo_arr.to_array_ref(),
     }
-}
-
-/// Convert to WKB
-fn to_wkb(arr: &dyn GeoArrowArray) -> Result<WkbArray<i32>> {
-    use GeoArrowType::*;
-    match arr.data_type() {
-        Point(_) => impl_to_wkb(arr.as_point()),
-        LineString(_) => impl_to_wkb(arr.as_line_string()),
-        Polygon(_) => impl_to_wkb(arr.as_polygon()),
-        MultiPoint(_) => impl_to_wkb(arr.as_multi_point()),
-        MultiLineString(_) => impl_to_wkb(arr.as_multi_line_string()),
-        MultiPolygon(_) => impl_to_wkb(arr.as_multi_polygon()),
-        Geometry(_) => impl_to_wkb(arr.as_geometry()),
-        GeometryCollection(_) => impl_to_wkb(arr.as_geometry_collection()),
-        Rect(_) => impl_to_wkb(arr.as_rect()),
-        Wkb(_) => impl_to_wkb(arr.as_wkb::<i32>()),
-        LargeWkb(_) => impl_to_wkb(arr.as_wkb::<i64>()),
-        Wkt(_) => todo!(),      // impl_to_wkb(arr.as_wkt()),
-        LargeWkt(_) => todo!(), // impl_to_wkb(arr.as_wkt()),
-    }
-}
-
-fn impl_to_wkb<'a>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WkbArray<i32>> {
-    // let metadata = geo_arr.metadata().clone();
-
-    let geoms = geo_arr
-        .iter()
-        .map(|x| x.transpose())
-        .collect::<Result<Vec<_>>>()?;
-    let wkb_type = WkbType::new(Default::default());
-    Ok(WkbBuilder::from_nullable_geometries(geoms.as_slice(), wkb_type).finish())
 }

--- a/rust/geodatafusion/src/udf/native/io/wkt.rs
+++ b/rust/geodatafusion/src/udf/native/io/wkt.rs
@@ -11,6 +11,7 @@ use geoarrow::ArrayBase;
 use geoarrow::array::WKTArray;
 use geoarrow::io::wkt::{ToWKT, read_wkt};
 use geoarrow_schema::CoordType;
+use geoarrow_array::cast::to_wkt;
 
 use crate::data_types::{GEOMETRY_TYPE, any_single_geometry_type_input, parse_to_native_array};
 use crate::error::GeoDataFusionResult;
@@ -71,7 +72,7 @@ fn as_text_impl(args: &[ColumnarValue]) -> GeoDataFusionResult<ColumnarValue> {
         .next()
         .unwrap();
     let native_array = parse_to_native_array(array)?;
-    let wkt_arr = native_array.as_ref().to_wkt::<i32>()?;
+    let wkt_arr = to_wkt::<i32>(&native_array)?;
     Ok(wkt_arr.into_array_ref().into())
 }
 


### PR DESCRIPTION
### Change list

- New `to_wkb`, `to_wkt`, `from_wkb`, `from_wkt`.
- I really don't like the `prefer_multi` parameter in `from_wkb` and `from_wkt` but not sure what to do about it.
- Added tests.
- ~~Skipped `GeometryArray` tests because it looks like we might have some general nullability issues in the `GeometryArray` implementation that I want to look into separately.~~ [`d7680de` (#1070)](https://github.com/geoarrow/geoarrow-rs/pull/1070/commits/d7680deb362c1b58ebd7eb40a8167ca51bc075a8) restored these tests, thanks to fixes in #1071 