### PR TITLE
Allow missing GeoArrow metadata in WktArray::try_from and WkbArray::try_from

### DIFF
--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1335,7 +1335,7 @@ fn parse_box(data_type: &DataType) -> Result<Dimension, ArrowError> {
 /// A type representing a geoarrow WKB array.
 ///
 /// This implements the [`ExtensionType`] trait.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct WkbType {
     metadata: Arc<Metadata>,
 }
@@ -1395,7 +1395,7 @@ impl ExtensionType for WkbType {
 /// A type representing a geoarrow WKT array.
 ///
 /// This implements the [`ExtensionType`] trait.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct WktType {
     metadata: Arc<Metadata>,
 }


### PR DESCRIPTION
We should be able to construct a `WkbArray` or `WktArray` from a binary/string array that doesn't have any existing geospatial metadata on the `Field`.

- Add `Default` to `WktArray` and `WkbArray` (since there's no need to choose coord type)
- Define a default wkt/wkb type (with empty CRS) if no geoarrow metadata exists already on the field.
- Adds tests