### PR TITLE
Add `WkbViewArray` and `WktViewArray`

### DIFF
--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -14,7 +14,9 @@ mod point;
 mod polygon;
 mod rect;
 mod wkb;
+mod wkb_view;
 mod wkt;
+mod wkt_view;
 
 pub use coord::{CoordBuffer, InterleavedCoordBuffer, SeparatedCoordBuffer};
 pub(crate) use geometry::DimensionIndex;
@@ -29,7 +31,9 @@ pub use point::PointArray;
 pub use polygon::PolygonArray;
 pub use rect::RectArray;
 pub use wkb::WkbArray;
+pub use wkb_view::WkbViewArray;
 pub use wkt::WktArray;
+pub use wkt_view::WktViewArray;
 
 use std::sync::Arc;
 
@@ -55,8 +59,10 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
         Geometry(_) => Arc::new(GeometryArray::try_from((array, field))?),
         Wkb(_) => Arc::new(WkbArray::<i32>::try_from((array, field))?),
         LargeWkb(_) => Arc::new(WkbArray::<i64>::try_from((array, field))?),
+        WkbView(_) => Arc::new(WkbViewArray::try_from((array, field))?),
         Wkt(_) => Arc::new(WktArray::<i32>::try_from((array, field))?),
         LargeWkt(_) => Arc::new(WktArray::<i64>::try_from((array, field))?),
+        WktView(_) => Arc::new(WktViewArray::try_from((array, field))?),
     };
     Ok(result)
 }

--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -66,3 +66,44 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
     };
     Ok(result)
 }
+
+/// A trait for GeoArrow arrays that can hold WKB data.
+///
+/// Currently three types are supported:
+///
+/// - [`WkbArray<i32>`]
+/// - [`WkbArray<i64>`]
+/// - [`WkbViewArray`]
+///
+/// This trait helps to abstract over the different types of WKB arrays so that we don’t need to
+/// duplicate the implementation for each type.
+///
+/// This is modeled after the upstream [`BinaryArrayType`][arrow_array::array::BinaryArrayType]
+/// trait.
+pub trait WkbArrayType<'a>:
+    Sized + crate::ArrayAccessor<'a, Item = ::wkb::reader::Wkb<'a>>
+{
+}
+
+impl<'a> WkbArrayType<'a> for WkbArray<i32> {}
+impl<'a> WkbArrayType<'a> for WkbArray<i64> {}
+impl<'a> WkbArrayType<'a> for WkbViewArray {}
+
+/// A trait for GeoArrow arrays that can hold WKT data.
+///
+/// Currently three types are supported:
+///
+/// - [`WktArray<i32>`]
+/// - [`WktArray<i64>`]
+/// - [`WktViewArray`]
+///
+/// This trait helps to abstract over the different types of WKT arrays so that we don’t need to
+/// duplicate the implementation for each type.
+///
+/// This is modeled after the upstream [`StringArrayType`][arrow_array::array::StringArrayType]
+/// trait.
+pub trait WktArrayType: Sized + for<'a> crate::ArrayAccessor<'a, Item = ::wkt::Wkt> {}
+
+impl WktArrayType for WktArray<i32> {}
+impl WktArrayType for WktArray<i64> {}
+impl WktArrayType for WktViewArray {}

--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -67,6 +67,8 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
     Ok(result)
 }
 
+// TODO: should we have an API to get the raw underlying string/&[u8] value?
+
 /// A trait for GeoArrow arrays that can hold WKB data.
 ///
 /// Currently three types are supported:
@@ -85,9 +87,9 @@ pub trait WkbArrayType<'a>:
 {
 }
 
-impl<'a> WkbArrayType<'a> for WkbArray<i32> {}
-impl<'a> WkbArrayType<'a> for WkbArray<i64> {}
-impl<'a> WkbArrayType<'a> for WkbViewArray {}
+impl WkbArrayType<'_> for WkbArray<i32> {}
+impl WkbArrayType<'_> for WkbArray<i64> {}
+impl WkbArrayType<'_> for WkbViewArray {}
 
 /// A trait for GeoArrow arrays that can hold WKT data.
 ///

