### PR TITLE
GeometryArray: Fix offsets when pushing null

### DIFF
--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -874,6 +874,7 @@ impl PartialEq for GeometryArray {
 #[cfg(test)]
 mod test {
     use geo_traits::to_geo::ToGeoGeometry;
+    use geoarrow_test::raw;
 
     use super::*;
     use crate::test::{linestring, multilinestring, multipoint, multipolygon, point, polygon};

--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -452,6 +452,22 @@ impl GeoArrowArray for GeometryArray {
         None
     }
 
+    fn is_null(&self, i: usize) -> bool {
+        let type_id = self.type_ids[i];
+        let offset = self.offsets[i] as usize;
+        let dim = (type_id / 10) as usize;
+        match type_id % 10 {
+            1 => self.points[dim].is_null(offset),
+            2 => self.line_strings[dim].is_null(offset),
+            3 => self.polygons[dim].is_null(offset),
+            4 => self.mpoints[dim].is_null(offset),
+            5 => self.mline_strings[dim].is_null(offset),
+            6 => self.mpolygons[dim].is_null(offset),
+            7 => self.gcs[dim].is_null(offset),
+            _ => panic!("unknown type_id {}", type_id),
+        }
+    }
+
     fn data_type(&self) -> GeoArrowType {
         GeoArrowType::Geometry(self.data_type.clone())
     }
@@ -936,6 +952,27 @@ mod test {
                 assert_eq!(geo_arr, geo_arr2);
                 assert_eq!(geo_arr, geo_arr3);
             }
+        }
+    }
+
+    #[test]
+    fn test_nullability() {
+        let geoms = raw::geometry::geoms();
+        let null_idxs = geoms
+            .iter()
+            .enumerate()
+            .filter_map(|(i, geom)| if geom.is_none() { Some(i) } else { None })
+            .collect::<Vec<_>>();
+
+        let typ = GeometryType::new(CoordType::Interleaved, Default::default());
+        let geo_arr = GeometryBuilder::from_nullable_geometries(&geoms, typ, false)
+            .unwrap()
+            .finish();
+        // let arrow_arr = geo_arr.to_array_ref();
+
+        for null_idx in &null_idxs {
+            assert!(geo_arr.is_null(*null_idx));
+            // assert!(arrow_arr.is_null(*null_idx));
         }
     }
 

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -656,45 +656,51 @@ impl<'a> GeometryBuilder {
     // added any valid geometries.
     #[inline]
     pub fn push_null(&mut self) {
-        for arr in &mut self.points {
-            if !arr.is_empty() {
-                arr.push_null();
+        // Iterate through each dimension, then iterate through each child type. If a child exists,
+        // push a null to it.
+        //
+        // Note that we must **also** call `add_*_type` so that the offsets are correct to point
+        // the union array to the child.
+        for dim in [
+            Dimension::XY,
+            Dimension::XYZ,
+            Dimension::XYM,
+            Dimension::XYZM,
+        ] {
+            let dim_idx = dim.order();
+            if !self.points[dim_idx].is_empty() {
+                self.add_point_type(dim);
+                self.points[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.line_strings {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.line_strings[dim_idx].is_empty() {
+                self.add_line_string_type(dim);
+                self.line_strings[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.polygons {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.polygons[dim_idx].is_empty() {
+                self.add_polygon_type(dim);
+                self.polygons[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.mpoints {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.mpoints[dim_idx].is_empty() {
+                self.add_multi_point_type(dim);
+                self.mpoints[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.mline_strings {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.mline_strings[dim_idx].is_empty() {
+                self.add_multi_line_string_type(dim);
+                self.mline_strings[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.mpolygons {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.mpolygons[dim_idx].is_empty() {
+                self.add_multi_polygon_type(dim);
+                self.mpolygons[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.gcs {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.gcs[dim_idx].is_empty() {
+                self.add_geometry_collection_type(dim);
+                self.gcs[dim_idx].push_null();
                 return;
             }
         }


### PR DESCRIPTION
Ensures that the null indices are correctly retrieved from a union array (e.g. GeometryArray)