### PR TITLE
Fix deferred null handling in `GeometryBuilder`

### DIFF
--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -453,8 +453,8 @@ impl GeoArrowArray for GeometryArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
-        self.to_array_ref().null_count()
+    fn logical_null_count(&self) -> usize {
+        self.to_array_ref().logical_null_count()
     }
 
     #[inline]

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -131,7 +131,7 @@ impl GeoArrowArray for GeometryCollectionArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
+    fn logical_null_count(&self) -> usize {
         self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
     }
 

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -185,7 +185,7 @@ impl GeoArrowArray for LineStringArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
+    fn logical_null_count(&self) -> usize {
         self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
     }
 

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -213,7 +213,7 @@ impl GeoArrowArray for MultiLineStringArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
+    fn logical_null_count(&self) -> usize {
         self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
     }
 

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -189,7 +189,7 @@ impl GeoArrowArray for MultiPointArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
+    fn logical_null_count(&self) -> usize {
         self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
     }
 

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -267,7 +267,7 @@ impl GeoArrowArray for MultiPolygonArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
+    fn logical_null_count(&self) -> usize {
         self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
     }
 

--- a/rust/geoarrow-array/src/array/point.rs
+++ b/rust/geoarrow-array/src/array/point.rs
@@ -149,7 +149,7 @@ impl GeoArrowArray for PointArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
+    fn logical_null_count(&self) -> usize {
         self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
     }
 

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -217,7 +217,7 @@ impl GeoArrowArray for PolygonArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
+    fn logical_null_count(&self) -> usize {
         self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
     }
 