--- a/rust/geoarrow-array/src/array/wkb_view.rs
+++ b/rust/geoarrow-array/src/array/wkb_view.rs
@@ -1,0 +1,162 @@
+use std::sync::Arc;
+
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef, BinaryViewArray};
+use arrow_buffer::NullBuffer;
+use arrow_schema::{DataType, Field};
+use geoarrow_schema::{Metadata, WkbType};
+use wkb::reader::Wkb;
+
+use crate::error::{GeoArrowError, Result};
+use crate::{ArrayAccessor, GeoArrowArray, GeoArrowType, IntoArrow};
+
+/// An immutable array of WKB geometries.
+///
+/// This is semantically equivalent to `Vec<Option<Wkb>>` due to the internal validity bitmap.
+///
+/// This is stored as an Arrow [`BinaryViewArray`]
+#[derive(Debug, Clone, PartialEq)]
+pub struct WkbViewArray {
+    pub(crate) data_type: WkbType,
+    pub(crate) array: BinaryViewArray,
+}
+
+impl WkbViewArray {
+    /// Create a new WkbArray from a BinaryArray
+    pub fn new(array: BinaryViewArray, metadata: Arc<Metadata>) -> Self {
+        Self {
+            data_type: WkbType::new(metadata),
+            array,
+        }
+    }
+
+    /// Returns true if the array is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Slices this [`WkbArray`] in place.
+    /// # Panic
+    /// This function panics iff `offset + length > self.len()`.
+    #[inline]
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        Self {
+            array: self.array.slice(offset, length),
+            data_type: self.data_type.clone(),
+        }
+    }
+
+    /// Replace the [ArrayMetadata] in the array with the given metadata
+    pub fn with_metadata(&self, metadata: Arc<Metadata>) -> Self {
+        let mut arr = self.clone();
+        arr.data_type = self.data_type.clone().with_metadata(metadata);
+        arr
+    }
+}
+
+impl GeoArrowArray for WkbViewArray {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn into_array_ref(self) -> ArrayRef {
+        Arc::new(self.into_arrow())
+    }
+
+    fn to_array_ref(&self) -> ArrayRef {
+        self.clone().into_array_ref()
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.array.len()
+    }
+
+    #[inline]
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.array.logical_nulls()
+    }
+
+    #[inline]
+    fn logical_null_count(&self) -> usize {
+        self.array.logical_null_count()
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.array.is_null(i)
+    }
+
+    fn data_type(&self) -> GeoArrowType {
+        GeoArrowType::WkbView(self.data_type.clone())
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> Arc<dyn GeoArrowArray> {
+        Arc::new(self.slice(offset, length))
+    }
+
+    fn with_metadata(self, metadata: Arc<Metadata>) -> Arc<dyn GeoArrowArray> {
+        Arc::new(Self::with_metadata(&self, metadata))
+    }
+}
+
+impl<'a> ArrayAccessor<'a> for WkbViewArray {
+    type Item = Wkb<'a>;
+
+    unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {
+        let buf = self.array.value(index);
+        Ok(Wkb::try_new(buf)?)
+    }
+}
+
+impl IntoArrow for WkbViewArray {
+    type ArrowArray = BinaryViewArray;
+    type ExtensionType = WkbType;
+
+    fn into_arrow(self) -> Self::ArrowArray {
+        self.array
+    }
+
+    fn ext_type(&self) -> &Self::ExtensionType {
+        &self.data_type
+    }
+}
+
+impl From<(BinaryViewArray, WkbType)> for WkbViewArray {
+    fn from((value, typ): (BinaryViewArray, WkbType)) -> Self {
+        Self {
+            data_type: typ,
+            array: value,
+        }
+    }
+}
+
+impl TryFrom<(&dyn Array, WkbType)> for WkbViewArray {
+    type Error = GeoArrowError;
+
+    fn try_from((value, typ): (&dyn Array, WkbType)) -> Result<Self> {
+        match value.data_type() {
+            DataType::BinaryView => Ok((value.as_binary_view().clone(), typ).into()),
+            _ => Err(GeoArrowError::General(format!(
+                "Unexpected type: {:?}",
+                value.data_type()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<(&dyn Array, &Field)> for WkbViewArray {
+    type Error = GeoArrowError;
+
+    fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
+        let typ = field
+            .try_extension_type::<WkbType>()
+            .ok()
+            .unwrap_or_default();
+        (arr, typ).try_into()
+    }
+}

--- a/rust/geoarrow-array/src/array/wkt_view.rs
+++ b/rust/geoarrow-array/src/array/wkt_view.rs
@@ -1,0 +1,163 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef, StringViewArray};
+use arrow_buffer::NullBuffer;
+use arrow_schema::{DataType, Field};
+use geoarrow_schema::{Metadata, WktType};
+use wkt::Wkt;
+
+use crate::error::{GeoArrowError, Result};
+use crate::{ArrayAccessor, GeoArrowArray, GeoArrowType, IntoArrow};
+
+/// An immutable array of WKT geometries.
+///
+/// This is semantically equivalent to `Vec<Option<Wkt>>` due to the internal validity bitmap.
+///
+/// This is stored as an Arrow [`StringViewArray`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct WktViewArray {
+    pub(crate) data_type: WktType,
+    pub(crate) array: StringViewArray,
+}
+
+impl WktViewArray {
+    /// Create a new WktViewArray from a StringViewArray
+    pub fn new(array: StringViewArray, metadata: Arc<Metadata>) -> Self {
+        Self {
+            data_type: WktType::new(metadata),
+            array,
+        }
+    }
+
+    /// Returns true if the array is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Slices this [`WktViewArray`] in place.
+    /// # Panic
+    /// This function panics iff `offset + length > self.len()`.
+    #[inline]
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        Self {
+            array: self.array.slice(offset, length),
+            data_type: self.data_type.clone(),
+        }
+    }
+
+    /// Replace the [ArrayMetadata] in the array with the given metadata
+    pub fn with_metadata(&self, metadata: Arc<Metadata>) -> Self {
+        let mut arr = self.clone();
+        arr.data_type = self.data_type.clone().with_metadata(metadata);
+        arr
+    }
+}
+
+impl GeoArrowArray for WktViewArray {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn into_array_ref(self) -> ArrayRef {
+        Arc::new(self.into_arrow())
+    }
+
+    fn to_array_ref(&self) -> ArrayRef {
+        self.clone().into_array_ref()
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.array.len()
+    }
+
+    #[inline]
+    fn logical_nulls(&self) -> Option<NullBuffer> {
+        self.array.logical_nulls()
+    }
+
+    #[inline]
+    fn logical_null_count(&self) -> usize {
+        self.array.logical_null_count()
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        self.array.is_null(i)
+    }
+
+    fn data_type(&self) -> GeoArrowType {
+        GeoArrowType::WktView(self.data_type.clone())
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> Arc<dyn GeoArrowArray> {
+        Arc::new(self.slice(offset, length))
+    }
+
+    fn with_metadata(self, metadata: Arc<Metadata>) -> Arc<dyn GeoArrowArray> {
+        Arc::new(Self::with_metadata(&self, metadata))
+    }
+}
+
+impl<'a> ArrayAccessor<'a> for WktViewArray {
+    type Item = Wkt<f64>;
+
+    unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {
+        let s = unsafe { self.array.value_unchecked(index) };
+        Wkt::from_str(s).map_err(GeoArrowError::WktStrError)
+    }
+}
+
+impl IntoArrow for WktViewArray {
+    type ArrowArray = StringViewArray;
+    type ExtensionType = WktType;
+
+    fn into_arrow(self) -> Self::ArrowArray {
+        self.array
+    }
+
+    fn ext_type(&self) -> &Self::ExtensionType {
+        &self.data_type
+    }
+}
+
+impl From<(StringViewArray, WktType)> for WktViewArray {
+    fn from((value, typ): (StringViewArray, WktType)) -> Self {
+        Self {
+            data_type: typ,
+            array: value,
+        }
+    }
+}
+
+impl TryFrom<(&dyn Array, WktType)> for WktViewArray {
+    type Error = GeoArrowError;
+
+    fn try_from((value, typ): (&dyn Array, WktType)) -> Result<Self> {
+        match value.data_type() {
+            DataType::Utf8View => Ok((value.as_string_view().clone(), typ).into()),
+            _ => Err(GeoArrowError::General(format!(
+                "Unexpected type: {:?}",
+                value.data_type()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<(&dyn Array, &Field)> for WktViewArray {
+    type Error = GeoArrowError;
+
+    fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
+        let typ = field
+            .try_extension_type::<WktType>()
+            .ok()
+            .unwrap_or_default();
+        (arr, typ).try_into()
+    }
+}

--- a/rust/geoarrow-array/src/array/wkt_view.rs
+++ b/rust/geoarrow-array/src/array/wkt_view.rs
@@ -36,6 +36,11 @@ impl WktViewArray {
         self.len() == 0
     }
 
+    /// Access the underlying string array.
+    pub fn inner(&self) -> &StringViewArray {
+        &self.array
+    }
+
     /// Slices this [`WktViewArray`] in place.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use arrow_array::OffsetSizeTrait;
-use arrow_array::builder::GenericStringBuilder;
+use arrow_array::builder::{
+    BinaryViewBuilder, GenericByteBuilder, GenericStringBuilder, StringViewBuilder,
+};
 use arrow_array::cast::AsArray;
 use geoarrow_schema::WkbType;
 
@@ -14,7 +16,7 @@ use crate::builder::{
 };
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::GeoArrowArray;
-use crate::{ArrayAccessor, GeoArrowType};
+use crate::{ArrayAccessor, GeoArrowType, IntoArrow};
 
 /// Helpers for downcasting a [`GeoArrowArray`] to a concrete implementation.
 ///
@@ -343,8 +345,18 @@ pub fn to_wkb<O: OffsetSizeTrait>(arr: &dyn GeoArrowArray) -> Result<WkbArray<O>
                 Ok(WkbArray::new(array, typ.metadata().clone()))
             }
         }
+        WkbView(_) => {
+            let wkb_view_arr = arr.as_wkb_view();
+            let metadata = wkb_view_arr.data_type().metadata().clone();
+            let array = wkb_view_arr.clone().into_arrow();
+
+            let mut builder = GenericByteBuilder::new();
+            array.iter().for_each(|value| builder.append_option(value));
+            Ok(WkbArray::new(builder.finish(), metadata))
+        }
         Wkt(_) => impl_to_wkb(arr.as_wkt::<i32>()),
         LargeWkt(_) => impl_to_wkb(arr.as_wkt::<i64>()),
+        WktView(_) => impl_to_wkb(arr.as_wkt_view()),
     }
 }
 
@@ -357,12 +369,61 @@ fn impl_to_wkb<'a, O: OffsetSizeTrait>(geo_arr: &'a impl ArrayAccessor<'a>) -> R
     Ok(WkbBuilder::from_nullable_geometries(geoms.as_slice(), wkb_type).finish())
 }
 
+/// Convert a [GeoArrowArray] to a [WkbViewArray].
+pub fn to_wkb_view(arr: &dyn GeoArrowArray) -> Result<WkbViewArray> {
+    use GeoArrowType::*;
+    match arr.data_type() {
+        Point(_) => impl_to_wkb_view(arr.as_point()),
+        LineString(_) => impl_to_wkb_view(arr.as_line_string()),
+        Polygon(_) => impl_to_wkb_view(arr.as_polygon()),
+        MultiPoint(_) => impl_to_wkb_view(arr.as_multi_point()),
+        MultiLineString(_) => impl_to_wkb_view(arr.as_multi_line_string()),
+        MultiPolygon(_) => impl_to_wkb_view(arr.as_multi_polygon()),
+        Geometry(_) => impl_to_wkb_view(arr.as_geometry()),
+        GeometryCollection(_) => impl_to_wkb_view(arr.as_geometry_collection()),
+        Rect(_) => impl_to_wkb_view(arr.as_rect()),
+        Wkb(_) => impl_to_wkb_view(arr.as_wkb::<i32>()),
+        LargeWkb(_) => impl_to_wkb_view(arr.as_wkb::<i64>()),
+        WkbView(_) => Ok(arr.as_wkb_view().clone()),
+        Wkt(_) => impl_to_wkb_view(arr.as_wkt::<i32>()),
+        LargeWkt(_) => impl_to_wkb_view(arr.as_wkt::<i64>()),
+        WktView(_) => impl_to_wkb_view(arr.as_wkt_view()),
+    }
+}
+
+fn impl_to_wkb_view<'a>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WkbViewArray> {
+    let geoms = geo_arr
+        .iter()
+        .map(|x| x.transpose())
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut builder = BinaryViewBuilder::new();
+    for maybe_geom in geoms {
+        if let Some(geom) = maybe_geom {
+            let mut buf = Vec::new();
+            wkb::writer::write_geometry(&mut buf, &geom, wkb::Endianness::LittleEndian).unwrap();
+            builder.append_value(buf);
+        } else {
+            builder.append_null();
+        }
+    }
+
+    let binary_view_arr = builder.finish();
+    Ok(WkbViewArray::new(
+        binary_view_arr,
+        geo_arr.data_type().metadata().clone(),
+    ))
+}
+
 /// Parse a [WkbArray] to a [GeoArrowArray] with the designated [GeoArrowType].
 ///
 /// Note that the GeoArrow metadata on the new array is taken from `to_type` **not** the original
 /// array. Ensure you construct the [GeoArrowType] with the correct metadata.
+///
+/// Note that this will be slow if converting from a WKB array to another WKB-typed array. If
+/// possible, use the `From` impls on WKB-typed arrays.
 pub fn from_wkb<'a, A: WkbArrayType<'a>>(
-    arr: &A,
+    arr: &'a A,
     to_type: GeoArrowType,
 ) -> Result<Arc<dyn GeoArrowArray>> {
     let geoms = arr
@@ -406,6 +467,11 @@ pub fn from_wkb<'a, A: WkbArrayType<'a>>(
             wkb_arr.data_type = typ;
             Arc::new(wkb_arr)
         }
+        WkbView(typ) => {
+            let mut wkb_view_arr = to_wkb_view(arr)?;
+            wkb_view_arr.data_type = typ;
+            Arc::new(wkb_view_arr)
+        }
         Wkt(typ) => {
             let mut wkt_arr = to_wkt::<i32>(arr)?;
             wkt_arr.data_type = typ;
@@ -415,6 +481,11 @@ pub fn from_wkb<'a, A: WkbArrayType<'a>>(
             let mut wkt_arr = to_wkt::<i64>(arr)?;
             wkt_arr.data_type = typ;
             Arc::new(wkt_arr)
+        }
+        WktView(typ) => {
+            let mut wkt_view_arr = to_wkt_view(arr)?;
+            wkt_view_arr.data_type = typ;
+            Arc::new(wkt_view_arr)
         }
     };
     Ok(result)
@@ -435,6 +506,7 @@ pub fn to_wkt<O: OffsetSizeTrait>(arr: &dyn GeoArrowArray) -> Result<WktArray<O>
         Rect(_) => impl_to_wkt(arr.as_rect()),
         Wkb(_) => impl_to_wkt(arr.as_wkb::<i32>()),
         LargeWkb(_) => impl_to_wkt(arr.as_wkb::<i64>()),
+        WkbView(_) => impl_to_wkt(arr.as_wkb_view()),
         Wkt(typ) => {
             if O::IS_LARGE {
                 let large_arr: WktArray<i64> = arr.as_wkt::<i32>().clone().into();
@@ -461,6 +533,9 @@ pub fn to_wkt<O: OffsetSizeTrait>(arr: &dyn GeoArrowArray) -> Result<WktArray<O>
                 Ok(WktArray::new(array, typ.metadata().clone()))
             }
         }
+        WktView(_) => {
+            todo!("fast path that casts a string array to a wkt view array")
+        }
     }
 }
 
@@ -478,6 +553,45 @@ fn impl_to_wkt<'a, O: OffsetSizeTrait>(geo_arr: &'a impl ArrayAccessor<'a>) -> R
     }
 
     Ok(WktArray::new(builder.finish(), metadata))
