### PR TITLE
Improved null handling for `GeometryArray`

### DIFF
--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -448,10 +448,16 @@ impl GeoArrowArray for GeometryArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        None
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.to_array_ref().logical_nulls()
     }
 
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.to_array_ref().null_count()
+    }
+
+    #[inline]
     fn is_null(&self, i: usize) -> bool {
         let type_id = self.type_ids[i];
         let offset = self.offsets[i] as usize;

--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -874,6 +874,7 @@ impl PartialEq for GeometryArray {
 #[cfg(test)]
 mod test {
     use geo_traits::to_geo::ToGeoGeometry;
+    use geoarrow_test::raw;
 
     use super::*;
     use crate::test::{linestring, multilinestring, multipoint, multipolygon, point, polygon};

--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -452,6 +452,22 @@ impl GeoArrowArray for GeometryArray {
         None
     }
 
+    fn is_null(&self, i: usize) -> bool {
+        let type_id = self.type_ids[i];
+        let offset = self.offsets[i] as usize;
+        let dim = (type_id / 10) as usize;
+        match type_id % 10 {
+            1 => self.points[dim].is_null(offset),
+            2 => self.line_strings[dim].is_null(offset),
+            3 => self.polygons[dim].is_null(offset),
+            4 => self.mpoints[dim].is_null(offset),
+            5 => self.mline_strings[dim].is_null(offset),
+            6 => self.mpolygons[dim].is_null(offset),
+            7 => self.gcs[dim].is_null(offset),
+            _ => panic!("unknown type_id {}", type_id),
+        }
+    }
+
     fn data_type(&self) -> GeoArrowType {
         GeoArrowType::Geometry(self.data_type.clone())
     }
@@ -936,6 +952,27 @@ mod test {
                 assert_eq!(geo_arr, geo_arr2);
                 assert_eq!(geo_arr, geo_arr3);
             }
+        }
+    }
+
+    #[test]
+    fn test_nullability() {
+        let geoms = raw::geometry::geoms();
+        let null_idxs = geoms
+            .iter()
+            .enumerate()
+            .filter_map(|(i, geom)| if geom.is_none() { Some(i) } else { None })
+            .collect::<Vec<_>>();
+
+        let typ = GeometryType::new(CoordType::Interleaved, Default::default());
+        let geo_arr = GeometryBuilder::from_nullable_geometries(&geoms, typ, false)
+            .unwrap()
+            .finish();
+        // let arrow_arr = geo_arr.to_array_ref();
+
+        for null_idx in &null_idxs {
+            assert!(geo_arr.is_null(*null_idx));
+            // assert!(arrow_arr.is_null(*null_idx));
         }
     }
 

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -126,8 +126,21 @@ impl GeoArrowArray for GeometryCollectionArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity.as_ref()
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.nulls.clone()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.nulls
+            .as_ref()
+            .map(|n| n.is_null(i))
+            .unwrap_or_default()
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -180,8 +180,20 @@ impl GeoArrowArray for LineStringArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity.as_ref()
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.nulls.clone()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
+    }
+
+    fn is_null(&self, i: usize) -> bool {
+        self.nulls
+            .as_ref()
+            .map(|n| n.is_null(i))
+            .unwrap_or_default()
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/mixed.rs
+++ b/rust/geoarrow-array/src/array/mixed.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
-use arrow_array::{Array, ArrayRef, OffsetSizeTrait, UnionArray};
+use arrow_array::{Array, ArrayRef, UnionArray};
 use arrow_buffer::ScalarBuffer;
 use arrow_schema::{DataType, UnionMode};
 use geoarrow_schema::{
@@ -13,11 +13,11 @@ use geoarrow_schema::{
 use crate::ArrayAccessor;
 use crate::array::{
     DimensionIndex, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray,
-    PointArray, PolygonArray, WkbArray,
+    PointArray, PolygonArray,
 };
 use crate::builder::{
-    LineStringBuilder, MixedGeometryBuilder, MultiLineStringBuilder, MultiPointBuilder,
-    MultiPolygonBuilder, PointBuilder, PolygonBuilder,
+    LineStringBuilder, MultiLineStringBuilder, MultiPointBuilder, MultiPolygonBuilder,
+    PointBuilder, PolygonBuilder,
 };
 use crate::capacity::MixedCapacity;
 use crate::datatypes::GeoArrowType;
@@ -687,15 +687,6 @@ impl TryFrom<(&dyn Array, Dimension, CoordType)> for MixedGeometryArray {
                 value.data_type()
             ))),
         }