@@ -368,7 +368,7 @@ impl From<RectArray> for PolygonArray {
 
         // Each output polygon has exactly 5 coordinates
         // Don't reserve capacity for null entries
-        let coord_capacity = (value.len() - value.null_count()) * 5;
+        let coord_capacity = (value.len() - value.logical_null_count()) * 5;
 
         let capacity = PolygonCapacity::new(coord_capacity, ring_capacity, geom_capacity);
         let mut output_array = PolygonBuilder::with_capacity(polygon_type, capacity);

--- a/rust/geoarrow-array/src/array/rect.rs
+++ b/rust/geoarrow-array/src/array/rect.rs
@@ -112,7 +112,7 @@ impl GeoArrowArray for RectArray {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
+    fn logical_null_count(&self) -> usize {
         self.nulls.as_ref().map(|v| v.null_count()).unwrap_or(0)
     }
 

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -111,8 +111,8 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WkbArray<O> {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
-        self.array.null_count()
+    fn logical_null_count(&self) -> usize {
+        self.array.logical_null_count()
     }
 
     #[inline]

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -97,8 +97,8 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
     }
 
     #[inline]
-    fn null_count(&self) -> usize {
-        self.array.null_count()
+    fn logical_null_count(&self) -> usize {
+        self.array.logical_null_count()
     }
 
     #[inline]

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -968,4 +968,25 @@ mod test {
             2
         );
     }
+
+    // Test pushing nulls that are added after a valid geometry has been pushed.
+    #[test]
+    fn nulls_no_deferred() {
+        let coord_type = CoordType::Interleaved;
+        let typ = GeometryType::new(coord_type, Default::default());
+
+        let mut builder = GeometryBuilder::new(typ, false);
+        let point = wkt! { POINT Z (30. 10. 40.) };
+        builder.push_point(Some(&point)).unwrap();
+        builder.push_null();
+        builder.push_null();
+
+        let geom_arr = builder.finish();
+        assert_eq!(geom_arr.logical_null_count(), 2);
+        // All nulls should be in point XYZ child.
+        assert_eq!(
+            geom_arr.points[Dimension::XYZ.order()].logical_null_count(),
+            2
+        );
+    }
 }

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -892,10 +892,10 @@ mod test {
         builder.push_null();
 
         let array = builder.finish();
-        assert_eq!(array.null_count(), 3);
+        assert_eq!(array.logical_null_count(), 3);
 
         // We expect the nulls to be placed in (canonically) the first child
-        assert_eq!(array.points[0].null_count(), 3);
+        assert_eq!(array.points[0].logical_null_count(), 3);
     }
 
     #[test]
@@ -908,7 +908,7 @@ mod test {
         builder.push_null();
 
         let linestring_arr = crate::test::linestring::array(coord_type, Dimension::XYZ);
-        let linestring_arr_null_count = linestring_arr.null_count();
+        let linestring_arr_null_count = linestring_arr.logical_null_count();
 
         // Push the geometries from the linestring arr onto the geometry builder
         for geom in linestring_arr.iter() {
@@ -921,11 +921,11 @@ mod test {
 
         // Since there are 2 nulls pushed manually and a third from the LineString arr
         let total_expected_null_count = 2 + linestring_arr_null_count;
-        assert_eq!(geom_arr.null_count(), total_expected_null_count);
+        assert_eq!(geom_arr.logical_null_count(), total_expected_null_count);
 
         // All nulls should be in the XYZ linestring child
         assert_eq!(
-            geom_arr.line_strings[Dimension::XYZ.order()].null_count(),
+            geom_arr.line_strings[Dimension::XYZ.order()].logical_null_count(),
             total_expected_null_count
         );
     }
@@ -950,16 +950,22 @@ mod test {
 
         let geom_arr = builder.finish();
 
-        assert_eq!(geom_arr.null_count(), 4);
+        assert_eq!(geom_arr.logical_null_count(), 4);
 
         // The first two nulls get added to the point z child because those are deferred and the
         // point z is the first non-null geometry added.
-        assert_eq!(geom_arr.points[Dimension::XYZ.order()].null_count(), 2);
+        assert_eq!(
+            geom_arr.points[Dimension::XYZ.order()].logical_null_count(),
+            2
+        );
 
         // The last two nulls get added to the linestring XY child because the current
         // implementation looks through all XY arrays then all XYZ then etc looking for the first
         // non-empty array. Since the linestring XY child is non-empty, the last nulls get pushed
         // here.
-        assert_eq!(geom_arr.line_strings[Dimension::XY.order()].null_count(), 2);
+        assert_eq!(
+            geom_arr.line_strings[Dimension::XY.order()].logical_null_count(),
+            2
+        );
     }
 }

--- a/rust/geoarrow-array/src/trait_.rs
+++ b/rust/geoarrow-array/src/trait_.rs
@@ -147,7 +147,7 @@ pub trait GeoArrowArray: Debug + Send + Sync {
     /// let array: PointArray = (vec![point].as_slice(), Dimension::XY).into();
     /// assert_eq!(array.null_count(), 0);
     /// ```
-    fn null_count(&self) -> usize;
+    fn logical_null_count(&self) -> usize;
 
     /// Returns whether slot `i` is null.
     ///

--- a/rust/pyo3-geoarrow/src/array.rs
+++ b/rust/pyo3-geoarrow/src/array.rs
@@ -142,7 +142,7 @@ impl PyGeoArrowArray {
 
     #[getter]
     fn null_count(&self) -> usize {
-        self.0.null_count()
+        self.0.logical_null_count()
     }
 
     #[getter]

--- a/rust/pyo3-geoarrow/src/chunked_array.rs
+++ b/rust/pyo3-geoarrow/src/chunked_array.rs
@@ -120,7 +120,10 @@ impl PyChunkedGeoArrowArray {
 
     #[getter]
     fn null_count(&self) -> usize {
-        self.chunks.iter().map(|chunk| chunk.null_count()).sum()
+        self.chunks
+            .iter()
+            .map(|chunk| chunk.logical_null_count())
+            .sum()
     }
 
     #[getter]


### PR DESCRIPTION
- Fix deferred null application in geometry builder. The `GeometryBuilder` has an (internal) concept of "deferred nulls". That is, before a valid geometry has been pushed, we don't know where to push a null value. Ideally we want to push a null value to the same array as future valid geometries, so that it's easier to "downcast" to a single concrete array type if desired. 
- Previously the deferred nulls were broken because we were pushing the nulls to the children but not updating the `types` and `offsets` in the top-level union array.
- Add a test where all nulls and no valid geometries are pushed. 
- Add a test where partial nulls are pushed.