+}
+
+/// Convert a [GeoArrowArray] to a [WktViewArray].
+pub fn to_wkt_view(arr: &dyn GeoArrowArray) -> Result<WktViewArray> {
+    use GeoArrowType::*;
+    match arr.data_type() {
+        Point(_) => impl_to_wkt_view(arr.as_point()),
+        LineString(_) => impl_to_wkt_view(arr.as_line_string()),
+        Polygon(_) => impl_to_wkt_view(arr.as_polygon()),
+        MultiPoint(_) => impl_to_wkt_view(arr.as_multi_point()),
+        MultiLineString(_) => impl_to_wkt_view(arr.as_multi_line_string()),
+        MultiPolygon(_) => impl_to_wkt_view(arr.as_multi_polygon()),
+        Geometry(_) => impl_to_wkt_view(arr.as_geometry()),
+        GeometryCollection(_) => impl_to_wkt_view(arr.as_geometry_collection()),
+        Rect(_) => impl_to_wkt_view(arr.as_rect()),
+        Wkb(_) => impl_to_wkt_view(arr.as_wkb::<i32>()),
+        LargeWkb(_) => impl_to_wkt_view(arr.as_wkb::<i64>()),
+        WkbView(_) => impl_to_wkt_view(arr.as_wkb_view()),
+        Wkt(_) => impl_to_wkt_view(arr.as_wkt::<i32>()),
+        LargeWkt(_) => impl_to_wkt_view(arr.as_wkt::<i64>()),
+        WktView(_) => Ok(arr.as_wkt_view().clone()),
+    }
+}
+
+fn impl_to_wkt_view<'a>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WktViewArray> {
+    let metadata = geo_arr.data_type().metadata().clone();
+    let mut builder = StringViewBuilder::new();
+
+    for maybe_geom in geo_arr.iter() {
+        if let Some(geom) = maybe_geom {
+            let mut s = String::new();
+            wkt::to_wkt::write_geometry(&mut s, &geom?)?;
+            builder.append_value(s);
+        } else {
+            builder.append_null();
+        }
+    }
+
+    Ok(WktViewArray::new(builder.finish(), metadata))
 }
 
 /// Parse a [WktArray] to a [GeoArrowArray] with the designated [GeoArrowType].
