### PR TITLE
Default `prefer_multi` to `false` and require explicit opt-in

### DIFF
--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -147,7 +147,6 @@ impl GeometryArray {
             core::array::from_fn(|i| self.mline_strings[i].buffer_lengths()),
             core::array::from_fn(|i| self.mpolygons[i].buffer_lengths()),
             core::array::from_fn(|i| self.gcs[i].buffer_lengths()),
-            false,
         )
     }
 
@@ -759,14 +758,11 @@ impl TryFrom<(&UnionArray, GeometryType)> for GeometryArray {
             let new_val = if let Some(arr) = arr.take() {
                 arr
             } else {
-                GeometryCollectionBuilder::new(
-                    GeometryCollectionType::new(
-                        coord_type,
-                        Dimension::from_order(i),
-                        Default::default(),
-                    ),
-                    false,
-                )
+                GeometryCollectionBuilder::new(GeometryCollectionType::new(
+                    coord_type,
+                    Dimension::from_order(i),
+                    Default::default(),
+                ))
                 .finish()
             };
             arr.replace(new_val);
@@ -970,14 +966,11 @@ fn empty_children(coord_type: CoordType) -> ChildrenArrays {
             .finish()
         }),
         core::array::from_fn(|i| {
-            GeometryCollectionBuilder::new(
-                GeometryCollectionType::new(
-                    coord_type,
-                    Dimension::from_order(i),
-                    Default::default(),
-                ),
-                false,
-            )
+            GeometryCollectionBuilder::new(GeometryCollectionType::new(
+                coord_type,
+                Dimension::from_order(i),
+                Default::default(),
+            ))
             .finish()
         }),
     )
