### PR TITLE
Remove unused capacity APIs

### DIFF
--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -134,7 +134,7 @@ impl<'a> GeometryBuilder {
                     Dimension::from_order(i),
                     Default::default(),
                 ),
-                capacity.gcs()[i],
+                capacity.geometry_collections()[i],
                 prefer_multi,
             )
         });
@@ -200,9 +200,13 @@ impl<'a> GeometryBuilder {
             .for_each(|(i, cap)| {
                 self.mpolygons[i].reserve(*cap);
             });
-        capacity.gcs().iter().enumerate().for_each(|(i, cap)| {
-            self.gcs[i].reserve(*cap);
-        });
+        capacity
+            .geometry_collections()
+            .iter()
+            .enumerate()
+            .for_each(|(i, cap)| {
+                self.gcs[i].reserve(*cap);
+            });
     }
 
     /// Reserves the minimum capacity for at least `additional` more Geometries.
@@ -256,9 +260,13 @@ impl<'a> GeometryBuilder {
             .for_each(|(i, cap)| {
                 self.mpolygons[i].reserve_exact(*cap);
             });
-        capacity.gcs().iter().enumerate().for_each(|(i, cap)| {
-            self.gcs[i].reserve_exact(*cap);
-        });
+        capacity
+            .geometry_collections()
+            .iter()
+            .enumerate()
+            .for_each(|(i, cap)| {
+                self.gcs[i].reserve_exact(*cap);
+            });
     }
 
     /// Consume the builder and convert to an immutable [`GeometryArray`]

--- a/rust/geoarrow-array/src/capacity/geometry.rs
+++ b/rust/geoarrow-array/src/capacity/geometry.rs
@@ -60,11 +60,8 @@ impl GeometryCapacity {
     }
 
     /// Create a new empty capacity.