@@ -517,14 +631,19 @@ pub fn from_wkt<A: WktArrayType>(arr: &A, to_type: GeoArrowType) -> Result<Arc<d
         }
         Geometry(typ) => Arc::new(GeometryBuilder::from_nullable_geometries(&geoms, typ)?.finish()),
         Wkb(typ) => {
-            let mut wkt_arr = to_wkb::<i32>(arr)?;
-            wkt_arr.data_type = typ;
-            Arc::new(wkt_arr)
+            let mut wkb_arr = to_wkb::<i32>(arr)?;
+            wkb_arr.data_type = typ;
+            Arc::new(wkb_arr)
         }
         LargeWkb(typ) => {
-            let mut wkt_arr = to_wkb::<i64>(arr)?;
-            wkt_arr.data_type = typ;
-            Arc::new(wkt_arr)
+            let mut wkb_arr = to_wkb::<i64>(arr)?;
+            wkb_arr.data_type = typ;
+            Arc::new(wkb_arr)
+        }
+        WkbView(typ) => {
+            let mut wkb_view_arr = to_wkb_view(arr)?;
+            wkb_view_arr.data_type = typ;
+            Arc::new(wkb_view_arr)
         }
         Wkt(typ) => {
             let mut wkt_arr = to_wkt::<i32>(arr)?;
@@ -535,6 +654,11 @@ pub fn from_wkt<A: WktArrayType>(arr: &A, to_type: GeoArrowType) -> Result<Arc<d
             let mut wkt_arr = to_wkt::<i64>(arr)?;
             wkt_arr.data_type = typ;
             Arc::new(wkt_arr)
+        }
+        WktView(typ) => {
+            let mut wkt_view_arr = to_wkt_view(arr)?;
+            wkt_view_arr.data_type = typ;
+            Arc::new(wkt_view_arr)
         }
     };
     Ok(result)

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -138,6 +138,15 @@ pub trait AsGeoArrowArray {
         self.as_wkb_opt::<O>().unwrap()
     }
 