@@ -1051,7 +1044,7 @@ mod test {
     fn geom_array(coord_type: CoordType) -> GeometryArray {
         let geoms = geoms();
         let typ = GeometryType::new(coord_type, Default::default());
-        GeometryBuilder::from_geometries(&geoms, typ, false)
+        GeometryBuilder::from_geometries(&geoms, typ)
             .unwrap()
             .finish()
     }
@@ -1117,7 +1110,7 @@ mod test {
             .collect::<Vec<_>>();
 
         let typ = GeometryType::new(CoordType::Interleaved, Default::default());
-        let geo_arr = GeometryBuilder::from_nullable_geometries(&geoms, typ, false)
+        let geo_arr = GeometryBuilder::from_nullable_geometries(&geoms, typ)
             .unwrap()
             .finish();
 
@@ -1132,7 +1125,7 @@ mod test {
         let expected_nulls = NullBuffer::from_iter(geoms.iter().map(|g| g.is_some()));
 
         let typ = GeometryType::new(CoordType::Interleaved, Default::default());
-        let geo_arr = GeometryBuilder::from_nullable_geometries(&geoms, typ, false)
+        let geo_arr = GeometryBuilder::from_nullable_geometries(&geoms, typ)
             .unwrap()
             .finish();
 

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -307,10 +307,9 @@ mod test {
 
         let typ =
             GeometryCollectionType::new(CoordType::Interleaved, Dimension::XY, Default::default());
-        let geo_arr =
-            GeometryCollectionBuilder::from_nullable_geometry_collections(&geoms, typ, false)
-                .unwrap()
-                .finish();
+        let geo_arr = GeometryCollectionBuilder::from_nullable_geometry_collections(&geoms, typ)
+            .unwrap()
+            .finish();
 
         for null_idx in &null_idxs {
             assert!(geo_arr.is_null(*null_idx));
@@ -324,10 +323,9 @@ mod test {
 
         let typ =
             GeometryCollectionType::new(CoordType::Interleaved, Dimension::XY, Default::default());
-        let geo_arr =
-            GeometryCollectionBuilder::from_nullable_geometry_collections(&geoms, typ, false)
-                .unwrap()
-                .finish();
+        let geo_arr = GeometryCollectionBuilder::from_nullable_geometry_collections(&geoms, typ)
+            .unwrap()
+            .finish();
 
         assert_eq!(geo_arr.logical_nulls().unwrap(), expected_nulls);
     }

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -165,6 +165,8 @@ impl<'a> GeometryBuilder {
     /// This can be desired when the user wants to downcast the array to a single geometry array
     /// later, as casting to a, say, `MultiPointArray` from a `GeometryArray` could be done
     /// zero-copy.
+    ///
+    /// Note that only geometries added _after_ this method is called will be affected.
     pub fn with_prefer_multi(self, prefer_multi: bool) -> Self {
         Self {
             prefer_multi,

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -80,16 +80,12 @@ pub struct GeometryBuilder {
 
 impl<'a> GeometryBuilder {
     /// Creates a new empty [`GeometryBuilder`].
-    pub fn new(typ: GeometryType, prefer_multi: bool) -> Self {
-        Self::with_capacity(typ, Default::default(), prefer_multi)
+    pub fn new(typ: GeometryType) -> Self {
+        Self::with_capacity(typ, Default::default())
     }
 
     /// Creates a new [`GeometryBuilder`] with given capacity and no validity.
-    pub fn with_capacity(
-        typ: GeometryType,
-        capacity: GeometryCapacity,
-        prefer_multi: bool,
-    ) -> Self {
+    pub fn with_capacity(typ: GeometryType, capacity: GeometryCapacity) -> Self {
         let metadata = typ.metadata().clone();
         let coord_type = typ.coord_type();
 
@@ -140,7 +136,6 @@ impl<'a> GeometryBuilder {
             GeometryCollectionBuilder::with_capacity(
                 GeometryCollectionType::new(coord_type, dim, Default::default()),
                 capacity.geometry_collection(dim),
-                prefer_multi,
             )
         });
 
@@ -156,8 +151,25 @@ impl<'a> GeometryBuilder {
             mpolygons,
             gcs,
             offsets: vec![],
-            prefer_multi,
             deferred_nulls: 0,
+            prefer_multi: DEFAULT_PREFER_MULTI,
+        }
+    }
+
+    /// Change whether to prefer multi or single arrays for new single-part geometries.
+    ///
+    /// If `true`, a new `Point` will be added to the `MultiPointBuilder` child array, a new
+    /// `LineString` will be added to the `MultiLineStringBuilder` child array, and a new `Polygon`
+    /// will be added to the `MultiPolygonBuilder` child array.
+    ///
+    /// This can be desired when the user wants to downcast the array to a single geometry array
+    /// later, as casting to a, say, `MultiPointArray` from a `GeometryArray` could be done
+    /// zero-copy.
+    pub fn with_prefer_multi(self, prefer_multi: bool) -> Self {
+        Self {
+            prefer_multi,
+            gcs: self.gcs.map(|gc| gc.with_prefer_multi(prefer_multi)),
+            ..self
         }
     }
 
@@ -285,10 +297,9 @@ impl<'a> GeometryBuilder {
     pub fn with_capacity_from_iter<T: WktNum>(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = T> + 'a)>>,
         typ: GeometryType,
-        prefer_multi: bool,
     ) -> Result<Self> {
-        let counter = GeometryCapacity::from_geometries(geoms, prefer_multi)?;
-        Ok(Self::with_capacity(typ, counter, prefer_multi))
+        let counter = GeometryCapacity::from_geometries(geoms)?;
+        Ok(Self::with_capacity(typ, counter))
     }
 
     /// Reserve more space in the underlying buffers with the capacity inferred from the provided
@@ -296,9 +307,8 @@ impl<'a> GeometryBuilder {
     pub fn reserve_from_iter<T: WktNum>(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = T> + 'a)>>,
-        prefer_multi: bool,
     ) -> Result<()> {
-        let counter = GeometryCapacity::from_geometries(geoms, prefer_multi)?;
+        let counter = GeometryCapacity::from_geometries(geoms)?;
         self.reserve(counter);
         Ok(())
     }
@@ -308,9 +318,8 @@ impl<'a> GeometryBuilder {
     pub fn reserve_exact_from_iter<T: WktNum>(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = T> + 'a)>>,
-        prefer_multi: bool,
     ) -> Result<()> {
-        let counter = GeometryCapacity::from_geometries(geoms, prefer_multi)?;
+        let counter = GeometryCapacity::from_geometries(geoms)?;
         self.reserve_exact(counter);
         Ok(())
     }
@@ -786,9 +795,8 @@ impl<'a> GeometryBuilder {
     pub fn from_geometries(
         geoms: &[impl GeometryTrait<T = f64>],
         typ: GeometryType,
-        prefer_multi: bool,
     ) -> Result<Self> {
-        let mut array = Self::with_capacity_from_iter(geoms.iter().map(Some), typ, prefer_multi)?;
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(Some), typ)?;
         array.extend_from_iter(geoms.iter().map(Some));
         Ok(array)
     }
@@ -797,10 +805,8 @@ impl<'a> GeometryBuilder {
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
         typ: GeometryType,
-        prefer_multi: bool,
     ) -> Result<Self> {
-        let mut array =
-            Self::with_capacity_from_iter(geoms.iter().map(|x| x.as_ref()), typ, prefer_multi)?;
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(|x| x.as_ref()), typ)?;
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         Ok(array)
     }
@@ -816,7 +822,7 @@ impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryType)> for GeometryBuilde
             .iter()
             .map(|x| x.transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(&wkb_objects, typ, DEFAULT_PREFER_MULTI)
+        Self::from_nullable_geometries(&wkb_objects, typ)
     }
 }
 
@@ -876,7 +882,7 @@ mod test {
     fn all_items_null() {
         // Testing the behavior of deferred nulls when there are no valid geometries.
         let typ = GeometryType::new(CoordType::Interleaved, Default::default());
-        let mut builder = GeometryBuilder::new(typ, false);
+        let mut builder = GeometryBuilder::new(typ);
 
         builder.push_null();
         builder.push_null();
@@ -894,7 +900,7 @@ mod test {
         let coord_type = CoordType::Interleaved;
         let typ = GeometryType::new(coord_type, Default::default());
 
-        let mut builder = GeometryBuilder::new(typ, false);
+        let mut builder = GeometryBuilder::new(typ);
         builder.push_null();
         builder.push_null();
 
@@ -926,7 +932,7 @@ mod test {
         let coord_type = CoordType::Interleaved;
         let typ = GeometryType::new(coord_type, Default::default());
 
-        let mut builder = GeometryBuilder::new(typ, false);
+        let mut builder = GeometryBuilder::new(typ);
         builder.push_null();
         builder.push_null();
 
@@ -966,7 +972,7 @@ mod test {
         let coord_type = CoordType::Interleaved;
         let typ = GeometryType::new(coord_type, Default::default());
 
-        let mut builder = GeometryBuilder::new(typ, false);
+        let mut builder = GeometryBuilder::new(typ);
         let point = wkt! { POINT Z (30. 10. 40.) };
         builder.push_point(Some(&point)).unwrap();
         builder.push_null();

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -9,7 +9,6 @@ use wkt::WktNum;
 
 use crate::array::{GeometryCollectionArray, WkbArray};
 use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapper};
-use crate::builder::mixed::DEFAULT_PREFER_MULTI;
 use crate::builder::{MixedGeometryBuilder, OffsetsBuilder};
 use crate::capacity::GeometryCollectionCapacity;
 use crate::error::{GeoArrowError, Result};
@@ -32,15 +31,14 @@ pub struct GeometryCollectionBuilder {
 
 impl<'a> GeometryCollectionBuilder {
     /// Creates a new empty [`GeometryCollectionBuilder`].
-    pub fn new(typ: GeometryCollectionType, prefer_multi: bool) -> Self {
-        Self::with_capacity(typ, Default::default(), prefer_multi)
+    pub fn new(typ: GeometryCollectionType) -> Self {
+        Self::with_capacity(typ, Default::default())
     }
 
     /// Creates a new empty [`GeometryCollectionBuilder`] with the provided capacity.
     pub fn with_capacity(
         typ: GeometryCollectionType,
         capacity: GeometryCollectionCapacity,
-        prefer_multi: bool,
     ) -> Self {
         Self {
             geoms: MixedGeometryBuilder::with_capacity_and_options(
@@ -48,11 +46,26 @@ impl<'a> GeometryCollectionBuilder {
                 capacity.mixed_capacity,
                 typ.coord_type(),
                 typ.metadata().clone(),
-                prefer_multi,
             ),
             geom_offsets: OffsetsBuilder::with_capacity(capacity.geom_capacity),
             validity: NullBufferBuilder::new(capacity.geom_capacity),
             data_type: typ,
+        }
+    }
+
+    /// Change whether to prefer multi or single arrays for new single-part geometries.
+    ///
+    /// If `true`, a new `Point` will be added to the `MultiPointBuilder` child array, a new
+    /// `LineString` will be added to the `MultiLineStringBuilder` child array, and a new `Polygon`
+    /// will be added to the `MultiPolygonBuilder` child array.
+    ///
+    /// This can be desired when the user wants to downcast the array to a single geometry array
+    /// later, as casting to a, say, `MultiPointArray` from a `GeometryCollectionArray` could be
+    /// done zero-copy.
+    pub fn with_prefer_multi(self, prefer_multi: bool) -> Self {
+        Self {
+            geoms: self.geoms.with_prefer_multi(prefer_multi),
+            ..self
         }
     }
 
@@ -98,10 +111,9 @@ impl<'a> GeometryCollectionBuilder {
     pub fn with_capacity_from_iter<T: WktNum>(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryCollectionTrait<T = T> + 'a)>>,
         typ: GeometryCollectionType,
-        prefer_multi: bool,
     ) -> Result<Self> {
         let counter = GeometryCollectionCapacity::from_geometry_collections(geoms)?;
-        Ok(Self::with_capacity(typ, counter, prefer_multi))
+        Ok(Self::with_capacity(typ, counter))
     }
 
     /// Reserve more space in the underlying buffers with the capacity inferred from the provided
@@ -288,9 +300,8 @@ impl<'a> GeometryCollectionBuilder {
     pub fn from_geometry_collections(
         geoms: &[impl GeometryCollectionTrait<T = f64>],
         typ: GeometryCollectionType,
-        prefer_multi: bool,
     ) -> Result<Self> {
-        let mut array = Self::with_capacity_from_iter(geoms.iter().map(Some), typ, prefer_multi)?;
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(Some), typ)?;
         array.extend_from_iter(geoms.iter().map(Some));
         Ok(array)
     }
@@ -299,10 +310,8 @@ impl<'a> GeometryCollectionBuilder {
     pub fn from_nullable_geometry_collections(
         geoms: &[Option<impl GeometryCollectionTrait<T = f64>>],
         typ: GeometryCollectionType,
-        prefer_multi: bool,
     ) -> Result<Self> {
-        let mut array =
-            Self::with_capacity_from_iter(geoms.iter().map(|x| x.as_ref()), typ, prefer_multi)?;
+        let mut array = Self::with_capacity_from_iter(geoms.iter().map(|x| x.as_ref()), typ)?;
         array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
         Ok(array)
     }
@@ -311,10 +320,9 @@ impl<'a> GeometryCollectionBuilder {
     pub fn from_geometries(
         geoms: &[impl GeometryTrait<T = f64>],
         typ: GeometryCollectionType,
-        prefer_multi: bool,
     ) -> Result<Self> {
         let capacity = GeometryCollectionCapacity::from_geometries(geoms.iter().map(Some))?;
-        let mut array = Self::with_capacity(typ, capacity, prefer_multi);
+        let mut array = Self::with_capacity(typ, capacity);
         for geom in geoms {
             array.push_geometry(Some(geom))?;
         }
@@ -325,11 +333,10 @@ impl<'a> GeometryCollectionBuilder {
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
         typ: GeometryCollectionType,
-        prefer_multi: bool,
     ) -> Result<Self> {
         let capacity =
             GeometryCollectionCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()))?;
-        let mut array = Self::with_capacity(typ, capacity, prefer_multi);
+        let mut array = Self::with_capacity(typ, capacity);
         for geom in geoms {
             array.push_geometry(geom.as_ref())?;
         }
@@ -347,7 +354,7 @@ impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryCollectionType)>
             .iter()
             .map(|x| x.transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometries(&wkb_objects, typ, DEFAULT_PREFER_MULTI)
+        Self::from_nullable_geometries(&wkb_objects, typ)
     }
 }
 

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -62,6 +62,8 @@ impl<'a> GeometryCollectionBuilder {
     /// This can be desired when the user wants to downcast the array to a single geometry array
     /// later, as casting to a, say, `MultiPointArray` from a `GeometryCollectionArray` could be
     /// done zero-copy.
+    ///
+    /// Note that only geometries added _after_ this method is called will be affected.
     pub fn with_prefer_multi(self, prefer_multi: bool) -> Self {
         Self {
             geoms: self.geoms.with_prefer_multi(prefer_multi),

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -68,7 +68,6 @@ impl MixedGeometryBuilder {
         capacity: MixedCapacity,
         coord_type: CoordType,
         metadata: Arc<Metadata>,
-        prefer_multi: bool,
     ) -> Self {
         // Don't store array metadata on child arrays
         Self {
@@ -100,7 +99,14 @@ impl MixedGeometryBuilder {
                 capacity.multi_polygon,
             ),
             offsets: vec![],
+            prefer_multi: DEFAULT_PREFER_MULTI,
+        }
+    }
+
+    pub(crate) fn with_prefer_multi(self, prefer_multi: bool) -> Self {
+        Self {
             prefer_multi,
+            ..self
         }
     }
 

--- a/rust/geoarrow-array/src/capacity/geometry.rs
+++ b/rust/geoarrow-array/src/capacity/geometry.rs
@@ -47,7 +47,6 @@ impl GeometryCapacity {
         mline_strings: [MultiLineStringCapacity; 4],
         mpolygons: [MultiPolygonCapacity; 4],
         gcs: [GeometryCollectionCapacity; 4],
-        prefer_multi: bool,
     ) -> Self {
         Self {
             nulls,
@@ -58,7 +57,7 @@ impl GeometryCapacity {
             mline_strings,
             mpolygons,
             gcs,
-            prefer_multi,
+            prefer_multi: false,
         }
     }
 
@@ -290,9 +289,8 @@ impl GeometryCapacity {
     /// Construct a new counter pre-filled with the given geometries
     pub fn from_geometries<'a, T: WktNum>(
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = T> + 'a)>>,
-        prefer_multi: bool,
     ) -> Result<Self> {
-        let mut counter = Self::new_empty().with_prefer_multi(prefer_multi);
+        let mut counter = Self::new_empty();
         for maybe_geom in geoms.into_iter() {
             counter.add_geometry(maybe_geom)?;
         }

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -490,10 +490,10 @@ mod test {
         let data_type: GeoArrowType = (&field).try_into().unwrap();
         assert_eq!(ml_array.data_type(), data_type);
 
-        let mut builder = GeometryBuilder::new(
-            GeometryType::new(CoordType::Interleaved, Default::default()),
-            true,
-        );
+        let mut builder = GeometryBuilder::new(GeometryType::new(
+            CoordType::Interleaved,
+            Default::default(),
+        ));
         builder.push_point(Some(&crate::test::point::p0())).unwrap();
         builder.push_point(Some(&crate::test::point::p1())).unwrap();
         builder.push_point(Some(&crate::test::point::p2())).unwrap();

--- a/rust/geoarrow-array/src/geozero/import/geometry.rs
+++ b/rust/geoarrow-array/src/geozero/import/geometry.rs
@@ -16,29 +16,17 @@ use crate::trait_::GeometryArrayBuilder;
 /// (This is because the internal GeoWriter only supports XY dimensions.)
 pub trait ToGeometryArray {
     /// Convert to GeoArrow [`GeometryArray`]
-    fn to_geometry_array(
-        &self,
-        typ: GeometryType,
-        prefer_multi: bool,
-    ) -> geozero::error::Result<GeometryArray> {
-        Ok(self.to_geometry_builder(typ, prefer_multi)?.finish())
+    fn to_geometry_array(&self, typ: GeometryType) -> geozero::error::Result<GeometryArray> {
+        Ok(self.to_geometry_builder(typ)?.finish())
     }
 
     /// Convert to a GeoArrow [`GeometryBuilder`]
-    fn to_geometry_builder(
-        &self,
-        typ: GeometryType,
-        prefer_multi: bool,
-    ) -> geozero::error::Result<GeometryBuilder>;
+    fn to_geometry_builder(&self, typ: GeometryType) -> geozero::error::Result<GeometryBuilder>;
 }
 
 impl<T: GeozeroGeometry> ToGeometryArray for T {
-    fn to_geometry_builder(
-        &self,
-        typ: GeometryType,
-        prefer_multi: bool,
-    ) -> geozero::error::Result<GeometryBuilder> {
-        let mut stream_builder = GeometryStreamBuilder::new(typ, prefer_multi);
+    fn to_geometry_builder(&self, typ: GeometryType) -> geozero::error::Result<GeometryBuilder> {
+        let mut stream_builder = GeometryStreamBuilder::new(typ);
         self.process_geom(&mut stream_builder)?;
         Ok(stream_builder.builder)
     }
@@ -83,9 +71,9 @@ struct GeometryStreamBuilder {
 }
 
 impl GeometryStreamBuilder {
-    pub fn new(typ: GeometryType, prefer_multi: bool) -> Self {
+    pub fn new(typ: GeometryType) -> Self {
         Self {
-            builder: GeometryBuilder::new(typ, prefer_multi),
+            builder: GeometryBuilder::new(typ),
             current_geometry: GeoWriter::new(),
             geometry_collection_level: 0,
         }
@@ -291,9 +279,9 @@ mod test {
         let geo_geoms = geoms();
         let geo = Geometry::GeometryCollection(GeometryCollection(geo_geoms.clone()));
         let typ = GeometryType::new(CoordType::Interleaved, Default::default());
-        let geo_arr = geo.to_geometry_array(typ.clone(), true).unwrap();
+        let geo_arr = geo.to_geometry_array(typ.clone()).unwrap();
 
-        let geo_arr2 = GeometryBuilder::from_geometries(&geo_geoms, typ, true)
+        let geo_arr2 = GeometryBuilder::from_geometries(&geo_geoms, typ)
             .unwrap()
             .finish();
 

--- a/rust/geoarrow-array/src/test/geometry.rs
+++ b/rust/geoarrow-array/src/test/geometry.rs
@@ -4,9 +4,9 @@ use geoarrow_test::raw;
 use crate::array::GeometryArray;
 use crate::builder::GeometryBuilder;
 
-pub fn array(coord_type: CoordType, prefer_multi: bool) -> GeometryArray {
+pub fn array(coord_type: CoordType, _prefer_multi: bool) -> GeometryArray {
     let typ = GeometryType::new(coord_type, Default::default());
-    GeometryBuilder::from_nullable_geometries(&raw::geometry::geoms(), typ, prefer_multi)
+    GeometryBuilder::from_nullable_geometries(&raw::geometry::geoms(), typ)
         .unwrap()
         .finish()
 }

--- a/rust/geoarrow-array/src/test/geometrycollection.rs
+++ b/rust/geoarrow-array/src/test/geometrycollection.rs
@@ -4,7 +4,11 @@ use geoarrow_test::raw;
 use crate::array::GeometryCollectionArray;
 use crate::builder::GeometryCollectionBuilder;
 
-pub fn array(coord_type: CoordType, dim: Dimension, prefer_multi: bool) -> GeometryCollectionArray {
+pub fn array(
+    coord_type: CoordType,
+    dim: Dimension,
+    _prefer_multi: bool,
+) -> GeometryCollectionArray {
     let typ = GeometryCollectionType::new(coord_type, dim, Default::default());
     let geoms = match dim {
         Dimension::XY => raw::geometrycollection::xy::geoms(),
@@ -13,7 +17,7 @@ pub fn array(coord_type: CoordType, dim: Dimension, prefer_multi: bool) -> Geome
         Dimension::XYZM => raw::geometrycollection::xyzm::geoms(),
     };
 
-    GeometryCollectionBuilder::from_nullable_geometry_collections(&geoms, typ, prefer_multi)
+    GeometryCollectionBuilder::from_nullable_geometry_collections(&geoms, typ)
         .unwrap()
         .finish()
 }

--- a/rust/geoarrow-cast/src/cast.rs
+++ b/rust/geoarrow-cast/src/cast.rs
@@ -222,7 +222,7 @@ pub fn cast(array: &dyn GeoArrowArray, to_type: &GeoArrowType) -> Result<Arc<dyn
             let g_capacity = g_array.buffer_lengths();
             let gc_capacity = g_capacity.geometry_collection(to_type.dimension());
             let mut builder =
-                GeometryCollectionBuilder::with_capacity(to_type.clone(), gc_capacity, false);
+                GeometryCollectionBuilder::with_capacity(to_type.clone(), gc_capacity);
             for geom in array.as_geometry().iter() {
                 builder.push_geometry(geom.transpose()?.as_ref())?;
             }
@@ -244,10 +244,10 @@ pub fn cast(array: &dyn GeoArrowArray, to_type: &GeoArrowType) -> Result<Arc<dyn
         (_, LargeWkb(_)) => Arc::new(to_wkb::<i64>(array)?),
         (_, Wkt(_)) => Arc::new(to_wkt::<i32>(array)?),
         (_, LargeWkt(_)) => Arc::new(to_wkt::<i64>(array)?),
-        (Wkb(_), _) => from_wkb(array.as_wkb::<i32>(), to_type.clone(), false)?,
-        (LargeWkb(_), _) => from_wkb(array.as_wkb::<i64>(), to_type.clone(), false)?,
-        (Wkt(_), _) => from_wkt(array.as_wkt::<i32>(), to_type.clone(), false)?,
-        (LargeWkt(_), _) => from_wkt(array.as_wkt::<i64>(), to_type.clone(), false)?,
+        (Wkb(_), _) => from_wkb(array.as_wkb::<i32>(), to_type.clone())?,
+        (LargeWkb(_), _) => from_wkb(array.as_wkb::<i64>(), to_type.clone())?,
+        (Wkt(_), _) => from_wkt(array.as_wkt::<i32>(), to_type.clone())?,
+        (LargeWkt(_), _) => from_wkt(array.as_wkt::<i64>(), to_type.clone())?,
         (_, _) => {
             return Err(GeoArrowError::General(format!(
                 "Unsupported cast from {:?} to {:?}",

--- a/rust/geoarrow-geoparquet/src/reader/parse.rs
+++ b/rust/geoarrow-geoparquet/src/reader/parse.rs
@@ -3,17 +3,14 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use arrow_array::{Array, ArrayRef, OffsetSizeTrait, RecordBatch};
+use arrow_array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use geoarrow_array::array::{
     LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray,
     PolygonArray, WkbArray,
 };
-use geoarrow_array::builder::{
-    GeometryBuilder, GeometryCollectionBuilder, LineStringBuilder, MultiLineStringBuilder,
-    MultiPointBuilder, MultiPolygonBuilder, PointBuilder, PolygonBuilder,
-};
-use geoarrow_array::{ArrayAccessor, GeoArrowArray, GeoArrowType};
+use geoarrow_array::cast::from_wkb;
+use geoarrow_array::{GeoArrowArray, GeoArrowType};
 use geoarrow_schema::{
     CoordType, GeometryType, LineStringType, Metadata, MultiLineStringType, MultiPointType,
     MultiPolygonType, PointType, PolygonType, WkbType,
@@ -139,12 +136,12 @@ fn parse_wkb_column(arr: &dyn Array, target_geo_data_type: GeoArrowType) -> Resu
     match arr.data_type() {
         DataType::Binary => {
             let wkb_arr = WkbArray::<i32>::try_from((arr, WkbType::new(Default::default())))?;
-            let geom_arr = from_wkb(&wkb_arr, target_geo_data_type, true)?;
+            let geom_arr = from_wkb(&wkb_arr, target_geo_data_type)?;
             Ok(geom_arr.to_array_ref())
         }
         DataType::LargeBinary => {
             let wkb_arr = WkbArray::<i64>::try_from((arr, WkbType::new(Default::default())))?;
-            let geom_arr = from_wkb(&wkb_arr, target_geo_data_type, true)?;
+            let geom_arr = from_wkb(&wkb_arr, target_geo_data_type)?;
             Ok(geom_arr.to_array_ref())
         }
         dt => Err(GeoArrowError::General(format!(
@@ -181,64 +178,3 @@ impl_parse_fn!(
     MultiPolygonArray,
     MultiPolygonType
 );
-
-/// Parse a [WKBArray] to a GeometryArray with GeoArrow native encoding.
-///
-/// This supports either ISO or EWKB-flavored data.
-///
-/// The returned array is guaranteed to have exactly the type of `target_type`.
-///
-/// `GeoArrowType::Rect` is currently not allowed.
-fn from_wkb<O: OffsetSizeTrait>(
-    arr: &WkbArray<O>,
-    target_type: GeoArrowType,
-    prefer_multi: bool,
-) -> Result<Arc<dyn GeoArrowArray>> {
-    use GeoArrowType::*;
-
-    let geoms = arr
-        .iter()
-        .map(|x| x.transpose())
-        .collect::<Result<Vec<Option<_>>>>()?;
-
-    match target_type {
-        Point(typ) => {
-            let builder = PointBuilder::from_nullable_geometries(&geoms, typ)?;
-            Ok(Arc::new(builder.finish()))
-        }
-        LineString(typ) => {
-            let builder = LineStringBuilder::from_nullable_geometries(&geoms, typ)?;
-            Ok(Arc::new(builder.finish()))
-        }
-        Polygon(typ) => {
-            let builder = PolygonBuilder::from_nullable_geometries(&geoms, typ)?;
-            Ok(Arc::new(builder.finish()))
-        }
-        MultiPoint(typ) => {
-            let builder = MultiPointBuilder::from_nullable_geometries(&geoms, typ)?;
-            Ok(Arc::new(builder.finish()))
-        }
-        MultiLineString(typ) => {
-            let builder = MultiLineStringBuilder::from_nullable_geometries(&geoms, typ)?;
-            Ok(Arc::new(builder.finish()))
-        }
-        MultiPolygon(typ) => {
-            let builder = MultiPolygonBuilder::from_nullable_geometries(&geoms, typ)?;
-            Ok(Arc::new(builder.finish()))
-        }
-        GeometryCollection(typ) => {
-            let builder =
-                GeometryCollectionBuilder::from_nullable_geometries(&geoms, typ, prefer_multi)?;
-            Ok(Arc::new(builder.finish()))
-        }
-        Rect(_) => Err(GeoArrowError::General(format!(
-            "Unexpected data type {:?}",
-            target_type,
-        ))),
-        Geometry(typ) => {
-            let builder = GeometryBuilder::from_nullable_geometries(&geoms, typ, prefer_multi)?;
-            Ok(Arc::new(builder.finish()))
-        }
-        _ => todo!("Handle target WKB/WKT in `from_wkb`"),
-    }
-}

--- a/rust/geoarrow-geoparquet/src/test/geoarrow_data/example.rs
+++ b/rust/geoarrow-geoparquet/src/test/geoarrow_data/example.rs
@@ -293,7 +293,7 @@ fn geometrycollection() {
         // NOTE: this hard-coding of `prefer_multi` to `true` matches some hard-coding somewhere in
         // the Parquet reader. Ideally we'd find a way to expose this.
         let from_wkt =
-            GeometryCollectionBuilder::from_nullable_geometries(&wkt_geoms, expected_typ, true)
+            GeometryCollectionBuilder::from_nullable_geometries(&wkt_geoms, expected_typ)
                 .unwrap()
                 .finish();
 

--- a/rust/geoarrow-geos/src/import/array/geometry.rs
+++ b/rust/geoarrow-geos/src/import/array/geometry.rs
@@ -6,8 +6,6 @@ use geoarrow_schema::GeometryType;
 use crate::import::array::FromGEOS;
 use crate::import::scalar::GEOSGeometry;
 
-const DEFAULT_PREFER_MULTI: bool = false;
-
 impl FromGEOS for GeometryBuilder {
     type GeoArrowType = GeometryType;
 
@@ -19,7 +17,7 @@ impl FromGEOS for GeometryBuilder {
             .into_iter()
             .map(|geom| geom.map(GEOSGeometry::new))
             .collect::<Vec<_>>();
-        Self::from_nullable_geometries(&geoms, typ, DEFAULT_PREFER_MULTI)
+        Self::from_nullable_geometries(&geoms, typ)
     }
 }
 

--- a/rust/geoarrow-geos/src/import/array/geometrycollection.rs
+++ b/rust/geoarrow-geos/src/import/array/geometrycollection.rs
@@ -6,8 +6,6 @@ use geoarrow_schema::GeometryCollectionType;
 use crate::import::array::FromGEOS;
 use crate::import::scalar::GEOSGeometryCollection;
 
-const DEFAULT_PREFER_MULTI: bool = false;
-
 impl FromGEOS for GeometryCollectionBuilder {
     type GeoArrowType = GeometryCollectionType;
 
@@ -19,7 +17,7 @@ impl FromGEOS for GeometryCollectionBuilder {
             .into_iter()
             .map(|geom| geom.map(GEOSGeometryCollection::try_new).transpose())
             .collect::<Result<Vec<_>>>()?;
-        Self::from_nullable_geometry_collections(&geoms, typ, DEFAULT_PREFER_MULTI)
+        Self::from_nullable_geometry_collections(&geoms, typ)
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/geoarrow/geoarrow-rs/issues/1075.
Ref https://github.com/stac-utils/rustac/pull/708#discussion_r2052669060, cc @gadomski 

- Removes `prefer_multi` as part of the primary constructors, always defaulting to `false`, and then adds a `with_prefer_multi` after the constructor. 