### PR TITLE
Remove unnecessary builder APIs from public API

### DIFF
--- a/rust/geoarrow-array/src/array/coord/combined.rs
+++ b/rust/geoarrow-array/src/array/coord/combined.rs
@@ -106,7 +106,7 @@ impl CoordBuffer {
                     let coord = cb.value(i);
                     new_buffer.push_coord(&coord);
                 }
-                CoordBuffer::Separated(new_buffer.into())
+                CoordBuffer::Separated(new_buffer.finish())
             }
             (CoordBuffer::Separated(cb), CoordType::Separated) => CoordBuffer::Separated(cb),
             (CoordBuffer::Separated(cb), CoordType::Interleaved) => {
@@ -115,7 +115,7 @@ impl CoordBuffer {
                     let coord = cb.value(i);
                     new_buffer.push_coord(&coord);
                 }
-                CoordBuffer::Interleaved(new_buffer.into())
+                CoordBuffer::Interleaved(new_buffer.finish())
             }
         }
     }

--- a/rust/geoarrow-array/src/array/coord/interleaved.rs
+++ b/rust/geoarrow-array/src/array/coord/interleaved.rs
@@ -65,7 +65,7 @@ impl InterleavedCoordBuffer {
         coords: impl ExactSizeIterator<Item = &'a (impl CoordTrait<T = f64> + 'a)>,
         dim: Dimension,
     ) -> Result<Self> {
-        Ok(InterleavedCoordBufferBuilder::from_coords(coords, dim)?.into())
+        Ok(InterleavedCoordBufferBuilder::from_coords(coords, dim)?.finish())
     }
 
     /// Access the underlying coordinate buffer.