-    }
-}
-
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, Dimension)> for MixedGeometryArray {
-    type Error = GeoArrowError;
-
-    fn try_from(value: (WkbArray<O>, Dimension)) -> Result<Self> {
-        let mut_arr: MixedGeometryBuilder = value.try_into()?;
-        Ok(mut_arr.finish())
     }
 }
 

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -208,8 +208,21 @@ impl GeoArrowArray for MultiLineStringArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity.as_ref()
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.nulls.clone()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.nulls
+            .as_ref()
+            .map(|n| n.is_null(i))
+            .unwrap_or_default()
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -30,7 +30,7 @@ pub struct MultiPointArray {
     pub(crate) geom_offsets: OffsetBuffer<i32>,
 
     /// Validity bitmap
-    pub(crate) validity: Option<NullBuffer>,
+    pub(crate) nulls: Option<NullBuffer>,
 }
 
 pub(super) fn check(
@@ -40,7 +40,7 @@ pub(super) fn check(
 ) -> Result<()> {
     if validity_len.is_some_and(|len| len != geom_offsets.len_proxy()) {
         return Err(GeoArrowError::General(
-            "validity mask length must match the number of values".to_string(),
+            "nulls mask length must match the number of values".to_string(),
         ));
     }
 
@@ -62,15 +62,15 @@ impl MultiPointArray {
     ///
     /// # Panics
     ///
-    /// - if the validity is not `None` and its length is different from the number of geometries
+    /// - if the nulls is not `None` and its length is different from the number of geometries
     /// - if the largest geometry offset does not match the number of coordinates
     pub fn new(
         coords: CoordBuffer,
         geom_offsets: OffsetBuffer<i32>,
-        validity: Option<NullBuffer>,
+        nulls: Option<NullBuffer>,
         metadata: Arc<Metadata>,
     ) -> Self {
-        Self::try_new(coords, geom_offsets, validity, metadata).unwrap()
+        Self::try_new(coords, geom_offsets, nulls, metadata).unwrap()
     }
 
     /// Create a new MultiPointArray from parts
@@ -81,20 +81,20 @@ impl MultiPointArray {
     ///
     /// # Errors
     ///
-    /// - if the validity is not `None` and its length is different from the number of geometries
+    /// - if the nulls is not `None` and its length is different from the number of geometries
     /// - if the geometry offsets do not match the number of coordinates
     pub fn try_new(
         coords: CoordBuffer,
         geom_offsets: OffsetBuffer<i32>,
-        validity: Option<NullBuffer>,
+        nulls: Option<NullBuffer>,
         metadata: Arc<Metadata>,
     ) -> Result<Self> {
-        check(&coords, validity.as_ref().map(|v| v.len()), &geom_offsets)?;
+        check(&coords, nulls.as_ref().map(|v| v.len()), &geom_offsets)?;
         Ok(Self {
             data_type: MultiPointType::new(coords.coord_type(), coords.dim(), metadata),
             coords,
             geom_offsets,
-            validity,
+            nulls,
         })
     }
 
@@ -109,7 +109,7 @@ impl MultiPointArray {
 
     #[allow(dead_code)]
     pub(crate) fn into_inner(self) -> (CoordBuffer, OffsetBuffer<i32>, Option<NullBuffer>) {
-        (self.coords, self.geom_offsets, self.validity)
+        (self.coords, self.geom_offsets, self.nulls)
     }
 
     /// Access the underlying geometry offsets buffer
@@ -124,7 +124,7 @@ impl MultiPointArray {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls.as_ref().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes()
     }
 
@@ -149,7 +149,7 @@ impl MultiPointArray {
             data_type: self.data_type.clone(),
             coords: self.coords.clone(),
             geom_offsets: self.geom_offsets.slice(offset, length),
-            validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
+            nulls: self.nulls.as_ref().map(|v| v.slice(offset, length)),
         }
     }
 
@@ -159,7 +159,7 @@ impl MultiPointArray {
         Self::new(
             self.coords.into_coord_type(coord_type),
             self.geom_offsets,
-            self.validity,
+            self.nulls,
             metadata,
         )
     }
@@ -224,9 +224,9 @@ impl IntoArrow for MultiPointArray {
 
     fn into_arrow(self) -> Self::ArrowArray {
         let vertices_field = self.vertices_field();
-        let validity = self.validity;
+        let nulls = self.nulls;
         let coord_array = self.coords.into();
-        GenericListArray::new(vertices_field, self.geom_offsets, coord_array, validity)
+        GenericListArray::new(vertices_field, self.geom_offsets, coord_array, nulls)
     }
 
     fn ext_type(&self) -> &Self::ExtensionType {
@@ -240,12 +240,12 @@ impl TryFrom<(&GenericListArray<i32>, MultiPointType)> for MultiPointArray {
     fn try_from((value, typ): (&GenericListArray<i32>, MultiPointType)) -> Result<Self> {
         let coords = CoordBuffer::from_arrow(value.values().as_ref(), typ.dimension())?;
         let geom_offsets = value.offsets();
-        let validity = value.nulls();
+        let nulls = value.nulls();
 
         Ok(Self::new(
             coords,
             geom_offsets.clone(),
-            validity.cloned(),
+            nulls.cloned(),
             typ.metadata().clone(),
         ))
     }
@@ -257,12 +257,12 @@ impl TryFrom<(&GenericListArray<i64>, MultiPointType)> for MultiPointArray {
     fn try_from((value, typ): (&GenericListArray<i64>, MultiPointType)) -> Result<Self> {
         let coords = CoordBuffer::from_arrow(value.values().as_ref(), typ.dimension())?;
         let geom_offsets = offsets_buffer_i64_to_i32(value.offsets())?;
-        let validity = value.nulls();
+        let nulls = value.nulls();
 
         Ok(Self::new(
             coords,
             geom_offsets,
-            validity.cloned(),
+            nulls.cloned(),
             typ.metadata().clone(),
         ))
     }
@@ -306,7 +306,7 @@ impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPointType)> for MultiPointAr
 impl From<MultiPointArray> for LineStringArray {
     fn from(value: MultiPointArray) -> Self {
         let metadata = value.data_type.metadata().clone();
-        Self::new(value.coords, value.geom_offsets, value.validity, metadata)
+        Self::new(value.coords, value.geom_offsets, value.nulls, metadata)
     }
 }
 
@@ -315,14 +315,14 @@ impl From<PointArray> for MultiPointArray {
         let metadata = value.data_type.metadata().clone();
         let coords = value.coords;
         let geom_offsets = OffsetBuffer::from_lengths(vec![1; coords.len()]);
-        let validity = value.validity;
-        Self::new(coords, geom_offsets, validity, metadata)
+        let nulls = value.nulls;
+        Self::new(coords, geom_offsets, nulls, metadata)
     }
 }
 
 impl PartialEq for MultiPointArray {
     fn eq(&self, other: &Self) -> bool {
-        self.validity == other.validity
+        self.nulls == other.nulls
             && offset_buffer_eq(&self.geom_offsets, &other.geom_offsets)
             && self.coords == other.coords
     }

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -184,8 +184,21 @@ impl GeoArrowArray for MultiPointArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity.as_ref()
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.nulls.clone()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.nulls
+            .as_ref()
+            .map(|n| n.is_null(i))
+            .unwrap_or_default()
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -262,8 +262,21 @@ impl GeoArrowArray for MultiPolygonArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity.as_ref()
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.nulls.clone()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.nulls
+            .as_ref()
+            .map(|n| n.is_null(i))
+            .unwrap_or_default()
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/point.rs
+++ b/rust/geoarrow-array/src/array/point.rs
@@ -144,8 +144,21 @@ impl GeoArrowArray for PointArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity.as_ref()
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.nulls.clone()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.nulls
+            .as_ref()
+            .map(|n| n.is_null(i))
+            .unwrap_or_default()
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/point.rs
+++ b/rust/geoarrow-array/src/array/point.rs
@@ -22,7 +22,7 @@ use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
 pub struct PointArray {
     pub(crate) data_type: PointType,
     pub(crate) coords: CoordBuffer,
-    pub(crate) validity: Option<NullBuffer>,
+    pub(crate) nulls: Option<NullBuffer>,
 }
 
 /// Perform checks:
@@ -60,17 +60,17 @@ impl PointArray {
     ///
     /// # Errors
     ///
-    /// - if the validity is not `None` and its length is different from the number of geometries
+    /// - if the nulls is not `None` and its length is different from the number of geometries
     pub fn try_new(
         coords: CoordBuffer,
-        validity: Option<NullBuffer>,
+        nulls: Option<NullBuffer>,
         metadata: Arc<Metadata>,
     ) -> Result<Self> {
-        check(&coords, validity.as_ref().map(|v| v.len()))?;
+        check(&coords, nulls.as_ref().map(|v| v.len()))?;
         Ok(Self {
             data_type: PointType::new(coords.coord_type(), coords.dim(), metadata),
             coords,
-            validity,
+            nulls,
         })
     }
 
@@ -83,7 +83,7 @@ impl PointArray {
 
     /// Access the
     pub fn into_inner(self) -> (CoordBuffer, Option<NullBuffer>) {
-        (self.coords, self.validity)
+        (self.coords, self.nulls)
     }
 
     /// The lengths of each buffer contained in this array.
@@ -94,7 +94,7 @@ impl PointArray {
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
         let dimension = self.data_type.dimension();
-        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self.nulls.as_ref().map(|v| v.buffer().len()).unwrap_or(0);
         validity_len + self.buffer_lengths() * dimension.size() * 8
     }
 
@@ -110,7 +110,7 @@ impl PointArray {
         Self {
             data_type: self.data_type.clone(),
             coords: self.coords.slice(offset, length),
-            validity: self.validity.as_ref().map(|v| v.slice(offset, length)),
+            nulls: self.nulls.as_ref().map(|v| v.slice(offset, length)),
         }
     }
 
@@ -119,7 +119,7 @@ impl PointArray {
         let metadata = self.data_type.metadata().clone();
         Self::new(
             self.coords.into_coord_type(coord_type),
-            self.validity,
+            self.nulls,
             metadata,
         )
     }
@@ -183,7 +183,7 @@ impl IntoArrow for PointArray {
     type ExtensionType = PointType;
 
     fn into_arrow(self) -> Self::ArrowArray {
-        let validity = self.validity;
+        let validity = self.nulls;
         let dim = self.coords.dim();
         match self.coords {
             CoordBuffer::Interleaved(c) => Arc::new(FixedSizeListArray::new(
@@ -259,7 +259,7 @@ impl TryFrom<(&dyn Array, &Field)> for PointArray {
 // as (NaN, NaN). By default, these resolve to false
 impl PartialEq for PointArray {
     fn eq(&self, other: &Self) -> bool {
-        if self.validity != other.validity {
+        if self.nulls != other.nulls {
             return false;
         }
 

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -212,8 +212,21 @@ impl GeoArrowArray for PolygonArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity.as_ref()
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.nulls.clone()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.nulls
+            .as_ref()
+            .map(|n| n.is_null(i))
+            .unwrap_or_default()
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/rect.rs
+++ b/rust/geoarrow-array/src/array/rect.rs
@@ -107,8 +107,21 @@ impl GeoArrowArray for RectArray {
     }
 
     #[inline]
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.validity.as_ref()
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.nulls.clone()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.nulls
+            .as_ref()
+            .map(|n| n.is_null(i))
+            .unwrap_or_default()
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -55,7 +55,12 @@ impl<O: OffsetSizeTrait> WkbArray<O> {
 
     /// The number of bytes occupied by this array.
     pub fn num_bytes(&self) -> usize {
-        let validity_len = self.nulls().map(|v| v.buffer().len()).unwrap_or(0);
+        let validity_len = self
+            .array
+            .nulls()
+            .as_ref()
+            .map(|v| v.buffer().len())
+            .unwrap_or(0);
         validity_len + self.buffer_lengths().num_bytes::<O>()
     }
 

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -100,8 +100,19 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WkbArray<O> {
         self.array.len()
     }
 
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.array.nulls()
+    #[inline]
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.array.logical_nulls()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.array.null_count()
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.array.is_null(i)
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -91,8 +91,19 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
         self.array.len()
     }
 
-    fn nulls(&self) -> Option<&NullBuffer> {
-        self.array.nulls()
+    #[inline]
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.array.logical_nulls()
+    }
+
+    #[inline]
+    fn null_count(&self) -> usize {
+        self.array.null_count()
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.array.is_null(i)
     }
 
     fn data_type(&self) -> GeoArrowType {

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -14,7 +14,7 @@ use crate::builder::{
 };
 use crate::capacity::GeometryCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeoArrowArray, GeometryArrayBuilder};
+use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
 
 pub(crate) const DEFAULT_PREFER_MULTI: bool = false;
 
@@ -757,12 +757,6 @@ impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryType)> for GeometryBuilde
     fn try_from(
         (value, typ): (WkbArray<O>, GeometryType),
     ) -> std::result::Result<Self, Self::Error> {
-        assert_eq!(
-            value.nulls().map_or(0, |validity| validity.null_count()),
-            0,
-            "Parsing a WkbArray with null elements not supported",
-        );
-
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -656,45 +656,51 @@ impl<'a> GeometryBuilder {
     // added any valid geometries.
     #[inline]
     pub fn push_null(&mut self) {
-        for arr in &mut self.points {
-            if !arr.is_empty() {
-                arr.push_null();
+        // Iterate through each dimension, then iterate through each child type. If a child exists,
+        // push a null to it.
+        //
+        // Note that we must **also** call `add_*_type` so that the offsets are correct to point
+        // the union array to the child.
+        for dim in [
+            Dimension::XY,
+            Dimension::XYZ,
+            Dimension::XYM,
+            Dimension::XYZM,
+        ] {
+            let dim_idx = dim.order();
+            if !self.points[dim_idx].is_empty() {
+                self.add_point_type(dim);
+                self.points[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.line_strings {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.line_strings[dim_idx].is_empty() {
+                self.add_line_string_type(dim);
+                self.line_strings[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.polygons {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.polygons[dim_idx].is_empty() {
+                self.add_polygon_type(dim);
+                self.polygons[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.mpoints {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.mpoints[dim_idx].is_empty() {
+                self.add_multi_point_type(dim);
+                self.mpoints[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.mline_strings {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.mline_strings[dim_idx].is_empty() {
+                self.add_multi_line_string_type(dim);
+                self.mline_strings[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.mpolygons {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.mpolygons[dim_idx].is_empty() {
+                self.add_multi_polygon_type(dim);
+                self.mpolygons[dim_idx].push_null();
                 return;
             }
-        }
-        for arr in &mut self.gcs {
-            if !arr.is_empty() {
-                arr.push_null();
+            if !self.gcs[dim_idx].is_empty() {
+                self.add_geometry_collection_type(dim);
+                self.gcs[dim_idx].push_null();
                 return;
             }
         }

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -127,9 +127,13 @@ impl<'a> GeometryCollectionBuilder {
     /// Push a Point onto the end of this builder
     #[inline]
     pub fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
-        self.geoms.push_point(value)?;
-        self.geom_offsets.try_push_usize(1)?;
-        self.validity.append(value.is_some());
+        if let Some(geom) = value {
+            self.geoms.push_point(geom)?;
+            self.geom_offsets.try_push_usize(1)?;
+            self.validity.append(value.is_some());
+        } else {
+            self.push_null();
+        }
         Ok(())
     }
 
@@ -139,18 +143,26 @@ impl<'a> GeometryCollectionBuilder {
         &mut self,
         value: Option<&impl LineStringTrait<T = f64>>,
     ) -> Result<()> {
-        self.geoms.push_line_string(value)?;
-        self.geom_offsets.try_push_usize(1)?;
-        self.validity.append(value.is_some());
+        if let Some(geom) = value {
+            self.geoms.push_line_string(geom)?;
+            self.geom_offsets.try_push_usize(1)?;
+            self.validity.append(value.is_some());
+        } else {
+            self.push_null();
+        }
         Ok(())
     }
 
     /// Push a Polygon onto the end of this builder
     #[inline]
     pub fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
-        self.geoms.push_polygon(value)?;
-        self.geom_offsets.try_push_usize(1)?;
-        self.validity.append(value.is_some());
+        if let Some(geom) = value {
+            self.geoms.push_polygon(geom)?;
+            self.geom_offsets.try_push_usize(1)?;
+            self.validity.append(value.is_some());
+        } else {
+            self.push_null();
+        }
         Ok(())
     }
 
@@ -160,9 +172,13 @@ impl<'a> GeometryCollectionBuilder {
         &mut self,
         value: Option<&impl MultiPointTrait<T = f64>>,
     ) -> Result<()> {
-        self.geoms.push_multi_point(value)?;
-        self.geom_offsets.try_push_usize(1)?;
-        self.validity.append(value.is_some());
+        if let Some(geom) = value {
+            self.geoms.push_multi_point(geom)?;
+            self.geom_offsets.try_push_usize(1)?;
+            self.validity.append(value.is_some());
+        } else {
+            self.push_null();
+        }
         Ok(())
     }
 
@@ -172,9 +188,13 @@ impl<'a> GeometryCollectionBuilder {
         &mut self,
         value: Option<&impl MultiLineStringTrait<T = f64>>,
     ) -> Result<()> {
-        self.geoms.push_multi_line_string(value)?;
-        self.geom_offsets.try_push_usize(1)?;
-        self.validity.append(value.is_some());
+        if let Some(geom) = value {
+            self.geoms.push_multi_line_string(geom)?;
+            self.geom_offsets.try_push_usize(1)?;
+            self.validity.append(value.is_some());
+        } else {
+            self.push_null();
+        }
         Ok(())
     }
 
@@ -184,9 +204,13 @@ impl<'a> GeometryCollectionBuilder {
         &mut self,
         value: Option<&impl MultiPolygonTrait<T = f64>>,
     ) -> Result<()> {
-        self.geoms.push_multi_polygon(value)?;
-        self.geom_offsets.try_push_usize(1)?;
-        self.validity.append(value.is_some());
+        if let Some(geom) = value {
+            self.geoms.push_multi_polygon(geom)?;
+            self.geom_offsets.try_push_usize(1)?;
+            self.validity.append(value.is_some());
+        } else {
+            self.push_null();
+        }
         Ok(())
     }
 
@@ -223,7 +247,7 @@ impl<'a> GeometryCollectionBuilder {
         if let Some(gc) = value {
             let num_geoms = gc.num_geometries();
             for g in gc.geometries() {
-                self.geoms.push_geometry(Some(&g))?;
+                self.geoms.push_geometry(&g)?;
             }
             self.try_push_length(num_geoms)?;
         } else {

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -61,7 +61,7 @@ pub(crate) struct MixedGeometryBuilder {
     pub(crate) prefer_multi: bool,
 }
 
-impl<'a> MixedGeometryBuilder {
+impl MixedGeometryBuilder {
     pub(crate) fn with_capacity_and_options(
         dim: Dimension,
         capacity: MixedCapacity,
@@ -169,43 +169,6 @@ impl<'a> MixedGeometryBuilder {
             Some(self.multi_polygons.finish()),
             self.metadata,
         )
-    }
-
-    pub(crate) fn with_capacity_and_options_from_iter(
-        geoms: impl Iterator<Item = &'a (impl GeometryTrait + 'a)>,
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        let counter = MixedCapacity::from_geometries(geoms)?;
-        Ok(Self::with_capacity_and_options(
-            dim,
-            counter,
-            coord_type,
-            metadata,
-            prefer_multi,
-        ))
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn reserve_from_iter(
-        &mut self,
-        geoms: impl Iterator<Item = &'a (impl GeometryTrait + 'a)>,
-    ) -> Result<()> {
-        let counter = MixedCapacity::from_geometries(geoms)?;
-        self.reserve(counter);
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn reserve_exact_from_iter(
-        &mut self,
-        geoms: impl Iterator<Item = &'a (impl GeometryTrait + 'a)>,
-    ) -> Result<()> {
-        let counter = MixedCapacity::from_geometries(geoms)?;
-        self.reserve_exact(counter);
-        Ok(())
     }
 
     /// Add a new Point to the end of this array.
@@ -372,7 +335,7 @@ impl<'a> MixedGeometryBuilder {
     }
 
     #[inline]
-    pub(crate) fn push_geometry(&mut self, geom: &'a impl GeometryTrait<T = f64>) -> Result<()> {
+    pub(crate) fn push_geometry(&mut self, geom: &'_ impl GeometryTrait<T = f64>) -> Result<()> {
         use geo_traits::GeometryType::*;
 
         match geom.as_type() {
@@ -400,50 +363,5 @@ impl<'a> MixedGeometryBuilder {
             Rect(_) | Triangle(_) | Line(_) => todo!(),
         };
         Ok(())
-    }
-
-    #[inline]
-    pub(crate) fn push_null(&mut self) {
-        todo!("push null geometry")
-    }
-
-    /// Extend this builder with the given geometries
-    pub(crate) fn extend_from_iter(
-        &mut self,
-        geoms: impl Iterator<Item = &'a (impl GeometryTrait<T = f64> + 'a)>,
-    ) {
-        geoms
-            .into_iter()
-            .try_for_each(|maybe_geom| self.push_geometry(maybe_geom))
-            .unwrap();
-    }
-
-    /// Create this builder from a slice of nullable Geometries.
-    pub(crate) fn from_nullable_geometries(
-        geoms: &[impl GeometryTrait<T = f64>],
-        dim: Dimension,
-        coord_type: CoordType,
-        metadata: Arc<Metadata>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        let mut array = Self::with_capacity_and_options_from_iter(
-            geoms.iter(),
-            dim,
-            coord_type,
-            metadata,
-            prefer_multi,
-        )?;
-        array.extend_from_iter(geoms.iter());
-        Ok(array)
-    }
-}
-
-impl GeometryArrayBuilder for MixedGeometryBuilder {
-    fn len(&self) -> usize {
-        self.types.len()
-    }
-
-    fn push_null(&mut self) {
-        self.push_null();
     }
 }

--- a/rust/geoarrow-array/src/capacity/geometrycollection.rs
+++ b/rust/geoarrow-array/src/capacity/geometrycollection.rs
@@ -48,33 +48,33 @@ impl GeometryCollectionCapacity {
 
     #[inline]
     fn add_valid_line_string(&mut self, geom: &impl LineStringTrait) {
-        self.mixed_capacity.add_line_string(Some(geom));
+        self.mixed_capacity.add_line_string(geom);
     }
 
     #[inline]
     fn add_valid_polygon(&mut self, geom: &impl PolygonTrait) {
-        self.mixed_capacity.add_polygon(Some(geom));
+        self.mixed_capacity.add_polygon(geom);
     }
 
     #[inline]
     fn add_valid_multi_point(&mut self, geom: &impl MultiPointTrait) {
-        self.mixed_capacity.add_multi_point(Some(geom));
+        self.mixed_capacity.add_multi_point(geom);
     }
 
     #[inline]
     fn add_valid_multi_line_string(&mut self, geom: &impl MultiLineStringTrait) {
-        self.mixed_capacity.add_multi_line_string(Some(geom));
+        self.mixed_capacity.add_multi_line_string(geom);
     }
 
     #[inline]
     fn add_valid_multi_polygon(&mut self, geom: &impl MultiPolygonTrait) {
-        self.mixed_capacity.add_multi_polygon(Some(geom));
+        self.mixed_capacity.add_multi_polygon(geom);
     }
 
     #[inline]
     fn add_valid_geometry_collection(&mut self, geom: &impl GeometryCollectionTrait) -> Result<()> {
         for g in geom.geometries() {
-            self.mixed_capacity.add_geometry(Some(&g))?
+            self.mixed_capacity.add_geometry(&g)?
         }
         Ok(())
     }

--- a/rust/geoarrow-array/src/capacity/mixed.rs
+++ b/rust/geoarrow-array/src/capacity/mixed.rs
@@ -150,54 +150,50 @@ impl MixedCapacity {
     }
 
     #[inline]
-    pub fn add_line_string(&mut self, line_string: Option<&impl LineStringTrait>) {
-        self.line_string.add_line_string(line_string);
+    pub fn add_line_string(&mut self, line_string: &impl LineStringTrait) {
+        self.line_string.add_line_string(Some(line_string));
     }
 
     #[inline]
-    pub fn add_polygon(&mut self, polygon: Option<&impl PolygonTrait>) {
-        self.polygon.add_polygon(polygon);
+    pub fn add_polygon(&mut self, polygon: &impl PolygonTrait) {
+        self.polygon.add_polygon(Some(polygon));
     }
 
     #[inline]
-    pub fn add_multi_point(&mut self, multi_point: Option<&impl MultiPointTrait>) {
-        self.multi_point.add_multi_point(multi_point);
+    pub fn add_multi_point(&mut self, multi_point: &impl MultiPointTrait) {
+        self.multi_point.add_multi_point(Some(multi_point));
     }
 
     #[inline]
-    pub fn add_multi_line_string(&mut self, multi_line_string: Option<&impl MultiLineStringTrait>) {
+    pub fn add_multi_line_string(&mut self, multi_line_string: &impl MultiLineStringTrait) {
         self.multi_line_string
-            .add_multi_line_string(multi_line_string);
+            .add_multi_line_string(Some(multi_line_string));
     }
 
     #[inline]
-    pub fn add_multi_polygon(&mut self, multi_polygon: Option<&impl MultiPolygonTrait>) {
-        self.multi_polygon.add_multi_polygon(multi_polygon);
+    pub fn add_multi_polygon(&mut self, multi_polygon: &impl MultiPolygonTrait) {
+        self.multi_polygon.add_multi_polygon(Some(multi_polygon));
     }
 
     #[inline]
-    pub fn add_geometry(&mut self, geom: Option<&impl GeometryTrait>) -> Result<()> {
-        // TODO: what to do about null geometries? We don't know which type they have
-        assert!(geom.is_some());
-        if let Some(geom) = geom {
-            match geom.as_type() {
-                geo_traits::GeometryType::Point(_) => self.add_point(),
-                geo_traits::GeometryType::LineString(g) => self.add_line_string(Some(g)),
-                geo_traits::GeometryType::Polygon(g) => self.add_polygon(Some(g)),
-                geo_traits::GeometryType::MultiPoint(p) => self.add_multi_point(Some(p)),
-                geo_traits::GeometryType::MultiLineString(p) => self.add_multi_line_string(Some(p)),
-                geo_traits::GeometryType::MultiPolygon(p) => self.add_multi_polygon(Some(p)),
-                geo_traits::GeometryType::GeometryCollection(_) => {
-                    panic!("nested geometry collections not supported")
-                }
-                _ => todo!(), // geo_traits::GeometryType::Rect(_) => todo!(),
-            };
+    pub fn add_geometry(&mut self, geom: &impl GeometryTrait) -> Result<()> {
+        match geom.as_type() {
+            geo_traits::GeometryType::Point(_) => self.add_point(),
+            geo_traits::GeometryType::LineString(g) => self.add_line_string(g),
+            geo_traits::GeometryType::Polygon(g) => self.add_polygon(g),
+            geo_traits::GeometryType::MultiPoint(p) => self.add_multi_point(p),
+            geo_traits::GeometryType::MultiLineString(p) => self.add_multi_line_string(p),
+            geo_traits::GeometryType::MultiPolygon(p) => self.add_multi_polygon(p),
+            geo_traits::GeometryType::GeometryCollection(_) => {
+                panic!("nested geometry collections not supported")
+            }
+            _ => todo!(), // geo_traits::GeometryType::Rect(_) => todo!(),
         };
         Ok(())
     }
 
     pub fn from_geometries<'a>(
-        geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
+        geoms: impl Iterator<Item = &'a (impl GeometryTrait + 'a)>,
     ) -> Result<Self> {
         let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
@@ -207,11 +203,11 @@ impl MixedCapacity {
     }
 
     pub fn from_owned_geometries<'a>(
-        geoms: impl Iterator<Item = Option<(impl GeometryTrait + 'a)>>,
+        geoms: impl Iterator<Item = (impl GeometryTrait + 'a)>,
     ) -> Result<Self> {
         let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
-            counter.add_geometry(maybe_geom.as_ref())?;
+            counter.add_geometry(&maybe_geom)?;
         }
         Ok(counter)
     }

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -324,7 +324,7 @@ pub mod __private {
 ///     match array.data_type() {
 ///         Point(_) | LineString(_) | MultiPoint(_) | MultiLineString(_) => {
 ///             let values = vec![0.0f64; array.len()];
-///             Ok(Float64Array::new(values.into(), array.nulls().cloned()))
+///             Ok(Float64Array::new(values.into(), array.logical_nulls()))
 ///         }
 ///         _ => impl_unsigned_area(array),
 ///     }


### PR DESCRIPTION
### Change list

- Partly a legacy holdover but we have a "MixedArray" concept. This is now used only as the child of a `GeometryCollectionArray`. So a `GeometryCollectionArray` holds an offset buffer + a Mixed array. This means that the `MixedArray` itself will **never** need to be concerned with null input. Because the `GeometryCollectionArray` will always itself handle null input before it reaches the `MixedArray`. This means we can simplify a lot of the `MixedArrayBuilder` APIs to only take in non-null geometries.
- Modify `GeoArrowArray` trait to have `logical_nulls` but not `nulls`. The upstream `Array` trait has a weird separation between [`nulls`](https://docs.rs/arrow/latest/arrow/array/trait.Array.html#tymethod.nulls) and [`logical_nulls`](https://docs.rs/arrow/latest/arrow/array/trait.Array.html#method.logical_nulls). `nulls` is always a reference whereas `logical_nulls` may be computed. In our case, we use union arrays heavily in our `GeometryArray`. In upstream, `nulls` is **wrong** for a `UnionArray`. You have to **know** that the result will be invalid for `UnionArray`. This is an easy way to shoot yourself in the foot. Here, we remove the `nulls` API and only present `logical_nulls` so that the result is always valid. 
- Additionally, we specialize `is_null` and `null_count` so that those code paths don't need to construct the `logical_nulls`.
- Simple rename of internal `NullBuffer` in each geometry array type from `validity` to `nulls`.
- Fix pushing null geometries to GeometryCollectionBuilder
- Remove unused code from MixedGeometryBuilder
- Add logical nulls tests for `GeometryArray` and `GeometryCollectionArray`