### PR TITLE
Rename `ArrayAccessor` to `GeoArrowArrayAccessor`

### DIFF
--- a/rust/geoarrow-array/README.md
+++ b/rust/geoarrow-array/README.md
@@ -15,7 +15,7 @@ Use [builders][builder] to construct GeoArrow arrays. These builders offer a pus
 # use geoarrow_array::array::PointArray;
 # use geoarrow_array::builder::PointBuilder;
 # use geoarrow_array::scalar::Point;
-# use geoarrow_array::ArrayAccessor;
+# use geoarrow_array::GeoArrowArrayAccessor;
 # use geoarrow_schema::{CoordType, Dimension, PointType};
 #
 let point_type = PointType::new(CoordType::Separated, Dimension::XY, Default::default());
@@ -93,7 +93,7 @@ This requires downcasting to the concrete type of the array. Use the [`cast::AsG
 
 ```rust
 use geoarrow_array::cast::AsGeoArrowArray;
-use geoarrow_array::{ArrayAccessor, GeoArrowArray};
+use geoarrow_array::{GeoArrowArrayAccessor, GeoArrowArray};
 
 fn iter_line_string_array(array: &dyn GeoArrowArray) {
     for row in array.as_line_string().iter() {

--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -16,7 +16,7 @@ use crate::capacity::GeometryCapacity;
 use crate::datatypes::GeoArrowType;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::Geometry;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 
 /// An immutable array of geometries of unknown geometry type and dimension.
 ///
@@ -499,7 +499,7 @@ impl GeoArrowArray for GeometryArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for GeometryArray {
+impl<'a> GeoArrowArrayAccessor<'a> for GeometryArray {
     type Item = Geometry<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -13,7 +13,7 @@ use crate::datatypes::GeoArrowType;
 use crate::eq::offset_buffer_eq;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::GeometryCollection;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{OffsetBufferUtils, offsets_buffer_i64_to_i32};
 
 /// An immutable array of GeometryCollection geometries.
@@ -162,7 +162,7 @@ impl GeoArrowArray for GeometryCollectionArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for GeometryCollectionArray {
+impl<'a> GeoArrowArrayAccessor<'a> for GeometryCollectionArray {
     type Item = GeometryCollection<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -7,7 +7,7 @@ use crate::datatypes::GeoArrowType;
 use crate::eq::offset_buffer_eq;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::LineString;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{OffsetBufferUtils, offsets_buffer_i64_to_i32};
 
 use arrow_array::cast::AsArray;
@@ -215,7 +215,7 @@ impl GeoArrowArray for LineStringArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for LineStringArray {
+impl<'a> GeoArrowArrayAccessor<'a> for LineStringArray {
     type Item = LineString<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/mixed.rs
+++ b/rust/geoarrow-array/src/array/mixed.rs
@@ -10,7 +10,7 @@ use geoarrow_schema::{
     MultiPointType, MultiPolygonType, PointType, PolygonType,
 };
 
-use crate::ArrayAccessor;
+use crate::GeoArrowArrayAccessor;
 use crate::array::{
     DimensionIndex, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray,
     PointArray, PolygonArray,

--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -83,7 +83,7 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
 /// This is modeled after the upstream [`BinaryArrayType`][arrow_array::array::BinaryArrayType]
 /// trait.
 pub trait WkbArrayType<'a>:
-    Sized + crate::ArrayAccessor<'a, Item = ::wkb::reader::Wkb<'a>>
+    Sized + crate::GeoArrowArrayAccessor<'a, Item = ::wkb::reader::Wkb<'a>>
 {
 }
 
@@ -104,7 +104,10 @@ impl WkbArrayType<'_> for WkbViewArray {}
 ///
 /// This is modeled after the upstream [`StringArrayType`][arrow_array::array::StringArrayType]
 /// trait.
-pub trait WktArrayType: Sized + for<'a> crate::ArrayAccessor<'a, Item = ::wkt::Wkt> {}
+pub trait WktArrayType:
+    Sized + for<'a> crate::GeoArrowArrayAccessor<'a, Item = ::wkt::Wkt>
+{
+}
 
 impl WktArrayType for WktArray<i32> {}
 impl WktArrayType for WktArray<i64> {}

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -13,7 +13,7 @@ use crate::datatypes::GeoArrowType;
 use crate::eq::offset_buffer_eq;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::MultiLineString;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{OffsetBufferUtils, offsets_buffer_i64_to_i32};
 
 /// An immutable array of MultiLineString geometries.
@@ -243,7 +243,7 @@ impl GeoArrowArray for MultiLineStringArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for MultiLineStringArray {
+impl<'a> GeoArrowArrayAccessor<'a> for MultiLineStringArray {
     type Item = MultiLineString<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -13,7 +13,7 @@ use crate::datatypes::GeoArrowType;
 use crate::eq::offset_buffer_eq;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::MultiPoint;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{OffsetBufferUtils, offsets_buffer_i64_to_i32};
 
 /// An immutable array of MultiPoint geometries.
@@ -220,7 +220,7 @@ impl GeoArrowArray for MultiPointArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for MultiPointArray {
+impl<'a> GeoArrowArrayAccessor<'a> for MultiPointArray {
     type Item = MultiPoint<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -13,7 +13,7 @@ use crate::datatypes::GeoArrowType;
 use crate::eq::offset_buffer_eq;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::MultiPolygon;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{OffsetBufferUtils, offsets_buffer_i64_to_i32};
 
 /// An immutable array of MultiPolygon geometries.
@@ -296,7 +296,7 @@ impl GeoArrowArray for MultiPolygonArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for MultiPolygonArray {
+impl<'a> GeoArrowArrayAccessor<'a> for MultiPolygonArray {
     type Item = MultiPolygon<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/point.rs
+++ b/rust/geoarrow-array/src/array/point.rs
@@ -11,7 +11,7 @@ use crate::array::{CoordBuffer, InterleavedCoordBuffer, SeparatedCoordBuffer};
 use crate::eq::point_eq;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::Point;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 
 /// An immutable array of Point geometries.
 ///
@@ -181,7 +181,7 @@ impl GeoArrowArray for PointArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for PointArray {
+impl<'a> GeoArrowArrayAccessor<'a> for PointArray {
     type Item = Point<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -14,7 +14,7 @@ use crate::datatypes::GeoArrowType;
 use crate::eq::offset_buffer_eq;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::Polygon;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{OffsetBufferUtils, offsets_buffer_i64_to_i32};
 
 /// An immutable array of Polygon geometries using GeoArrow's in-memory representation.
@@ -247,7 +247,7 @@ impl GeoArrowArray for PolygonArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for PolygonArray {
+impl<'a> GeoArrowArrayAccessor<'a> for PolygonArray {
     type Item = Polygon<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/rect.rs
+++ b/rust/geoarrow-array/src/array/rect.rs
@@ -11,7 +11,7 @@ use crate::array::SeparatedCoordBuffer;
 use crate::datatypes::GeoArrowType;
 use crate::error::{GeoArrowError, Result};
 use crate::scalar::Rect;
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 
 /// An immutable array of Rect or Box geometries.
 ///
@@ -145,7 +145,7 @@ impl GeoArrowArray for RectArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for RectArray {
+impl<'a> GeoArrowArrayAccessor<'a> for RectArray {
     type Item = Rect<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -14,7 +14,7 @@ use crate::array::WkbViewArray;
 use crate::capacity::WkbCapacity;
 use crate::datatypes::GeoArrowType;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 
 /// An immutable array of WKB geometries.
@@ -135,7 +135,7 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WkbArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> ArrayAccessor<'a> for WkbArray<O> {
+impl<'a, O: OffsetSizeTrait> GeoArrowArrayAccessor<'a> for WkbArray<O> {
     type Item = Wkb<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/wkb_view.rs
+++ b/rust/geoarrow-array/src/array/wkb_view.rs
@@ -10,7 +10,7 @@ use wkb::reader::Wkb;
 
 use crate::array::WkbArray;
 use crate::error::{GeoArrowError, Result};
-use crate::{ArrayAccessor, GeoArrowArray, GeoArrowType, IntoArrow};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType, IntoArrow};
 
 /// An immutable array of WKB geometries.
 ///
@@ -106,7 +106,7 @@ impl GeoArrowArray for WkbViewArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for WkbViewArray {
+impl<'a> GeoArrowArrayAccessor<'a> for WkbViewArray {
     type Item = Wkb<'a>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -11,7 +11,7 @@ use arrow_schema::{DataType, Field};
 use geoarrow_schema::{Metadata, WktType};
 use wkt::Wkt;
 
-use crate::ArrayAccessor;
+use crate::GeoArrowArrayAccessor;
 use crate::array::WktViewArray;
 use crate::datatypes::GeoArrowType;
 use crate::error::{GeoArrowError, Result};
@@ -130,7 +130,7 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> ArrayAccessor<'a> for WktArray<O> {
+impl<'a, O: OffsetSizeTrait> GeoArrowArrayAccessor<'a> for WktArray<O> {
     type Item = Wkt<f64>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/array/wkt_view.rs
+++ b/rust/geoarrow-array/src/array/wkt_view.rs
@@ -11,7 +11,7 @@ use wkt::Wkt;
 
 use crate::array::WktArray;
 use crate::error::{GeoArrowError, Result};
-use crate::{ArrayAccessor, GeoArrowArray, GeoArrowType, IntoArrow};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType, IntoArrow};
 
 /// An immutable array of WKT geometries.
 ///
@@ -112,7 +112,7 @@ impl GeoArrowArray for WktViewArray {
     }
 }
 
-impl<'a> ArrayAccessor<'a> for WktViewArray {
+impl<'a> GeoArrowArrayAccessor<'a> for WktViewArray {
     type Item = Wkt<f64>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -16,7 +16,7 @@ use crate::builder::{
 };
 use crate::capacity::GeometryCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
 
 pub(crate) const DEFAULT_PREFER_MULTI: bool = false;
 

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -12,7 +12,7 @@ use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapp
 use crate::builder::{MixedGeometryBuilder, OffsetsBuilder};
 use crate::capacity::GeometryCollectionCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<GeometryCollection>>`: a mutable collection of
 /// GeometryCollections.

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -10,7 +10,7 @@ use crate::builder::{
 };
 use crate::capacity::LineStringCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<LineString>>`: a mutable collection of LineStrings.
 ///

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -10,7 +10,7 @@ use crate::builder::{
 };
 use crate::capacity::MultiLineStringCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiLineString>>`: a mutable collection of
 /// MultiLineStrings.

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -10,7 +10,7 @@ use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiPoint>>`: a mutable collection of MultiPoints.
 ///

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -12,7 +12,7 @@ use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiPolygon>>`: a mutable collection of MultiPolygons.
 ///

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -9,7 +9,7 @@ use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<Point>>`: a mutable collection of Points.
 ///

--- a/rust/geoarrow-array/src/builder/polygon.rs
+++ b/rust/geoarrow-array/src/builder/polygon.rs
@@ -13,7 +13,7 @@ use crate::builder::{
 };
 use crate::capacity::PolygonCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{ArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
 
 pub type MutablePolygonParts = (
     CoordBufferBuilder,
@@ -366,7 +366,7 @@ mod test {
     use geo_types::{Rect, coord};
     use geoarrow_schema::{CoordType, Dimension, PolygonType};
 
-    use crate::ArrayAccessor;
+    use crate::GeoArrowArrayAccessor;
     use crate::builder::PolygonBuilder;
 
     #[test]

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -16,7 +16,7 @@ use crate::builder::{
 };
 use crate::error::{GeoArrowError, Result};
 use crate::trait_::GeoArrowArray;
-use crate::{ArrayAccessor, GeoArrowType, IntoArrow};
+use crate::{GeoArrowArrayAccessor, GeoArrowType, IntoArrow};
 
 /// Helpers for downcasting a [`GeoArrowArray`] to a concrete implementation.
 ///
@@ -360,7 +360,9 @@ pub fn to_wkb<O: OffsetSizeTrait>(arr: &dyn GeoArrowArray) -> Result<WkbArray<O>
     }
 }
 
-fn impl_to_wkb<'a, O: OffsetSizeTrait>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WkbArray<O>> {
+fn impl_to_wkb<'a, O: OffsetSizeTrait>(
+    geo_arr: &'a impl GeoArrowArrayAccessor<'a>,
+) -> Result<WkbArray<O>> {
     let geoms = geo_arr
         .iter()
         .map(|x| x.transpose())
@@ -391,7 +393,7 @@ pub fn to_wkb_view(arr: &dyn GeoArrowArray) -> Result<WkbViewArray> {
     }
 }
 
-fn impl_to_wkb_view<'a>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WkbViewArray> {
+fn impl_to_wkb_view<'a>(geo_arr: &'a impl GeoArrowArrayAccessor<'a>) -> Result<WkbViewArray> {
     let geoms = geo_arr
         .iter()
         .map(|x| x.transpose())
@@ -539,7 +541,9 @@ pub fn to_wkt<O: OffsetSizeTrait>(arr: &dyn GeoArrowArray) -> Result<WktArray<O>
     }
 }
 
-fn impl_to_wkt<'a, O: OffsetSizeTrait>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WktArray<O>> {
+fn impl_to_wkt<'a, O: OffsetSizeTrait>(
+    geo_arr: &'a impl GeoArrowArrayAccessor<'a>,
+) -> Result<WktArray<O>> {
     let metadata = geo_arr.data_type().metadata().clone();
     let mut builder = GenericStringBuilder::new();
 
@@ -577,7 +581,7 @@ pub fn to_wkt_view(arr: &dyn GeoArrowArray) -> Result<WktViewArray> {
     }
 }
 
-fn impl_to_wkt_view<'a>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WktViewArray> {
+fn impl_to_wkt_view<'a>(geo_arr: &'a impl GeoArrowArrayAccessor<'a>) -> Result<WktViewArray> {
     let metadata = geo_arr.data_type().metadata().clone();
     let mut builder = StringViewBuilder::new();
 
@@ -682,13 +686,13 @@ pub mod __private {
 /// use geo::Area;
 /// use geo_traits::to_geo::ToGeoGeometry;
 /// use geoarrow_array::error::Result;
-/// use geoarrow_array::{ArrayAccessor, GeoArrowArray, downcast_geoarrow_array};
+/// use geoarrow_array::{GeoArrowArrayAccessor, GeoArrowArray, downcast_geoarrow_array};
 ///
 /// pub fn unsigned_area(array: &dyn GeoArrowArray) -> Result<Float64Array> {
 ///     downcast_geoarrow_array!(array, impl_unsigned_area)
 /// }
 ///
-/// fn impl_unsigned_area<'a>(array: &'a impl ArrayAccessor<'a>) -> Result<Float64Array> {
+/// fn impl_unsigned_area<'a>(array: &'a impl GeoArrowArrayAccessor<'a>) -> Result<Float64Array> {
 ///     let mut builder = Float64Builder::with_capacity(array.len());
 ///
 ///     for item in array.iter() {
@@ -713,9 +717,9 @@ pub mod __private {
 /// # use geo::Area;
 /// # use geo_traits::to_geo::ToGeoGeometry;
 /// # use geoarrow_array::error::Result;
-/// # use geoarrow_array::{ArrayAccessor, GeoArrowType};
+/// # use geoarrow_array::{GeoArrowArrayAccessor, GeoArrowType};
 /// #
-/// # fn impl_unsigned_area<'a>(array: &'a impl ArrayAccessor<'a>) -> Result<Float64Array> {
+/// # fn impl_unsigned_area<'a>(array: &'a impl GeoArrowArrayAccessor<'a>) -> Result<Float64Array> {
 /// #     let mut builder = Float64Builder::with_capacity(array.len());
 /// #
 /// #     for item in array.iter() {
@@ -729,7 +733,7 @@ pub mod __private {
 /// #     Ok(builder.finish())
 /// # }
 /// #
-/// fn impl_unsigned_area_specialized<'a>(array: &'a impl ArrayAccessor<'a>) -> Result<Float64Array> {
+/// fn impl_unsigned_area_specialized<'a>(array: &'a impl GeoArrowArrayAccessor<'a>) -> Result<Float64Array> {
 ///     use GeoArrowType::*;
 ///     match array.data_type() {
 ///         Point(_) | LineString(_) | MultiPoint(_) | MultiLineString(_) => {
@@ -1175,7 +1179,7 @@ mod test {
         downcast_geoarrow_array!(arr, impl_to_wkb)
     }
 
-    fn impl_to_wkb<'a>(geo_arr: &'a impl ArrayAccessor<'a>) -> Result<WkbArray<i32>> {
+    fn impl_to_wkb<'a>(geo_arr: &'a impl GeoArrowArrayAccessor<'a>) -> Result<WkbArray<i32>> {
         let geoms = geo_arr
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/geozero/export/array/geometry.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/geometry.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::GeometryArray;
 use crate::geozero::export::scalar::process_geometry;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl GeozeroGeometry for GeometryArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/geometrycollection.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::GeometryCollectionArray;
 use crate::geozero::export::scalar::process_geometry_collection;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl GeozeroGeometry for GeometryCollectionArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/linestring.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/linestring.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::LineStringArray;
 use crate::geozero::export::scalar::process_line_string;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl GeozeroGeometry for LineStringArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/multilinestring.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::MultiLineStringArray;
 use crate::geozero::export::scalar::process_multi_line_string;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl GeozeroGeometry for MultiLineStringArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/multipoint.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/multipoint.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::MultiPointArray;
 use crate::geozero::export::scalar::process_multi_point;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl GeozeroGeometry for MultiPointArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/multipolygon.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::MultiPolygonArray;
 use crate::geozero::export::scalar::process_multi_polygon;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl GeozeroGeometry for MultiPolygonArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/point.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/point.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::PointArray;
 use crate::geozero::export::scalar::process_point;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl GeozeroGeometry for PointArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/polygon.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/polygon.rs
@@ -2,7 +2,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::PolygonArray;
 use crate::geozero::export::scalar::process_polygon;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl GeozeroGeometry for PolygonArray {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/wkb.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/wkb.rs
@@ -4,7 +4,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::WkbArray;
 use crate::geozero::export::scalar::process_geometry;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl<O: OffsetSizeTrait> GeozeroGeometry for WkbArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/array/wkt.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/wkt.rs
@@ -4,7 +4,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::WktArray;
 use crate::geozero::export::scalar::process_geometry;
-use crate::{ArrayAccessor, GeoArrowArray};
+use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
 impl<O: OffsetSizeTrait> GeozeroGeometry for WktArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>

--- a/rust/geoarrow-array/src/geozero/export/data_source/mod.rs
+++ b/rust/geoarrow-array/src/geozero/export/data_source/mod.rs
@@ -23,7 +23,7 @@ use crate::geozero::export::scalar::{
     process_geometry, process_geometry_collection, process_line_string, process_multi_line_string,
     process_multi_point, process_multi_polygon, process_point, process_polygon,
 };
-use crate::trait_::ArrayAccessor;
+use crate::trait_::GeoArrowArrayAccessor;
 
 impl GeozeroDatasource for GeozeroRecordBatchReader {
     fn process<P: FeatureProcessor>(&mut self, processor: &mut P) -> Result<(), GeozeroError> {

--- a/rust/geoarrow-array/src/geozero/import/point.rs
+++ b/rust/geoarrow-array/src/geozero/import/point.rs
@@ -156,7 +156,7 @@ mod test {
     use geo_types::{Geometry, GeometryCollection};
     use geoarrow_schema::{CoordType, Dimension};
 
-    use crate::ArrayAccessor;
+    use crate::GeoArrowArrayAccessor;
     use crate::test::{linestring, point};
 
     use super::*;

--- a/rust/geoarrow-array/src/lib.rs
+++ b/rust/geoarrow-array/src/lib.rs
@@ -17,7 +17,7 @@ mod trait_;
 pub(crate) mod util;
 
 pub use datatypes::GeoArrowType;
-pub use trait_::{ArrayAccessor, GeoArrowArray, IntoArrow};
+pub use trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 
 #[cfg(any(test, feature = "test-data"))]
 #[allow(missing_docs)]

--- a/rust/geoarrow-array/src/scalar/multilinestring.rs
+++ b/rust/geoarrow-array/src/scalar/multilinestring.rs
@@ -94,7 +94,7 @@ impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for MultiLineString<'_> {
 mod test {
     use crate::builder::MultiLineStringBuilder;
     use crate::test::multilinestring::{ml0, ml1};
-    use crate::trait_::ArrayAccessor;
+    use crate::trait_::GeoArrowArrayAccessor;
     use geoarrow_schema::{CoordType, Dimension, MultiLineStringType};
 
     /// Test Eq where the current index is true but another index is false

--- a/rust/geoarrow-array/src/scalar/polygon.rs
+++ b/rust/geoarrow-array/src/scalar/polygon.rs
@@ -117,7 +117,7 @@ mod test {
     use geoarrow_schema::{CoordType, Dimension, PolygonType};
     use wkt::wkt;
 
-    use crate::ArrayAccessor;
+    use crate::GeoArrowArrayAccessor;
     use crate::builder::PolygonBuilder;
 
     /// Test Eq where the current index is true but another index is false

--- a/rust/geoarrow-array/src/trait_.rs
+++ b/rust/geoarrow-array/src/trait_.rs
@@ -237,12 +237,12 @@ pub trait GeoArrowArray: Debug + Send + Sync {
 ///
 /// # Validity
 ///
-/// An [`ArrayAccessor`] must always return a well-defined value for an index that is
+/// A [`GeoArrowArrayAccessor`] must always return a well-defined value for an index that is
 /// within the bounds `0..Array::len`, including for null indexes where [`Array::is_null`] is true.
 ///
 /// The value at null indexes is unspecified, and implementations must not rely on a specific
 /// value such as [`Default::default`] being returned, however, it must not be undefined.
-pub trait ArrayAccessor<'a>: GeoArrowArray {
+pub trait GeoArrowArrayAccessor<'a>: GeoArrowArray {
     /// The [geoarrow scalar object][crate::scalar] for this geometry array type.
     type Item: Send + Sync + GeometryTrait<T = f64>;
 

--- a/rust/geoarrow-cast/src/cast.rs
+++ b/rust/geoarrow-cast/src/cast.rs
@@ -10,7 +10,7 @@ use geoarrow_array::builder::{
 use geoarrow_array::capacity::{LineStringCapacity, PolygonCapacity};
 use geoarrow_array::cast::{AsGeoArrowArray, from_wkb, from_wkt, to_wkb, to_wkt};
 use geoarrow_array::error::{GeoArrowError, Result};
-use geoarrow_array::{ArrayAccessor, GeoArrowArray, GeoArrowType};
+use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType};
 
 /// Cast a `GeoArrowArray` to another `GeoArrowType`.
 ///

--- a/rust/geoarrow-cast/src/downcast.rs
+++ b/rust/geoarrow-cast/src/downcast.rs
@@ -6,7 +6,7 @@ use geo_traits::{
 };
 use geoarrow_array::cast::AsGeoArrowArray;
 use geoarrow_array::error::{GeoArrowError, Result};
-use geoarrow_array::{ArrayAccessor, GeoArrowArray, GeoArrowType};
+use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType};
 use geoarrow_schema::Dimension;
 
 /// Infer a common native geometry type, if any

--- a/rust/geoarrow-geoparquet/src/reader/spatial_filter.rs
+++ b/rust/geoarrow-geoparquet/src/reader/spatial_filter.rs
@@ -8,7 +8,7 @@ use arrow_buffer::ScalarBuffer;
 use arrow_ord::cmp::{gt_eq, lt_eq};
 use geo_traits::{CoordTrait, RectTrait};
 use geo_types::{CoordNum, Rect, coord};
-use geoarrow_array::ArrayAccessor;
+use geoarrow_array::GeoArrowArrayAccessor;
 use geoarrow_array::array::{RectArray, from_arrow_array};
 use geoarrow_array::builder::RectBuilder;
 use geoarrow_array::error::{GeoArrowError, Result};

--- a/rust/geoarrow-geoparquet/src/test/geoarrow_data/example.rs
+++ b/rust/geoarrow-geoparquet/src/test/geoarrow_data/example.rs
@@ -11,7 +11,7 @@ use geoarrow_array::builder::{
     MultiPolygonBuilder, PointBuilder, PolygonBuilder,
 };
 use geoarrow_array::cast::AsGeoArrowArray;
-use geoarrow_array::{ArrayAccessor, GeoArrowArray, GeoArrowType};
+use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType};
 use geoarrow_schema::{
     CoordType, Dimension, GeometryCollectionType, LineStringType, MultiLineStringType,
     MultiPointType, MultiPolygonType, PointType, PolygonType,

--- a/rust/geoarrow-geoparquet/src/total_bounds.rs
+++ b/rust/geoarrow-geoparquet/src/total_bounds.rs
@@ -9,7 +9,7 @@ use geoarrow_array::array::RectArray;
 use geoarrow_array::builder::RectBuilder;
 use geoarrow_array::cast::AsGeoArrowArray;
 use geoarrow_array::error::Result;
-use geoarrow_array::{ArrayAccessor, GeoArrowArray, GeoArrowType};
+use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType};
 use geoarrow_schema::{BoxType, Dimension};
 
 #[derive(Debug, Clone, Copy)]
@@ -248,7 +248,7 @@ pub(crate) fn bounding_rect(arr: &dyn GeoArrowArray) -> Result<RectArray> {
 }
 
 /// The actual implementation of computing the bounding rect
-fn impl_array_accessor<'a>(arr: &'a impl ArrayAccessor<'a>) -> Result<RectArray> {
+fn impl_array_accessor<'a>(arr: &'a impl GeoArrowArrayAccessor<'a>) -> Result<RectArray> {
     match arr.data_type() {
         GeoArrowType::Rect(_) => unreachable!(),
         _ => {
@@ -293,7 +293,7 @@ pub(crate) fn total_bounds(arr: &dyn GeoArrowArray) -> Result<BoundingRect> {
 }
 
 /// The actual implementation of computing the total bounds
-fn impl_total_bounds<'a>(arr: &'a impl ArrayAccessor<'a>) -> Result<BoundingRect> {
+fn impl_total_bounds<'a>(arr: &'a impl GeoArrowArrayAccessor<'a>) -> Result<BoundingRect> {
     let mut rect = BoundingRect::new();
 
     for item in arr.iter().flatten() {

--- a/rust/geoarrow-geos/src/import/array/geometry.rs
+++ b/rust/geoarrow-geos/src/import/array/geometry.rs
@@ -38,7 +38,7 @@ mod test {
     use crate::export::to_geos_geometry;
 
     use geoarrow_array::test::geometry::array;
-    use geoarrow_array::{ArrayAccessor, IntoArrow};
+    use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::CoordType;
 
     #[ignore = "GEOS doesn't support XYM, XYZM; need to add option to only construct specific dimensions in geometry test array"]

--- a/rust/geoarrow-geos/src/import/array/geometrycollection.rs
+++ b/rust/geoarrow-geos/src/import/array/geometrycollection.rs
@@ -38,7 +38,7 @@ mod test {
     use crate::export::to_geos_geometry;
 
     use geoarrow_array::test::geometrycollection::array;
-    use geoarrow_array::{ArrayAccessor, IntoArrow};
+    use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
 
     #[ignore = "geometry collection import from GEOS not yet implemented"]

--- a/rust/geoarrow-geos/src/import/array/linestring.rs
+++ b/rust/geoarrow-geos/src/import/array/linestring.rs
@@ -38,7 +38,7 @@ mod test {
     use crate::export::to_geos_geometry;
 
     use geoarrow_array::test::linestring::array;
-    use geoarrow_array::{ArrayAccessor, IntoArrow};
+    use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
 
     #[test]

--- a/rust/geoarrow-geos/src/import/array/multilinestring.rs
+++ b/rust/geoarrow-geos/src/import/array/multilinestring.rs
@@ -38,7 +38,7 @@ mod test {
     use crate::export::to_geos_geometry;
 
     use geoarrow_array::test::multilinestring::array;
-    use geoarrow_array::{ArrayAccessor, IntoArrow};
+    use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
 
     #[test]

--- a/rust/geoarrow-geos/src/import/array/multipoint.rs
+++ b/rust/geoarrow-geos/src/import/array/multipoint.rs
@@ -38,7 +38,7 @@ mod test {
     use crate::export::to_geos_geometry;
 
     use geoarrow_array::test::multipoint::array;
-    use geoarrow_array::{ArrayAccessor, IntoArrow};
+    use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
 
     #[test]

--- a/rust/geoarrow-geos/src/import/array/multipolygon.rs
+++ b/rust/geoarrow-geos/src/import/array/multipolygon.rs
@@ -37,7 +37,7 @@ mod test {
     use crate::export::to_geos_geometry;
 
     use geoarrow_array::test::multipolygon::array;
-    use geoarrow_array::{ArrayAccessor, IntoArrow};
+    use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
 
     #[test]

--- a/rust/geoarrow-geos/src/import/array/point.rs
+++ b/rust/geoarrow-geos/src/import/array/point.rs
@@ -41,7 +41,7 @@ mod test {
     use crate::export::to_geos_geometry;
 
     use geoarrow_array::test::point::array;
-    use geoarrow_array::{ArrayAccessor, IntoArrow};
+    use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
 
     #[test]

--- a/rust/geoarrow-geos/src/import/array/polygon.rs
+++ b/rust/geoarrow-geos/src/import/array/polygon.rs
@@ -38,7 +38,7 @@ mod test {
     use crate::export::to_geos_geometry;
 
     use geoarrow_array::test::polygon::array;
-    use geoarrow_array::{ArrayAccessor, IntoArrow};
+    use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
 
     #[test]

--- a/rust/geodatafusion/src/udf/native/constructors/point.rs
+++ b/rust/geodatafusion/src/udf/native/constructors/point.rs
@@ -636,7 +636,7 @@ mod test {
     use arrow_schema::Schema;
     use datafusion::prelude::SessionContext;
     use geo_traits::{CoordTrait, PointTrait};
-    use geoarrow_array::ArrayAccessor;
+    use geoarrow_array::GeoArrowArrayAccessor;
 
     use super::*;
 


### PR DESCRIPTION
The `ArrayAccessor` name conflicts with an upstream `arrow-rs` name, so we should use a different name for readability

Closes https://github.com/geoarrow/geoarrow-rs/issues/1109