--- a/rust/geoarrow-array/src/array/coord/separated.rs
+++ b/rust/geoarrow-array/src/array/coord/separated.rs
@@ -243,7 +243,7 @@ impl SeparatedCoordBuffer {
         coords: impl ExactSizeIterator<Item = &'a (impl CoordTrait<T = f64> + 'a)>,
         dim: Dimension,
     ) -> Result<Self> {
-        Ok(SeparatedCoordBufferBuilder::from_coords(coords, dim)?.into())
+        Ok(SeparatedCoordBufferBuilder::from_coords(coords, dim)?.finish())
     }
 }
 

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -85,7 +85,7 @@ impl<'a> GeometryCollectionBuilder {
         let validity = self.validity.finish();
         GeometryCollectionArray::new(
             self.geoms.finish(),
-            self.geom_offsets.into(),
+            self.geom_offsets.finish(),
             validity,
             self.data_type.metadata().clone(),
         )

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -102,8 +102,8 @@ impl LineStringBuilder {
     pub fn finish(mut self) -> LineStringArray {
         let validity = self.validity.finish();
         LineStringArray::new(
-            self.coords.into(),
-            self.geom_offsets.into(),
+            self.coords.finish(),
+            self.geom_offsets.finish(),
             validity,
             self.data_type.metadata().clone(),
         )
@@ -199,12 +199,12 @@ impl LineStringBuilder {
 
     /// Push a raw coordinate to the underlying coordinate array.
     ///
-    /// # Safety
+    /// # Invariants
     ///
-    /// This is marked as unsafe because care must be taken to ensure that pushing raw coordinates
-    /// to the array upholds the necessary invariants of the array.
+    /// Care must be taken to ensure that pushing raw coordinates to the array upholds the
+    /// necessary invariants of the array.
     #[inline]
-    pub unsafe fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) -> Result<()> {
+    pub(crate) fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) -> Result<()> {
         self.coords.try_push_coord(coord)
     }
 

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -128,35 +128,6 @@ impl MixedGeometryBuilder {
         self.multi_polygons.reserve_exact(capacity.multi_polygon);
     }
 
-    // /// The canonical method to create a [`MixedGeometryBuilder`] out of its internal
-    // /// components.
-    // ///
-    // /// # Implementation
-    // ///
-    // /// This function is `O(1)`.
-    // ///
-    // /// # Errors
-    // ///
-    // pub(crate) fn try_new(
-    //     coords: CoordBufferBuilder,
-    //     geom_offsets: BufferBuilder<O>,
-    //     ring_offsets: BufferBuilder<O>,
-    //     validity: Option<MutableBitmap>,
-    // ) -> Result<Self> {
-    //     check(
-    //         &coords.clone().into(),
-    //         &geom_offsets.clone().into(),
-    //         &ring_offsets.clone().into(),
-    //         validity.as_ref().map(|x| x.len()),
-    //     )?;
-    //     Ok(Self {
-    //         coords,
-    //         geom_offsets,
-    //         ring_offsets,
-    //         validity,
-    //     })
-    // }
-
     pub(crate) fn finish(self) -> MixedGeometryArray {
         MixedGeometryArray::new(
             self.types.into(),

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -1,5 +1,5 @@
 use arrow_array::OffsetSizeTrait;
-use arrow_buffer::{NullBufferBuilder, OffsetBuffer};
+use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
 use geoarrow_schema::{CoordType, MultiLineStringType};
 // use super::array::check;
@@ -127,12 +127,12 @@ impl MultiLineStringBuilder {
 
     /// Push a raw offset to the underlying geometry offsets buffer.
     ///
-    /// # Safety
+    /// # Invariants
     ///
-    /// This is marked as unsafe because care must be taken to ensure that pushing raw offsets
+    /// Care must be taken to ensure that pushing raw offsets
     /// upholds the necessary invariants of the array.
     #[inline]
-    pub unsafe fn try_push_geom_offset(&mut self, offsets_length: usize) -> Result<()> {
+    pub(crate) fn try_push_geom_offset(&mut self, offsets_length: usize) -> Result<()> {
         self.geom_offsets.try_push_usize(offsets_length)?;
         self.validity.append(true);
         Ok(())
@@ -140,12 +140,12 @@ impl MultiLineStringBuilder {
 
     /// Push a raw offset to the underlying ring offsets buffer.
     ///
-    /// # Safety
+    /// # Invariants
     ///
-    /// This is marked as unsafe because care must be taken to ensure that pushing raw offsets
+    /// Care must be taken to ensure that pushing raw offsets
     /// upholds the necessary invariants of the array.
     #[inline]
-    pub unsafe fn try_push_ring_offset(&mut self, offsets_length: usize) -> Result<()> {
+    pub(crate) fn try_push_ring_offset(&mut self, offsets_length: usize) -> Result<()> {
         self.ring_offsets.try_push_usize(offsets_length)?;
         Ok(())
     }
@@ -154,13 +154,10 @@ impl MultiLineStringBuilder {
     pub fn finish(mut self) -> MultiLineStringArray {
         let validity = self.validity.finish();
 
-        let geom_offsets: OffsetBuffer<i32> = self.geom_offsets.into();
-        let ring_offsets: OffsetBuffer<i32> = self.ring_offsets.into();
-
         MultiLineStringArray::new(
-            self.coords.into(),
-            geom_offsets,
-            ring_offsets,
+            self.coords.finish(),
+            self.geom_offsets.finish(),
+            self.ring_offsets.finish(),
             validity,
             self.data_type.metadata().clone(),
         )
@@ -307,12 +304,12 @@ impl MultiLineStringBuilder {
 
     /// Push a raw coordinate to the underlying coordinate array.
     ///
-    /// # Safety
+    /// # Invariants
     ///
-    /// This is marked as unsafe because care must be taken to ensure that pushing raw coordinates
+    /// Care must be taken to ensure that pushing raw coordinates
     /// to the array upholds the necessary invariants of the array.
     #[inline]
-    pub unsafe fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) -> Result<()> {
+    pub(crate) fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) -> Result<()> {
         self.coords.push_coord(coord);
         Ok(())
     }

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -92,8 +92,8 @@ impl MultiPointBuilder {
         self.geom_offsets.shrink_to_fit();
 
         MultiPointArray::new(
-            self.coords.into(),
-            self.geom_offsets.into(),
+            self.coords.finish(),
+            self.geom_offsets.finish(),
             validity,
             self.data_type.metadata().clone(),
         )
@@ -206,29 +206,13 @@ impl MultiPointBuilder {
 
     /// Push a raw coordinate to the underlying coordinate array.
     ///
-    /// # Safety
+    /// # Invariant
     ///
-    /// This is marked as unsafe because care must be taken to ensure that pushing raw coordinates
-    /// to the array upholds the necessary invariants of the array.
+    /// Care must be taken to ensure that pushing raw coordinates to the array upholds the
+    /// necessary invariants of the array.
     #[inline]
-    pub unsafe fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) -> Result<()> {
+    pub(crate) fn push_coord(&mut self, coord: &impl CoordTrait<T = f64>) -> Result<()> {
         self.coords.try_push_coord(coord)
-    }
-
-    fn calculate_added_length(&self) -> Result<usize> {
-        let total_length = self.coords.len();
-        let offset = *self.geom_offsets.last() as usize;
-        total_length
-            .checked_sub(offset)
-            .ok_or(GeoArrowError::Overflow)
-    }
-
-    /// Needs to be called when a valid value was extended to this array.
-    /// This is a relatively low level function, prefer `try_push` when you can.
-    #[inline]
-    pub fn try_push_valid(&mut self) -> Result<()> {
-        let length = self.calculate_added_length()?;
-        self.try_push_length(length)
     }
 
     /// Needs to be called when a valid value was extended to this array.

--- a/rust/geoarrow-array/src/builder/offsets.rs
+++ b/rust/geoarrow-array/src/builder/offsets.rs
@@ -1,10 +1,10 @@
-//! Contains the declaration of [`Offset`]
+//! This was originally copied from arrow2.
+
 use std::hint::unreachable_unchecked;
 
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 
-// use crate::buffer::Buffer;
 use crate::error::GeoArrowError as Error;
 
 /// A wrapper type of [`Vec<O>`] representing the invariants of Arrow's offsets.
@@ -110,36 +110,6 @@ impl<O: OffsetSizeTrait> OffsetsBuilder<O> {
         OffsetBuffer::new(self.0.into())
     }
 }
-
-// /// Checks that `offsets` is monotonically increasing.
-// fn try_check_offsets<O: OffsetSizeTrait>(offsets: &[O]) -> Result<(), Error> {
-//     // this code is carefully constructed to auto-vectorize, don't change naively!
-//     match offsets.first() {
-//         None => Err(Error::oos("offsets must have at least one element")),
-//         Some(first) => {
-//             if *first < O::zero() {
-//                 return Err(Error::oos("offsets must be larger than 0"));
-//             }
-//             let mut previous = *first;
-//             let mut any_invalid = false;
-
-//             // This loop will auto-vectorize because there is not any break,
-//             // an invalid value will be returned once the whole offsets buffer is processed.
-//             for offset in offsets {
-//                 if previous > *offset {
-//                     any_invalid = true
-//                 }
-//                 previous = *offset;
-//             }
-
-//             if any_invalid {
-//                 Err(Error::oos("offsets must be monotonically increasing"))
-//             } else {
-//                 Ok(())
-//             }
-//         }
-//     }
-// }
 
 impl From<OffsetsBuilder<i32>> for OffsetsBuilder<i64> {
     fn from(offsets: OffsetsBuilder<i32>) -> Self {

--- a/rust/geoarrow-array/src/builder/offsets.rs
+++ b/rust/geoarrow-array/src/builder/offsets.rs
@@ -24,80 +24,30 @@ impl<O: OffsetSizeTrait> Default for OffsetsBuilder<O> {
 impl<O: OffsetSizeTrait> OffsetsBuilder<O> {
     /// Returns an empty [`Offsets`] (i.e. with a single element, the zero)
     #[inline]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self(vec![O::zero()])
     }
 
-    /// Returns an [`Offsets`] whose all lengths are zero.
-    #[inline]
-    pub fn new_zeroed(length: usize) -> Self {
-        Self(vec![O::zero(); length + 1])
-    }
-
-    /// Returns an [`Offsets`] whose all lengths are all 1.
-    ///
-    /// This is useful for casting from a PointArray to a MultiPointArray where you need to
-    /// create a `geom_offsets` buffer where every element has length 1.
-    #[inline]
-    pub fn new_ones(length: usize) -> Result<Self, Error> {
-        // Overflow check
-        O::from_usize(length + 1).ok_or(Error::Overflow)?;
-
-        Ok(Self((0..length + 1).map(|x| O::usize_as(x)).collect()))
-    }
-
-    /// Creates a new [`Offsets`] from an iterator of lengths
-    #[inline]
-    pub fn try_from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Result<Self, Error> {
-        let iterator = iter.into_iter();
-        let (lower, _) = iterator.size_hint();
-        let mut offsets = Self::with_capacity(lower);
-        for item in iterator {
-            offsets.try_push_usize(item)?
-        }
-        Ok(offsets)
-    }
-
     /// Returns a new [`Offsets`] with a capacity, allocating at least `capacity + 1` entries.
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
         let mut offsets = Vec::with_capacity(capacity + 1);
         offsets.push(O::zero());
         Self(offsets)
     }
 
-    /// Returns the capacity of [`Offsets`].
-    pub fn capacity(&self) -> usize {
-        self.0.capacity() - 1
-    }
-
     /// Reserves `additional` entries.
-    pub fn reserve(&mut self, additional: usize) {
+    pub(crate) fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }
 
     /// Reserves exactly `additional` entries.
-    pub fn reserve_exact(&mut self, additional: usize) {
+    pub(crate) fn reserve_exact(&mut self, additional: usize) {
         self.0.reserve_exact(additional);
     }
 
     /// Shrinks the capacity of self to fit.
-    pub fn shrink_to_fit(&mut self) {
+    pub(crate) fn shrink_to_fit(&mut self) {
         self.0.shrink_to_fit();
-    }
-
-    /// Pushes a new element with a given length.
-    /// # Error
-    /// This function errors iff the new last item is larger than what `O` supports.
-    /// # Panic
-    /// This function asserts that `length >= 0`.
-    #[inline]
-    pub fn try_push(&mut self, length: O) -> Result<(), Error> {
-        let old_length = self.last();
-        assert!(length >= O::zero());
-        // let new_length = old_length.checked_add(&length).ok_or(Error::Overflow)?;
-        let new_length = *old_length + length;
-        self.0.push(new_length);
-        Ok(())
     }
 
     /// Pushes a new element with a given length.
@@ -107,7 +57,7 @@ impl<O: OffsetSizeTrait> OffsetsBuilder<O> {
     /// This function:
     /// * checks that this length does not overflow
     #[inline]
-    pub fn try_push_usize(&mut self, length: usize) -> Result<(), Error> {
+    pub(crate) fn try_push_usize(&mut self, length: usize) -> Result<(), Error> {
         let length = O::usize_as(length);
 
         let old_length = self.last();
@@ -117,83 +67,37 @@ impl<O: OffsetSizeTrait> OffsetsBuilder<O> {
         Ok(())
     }
 
-    /// Returns [`Offsets`] assuming that `offsets` fulfills its invariants
-    /// # Safety
-    /// This is safe iff the invariants of this struct are guaranteed in `offsets`.
-    #[inline]
-    pub unsafe fn new_unchecked(offsets: Vec<O>) -> Self {
-        Self(offsets)
-    }
-
     /// Returns the last offset of this container.
     #[inline]
-    pub fn last(&self) -> &O {
+    pub(crate) fn last(&self) -> &O {
         match self.0.last() {
             Some(element) => element,
             None => unsafe { unreachable_unchecked() },
         }
     }
 
-    /// Returns a range (start, end) corresponding to the position `index`
-    /// # Panic
-    /// This function panics iff `index >= len_proxy()`
-    #[inline]
-    pub fn start_end(&self, index: usize) -> (usize, usize) {
-        // soundness: the invariant of the function
-        assert!(index < self.len_proxy());
-        unsafe { self.start_end_unchecked(index) }
-    }
-
-    /// Returns a range (start, end) corresponding to the position `index`
-    /// # Safety
-    /// `index` must be `< self.len()`
-    #[inline]
-    pub unsafe fn start_end_unchecked(&self, index: usize) -> (usize, usize) {
-        // soundness: the invariant of the function
-        let start = unsafe { self.0.get_unchecked(index) }.to_usize().unwrap();
-        let end = unsafe { self.0.get_unchecked(index + 1) }
-            .to_usize()
-            .unwrap();
-        (start, end)
-    }
-
     /// Returns the length an array with these offsets would be.
     #[inline]
-    pub fn len_proxy(&self) -> usize {
+    pub(crate) fn len_proxy(&self) -> usize {
         self.0.len() - 1
     }
 
     #[inline]
     /// Returns the number of offsets in this container.
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.0.len()
-    }
-
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
     }
 
     /// Returns the byte slice stored in this buffer
     #[inline]
-    pub fn as_slice(&self) -> &[O] {
+    pub(crate) fn as_slice(&self) -> &[O] {
         self.0.as_slice()
-    }
-
-    /// Pops the last element
-    #[inline]
-    pub fn pop(&mut self) -> Option<O> {
-        if self.len_proxy() == 0 {
-            None
-        } else {
-            self.0.pop()
-        }
     }
 
     /// Extends itself with `additional` elements equal to the last offset.
     /// This is useful to extend offsets with empty values, e.g. for null slots.
     #[inline]
-    pub fn extend_constant(&mut self, additional: usize) {
+    pub(crate) fn extend_constant(&mut self, additional: usize) {
         let offset = *self.last();
         if additional == 1 {
             self.0.push(offset)
@@ -202,73 +106,8 @@ impl<O: OffsetSizeTrait> OffsetsBuilder<O> {
         }
     }
 
-    /// Try to create a new [`Offsets`] from a sequence of `lengths`
-    /// # Errors
-    /// This function errors iff this operation overflows for the maximum value of `O`.
-    #[inline]
-    pub fn try_from_lengths<I: Iterator<Item = usize>>(lengths: I) -> Result<Self, Error> {
-        let mut self_ = Self::with_capacity(lengths.size_hint().0);
-        self_.try_extend_from_lengths(lengths)?;
-        Ok(self_)
-    }
-
-    /// Try extend from an iterator of lengths
-    /// # Errors
-    /// This function errors iff this operation overflows for the maximum value of `O`.
-    #[inline]
-    pub fn try_extend_from_lengths<I: Iterator<Item = usize>>(
-        &mut self,
-        lengths: I,
-    ) -> Result<(), Error> {
-        let mut total_length = 0;
-        let mut offset = *self.last();
-        let original_offset = offset.to_usize().unwrap();
-
-        let lengths = lengths.map(|length| {
-            total_length += length;
-            O::usize_as(length)
-        });
-
-        let offsets = lengths.map(|length| {
-            offset += length; // this may overflow, checked below
-            offset
-        });
-        self.0.extend(offsets);
-
-        let last_offset = original_offset
-            .checked_add(total_length)
-            .ok_or(Error::Overflow)?;
-        O::from_usize(last_offset).ok_or(Error::Overflow)?;
-        Ok(())
-    }
-
-    /// Extends itself from another [`Offsets`]
-    /// # Errors
-    /// This function errors iff this operation overflows for the maximum value of `O`.
-    pub fn try_extend_from_self(&mut self, other: &Self) -> Result<(), Error> {
-        let mut length = *self.last();
-        let other_length = *other.last();
-        // check if the operation would overflow
-        // length.checked_add(&other_length).ok_or(Error::Overflow)?;
-        length += other_length;
-
-        let lengths = other.as_slice().windows(2).map(|w| w[1] - w[0]);
-        let offsets = lengths.map(|new_length| {
-            length += new_length;
-            length
-        });
-        self.0.extend(offsets);
-        Ok(())
-    }
-
-    /// Returns the inner [`Vec`].
-    #[inline]
-    pub fn into_inner(self) -> Vec<O> {
-        self.0
-    }
-
-    pub fn finish(self) -> OffsetBuffer<O> {
-        self.into()
+    pub(crate) fn finish(self) -> OffsetBuffer<O> {
+        OffsetBuffer::new(self.0.into())
     }
 }
 
@@ -329,11 +168,5 @@ impl TryFrom<OffsetsBuilder<i64>> for OffsetsBuilder<i32> {
                 .map(|x| *x as i32)
                 .collect::<Vec<_>>(),
         ))
-    }
-}
-
-impl<O: OffsetSizeTrait> From<OffsetsBuilder<O>> for OffsetBuffer<O> {
-    fn from(value: OffsetsBuilder<O>) -> Self {
-        OffsetBuffer::new(value.0.into())
     }
 }

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -72,13 +72,13 @@ impl PointBuilder {
     pub fn finish(mut self) -> PointArray {
         let validity = self.validity.finish();
         PointArray::new(
-            self.coords.into(),
+            self.coords.finish(),
             validity,
             self.data_type.metadata().clone(),
         )
     }
 
-    /// Add a new coord to the end of this array, where the coord is a non-empty point
+    /// Add a new coord to the end of this array, interpreting the coord as a non-empty point.
     ///
     /// ## Panics
     ///
@@ -133,14 +133,14 @@ impl PointBuilder {
     /// Add a valid but empty point to the end of this array.
     #[inline]
     pub fn push_empty(&mut self) {
-        self.coords.push_nan_coord();
+        self.coords.push_constant(f64::NAN);
         self.validity.append_non_null();
     }
 
     /// Add a new null value to the end of this array.
     #[inline]
     pub fn push_null(&mut self) {
-        self.coords.push_nan_coord();
+        self.coords.push_constant(f64::NAN);
         self.validity.append_null();
     }
 

--- a/rust/geoarrow-array/src/builder/rect.rs
+++ b/rust/geoarrow-array/src/builder/rect.rs
@@ -93,8 +93,8 @@ impl RectBuilder {
     /// Consume the builder and convert to an immutable [`RectArray`]
     pub fn finish(mut self) -> RectArray {
         RectArray::new(
-            self.lower.into(),
-            self.upper.into(),
+            self.lower.finish(),
+            self.upper.finish(),
             self.validity.finish(),
             self.data_type.metadata().clone(),
         )
@@ -112,8 +112,8 @@ impl RectBuilder {
             self.validity.append_non_null()
         } else {
             // Since it's a struct, we still need to push coords when null
-            self.lower.push_nan_coord();
-            self.upper.push_nan_coord();
+            self.lower.push_constant(f64::NAN);
+            self.upper.push_constant(f64::NAN);
             self.validity.append_null();
         }
     }

--- a/rust/geoarrow-array/src/geozero/import/linestring.rs
+++ b/rust/geoarrow-array/src/geozero/import/linestring.rs
@@ -48,7 +48,8 @@ impl GeomProcessor for LineStringBuilder {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_coord(&from_xy(x, y).expect("valid coord")) }.unwrap();
+        self.push_coord(&from_xy(x, y).expect("valid coord"))
+            .unwrap();
         Ok(())
     }
 
@@ -65,7 +66,8 @@ impl GeomProcessor for LineStringBuilder {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_coord(&from_xyzm(x, y, z, m).expect("valid coord")) }.unwrap();
+        self.push_coord(&from_xyzm(x, y, z, m).expect("valid coord"))
+            .unwrap();
         Ok(())
     }
 

--- a/rust/geoarrow-array/src/geozero/import/multilinestring.rs
+++ b/rust/geoarrow-array/src/geozero/import/multilinestring.rs
@@ -52,7 +52,8 @@ impl GeomProcessor for MultiLineStringBuilder {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_coord(&from_xy(x, y).expect("valid coord")) }.unwrap();
+        self.push_coord(&from_xy(x, y).expect("valid coord"))
+            .unwrap();
         Ok(())
     }
 
@@ -69,7 +70,8 @@ impl GeomProcessor for MultiLineStringBuilder {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_coord(&from_xyzm(x, y, z, m).expect("valid coord")) }.unwrap();
+        self.push_coord(&from_xyzm(x, y, z, m).expect("valid coord"))
+            .unwrap();
         Ok(())
     }
 
@@ -82,7 +84,7 @@ impl GeomProcessor for MultiLineStringBuilder {
         // # Safety:
         // This upholds invariants because we separately update the ring offsets in
         // linestring_begin
-        unsafe { self.try_push_geom_offset(size).unwrap() }
+        self.try_push_geom_offset(size).unwrap();
         Ok(())
     }
 
@@ -102,7 +104,7 @@ impl GeomProcessor for MultiLineStringBuilder {
             // # Safety:
             // This upholds invariants because we separately update the ring offsets in
             // linestring_begin
-            unsafe { self.try_push_geom_offset(1).unwrap() }
+            self.try_push_geom_offset(1).unwrap();
         }
 
         // reserve `size` coordinates
@@ -112,7 +114,7 @@ impl GeomProcessor for MultiLineStringBuilder {
         // # Safety:
         // This upholds invariants because we separately update the geometry offsets in
         // polygon_begin
-        unsafe { self.try_push_ring_offset(size).unwrap() }
+        self.try_push_ring_offset(size).unwrap();
         Ok(())
     }
 }

--- a/rust/geoarrow-array/src/geozero/import/multipoint.rs
+++ b/rust/geoarrow-array/src/geozero/import/multipoint.rs
@@ -43,7 +43,8 @@ impl GeomProcessor for MultiPointBuilder {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_coord(&from_xy(x, y).expect("valid coord")) }.unwrap();
+        self.push_coord(&from_xy(x, y).expect("valid coord"))
+            .unwrap();
         Ok(())
     }
 
@@ -60,7 +61,8 @@ impl GeomProcessor for MultiPointBuilder {
         // # Safety:
         // This upholds invariants because we call try_push_length in multipoint_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_coord(&from_xyzm(x, y, z, m).expect("valid coord")) }.unwrap();
+        self.push_coord(&from_xyzm(x, y, z, m).expect("valid coord"))
+            .unwrap();
         Ok(())
     }
 

--- a/rust/geoarrow-array/src/geozero/import/multipolygon.rs
+++ b/rust/geoarrow-array/src/geozero/import/multipolygon.rs
@@ -86,7 +86,7 @@ impl GeomProcessor for MultiPolygonBuilder {
         // # Safety:
         // This upholds invariants because we separately update the ring offsets in
         // linestring_begin
-        unsafe { self.try_push_geom_offset(size).unwrap() }
+        self.try_push_geom_offset(size).unwrap();
         Ok(())
     }
 
@@ -105,7 +105,7 @@ impl GeomProcessor for MultiPolygonBuilder {
             // # Safety:
             // This upholds invariants because we separately update the ring offsets in
             // linestring_begin
-            unsafe { self.try_push_geom_offset(1).unwrap() }
+            self.try_push_geom_offset(1).unwrap();
         }
 
         // reserve `size` rings
@@ -115,7 +115,7 @@ impl GeomProcessor for MultiPolygonBuilder {
         // # Safety:
         // This upholds invariants because we separately update the geometry offsets in
         // polygon_begin
-        unsafe { self.try_push_polygon_offset(size).unwrap() }
+        self.try_push_polygon_offset(size).unwrap();
         Ok(())
     }
 
@@ -134,7 +134,7 @@ impl GeomProcessor for MultiPolygonBuilder {
         // # Safety:
         // This upholds invariants because we separately update the ring offsets in
         // linestring_begin
-        unsafe { self.try_push_ring_offset(size).unwrap() }
+        self.try_push_ring_offset(size).unwrap();
         Ok(())
     }
 }

--- a/rust/geoarrow-array/src/geozero/import/polygon.rs
+++ b/rust/geoarrow-array/src/geozero/import/polygon.rs
@@ -43,7 +43,8 @@ impl GeomProcessor for PolygonBuilder {
         // # Safety:
         // This upholds invariants because we call try_push_length in polygon_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_coord(&from_xy(x, y).expect("valid coord")) }.unwrap();
+        self.push_coord(&from_xy(x, y).expect("valid coord"))
+            .unwrap();
         Ok(())
     }
 
@@ -60,7 +61,8 @@ impl GeomProcessor for PolygonBuilder {
         // # Safety:
         // This upholds invariants because we call try_push_length in polygon_begin to ensure
         // offset arrays are correct.
-        unsafe { self.push_coord(&from_xyzm(x, y, z, m).expect("valid coord")) }.unwrap();
+        self.push_coord(&from_xyzm(x, y, z, m).expect("valid coord"))
+            .unwrap();
         Ok(())
     }
 
@@ -78,7 +80,7 @@ impl GeomProcessor for PolygonBuilder {
         // # Safety:
         // This upholds invariants because we separately update the ring offsets in
         // linestring_begin
-        unsafe { self.try_push_geom_offset(size).unwrap() }
+        self.try_push_geom_offset(size).unwrap();
         Ok(())
     }
 
@@ -95,7 +97,7 @@ impl GeomProcessor for PolygonBuilder {
         // # Safety:
         // This upholds invariants because we separately update the geometry offsets in
         // polygon_begin
-        unsafe { self.try_push_ring_offset(size).unwrap() }
+        self.try_push_ring_offset(size).unwrap();
         Ok(())
     }
 }


### PR DESCRIPTION
- Remove `From` for converting a builder to a buffer; always use `finish`
- Add parameter for default value in `initialize`
- Remove from public API: `CoordBuffer::push_nan_coord`, `CoordBuffer::push_point`, 
- Make low-level builder APIs `push_coord`, `try_push_usize`, `try_push_geom_offset`, etc, `pub(crate)`. I think these are only used by the geozero builders.
- Remove unused methods from `OffsetBuilder`
- 