### PR TITLE
Allow Arrow binary view and string view types for `WkbType` and `WktType` in `geoarrow-schema`

### DIFF
--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -267,7 +267,9 @@ mod test {
     fn parse_dyn_array_i32() {
         let wkb_array = wkb_data::<i32>();
         let array = wkb_array.to_array_ref();
-        let field = wkb_array.data_type.to_field("geometry", true, false);
+        let field = wkb_array
+            .data_type
+            .to_field("geometry", true, array.data_type().clone());
         let wkb_array_retour: WkbArray<i32> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
@@ -277,7 +279,9 @@ mod test {
     fn parse_dyn_array_i64() {
         let wkb_array = wkb_data::<i64>();
         let array = wkb_array.to_array_ref();
-        let field = wkb_array.data_type.to_field("geometry", true, false);
+        let field = wkb_array
+            .data_type
+            .to_field("geometry", true, array.data_type().clone());
         let wkb_array_retour: WkbArray<i64> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -267,9 +267,8 @@ mod test {
     fn parse_dyn_array_i32() {
         let wkb_array = wkb_data::<i32>();
         let array = wkb_array.to_array_ref();
-        let field = wkb_array
-            .data_type
-            .to_field("geometry", true, array.data_type().clone());
+        let field = Field::new("geometry", array.data_type().clone(), true)
+            .with_extension_type(wkb_array.data_type.clone());
         let wkb_array_retour: WkbArray<i32> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
@@ -279,9 +278,8 @@ mod test {
     fn parse_dyn_array_i64() {
         let wkb_array = wkb_data::<i64>();
         let array = wkb_array.to_array_ref();
-        let field = wkb_array
-            .data_type
-            .to_field("geometry", true, array.data_type().clone());
+        let field = Field::new("geometry", array.data_type().clone(), true)
+            .with_extension_type(wkb_array.data_type.clone());
         let wkb_array_retour: WkbArray<i64> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -256,7 +256,9 @@ mod test {
     fn parse_dyn_array_i32() {
         let wkb_array = wkt_data::<i32>();
         let array = wkb_array.to_array_ref();
-        let field = wkb_array.data_type.to_field("geometry", true, false);
+        let field = wkb_array
+            .data_type
+            .to_field("geometry", true, array.data_type().clone());
         let wkb_array_retour: WktArray<i32> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
@@ -266,7 +268,9 @@ mod test {
     fn parse_dyn_array_i64() {
         let wkb_array = wkt_data::<i64>();
         let array = wkb_array.to_array_ref();
-        let field = wkb_array.data_type.to_field("geometry", true, false);
+        let field = wkb_array
+            .data_type
+            .to_field("geometry", true, array.data_type().clone());
         let wkb_array_retour: WktArray<i64> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -256,9 +256,8 @@ mod test {
     fn parse_dyn_array_i32() {
         let wkb_array = wkt_data::<i32>();
         let array = wkb_array.to_array_ref();
-        let field = wkb_array
-            .data_type
-            .to_field("geometry", true, array.data_type().clone());
+        let field = Field::new("geometry", array.data_type().clone(), true)
+            .with_extension_type(wkb_array.data_type.clone());
         let wkb_array_retour: WktArray<i32> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
@@ -268,9 +267,8 @@ mod test {
     fn parse_dyn_array_i64() {
         let wkb_array = wkt_data::<i64>();
         let array = wkb_array.to_array_ref();
-        let field = wkb_array
-            .data_type
-            .to_field("geometry", true, array.data_type().clone());
+        let field = Field::new("geometry", array.data_type().clone(), true)
+            .with_extension_type(wkb_array.data_type.clone());
         let wkb_array_retour: WktArray<i64> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -184,10 +184,14 @@ impl GeoArrowType {
             GeometryCollection(t) => t.to_field(name, nullable),
             Rect(t) => t.to_field(name, nullable),
             Geometry(t) => t.to_field(name, nullable),
-            Wkb(t) => t.to_field(name, nullable, DataType::Binary),
-            LargeWkb(t) => t.to_field(name, nullable, DataType::LargeBinary),
-            Wkt(t) => t.to_field(name, nullable, DataType::Utf8),
-            LargeWkt(t) => t.to_field(name, nullable, DataType::LargeUtf8),
+            Wkb(t) => Field::new(name, DataType::Binary, nullable).with_extension_type(t.clone()),
+            LargeWkb(t) => {
+                Field::new(name, DataType::LargeBinary, nullable).with_extension_type(t.clone())
+            }
+            Wkt(t) => Field::new(name, DataType::Utf8, nullable).with_extension_type(t.clone()),
+            LargeWkt(t) => {
+                Field::new(name, DataType::LargeUtf8, nullable).with_extension_type(t.clone())
+            }
         }
     }
 

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -151,10 +151,10 @@ impl GeoArrowType {
             GeometryCollection(t) => t.data_type(),
             Rect(t) => t.data_type(),
             Geometry(t) => t.data_type(),
-            Wkb(t) => t.data_type(false),
-            LargeWkb(t) => t.data_type(true),
-            Wkt(t) => t.data_type(false),
-            LargeWkt(t) => t.data_type(true),
+            Wkb(_) => DataType::Binary,
+            LargeWkb(_) => DataType::LargeBinary,
+            Wkt(_) => DataType::Utf8,
+            LargeWkt(_) => DataType::LargeUtf8,
         }
     }
 
@@ -184,10 +184,10 @@ impl GeoArrowType {
             GeometryCollection(t) => t.to_field(name, nullable),
             Rect(t) => t.to_field(name, nullable),
             Geometry(t) => t.to_field(name, nullable),
-            Wkb(t) => t.to_field(name, nullable, false),
-            LargeWkb(t) => t.to_field(name, nullable, true),
-            Wkt(t) => t.to_field(name, nullable, false),
-            LargeWkt(t) => t.to_field(name, nullable, true),
+            Wkb(t) => t.to_field(name, nullable, DataType::Binary),
+            LargeWkb(t) => t.to_field(name, nullable, DataType::LargeBinary),
+            Wkt(t) => t.to_field(name, nullable, DataType::Utf8),
+            LargeWkt(t) => t.to_field(name, nullable, DataType::LargeUtf8),
         }
     }
 

--- a/rust/geoarrow-geoparquet/src/writer/metadata.rs
+++ b/rust/geoarrow-geoparquet/src/writer/metadata.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use arrow_array::ArrayRef;
 use arrow_schema::extension::{EXTENSION_TYPE_METADATA_KEY, EXTENSION_TYPE_NAME_KEY};
-use arrow_schema::{Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use geoarrow_array::GeoArrowType;
 use geoarrow_array::array::from_arrow_array;
 use geoarrow_array::crs::{CRSTransform, DefaultCRSTransform};
@@ -314,7 +314,9 @@ fn create_output_field(column_info: &ColumnInfo, name: String, nullable: bool) -
     use GeoParquetColumnEncoding as Encoding;
 
     match column_info.encoding {
-        Encoding::WKB => WkbType::new(Default::default()).to_field(name, nullable, false),
+        Encoding::WKB => {
+            WkbType::new(Default::default()).to_field(name, nullable, DataType::Binary)
+        }
         // A native encoding
         _ => {
             assert_eq!(column_info.geometry_types.len(), 1);

--- a/rust/geoarrow-geoparquet/src/writer/metadata.rs
+++ b/rust/geoarrow-geoparquet/src/writer/metadata.rs
@@ -314,9 +314,8 @@ fn create_output_field(column_info: &ColumnInfo, name: String, nullable: bool) -
     use GeoParquetColumnEncoding as Encoding;
 
     match column_info.encoding {
-        Encoding::WKB => {
-            WkbType::new(Default::default()).to_field(name, nullable, DataType::Binary)
-        }
+        Encoding::WKB => Field::new(name, DataType::Binary, nullable)
+            .with_extension_type(WkbType::new(Default::default())),
         // A native encoding
         _ => {
             assert_eq!(column_info.geometry_types.len(), 1);

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1356,29 +1356,12 @@ impl WkbType {
         &self.metadata
     }
 
-    /// Convert to the corresponding [`DataType`].
-    ///
-    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
-    ///
-    /// ```
-    /// use arrow_schema::DataType;
-    /// use geoarrow_schema::WkbType;
-    ///
-    /// let geom_type = WkbType::new(Default::default());
-    ///
-    /// assert_eq!(geom_type.data_type(false), DataType::Binary);
-    /// ```
-    pub fn data_type(&self, large: bool) -> DataType {
-        if large {
-            DataType::LargeBinary
-        } else {
-            DataType::Binary
-        }
-    }
-
     /// Convert this type to a [`Field`], retaining extension metadata.
-    pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool, large: bool) -> Field {
-        Field::new(name, self.data_type(large), nullable).with_extension_type(self.clone())
+    ///
+    /// This will panic if a data type is provided that is not compatible with WKB arrays.
+    pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool, data_type: DataType) -> Field {
+        self.supports_data_type(&data_type).unwrap();
+        Field::new(name, data_type, nullable).with_extension_type(self.clone())
     }
 }
 
@@ -1401,7 +1384,7 @@ impl ExtensionType for WkbType {
 
     fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
         match data_type {
-            DataType::Binary | DataType::LargeBinary => Ok(()),
+            DataType::Binary | DataType::LargeBinary | DataType::BinaryView => Ok(()),
             dt => Err(ArrowError::SchemaError(format!(
                 "Unexpected data type {dt}"
             ))),
@@ -1441,29 +1424,12 @@ impl WktType {
         &self.metadata
     }
 
-    /// Convert to the corresponding [`DataType`].
-    ///
-    /// Each type uniquely maps to a [`DataType`], so this is a 1:1 conversion.
-    ///
-    /// ```
-    /// use arrow_schema::DataType;
-    /// use geoarrow_schema::WktType;
-    ///
-    /// let geom_type = WktType::new(Default::default());
-    ///
-    /// assert_eq!(geom_type.data_type(false), DataType::Utf8);
-    /// ```
-    pub fn data_type(&self, large: bool) -> DataType {
-        if large {
-            DataType::LargeUtf8
-        } else {
-            DataType::Utf8
-        }
-    }
-
     /// Convert this type to a [`Field`], retaining extension metadata.
-    pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool, large: bool) -> Field {
-        Field::new(name, self.data_type(large), nullable).with_extension_type(self.clone())
+    ///
+    /// This will panic if a data type is provided that is not compatible with WKT arrays.
+    pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool, data_type: DataType) -> Field {
+        self.supports_data_type(&data_type).unwrap();
+        Field::new(name, data_type, nullable).with_extension_type(self.clone())
     }
 }
 
@@ -1486,7 +1452,7 @@ impl ExtensionType for WktType {
 
     fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
         match data_type {
-            DataType::Utf8 | DataType::LargeUtf8 => Ok(()),
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok(()),
             dt => Err(ArrowError::SchemaError(format!(
                 "Unexpected data type {dt}"
             ))),

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1355,14 +1355,6 @@ impl WkbType {
     pub fn metadata(&self) -> &Arc<Metadata> {
         &self.metadata
     }
-
-    /// Convert this type to a [`Field`], retaining extension metadata.
-    ///
-    /// This will panic if a data type is provided that is not compatible with WKB arrays.
-    pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool, data_type: DataType) -> Field {
-        self.supports_data_type(&data_type).unwrap();
-        Field::new(name, data_type, nullable).with_extension_type(self.clone())
-    }
 }
 
 impl ExtensionType for WkbType {
@@ -1422,14 +1414,6 @@ impl WktType {
     /// Retrieve the underlying [`Metadata`]
     pub fn metadata(&self) -> &Arc<Metadata> {
         &self.metadata
-    }
-
-    /// Convert this type to a [`Field`], retaining extension metadata.
-    ///
-    /// This will panic if a data type is provided that is not compatible with WKT arrays.
-    pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool, data_type: DataType) -> Field {
-        self.supports_data_type(&data_type).unwrap();
-        Field::new(name, data_type, nullable).with_extension_type(self.clone())
     }
 }
 

--- a/rust/geoarrow/src/array/binary/array.rs
+++ b/rust/geoarrow/src/array/binary/array.rs
@@ -99,12 +99,16 @@ impl<O: OffsetSizeTrait> ArrayBase for WKBArray<O> {
     }
 
     fn storage_type(&self) -> DataType {
-        self.data_type.data_type(O::IS_LARGE)
+        if O::IS_LARGE {
+            DataType::LargeBinary
+        } else {
+            DataType::Binary
+        }
     }
 
     fn extension_field(&self) -> Arc<Field> {
         self.data_type
-            .to_field("geometry", true, O::IS_LARGE)
+            .to_field("geometry", true, self.storage_type())
             .into()
     }
 

--- a/rust/geoarrow/src/array/binary/array.rs
+++ b/rust/geoarrow/src/array/binary/array.rs
@@ -107,8 +107,8 @@ impl<O: OffsetSizeTrait> ArrayBase for WKBArray<O> {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        self.data_type
-            .to_field("geometry", true, self.storage_type())
+        Field::new("geometry", self.storage_type(), true)
+            .with_extension_type(self.data_type.clone())
             .into()
     }
 

--- a/rust/geoarrow/src/array/wkt/array.rs
+++ b/rust/geoarrow/src/array/wkt/array.rs
@@ -79,12 +79,16 @@ impl<O: OffsetSizeTrait> ArrayBase for WKTArray<O> {
     }
 
     fn storage_type(&self) -> DataType {
-        self.data_type.data_type(O::IS_LARGE)
+        if O::IS_LARGE {
+            DataType::LargeUtf8
+        } else {
+            DataType::Utf8
+        }
     }
 
     fn extension_field(&self) -> Arc<Field> {
         self.data_type
-            .to_field("geometry", true, O::IS_LARGE)
+            .to_field("geometry", true, self.storage_type())
             .into()
     }
 

--- a/rust/geoarrow/src/array/wkt/array.rs
+++ b/rust/geoarrow/src/array/wkt/array.rs
@@ -87,8 +87,8 @@ impl<O: OffsetSizeTrait> ArrayBase for WKTArray<O> {
     }
 
     fn extension_field(&self) -> Arc<Field> {
-        self.data_type
-            .to_field("geometry", true, self.storage_type())
+        Field::new("geometry", self.storage_type(), true)
+            .with_extension_type(self.data_type.clone())
             .into()
     }
 

--- a/rust/geoarrow/src/datatypes.rs
+++ b/rust/geoarrow/src/datatypes.rs
@@ -306,10 +306,10 @@ impl SerializedType {
     pub fn to_data_type(&self) -> DataType {
         use SerializedType::*;
         match self {
-            WKB(t) => t.data_type(false),
-            LargeWKB(t) => t.data_type(true),
-            WKT(t) => t.data_type(false),
-            LargeWKT(t) => t.data_type(true),
+            WKB(_) => DataType::Binary,
+            LargeWKB(_) => DataType::LargeBinary,
+            WKT(_) => DataType::Utf8,
+            LargeWKT(_) => DataType::LargeUtf8,
         }
     }
 
@@ -326,10 +326,10 @@ impl SerializedType {
     /// metadata.
     pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool) -> Field {
         match self {
-            Self::WKB(t) => t.to_field(name, nullable, false),
-            Self::LargeWKB(t) => t.to_field(name, nullable, true),
-            Self::WKT(t) => t.to_field(name, nullable, false),
-            Self::LargeWKT(t) => t.to_field(name, nullable, true),
+            Self::WKB(t) => t.to_field(name, nullable, DataType::Binary),
+            Self::LargeWKB(t) => t.to_field(name, nullable, DataType::LargeBinary),
+            Self::WKT(t) => t.to_field(name, nullable, DataType::Utf8),
+            Self::LargeWKT(t) => t.to_field(name, nullable, DataType::LargeUtf8),
         }
     }
 }

--- a/rust/geoarrow/src/datatypes.rs
+++ b/rust/geoarrow/src/datatypes.rs
@@ -326,10 +326,18 @@ impl SerializedType {
     /// metadata.
     pub fn to_field<N: Into<String>>(&self, name: N, nullable: bool) -> Field {
         match self {
-            Self::WKB(t) => t.to_field(name, nullable, DataType::Binary),
-            Self::LargeWKB(t) => t.to_field(name, nullable, DataType::LargeBinary),
-            Self::WKT(t) => t.to_field(name, nullable, DataType::Utf8),
-            Self::LargeWKT(t) => t.to_field(name, nullable, DataType::LargeUtf8),
+            Self::WKB(t) => {
+                Field::new(name, DataType::Binary, nullable).with_extension_type(t.clone())
+            }
+            Self::LargeWKB(t) => {
+                Field::new(name, DataType::LargeBinary, nullable).with_extension_type(t.clone())
+            }
+            Self::WKT(t) => {
+                Field::new(name, DataType::Utf8, nullable).with_extension_type(t.clone())
+            }
+            Self::LargeWKT(t) => {
+                Field::new(name, DataType::LargeUtf8, nullable).with_extension_type(t.clone())
+            }
         }
     }
 }

--- a/rust/geodatafusion/src/udf/native/io/wkb.rs
+++ b/rust/geodatafusion/src/udf/native/io/wkb.rs
@@ -52,7 +52,7 @@ impl ScalarUDFImpl for AsBinary {
         let field = &args.arg_fields[0];
         let data_type = GeoArrowType::try_from(field).map_err(GeoDataFusionError::GeoArrow)?;
         let wkb_type = WkbType::new(data_type.metadata().clone());
-        Ok(wkb_type.to_field(field.name(), field.is_nullable(), false))
+        Ok(wkb_type.to_field(field.name(), field.is_nullable(), DataType::Binary))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {

--- a/rust/geodatafusion/src/udf/native/io/wkb.rs
+++ b/rust/geodatafusion/src/udf/native/io/wkb.rs
@@ -52,7 +52,10 @@ impl ScalarUDFImpl for AsBinary {
         let field = &args.arg_fields[0];
         let data_type = GeoArrowType::try_from(field).map_err(GeoDataFusionError::GeoArrow)?;
         let wkb_type = WkbType::new(data_type.metadata().clone());
-        Ok(wkb_type.to_field(field.name(), field.is_nullable(), DataType::Binary))
+        Ok(
+            Field::new(field.name(), DataType::Binary, field.is_nullable())
+                .with_extension_type(wkb_type),
+        )
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {


### PR DESCRIPTION
### Change list

- Allow `BinaryView` in `WkbType::supports_data_type` and allow `Utf8View` in `WkbType::supports_data_type`
- Remove `WkbType::data_type` and `WktType::data_type` because the geoarrow type concepts are no longer easily associated with a single `DataType`. (Previously, we had a `large: bool` parameter that determined whether `LargeBinary` or `Binary` would be generated as the `DataType`)
- Remove `to_field` from `WkbType` and `WktType` since it's just a wrapper around `with_extension_type`