+    /// Downcast this to a [`WkbViewArray`] returning `None` if not possible
+    fn as_wkb_view_opt(&self) -> Option<&WkbViewArray>;
+
+    /// Downcast this to a [`WkbViewArray`] panicking if not possible
+    #[inline]
+    fn as_wkb_view(&self) -> &WkbViewArray {
+        self.as_wkb_view_opt().unwrap()
+    }
+
     /// Downcast this to a [`WktArray`] with `O` offsets returning `None` if not possible
     fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WktArray<O>>;
 
@@ -145,6 +154,15 @@ pub trait AsGeoArrowArray {
     #[inline]
     fn as_wkt<O: OffsetSizeTrait>(&self) -> &WktArray<O> {
         self.as_wkt_opt::<O>().unwrap()
+    }
+
+    /// Downcast this to a [`WktViewArray`] returning `None` if not possible
+    fn as_wkt_view_opt(&self) -> Option<&WktViewArray>;
+
+    /// Downcast this to a [`WktViewArray`] panicking if not possible
+    #[inline]
+    fn as_wkt_view(&self) -> &WktViewArray {
+        self.as_wkt_view_opt().unwrap()
     }
 }
 
@@ -201,8 +219,18 @@ impl AsGeoArrowArray for dyn GeoArrowArray + '_ {
     }
 
     #[inline]