-    pub fn new_empty(prefer_multi: bool) -> Self {
-        Self {
-            prefer_multi,
-            ..Default::default()
-        }
+    pub fn new_empty() -> Self {
+        Default::default()
     }
 
     /// Set whether this capacity counter should prefer allocating "single-type" geometries like
@@ -181,54 +178,9 @@ impl GeometryCapacity {
     /// Access GeometryCollection capacities
     ///
     /// Values are represent dimensions in the order: XY, XYZ, XYM, XYZM.
-    pub fn gcs(&self) -> [GeometryCollectionCapacity; 4] {
+    pub fn geometry_collections(&self) -> [GeometryCollectionCapacity; 4] {
         self.gcs
     }
-
-    // pub fn point_compatible(&self) -> bool {
-    //     self.line_string.is_empty()
-    //         && self.polygon.is_empty()
-    //         && self.multi_point.is_empty()
-    //         && self.multi_line_string.is_empty()
-    //         && self.multi_polygon.is_empty()
-    // }
-
-    // pub fn line_string_compatible(&self) -> bool {
-    //     self.point == 0
-    //         && self.polygon.is_empty()
-    //         && self.multi_point.is_empty()
-    //         && self.multi_line_string.is_empty()
-    //         && self.multi_polygon.is_empty()
-    // }
-
-    // pub fn polygon_compatible(&self) -> bool {
-    //     self.point == 0
-    //         && self.line_string.is_empty()
-    //         && self.multi_point.is_empty()
-    //         && self.multi_line_string.is_empty()
-    //         && self.multi_polygon.is_empty()
-    // }
-
-    // pub fn multi_point_compatible(&self) -> bool {
-    //     self.line_string.is_empty()
-    //         && self.polygon.is_empty()
-    //         && self.multi_line_string.is_empty()
-    //         && self.multi_polygon.is_empty()
-    // }
-
-    // pub fn multi_line_string_compatible(&self) -> bool {
-    //     self.point == 0
-    //         && self.polygon.is_empty()
-    //         && self.multi_point.is_empty()
-    //         && self.multi_polygon.is_empty()
-    // }
-
-    // pub fn multi_polygon_compatible(&self) -> bool {
-    //     self.point == 0
-    //         && self.line_string.is_empty()
-    //         && self.multi_point.is_empty()
-    //         && self.multi_line_string.is_empty()
-    // }
 
     /// Add the capacity of the given Point
     #[inline]
@@ -345,21 +297,9 @@ impl GeometryCapacity {
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
         prefer_multi: bool,
     ) -> Result<Self> {
-        let mut counter = Self::new_empty(prefer_multi);
+        let mut counter = Self::new_empty().with_prefer_multi(prefer_multi);
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry(maybe_geom)?;
-        }
-        Ok(counter)
-    }
-
-    /// Construct a new counter pre-filled with the given geometries
-    pub fn from_owned_geometries<'a>(
-        geoms: impl Iterator<Item = Option<(impl GeometryTrait + 'a)>>,
-        prefer_multi: bool,
-    ) -> Result<Self> {
-        let mut counter = Self::new_empty(prefer_multi);
-        for maybe_geom in geoms.into_iter() {
-            counter.add_geometry(maybe_geom.as_ref())?;
         }
         Ok(counter)
     }

--- a/rust/geoarrow-array/src/capacity/geometrycollection.rs
+++ b/rust/geoarrow-array/src/capacity/geometrycollection.rs
@@ -123,17 +123,6 @@ impl GeometryCollectionCapacity {
     }
 
     /// Create a capacity counter from an iterator of Geometries.
-    pub fn from_owned_geometries<'a>(
-        geoms: impl Iterator<Item = Option<(impl GeometryCollectionTrait + 'a)>>,
-    ) -> Result<Self> {
-        let mut counter = Self::new_empty();
-        for maybe_geom in geoms.into_iter() {
-            counter.add_geometry_collection(maybe_geom.as_ref())?;
-        }
-        Ok(counter)
-    }
-
-    /// Create a capacity counter from an iterator of Geometries.
     pub fn from_geometries<'a>(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait + 'a)>>,
     ) -> Result<Self> {

--- a/rust/geoarrow-array/src/capacity/mixed.rs
+++ b/rust/geoarrow-array/src/capacity/mixed.rs
@@ -24,7 +24,7 @@ pub struct MixedCapacity {
 
 impl MixedCapacity {
     /// Create a new capacity with known sizes.
-    pub fn new(
+    pub(crate) fn new(
         point: usize,
         line_string: LineStringCapacity,
         polygon: PolygonCapacity,
@@ -43,7 +43,7 @@ impl MixedCapacity {
     }
 
     /// Create a new empty capacity.
-    pub fn new_empty() -> Self {
+    pub(crate) fn new_empty() -> Self {
         Self {
             point: 0,
             line_string: LineStringCapacity::new_empty(),
@@ -55,7 +55,7 @@ impl MixedCapacity {
     }
 
     /// Return `true` if the capacity is empty.
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.point == 0
             && self.line_string.is_empty()
             && self.polygon.is_empty()
@@ -64,7 +64,7 @@ impl MixedCapacity {
             && self.multi_polygon.is_empty()
     }
 
-    pub fn total_num_geoms(&self) -> usize {
+    pub(crate) fn total_num_geoms(&self) -> usize {
         let mut total = 0;
         total += self.point;
         total += self.line_string.geom_capacity();
@@ -75,108 +75,39 @@ impl MixedCapacity {
         total
     }
 
-    pub fn point_capacity(&self) -> usize {
-        self.point
-    }
-
-    pub fn line_string_capacity(&self) -> LineStringCapacity {
-        self.line_string
-    }
-
-    pub fn polygon_capacity(&self) -> PolygonCapacity {
-        self.polygon
-    }
-
-    pub fn multi_point_capacity(&self) -> MultiPointCapacity {
-        self.multi_point
-    }
-
-    pub fn multi_line_string_capacity(&self) -> MultiLineStringCapacity {
-        self.multi_line_string
-    }
-
-    pub fn multi_polygon_capacity(&self) -> MultiPolygonCapacity {
-        self.multi_polygon
-    }
-
-    pub fn point_compatible(&self) -> bool {
-        self.line_string.is_empty()
-            && self.polygon.is_empty()
-            && self.multi_point.is_empty()
-            && self.multi_line_string.is_empty()
-            && self.multi_polygon.is_empty()
-    }
-
-    pub fn line_string_compatible(&self) -> bool {
-        self.point == 0
-            && self.polygon.is_empty()
-            && self.multi_point.is_empty()
-            && self.multi_line_string.is_empty()
-            && self.multi_polygon.is_empty()
-    }
-
-    pub fn polygon_compatible(&self) -> bool {
-        self.point == 0
-            && self.line_string.is_empty()
-            && self.multi_point.is_empty()
-            && self.multi_line_string.is_empty()
-            && self.multi_polygon.is_empty()
-    }
-
-    pub fn multi_point_compatible(&self) -> bool {
-        self.line_string.is_empty()
-            && self.polygon.is_empty()
-            && self.multi_line_string.is_empty()
-            && self.multi_polygon.is_empty()
-    }
-
-    pub fn multi_line_string_compatible(&self) -> bool {
-        self.point == 0
-            && self.polygon.is_empty()
-            && self.multi_point.is_empty()
-            && self.multi_polygon.is_empty()
-    }
-
-    pub fn multi_polygon_compatible(&self) -> bool {
-        self.point == 0
-            && self.line_string.is_empty()
-            && self.multi_point.is_empty()
-            && self.multi_line_string.is_empty()
-    }
-
     #[inline]
-    pub fn add_point(&mut self) {
+    pub(crate) fn add_point(&mut self) {
         self.point += 1;
     }
 
     #[inline]
-    pub fn add_line_string(&mut self, line_string: &impl LineStringTrait) {
+    pub(crate) fn add_line_string(&mut self, line_string: &impl LineStringTrait) {
         self.line_string.add_line_string(Some(line_string));
     }
 
     #[inline]
-    pub fn add_polygon(&mut self, polygon: &impl PolygonTrait) {
+    pub(crate) fn add_polygon(&mut self, polygon: &impl PolygonTrait) {
         self.polygon.add_polygon(Some(polygon));
     }
 
     #[inline]
-    pub fn add_multi_point(&mut self, multi_point: &impl MultiPointTrait) {
+    pub(crate) fn add_multi_point(&mut self, multi_point: &impl MultiPointTrait) {
         self.multi_point.add_multi_point(Some(multi_point));
     }
 
     #[inline]
-    pub fn add_multi_line_string(&mut self, multi_line_string: &impl MultiLineStringTrait) {
+    pub(crate) fn add_multi_line_string(&mut self, multi_line_string: &impl MultiLineStringTrait) {
         self.multi_line_string
             .add_multi_line_string(Some(multi_line_string));
     }
 
     #[inline]
-    pub fn add_multi_polygon(&mut self, multi_polygon: &impl MultiPolygonTrait) {
+    pub(crate) fn add_multi_polygon(&mut self, multi_polygon: &impl MultiPolygonTrait) {
         self.multi_polygon.add_multi_polygon(Some(multi_polygon));
     }
 
     #[inline]
-    pub fn add_geometry(&mut self, geom: &impl GeometryTrait) -> Result<()> {
+    pub(crate) fn add_geometry(&mut self, geom: &impl GeometryTrait) -> Result<()> {
         match geom.as_type() {
             geo_traits::GeometryType::Point(_) => self.add_point(),
             geo_traits::GeometryType::LineString(g) => self.add_line_string(g),
@@ -192,28 +123,8 @@ impl MixedCapacity {
         Ok(())
     }
 
-    pub fn from_geometries<'a>(
-        geoms: impl Iterator<Item = &'a (impl GeometryTrait + 'a)>,
-    ) -> Result<Self> {
-        let mut counter = Self::new_empty();
-        for maybe_geom in geoms.into_iter() {
-            counter.add_geometry(maybe_geom)?;
-        }
-        Ok(counter)
-    }
-
-    pub fn from_owned_geometries<'a>(
-        geoms: impl Iterator<Item = (impl GeometryTrait + 'a)>,
-    ) -> Result<Self> {
-        let mut counter = Self::new_empty();
-        for maybe_geom in geoms.into_iter() {
-            counter.add_geometry(&maybe_geom)?;
-        }
-        Ok(counter)
-    }
-
     /// The number of bytes an array with this capacity would occupy.
-    pub fn num_bytes(&self) -> usize {
+    pub(crate) fn num_bytes(&self) -> usize {
         let mut count = self.point * 2 * 8;
         count += self.line_string.num_bytes();
         count += self.polygon.num_bytes();

--- a/rust/geoarrow-array/src/capacity/point.rs
+++ b/rust/geoarrow-array/src/capacity/point.rs
@@ -40,6 +40,7 @@ impl PointCapacity {
         if let Some(g) = value {
             match g.as_type() {
                 GeometryType::Point(p) => self.add_point(Some(p)),
+
                 _ => return Err(GeoArrowError::General("incorrect type".to_string())),
             }
         } else {

--- a/rust/geoarrow-array/src/capacity/wkb.rs
+++ b/rust/geoarrow-array/src/capacity/wkb.rs
@@ -214,17 +214,6 @@ impl WkbCapacity {
         counter
     }
 
-    /// Create a capacity counter from an iterator of Geometries.
-    pub fn from_owned_geometries<'a>(
-        geoms: impl Iterator<Item = Option<(impl GeometryTrait<T = f64> + 'a)>>,
-    ) -> Self {
-        let mut counter = Self::new_empty();
-        for maybe_geom in geoms.into_iter() {
-            counter.add_geometry(maybe_geom.as_ref());
-        }
-        counter
-    }
-
     /// The number of bytes an array with this capacity would occupy.
     pub fn num_bytes<O: OffsetSizeTrait>(&self) -> usize {
         let offsets_byte_width = if O::IS_LARGE { 8 } else { 4 };


### PR DESCRIPTION
- Rename `gcs` to `geometry_collections` in `GeometryCapacity`
- Remove `from_owned_geometries` (it's easy to map over an iterator to take a reference)
- Remove unused mixed capacity methods
- 