+    fn as_wkb_view_opt(&self) -> Option<&WkbViewArray> {
+        self.as_any().downcast_ref::<WkbViewArray>()
+    }
+
+    #[inline]
     fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WktArray<O>> {
         self.as_any().downcast_ref::<WktArray<O>>()
+    }
+
+    #[inline]
+    fn as_wkt_view_opt(&self) -> Option<&WktViewArray> {
+        self.as_any().downcast_ref::<WktViewArray>()
     }
 }
 
@@ -258,8 +286,18 @@ impl AsGeoArrowArray for Arc<dyn GeoArrowArray> {
     }
 
     #[inline]
+    fn as_wkb_view_opt(&self) -> Option<&WkbViewArray> {
+        self.as_any().downcast_ref::<WkbViewArray>()
+    }
+
+    #[inline]
     fn as_wkt_opt<O: OffsetSizeTrait>(&self) -> Option<&WktArray<O>> {
         self.as_any().downcast_ref::<WktArray<O>>()
+    }
+
+    #[inline]
+    fn as_wkt_view_opt(&self) -> Option<&WktViewArray> {
+        self.as_any().downcast_ref::<WktViewArray>()
     }
 }
 
@@ -651,11 +689,17 @@ macro_rules! downcast_geoarrow_array {
             $crate::cast::__private::GeoArrowType::LargeWkb(_) => {
                 $fn($crate::cast::AsGeoArrowArray::as_wkb::<i64>($array))
             }
+            $crate::cast::__private::GeoArrowType::WkbView(_) => {
+                $fn($crate::cast::AsGeoArrowArray::as_wkb_view($array))
+            }
             $crate::cast::__private::GeoArrowType::Wkt(_) => {
                 $fn($crate::cast::AsGeoArrowArray::as_wkt::<i32>($array))
             }
             $crate::cast::__private::GeoArrowType::LargeWkt(_) => {
                 $fn($crate::cast::AsGeoArrowArray::as_wkt::<i64>($array))
+            }
+            $crate::cast::__private::GeoArrowType::WktView(_) => {
+                $fn($crate::cast::AsGeoArrowArray::as_wkt_view($array))
             }
         }
     };

--- a/rust/geoarrow-array/src/geozero/export/data_source/mod.rs
+++ b/rust/geoarrow-array/src/geozero/export/data_source/mod.rs
@@ -370,6 +370,13 @@ fn process_geometry_n<P: GeomProcessor>(
                 .map_err(|err| GeozeroError::Geometry(err.to_string()))?;
             process_geometry(&geom, 0, processor)?;
         }
+        WkbView(_) => {
+            let geom = arr
+                .as_wkb_view()
+                .value(i)
+                .map_err(|err| GeozeroError::Geometry(err.to_string()))?;
+            process_geometry(&geom, 0, processor)?;
+        }
         Wkt(_) => {
             let geom = arr
                 .as_wkt::<i32>()
@@ -380,6 +387,13 @@ fn process_geometry_n<P: GeomProcessor>(
         LargeWkt(_) => {
             let geom = arr
                 .as_wkt::<i64>()
+                .value(i)
+                .map_err(|err| GeozeroError::Geometry(err.to_string()))?;
+            process_geometry(&geom, 0, processor)?;
+        }
+        WktView(_) => {
+            let geom = arr
+                .as_wkt_view()
                 .value(i)
                 .map_err(|err| GeozeroError::Geometry(err.to_string()))?;
             process_geometry(&geom, 0, processor)?;

--- a/rust/geoarrow-flatgeobuf/src/writer.rs
+++ b/rust/geoarrow-flatgeobuf/src/writer.rs
@@ -165,9 +165,8 @@ fn infer_flatgeobuf_geometry_type(schema: &Schema) -> Result<flatgeobuf::Geometr
         MultiPoint(_) => flatgeobuf::GeometryType::MultiPoint,
         MultiLineString(_) => flatgeobuf::GeometryType::MultiLineString,
         MultiPolygon(_) => flatgeobuf::GeometryType::MultiPolygon,
-        Rect(_) | Geometry(_) | Wkb(_) | LargeWkb(_) | Wkt(_) | LargeWkt(_) => {
-            flatgeobuf::GeometryType::Unknown
-        }
+        Rect(_) | Geometry(_) | Wkb(_) | LargeWkb(_) | WkbView(_) | Wkt(_) | LargeWkt(_)
+        | WktView(_) => flatgeobuf::GeometryType::Unknown,
         GeometryCollection(_) => flatgeobuf::GeometryType::GeometryCollection,
     };
     Ok(geometry_type)

--- a/rust/geoarrow-geoparquet/src/total_bounds.rs
+++ b/rust/geoarrow-geoparquet/src/total_bounds.rs
@@ -240,8 +240,10 @@ pub(crate) fn bounding_rect(arr: &dyn GeoArrowArray) -> Result<RectArray> {
         Rect(_) => Ok(arr.as_rect().clone()),
         Wkb(_) => impl_array_accessor(arr.as_wkb::<i32>()),
         LargeWkb(_) => impl_array_accessor(arr.as_wkb::<i64>()),
+        WkbView(_) => impl_array_accessor(arr.as_wkb_view()),
         Wkt(_) => impl_array_accessor(arr.as_wkt::<i32>()),
         LargeWkt(_) => impl_array_accessor(arr.as_wkt::<i64>()),
+        WktView(_) => impl_array_accessor(arr.as_wkt_view()),
     }
 }
 
@@ -283,8 +285,10 @@ pub(crate) fn total_bounds(arr: &dyn GeoArrowArray) -> Result<BoundingRect> {
         Rect(_) => impl_total_bounds(arr.as_rect()),
         Wkb(_) => impl_total_bounds(arr.as_wkb::<i32>()),
         LargeWkb(_) => impl_total_bounds(arr.as_wkb::<i64>()),
+        WkbView(_) => impl_total_bounds(arr.as_wkb_view()),
         Wkt(_) => impl_total_bounds(arr.as_wkt::<i32>()),
         LargeWkt(_) => impl_total_bounds(arr.as_wkt::<i64>()),
+        WktView(_) => impl_total_bounds(arr.as_wkt_view()),
     }
 }
 

--- a/rust/geoarrow-geoparquet/src/writer/metadata.rs
+++ b/rust/geoarrow-geoparquet/src/writer/metadata.rs
@@ -282,8 +282,10 @@ pub fn get_geometry_types(data_type: &GeoArrowType) -> HashSet<GeoParquetGeometr
         GeoArrowType::Geometry(_)
         | GeoArrowType::Wkb(_)
         | GeoArrowType::LargeWkb(_)
+        | GeoArrowType::WkbView(_)
         | GeoArrowType::Wkt(_)
-        | GeoArrowType::LargeWkt(_) => {
+        | GeoArrowType::LargeWkt(_)
+        | GeoArrowType::WktView(_) => {
             // We don't have access to the actual data here, so we can't inspect better than this.
         }
     };


### PR DESCRIPTION
Now that we support view types as part of the upcoming 0.2 spec release: https://github.com/geoarrow/geoarrow/pull/84

### Change list

- Add `WkbViewArray` and `WktViewArray` wrapping the underlying Arrow view array types.
- Add `WkbView` and `WktView` to `GeoArrowType` enum.
- Add `as_wkb_view` and `as_wkt_view` to `AsGeoArrowArray` trait.
- Add `WkbArrayType` and `WktArrayType` traits to abstract each of the concrete wkb/wkt array types
- Implement From between WKB and WKT array types

Closes #1081, closes #942.