### PR TITLE
Rename `WkbArray` to `GenericWkbArray`, `WktArray` to `GenericWktArray` and add type aliases

### DIFF
--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -817,10 +817,10 @@ impl TryFrom<(&dyn Array, &Field)> for GeometryArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryType)> for GeometryArray {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, GeometryType)> for GeometryArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WkbArray<O>, GeometryType)) -> Result<Self> {
+    fn try_from(value: (GenericWkbArray<O>, GeometryType)) -> Result<Self> {
         let mut_arr: GeometryBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, GeometryCollectionType, Metadata};
 
-use crate::array::{MixedGeometryArray, WkbArray};
+use crate::array::{MixedGeometryArray, GenericWkbArray};
 use crate::builder::GeometryCollectionBuilder;
 use crate::capacity::GeometryCollectionCapacity;
 use crate::datatypes::GeoArrowType;
@@ -250,12 +250,12 @@ impl TryFrom<(&dyn Array, &Field)> for GeometryCollectionArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryCollectionType)>
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, GeometryCollectionType)>
     for GeometryCollectionArray
 {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WkbArray<O>, GeometryCollectionType)) -> Result<Self> {
+    fn try_from(value: (GenericWkbArray<O>, GeometryCollectionType)) -> Result<Self> {
         let mut_arr: GeometryCollectionBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, GeometryCollectionType, Metadata};
 
-use crate::array::{MixedGeometryArray, GenericWkbArray};
+use crate::array::{GenericWkbArray, MixedGeometryArray};
 use crate::builder::GeometryCollectionBuilder;
 use crate::capacity::GeometryCollectionCapacity;
 use crate::datatypes::GeoArrowType;

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::array::{CoordBuffer, WkbArray};
+use crate::array::{CoordBuffer, GenericWkbArray};
 use crate::builder::LineStringBuilder;
 use crate::capacity::LineStringCapacity;
 use crate::datatypes::GeoArrowType;
@@ -299,10 +299,10 @@ impl TryFrom<(&dyn Array, &Field)> for LineStringArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, LineStringType)> for LineStringArray {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, LineStringType)> for LineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WkbArray<O>, LineStringType)) -> Result<Self> {
+    fn try_from(value: (GenericWkbArray<O>, LineStringType)) -> Result<Self> {
         let mut_arr: LineStringBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -30,7 +30,7 @@ pub use multipolygon::MultiPolygonArray;
 pub use point::PointArray;
 pub use polygon::PolygonArray;
 pub use rect::RectArray;
-pub use wkb::WkbArray;
+pub use wkb::{GenericWkbArray, LargeWkbArray, WkbArray};
 pub use wkb_view::WkbViewArray;
 pub use wkt::WktArray;
 pub use wkt_view::WktViewArray;
@@ -57,8 +57,8 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
         GeometryCollection(_) => Arc::new(GeometryCollectionArray::try_from((array, field))?),
         Rect(_) => Arc::new(RectArray::try_from((array, field))?),
         Geometry(_) => Arc::new(GeometryArray::try_from((array, field))?),
-        Wkb(_) => Arc::new(WkbArray::<i32>::try_from((array, field))?),
-        LargeWkb(_) => Arc::new(WkbArray::<i64>::try_from((array, field))?),
+        Wkb(_) => Arc::new(GenericWkbArray::<i32>::try_from((array, field))?),
+        LargeWkb(_) => Arc::new(GenericWkbArray::<i64>::try_from((array, field))?),
         WkbView(_) => Arc::new(WkbViewArray::try_from((array, field))?),
         Wkt(_) => Arc::new(WktArray::<i32>::try_from((array, field))?),
         LargeWkt(_) => Arc::new(WktArray::<i64>::try_from((array, field))?),
@@ -73,8 +73,8 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
 ///
 /// Currently three types are supported:
 ///
-/// - [`WkbArray<i32>`]
-/// - [`WkbArray<i64>`]
+/// - [`GenericWkbArray<i32>`]
+/// - [`GenericWkbArray<i64>`]
 /// - [`WkbViewArray`]
 ///
 /// This trait helps to abstract over the different types of WKB arrays so that we don’t need to
@@ -82,14 +82,14 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
 ///
 /// This is modeled after the upstream [`BinaryArrayType`][arrow_array::array::BinaryArrayType]
 /// trait.
-pub trait WkbArrayType<'a>:
+pub trait GenericWkbArrayType<'a>:
     Sized + crate::GeoArrowArrayAccessor<'a, Item = ::wkb::reader::Wkb<'a>>
 {
 }
 
-impl WkbArrayType<'_> for WkbArray<i32> {}
-impl WkbArrayType<'_> for WkbArray<i64> {}
-impl WkbArrayType<'_> for WkbViewArray {}
+impl GenericWkbArrayType<'_> for GenericWkbArray<i32> {}
+impl GenericWkbArrayType<'_> for GenericWkbArray<i64> {}
+impl GenericWkbArrayType<'_> for WkbViewArray {}
 
 /// A trait for GeoArrow arrays that can hold WKT data.
 ///

--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -32,7 +32,7 @@ pub use polygon::PolygonArray;
 pub use rect::RectArray;
 pub use wkb::{GenericWkbArray, LargeWkbArray, WkbArray};
 pub use wkb_view::WkbViewArray;
-pub use wkt::WktArray;
+pub use wkt::{GenericWktArray, LargeWktArray, WktArray};
 pub use wkt_view::WktViewArray;
 
 use std::sync::Arc;
@@ -57,11 +57,11 @@ pub fn from_arrow_array(array: &dyn Array, field: &Field) -> Result<Arc<dyn GeoA
         GeometryCollection(_) => Arc::new(GeometryCollectionArray::try_from((array, field))?),
         Rect(_) => Arc::new(RectArray::try_from((array, field))?),
         Geometry(_) => Arc::new(GeometryArray::try_from((array, field))?),
-        Wkb(_) => Arc::new(GenericWkbArray::<i32>::try_from((array, field))?),
-        LargeWkb(_) => Arc::new(GenericWkbArray::<i64>::try_from((array, field))?),
+        Wkb(_) => Arc::new(WkbArray::try_from((array, field))?),
+        LargeWkb(_) => Arc::new(LargeWkbArray::try_from((array, field))?),
         WkbView(_) => Arc::new(WkbViewArray::try_from((array, field))?),
-        Wkt(_) => Arc::new(WktArray::<i32>::try_from((array, field))?),
-        LargeWkt(_) => Arc::new(WktArray::<i64>::try_from((array, field))?),
+        Wkt(_) => Arc::new(WktArray::try_from((array, field))?),
+        LargeWkt(_) => Arc::new(LargeWktArray::try_from((array, field))?),
         WktView(_) => Arc::new(WktViewArray::try_from((array, field))?),
     };
     Ok(result)
@@ -95,8 +95,8 @@ impl GenericWkbArrayType<'_> for WkbViewArray {}
 ///
 /// Currently three types are supported:
 ///
-/// - [`WktArray<i32>`]
-/// - [`WktArray<i64>`]
+/// - [`GenericWktArray<i32>`]
+/// - [`GenericWktArray<i64>`]
 /// - [`WktViewArray`]
 ///
 /// This trait helps to abstract over the different types of WKT arrays so that we don’t need to
@@ -104,11 +104,11 @@ impl GenericWkbArrayType<'_> for WkbViewArray {}
 ///
 /// This is modeled after the upstream [`StringArrayType`][arrow_array::array::StringArrayType]
 /// trait.
-pub trait WktArrayType:
+pub trait GenericWktArrayType:
     Sized + for<'a> crate::GeoArrowArrayAccessor<'a, Item = ::wkt::Wkt>
 {
 }
 
-impl WktArrayType for WktArray<i32> {}
-impl WktArrayType for WktArray<i64> {}
-impl WktArrayType for WktViewArray {}
+impl GenericWktArrayType for GenericWktArray<i32> {}
+impl GenericWktArrayType for GenericWktArray<i64> {}
+impl GenericWktArrayType for WktViewArray {}

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, MultiLineStringType};
 
-use crate::array::{CoordBuffer, LineStringArray, GenericWkbArray};
+use crate::array::{CoordBuffer, GenericWkbArray, LineStringArray};
 use crate::builder::MultiLineStringBuilder;
 use crate::capacity::MultiLineStringCapacity;
 use crate::datatypes::GeoArrowType;
@@ -349,7 +349,9 @@ impl TryFrom<(&dyn Array, &Field)> for MultiLineStringArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiLineStringType)> for MultiLineStringArray {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiLineStringType)>
+    for MultiLineStringArray
+{
     type Error = GeoArrowError;
 
     fn try_from(value: (GenericWkbArray<O>, MultiLineStringType)) -> Result<Self> {

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, MultiLineStringType};
 
-use crate::array::{CoordBuffer, LineStringArray, WkbArray};
+use crate::array::{CoordBuffer, LineStringArray, GenericWkbArray};
 use crate::builder::MultiLineStringBuilder;
 use crate::capacity::MultiLineStringCapacity;
 use crate::datatypes::GeoArrowType;
@@ -349,10 +349,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiLineStringArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiLineStringType)> for MultiLineStringArray {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiLineStringType)> for MultiLineStringArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WkbArray<O>, MultiLineStringType)) -> Result<Self> {
+    fn try_from(value: (GenericWkbArray<O>, MultiLineStringType)) -> Result<Self> {
         let mut_arr: MultiLineStringBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, MultiPointType};
 
-use crate::array::{CoordBuffer, PointArray, WkbArray};
+use crate::array::{CoordBuffer, PointArray, GenericWkbArray};
 use crate::builder::MultiPointBuilder;
 use crate::capacity::MultiPointCapacity;
 use crate::datatypes::GeoArrowType;
@@ -302,10 +302,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPointArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPointType)> for MultiPointArray {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiPointType)> for MultiPointArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WkbArray<O>, MultiPointType)) -> Result<Self> {
+    fn try_from(value: (GenericWkbArray<O>, MultiPointType)) -> Result<Self> {
         let mut_arr: MultiPointBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, MultiPointType};
 
-use crate::array::{CoordBuffer, PointArray, GenericWkbArray};
+use crate::array::{CoordBuffer, GenericWkbArray, PointArray};
 use crate::builder::MultiPointBuilder;
 use crate::capacity::MultiPointCapacity;
 use crate::datatypes::GeoArrowType;

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, MultiPolygonType};
 
-use crate::array::{CoordBuffer, PolygonArray, GenericWkbArray};
+use crate::array::{CoordBuffer, GenericWkbArray, PolygonArray};
 use crate::builder::MultiPolygonBuilder;
 use crate::capacity::MultiPolygonCapacity;
 use crate::datatypes::GeoArrowType;

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -6,7 +6,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, MultiPolygonType};
 
-use crate::array::{CoordBuffer, PolygonArray, WkbArray};
+use crate::array::{CoordBuffer, PolygonArray, GenericWkbArray};
 use crate::builder::MultiPolygonBuilder;
 use crate::capacity::MultiPolygonCapacity;
 use crate::datatypes::GeoArrowType;
@@ -421,10 +421,10 @@ impl TryFrom<(&dyn Array, &Field)> for MultiPolygonArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPolygonType)> for MultiPolygonArray {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiPolygonType)> for MultiPolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WkbArray<O>, MultiPolygonType)) -> Result<Self> {
+    fn try_from(value: (GenericWkbArray<O>, MultiPolygonType)) -> Result<Self> {
         let mut_arr: MultiPolygonBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -7,7 +7,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, PolygonType};
 
-use crate::array::{CoordBuffer, RectArray, GenericWkbArray};
+use crate::array::{CoordBuffer, GenericWkbArray, RectArray};
 use crate::builder::PolygonBuilder;
 use crate::capacity::PolygonCapacity;
 use crate::datatypes::GeoArrowType;

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -7,7 +7,7 @@ use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::{CoordType, Metadata, PolygonType};
 
-use crate::array::{CoordBuffer, RectArray, WkbArray};
+use crate::array::{CoordBuffer, RectArray, GenericWkbArray};
 use crate::builder::PolygonBuilder;
 use crate::capacity::PolygonCapacity;
 use crate::datatypes::GeoArrowType;
@@ -352,10 +352,10 @@ impl TryFrom<(&dyn Array, &Field)> for PolygonArray {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, PolygonType)> for PolygonArray {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, PolygonType)> for PolygonArray {
     type Error = GeoArrowError;
 
-    fn try_from(value: (WkbArray<O>, PolygonType)) -> Result<Self> {
+    fn try_from(value: (GenericWkbArray<O>, PolygonType)) -> Result<Self> {
         let mut_arr: PolygonBuilder = value.try_into()?;
         Ok(mut_arr.finish())
     }

--- a/rust/geoarrow-array/src/array/wkb_view.rs
+++ b/rust/geoarrow-array/src/array/wkb_view.rs
@@ -8,7 +8,7 @@ use arrow_schema::{DataType, Field};
 use geoarrow_schema::{Metadata, WkbType};
 use wkb::reader::Wkb;
 
-use crate::array::WkbArray;
+use crate::array::GenericWkbArray;
 use crate::error::{GeoArrowError, Result};
 use crate::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType, IntoArrow};
 
@@ -24,7 +24,7 @@ pub struct WkbViewArray {
 }
 
 impl WkbViewArray {
-    /// Create a new WkbArray from a BinaryArray
+    /// Create a new GenericWkbArray from a BinaryArray
     pub fn new(array: BinaryViewArray, metadata: Arc<Metadata>) -> Self {
         Self {
             data_type: WkbType::new(metadata),
@@ -37,7 +37,7 @@ impl WkbViewArray {
         self.len() == 0
     }
 
-    /// Slices this [`WkbArray`] in place.
+    /// Slices this [`GenericWkbArray`] in place.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
@@ -163,8 +163,8 @@ impl TryFrom<(&dyn Array, &Field)> for WkbViewArray {
     }
 }
 
-impl<O: OffsetSizeTrait> From<WkbArray<O>> for WkbViewArray {
-    fn from(value: WkbArray<O>) -> Self {
+impl<O: OffsetSizeTrait> From<GenericWkbArray<O>> for WkbViewArray {
+    fn from(value: GenericWkbArray<O>) -> Self {
         let wkb_type = value.data_type;
         let binary_view_array = value.array;
 

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -57,7 +57,7 @@ impl<O: OffsetSizeTrait> WktArray<O> {
         self.array
     }
 
-    /// Slices this [`WkbArray`] in place.
+    /// Slices this [`GenericWkbArray`] in place.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     #[inline]

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -27,14 +27,14 @@ use crate::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
 ///
 /// Refer to [`crate::io::wkt`] for encoding and decoding this array to the native array types.
 #[derive(Debug, Clone, PartialEq)]
-pub struct WktArray<O: OffsetSizeTrait> {
+pub struct GenericWktArray<O: OffsetSizeTrait> {
     pub(crate) data_type: WktType,
     pub(crate) array: GenericStringArray<O>,
 }
 
 // Implement geometry accessors
-impl<O: OffsetSizeTrait> WktArray<O> {
-    /// Create a new WktArray from a StringArray
+impl<O: OffsetSizeTrait> GenericWktArray<O> {
+    /// Create a new GenericWktArray from a StringArray
     pub fn new(array: GenericStringArray<O>, metadata: Arc<Metadata>) -> Self {
         Self {
             data_type: WktType::new(metadata),
@@ -80,7 +80,7 @@ impl<O: OffsetSizeTrait> WktArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
+impl<O: OffsetSizeTrait> GeoArrowArray for GenericWktArray<O> {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -130,7 +130,7 @@ impl<O: OffsetSizeTrait> GeoArrowArray for WktArray<O> {
     }
 }
 
-impl<'a, O: OffsetSizeTrait> GeoArrowArrayAccessor<'a> for WktArray<O> {
+impl<'a, O: OffsetSizeTrait> GeoArrowArrayAccessor<'a> for GenericWktArray<O> {
     type Item = Wkt<f64>;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Result<Self::Item> {
@@ -139,7 +139,7 @@ impl<'a, O: OffsetSizeTrait> GeoArrowArrayAccessor<'a> for WktArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> IntoArrow for WktArray<O> {
+impl<O: OffsetSizeTrait> IntoArrow for GenericWktArray<O> {
     type ArrowArray = GenericStringArray<O>;
     type ExtensionType = WktType;
 
@@ -156,20 +156,21 @@ impl<O: OffsetSizeTrait> IntoArrow for WktArray<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<(GenericStringArray<O>, WktType)> for WktArray<O> {
+impl<O: OffsetSizeTrait> From<(GenericStringArray<O>, WktType)> for GenericWktArray<O> {
     fn from((value, typ): (GenericStringArray<O>, WktType)) -> Self {
         Self::new(value, typ.metadata().clone())
     }
 }
 
-impl TryFrom<(&dyn Array, WktType)> for WktArray<i32> {
+impl TryFrom<(&dyn Array, WktType)> for GenericWktArray<i32> {
     type Error = GeoArrowError;
 
     fn try_from((value, typ): (&dyn Array, WktType)) -> Result<Self> {
         match value.data_type() {
             DataType::Utf8 => Ok((value.as_string::<i32>().clone(), typ).into()),
             DataType::LargeUtf8 => {
-                let geom_array: WktArray<i64> = (value.as_string::<i64>().clone(), typ).into();
+                let geom_array: GenericWktArray<i64> =
+                    (value.as_string::<i64>().clone(), typ).into();
                 geom_array.try_into()
             }
             _ => Err(GeoArrowError::General(format!(
@@ -180,13 +181,14 @@ impl TryFrom<(&dyn Array, WktType)> for WktArray<i32> {
     }
 }
 
-impl TryFrom<(&dyn Array, WktType)> for WktArray<i64> {
+impl TryFrom<(&dyn Array, WktType)> for GenericWktArray<i64> {
     type Error = GeoArrowError;
 
     fn try_from((value, typ): (&dyn Array, WktType)) -> Result<Self> {
         match value.data_type() {
             DataType::Utf8 => {
-                let geom_array: WktArray<i32> = (value.as_string::<i32>().clone(), typ).into();
+                let geom_array: GenericWktArray<i32> =
+                    (value.as_string::<i32>().clone(), typ).into();
                 Ok(geom_array.into())
             }
             DataType::LargeUtf8 => Ok((value.as_string::<i64>().clone(), typ).into()),
@@ -198,7 +200,7 @@ impl TryFrom<(&dyn Array, WktType)> for WktArray<i64> {
     }
 }
 
-impl TryFrom<(&dyn Array, &Field)> for WktArray<i32> {
+impl TryFrom<(&dyn Array, &Field)> for GenericWktArray<i32> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -210,7 +212,7 @@ impl TryFrom<(&dyn Array, &Field)> for WktArray<i32> {
     }
 }
 
-impl TryFrom<(&dyn Array, &Field)> for WktArray<i64> {
+impl TryFrom<(&dyn Array, &Field)> for GenericWktArray<i64> {
     type Error = GeoArrowError;
 
     fn try_from((arr, field): (&dyn Array, &Field)) -> Result<Self> {
@@ -222,8 +224,8 @@ impl TryFrom<(&dyn Array, &Field)> for WktArray<i64> {
     }
 }
 
-impl From<WktArray<i32>> for WktArray<i64> {
-    fn from(value: WktArray<i32>) -> Self {
+impl From<GenericWktArray<i32>> for GenericWktArray<i64> {
+    fn from(value: GenericWktArray<i32>) -> Self {
         let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
         Self {
@@ -233,10 +235,10 @@ impl From<WktArray<i32>> for WktArray<i64> {
     }
 }
 
-impl TryFrom<WktArray<i64>> for WktArray<i32> {
+impl TryFrom<GenericWktArray<i64>> for GenericWktArray<i32> {
     type Error = GeoArrowError;
 
-    fn try_from(value: WktArray<i64>) -> Result<Self> {
+    fn try_from(value: GenericWktArray<i64>) -> Result<Self> {
         let binary_array = value.array;
         let (offsets, values, nulls) = binary_array.into_parts();
         Ok(Self {
@@ -246,7 +248,7 @@ impl TryFrom<WktArray<i64>> for WktArray<i32> {
     }
 }
 
-impl<O: OffsetSizeTrait> From<WktViewArray> for WktArray<O> {
+impl<O: OffsetSizeTrait> From<WktViewArray> for GenericWktArray<O> {
     fn from(value: WktViewArray) -> Self {
         let wkb_type = value.data_type;
         let binary_view_array = value.array;
@@ -264,6 +266,20 @@ impl<O: OffsetSizeTrait> From<WktViewArray> for WktArray<O> {
     }
 }
 
+/// A [`GenericWktArray`] using `i32` offsets
+///
+/// The byte length of each element is represented by an i32.
+///
+/// See [`GenericWktArray`] for more information and examples
+pub type WktArray = GenericWktArray<i32>;
+
+/// A [`GenericWktArray`] using `i64` offsets
+///
+/// The byte length of each element is represented by an i64.
+///
+/// See [`GenericWktArray`] for more information and examples
+pub type LargeWktArray = GenericWktArray<i64>;
+
 #[cfg(test)]
 mod test {
     use arrow_array::builder::{LargeStringBuilder, StringBuilder};
@@ -275,7 +291,7 @@ mod test {
 
     use super::*;
 
-    fn wkt_data<O: OffsetSizeTrait>() -> WktArray<O> {
+    fn wkt_data<O: OffsetSizeTrait>() -> GenericWktArray<O> {
         to_wkt(&point::array(CoordType::Interleaved, Dimension::XY)).unwrap()
     }
 
@@ -285,7 +301,7 @@ mod test {
         let array = wkb_array.to_array_ref();
         let field = Field::new("geometry", array.data_type().clone(), true)
             .with_extension_type(wkb_array.data_type.clone());
-        let wkb_array_retour: WktArray<i32> = (array.as_ref(), &field).try_into().unwrap();
+        let wkb_array_retour: GenericWktArray<i32> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
     }
@@ -296,7 +312,7 @@ mod test {
         let array = wkb_array.to_array_ref();
         let field = Field::new("geometry", array.data_type().clone(), true)
             .with_extension_type(wkb_array.data_type.clone());
-        let wkb_array_retour: WktArray<i64> = (array.as_ref(), &field).try_into().unwrap();
+        let wkb_array_retour: GenericWktArray<i64> = (array.as_ref(), &field).try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_retour);
     }
@@ -304,8 +320,8 @@ mod test {
     #[test]
     fn convert_i32_to_i64() {
         let wkb_array = wkt_data::<i32>();
-        let wkb_array_i64: WktArray<i64> = wkb_array.clone().into();
-        let wkb_array_i32: WktArray<i32> = wkb_array_i64.clone().try_into().unwrap();
+        let wkb_array_i64: GenericWktArray<i64> = wkb_array.clone().into();
+        let wkb_array_i32: GenericWktArray<i32> = wkb_array_i64.clone().try_into().unwrap();
 
         assert_eq!(wkb_array, wkb_array_i32);
     }
@@ -313,8 +329,8 @@ mod test {
     #[test]
     fn convert_i64_to_i32_to_i64() {
         let wkb_array = wkt_data::<i64>();
-        let wkb_array_i32: WktArray<i32> = wkb_array.clone().try_into().unwrap();
-        let wkb_array_i64: WktArray<i64> = wkb_array_i32.clone().into();
+        let wkb_array_i32: GenericWktArray<i32> = wkb_array.clone().try_into().unwrap();
+        let wkb_array_i64: GenericWktArray<i64> = wkb_array_i32.clone().into();
 
         assert_eq!(wkb_array, wkb_array_i64);
     }
@@ -327,13 +343,13 @@ mod test {
         builder.append_value("POINT(1 2)");
         let array = Arc::new(builder.finish()) as ArrayRef;
         let field = Field::new("geometry", array.data_type().clone(), true);
-        let _wkt_arr = WktArray::<i32>::try_from((array.as_ref(), &field)).unwrap();
+        let _wkt_arr = GenericWktArray::<i32>::try_from((array.as_ref(), &field)).unwrap();
 
         // Large string
         let mut builder = LargeStringBuilder::new();
         builder.append_value("POINT(1 2)");
         let array = Arc::new(builder.finish()) as ArrayRef;
         let field = Field::new("geometry", array.data_type().clone(), true);
-        let _wkt_arr = WktArray::<i64>::try_from((array.as_ref(), &field)).unwrap();
+        let _wkt_arr = GenericWktArray::<i64>::try_from((array.as_ref(), &field)).unwrap();
     }
 }

--- a/rust/geoarrow-array/src/array/wkt_view.rs
+++ b/rust/geoarrow-array/src/array/wkt_view.rs
@@ -9,7 +9,7 @@ use arrow_schema::{DataType, Field};
 use geoarrow_schema::{Metadata, WktType};
 use wkt::Wkt;
 
-use crate::array::WktArray;
+use crate::array::GenericWktArray;
 use crate::error::{GeoArrowError, Result};
 use crate::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType, IntoArrow};
 
@@ -169,8 +169,8 @@ impl TryFrom<(&dyn Array, &Field)> for WktViewArray {
     }
 }
 
-impl<O: OffsetSizeTrait> From<WktArray<O>> for WktViewArray {
-    fn from(value: WktArray<O>) -> Self {
+impl<O: OffsetSizeTrait> From<GenericWktArray<O>> for WktViewArray {
+    fn from(value: GenericWktArray<O>) -> Self {
         let wkb_type = value.data_type;
         let binary_view_array = value.array;
 

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -8,7 +8,7 @@ use geoarrow_schema::{
 };
 use wkt::WktNum;
 
-use crate::array::{DimensionIndex, GeometryArray, WkbArray};
+use crate::array::{DimensionIndex, GeometryArray, GenericWkbArray};
 use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapper};
 use crate::builder::{
     GeometryCollectionBuilder, LineStringBuilder, MultiLineStringBuilder, MultiPointBuilder,
@@ -814,11 +814,11 @@ impl<'a> GeometryBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryType)> for GeometryBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, GeometryType)> for GeometryBuilder {
     type Error = GeoArrowError;
 
     fn try_from(
-        (value, typ): (WkbArray<O>, GeometryType),
+        (value, typ): (GenericWkbArray<O>, GeometryType),
     ) -> std::result::Result<Self, Self::Error> {
         let wkb_objects = value
             .iter()

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -8,7 +8,7 @@ use geoarrow_schema::{
 };
 use wkt::WktNum;
 
-use crate::array::{DimensionIndex, GeometryArray, GenericWkbArray};
+use crate::array::{DimensionIndex, GenericWkbArray, GeometryArray};
 use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapper};
 use crate::builder::{
     GeometryCollectionBuilder, LineStringBuilder, MultiLineStringBuilder, MultiPointBuilder,

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -7,7 +7,7 @@ use geo_traits::{
 use geoarrow_schema::GeometryCollectionType;
 use wkt::WktNum;
 
-use crate::array::{GeometryCollectionArray, WkbArray};
+use crate::array::{GeometryCollectionArray, GenericWkbArray};
 use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapper};
 use crate::builder::{MixedGeometryBuilder, OffsetsBuilder};
 use crate::capacity::GeometryCollectionCapacity;
@@ -345,12 +345,12 @@ impl<'a> GeometryCollectionBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, GeometryCollectionType)>
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, GeometryCollectionType)>
     for GeometryCollectionBuilder
 {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WkbArray<O>, GeometryCollectionType)) -> Result<Self> {
+    fn try_from((value, typ): (GenericWkbArray<O>, GeometryCollectionType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -7,7 +7,7 @@ use geo_traits::{
 use geoarrow_schema::GeometryCollectionType;
 use wkt::WktNum;
 
-use crate::array::{GeometryCollectionArray, GenericWkbArray};
+use crate::array::{GenericWkbArray, GeometryCollectionArray};
 use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapper};
 use crate::builder::{MixedGeometryBuilder, OffsetsBuilder};
 use crate::capacity::GeometryCollectionCapacity;

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -3,7 +3,7 @@ use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
 use geoarrow_schema::{CoordType, LineStringType};
 
-use crate::array::{LineStringArray, GenericWkbArray};
+use crate::array::{GenericWkbArray, LineStringArray};
 use crate::builder::geo_trait_wrappers::LineWrapper;
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -3,7 +3,7 @@ use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
 use geoarrow_schema::{CoordType, LineStringType};
 
-use crate::array::{LineStringArray, WkbArray};
+use crate::array::{LineStringArray, GenericWkbArray};
 use crate::builder::geo_trait_wrappers::LineWrapper;
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
@@ -256,10 +256,10 @@ impl LineStringBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, LineStringType)> for LineStringBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, LineStringType)> for LineStringBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WkbArray<O>, LineStringType)) -> Result<Self> {
+    fn try_from((value, typ): (GenericWkbArray<O>, LineStringType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -4,7 +4,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, Multi
 use geoarrow_schema::{CoordType, MultiLineStringType};
 // use super::array::check;
 
-use crate::array::{MultiLineStringArray, WkbArray};
+use crate::array::{MultiLineStringArray, GenericWkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -354,10 +354,10 @@ impl MultiLineStringBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiLineStringType)> for MultiLineStringBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiLineStringType)> for MultiLineStringBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WkbArray<O>, MultiLineStringType)) -> Result<Self> {
+    fn try_from((value, typ): (GenericWkbArray<O>, MultiLineStringType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -4,7 +4,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, Multi
 use geoarrow_schema::{CoordType, MultiLineStringType};
 // use super::array::check;
 
-use crate::array::{MultiLineStringArray, GenericWkbArray};
+use crate::array::{GenericWkbArray, MultiLineStringArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -354,7 +354,9 @@ impl MultiLineStringBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiLineStringType)> for MultiLineStringBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiLineStringType)>
+    for MultiLineStringBuilder
+{
     type Error = GeoArrowError;
 
     fn try_from((value, typ): (GenericWkbArray<O>, MultiLineStringType)) -> Result<Self> {

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -5,7 +5,7 @@ use geoarrow_schema::{CoordType, MultiPointType};
 
 use crate::capacity::MultiPointCapacity;
 // use super::array::check;
-use crate::array::{MultiPointArray, GenericWkbArray};
+use crate::array::{GenericWkbArray, MultiPointArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -5,7 +5,7 @@ use geoarrow_schema::{CoordType, MultiPointType};
 
 use crate::capacity::MultiPointCapacity;
 // use super::array::check;
-use crate::array::{MultiPointArray, WkbArray};
+use crate::array::{MultiPointArray, GenericWkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -259,10 +259,10 @@ impl MultiPointBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPointType)> for MultiPointBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiPointType)> for MultiPointBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WkbArray<O>, MultiPointType)) -> Result<Self> {
+    fn try_from((value, typ): (GenericWkbArray<O>, MultiPointType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -7,7 +7,7 @@ use geoarrow_schema::{CoordType, MultiPolygonType};
 
 use crate::capacity::MultiPolygonCapacity;
 // use super::array::check;
-use crate::array::{MultiPolygonArray, WkbArray};
+use crate::array::{MultiPolygonArray, GenericWkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
@@ -375,10 +375,10 @@ impl MultiPolygonBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, MultiPolygonType)> for MultiPolygonBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiPolygonType)> for MultiPolygonBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WkbArray<O>, MultiPolygonType)) -> Result<Self> {
+    fn try_from((value, typ): (GenericWkbArray<O>, MultiPolygonType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -7,7 +7,7 @@ use geoarrow_schema::{CoordType, MultiPolygonType};
 
 use crate::capacity::MultiPolygonCapacity;
 // use super::array::check;
-use crate::array::{MultiPolygonArray, GenericWkbArray};
+use crate::array::{GenericWkbArray, MultiPolygonArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -4,7 +4,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, Point
 use geoarrow_schema::{CoordType, PointType};
 
 // use super::array::check;
-use crate::array::{PointArray, WkbArray};
+use crate::array::{PointArray, GenericWkbArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder,
 };
@@ -225,10 +225,10 @@ impl PointBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, PointType)> for PointBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, PointType)> for PointBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WkbArray<O>, PointType)) -> Result<Self> {
+    fn try_from((value, typ): (GenericWkbArray<O>, PointType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -4,7 +4,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, Point
 use geoarrow_schema::{CoordType, PointType};
 
 // use super::array::check;
-use crate::array::{PointArray, GenericWkbArray};
+use crate::array::{GenericWkbArray, PointArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder,
 };

--- a/rust/geoarrow-array/src/builder/polygon.rs
+++ b/rust/geoarrow-array/src/builder/polygon.rs
@@ -6,7 +6,7 @@ use geo_traits::{
 };
 use geoarrow_schema::{CoordType, PolygonType};
 
-use crate::array::{PolygonArray, GenericWkbArray};
+use crate::array::{GenericWkbArray, PolygonArray};
 use crate::builder::geo_trait_wrappers::{RectWrapper, TriangleWrapper};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,

--- a/rust/geoarrow-array/src/builder/polygon.rs
+++ b/rust/geoarrow-array/src/builder/polygon.rs
@@ -6,7 +6,7 @@ use geo_traits::{
 };
 use geoarrow_schema::{CoordType, PolygonType};
 
-use crate::array::{PolygonArray, WkbArray};
+use crate::array::{PolygonArray, GenericWkbArray};
 use crate::builder::geo_trait_wrappers::{RectWrapper, TriangleWrapper};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
@@ -337,10 +337,10 @@ impl PolygonBuilder {
     }
 }
 
-impl<O: OffsetSizeTrait> TryFrom<(WkbArray<O>, PolygonType)> for PolygonBuilder {
+impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, PolygonType)> for PolygonBuilder {
     type Error = GeoArrowError;
 
-    fn try_from((value, typ): (WkbArray<O>, PolygonType)) -> Result<Self> {
+    fn try_from((value, typ): (GenericWkbArray<O>, PolygonType)) -> Result<Self> {
         let wkb_objects = value
             .iter()
             .map(|x| x.transpose())

--- a/rust/geoarrow-array/src/builder/wkb.rs
+++ b/rust/geoarrow-array/src/builder/wkb.rs
@@ -11,12 +11,12 @@ use wkb::writer::{
     write_multi_point, write_multi_polygon, write_point, write_polygon,
 };
 
-use crate::array::WkbArray;
+use crate::array::GenericWkbArray;
 use crate::capacity::WkbCapacity;
 
 /// The GeoArrow equivalent to `Vec<Option<Wkb>>`: a mutable collection of Wkb buffers.
 ///
-/// Converting a [`WkbBuilder`] into a [`WkbArray`] is `O(1)`.
+/// Converting a [`WkbBuilder`] into a [`GenericWkbArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct WkbBuilder<O: OffsetSizeTrait>(GenericBinaryBuilder<O>, WkbType);
 
@@ -170,10 +170,10 @@ impl<O: OffsetSizeTrait> WkbBuilder<O> {
         array
     }
 
-    /// Consume this builder and convert to a [WkbArray].
+    /// Consume this builder and convert to a [GenericWkbArray].
     ///
     /// This is `O(1)`.
-    pub fn finish(mut self) -> WkbArray<O> {
-        WkbArray::new(self.0.finish(), self.1.metadata().clone())
+    pub fn finish(mut self) -> GenericWkbArray<O> {
+        GenericWkbArray::new(self.0.finish(), self.1.metadata().clone())
     }
 }

--- a/rust/geoarrow-array/src/capacity/wkb.rs
+++ b/rust/geoarrow-array/src/capacity/wkb.rs
@@ -12,7 +12,7 @@ use wkb::writer::{
     polygon_wkb_size,
 };
 
-/// A counter for the buffer sizes of a [`WkbArray`][crate::array::WkbArray].
+/// A counter for the buffer sizes of a [`GenericWkbArray`][crate::array::GenericWkbArray].
 ///
 /// This can be used to reduce allocations by allocating once for exactly the array size you need.
 #[derive(Debug, Clone, Copy)]

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -58,10 +58,10 @@ pub enum GeoArrowType {
     /// Represents a [WkbViewArray][crate::array::WkbViewArray].
     WkbView(WkbType),
 
-    /// Represents a [WktArray][crate::array::WktArray] with `i32` offsets.
+    /// Represents a [GenericWktArray][crate::array::GenericWktArray] with `i32` offsets.
     Wkt(WktType),
 
-    /// Represents a [WktArray][crate::array::WktArray] with `i64` offsets.
+    /// Represents a [GenericWktArray][crate::array::GenericWktArray] with `i64` offsets.
     LargeWkt(WktType),
 
     /// Represents a [WktViewArray][crate::array::WktViewArray].

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -49,10 +49,10 @@ pub enum GeoArrowType {
     /// Represents a mixed geometry array of unknown types or dimensions
     Geometry(GeometryType),
 
-    /// Represents a [WkbArray][crate::array::WkbArray] with `i32` offsets.
+    /// Represents a [GenericWkbArray][crate::array::GenericWkbArray] with `i32` offsets.
     Wkb(WkbType),
 
-    /// Represents a [WkbArray][crate::array::WkbArray] with `i64` offsets.
+    /// Represents a [GenericWkbArray][crate::array::GenericWkbArray] with `i64` offsets.
     LargeWkb(WkbType),
 
     /// Represents a [WkbViewArray][crate::array::WkbViewArray].

--- a/rust/geoarrow-array/src/geozero/export/array/wkb.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/wkb.rs
@@ -2,11 +2,11 @@ use arrow_array::OffsetSizeTrait;
 use geozero::error::GeozeroError;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-use crate::array::WkbArray;
+use crate::array::GenericWkbArray;
 use crate::geozero::export::scalar::process_geometry;
 use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for WkbArray<O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for GenericWkbArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow-array/src/geozero/export/array/wkt.rs
+++ b/rust/geoarrow-array/src/geozero/export/array/wkt.rs
@@ -2,11 +2,11 @@ use arrow_array::OffsetSizeTrait;
 use geozero::error::GeozeroError;
 use geozero::{GeomProcessor, GeozeroGeometry};
 
-use crate::array::WktArray;
+use crate::array::GenericWktArray;
 use crate::geozero::export::scalar::process_geometry;
 use crate::{GeoArrowArray, GeoArrowArrayAccessor};
 
-impl<O: OffsetSizeTrait> GeozeroGeometry for WktArray<O> {
+impl<O: OffsetSizeTrait> GeozeroGeometry for GenericWktArray<O> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> geozero::error::Result<()>
     where
         Self: Sized,

--- a/rust/geoarrow-array/src/scalar/mod.rs
+++ b/rust/geoarrow-array/src/scalar/mod.rs
@@ -4,7 +4,7 @@
 //! allocation-free for any coordinate access.
 //!
 //! For "serialized" scalars emitted from the [`GenericWkbArray`][crate::array::GenericWkbArray] and
-//! [`WktArray`][crate::array::WktArray], there is an initial parsing step when accessing the
+//! [`GenericWktArray`][crate::array::GenericWktArray], there is an initial parsing step when accessing the
 //! scalar from the [`ArrayAccessor`][crate::ArrayAccessor] trait.
 //!
 //! All scalars implement [`geo_traits`]. You can iterate through geometry parts directly using the

--- a/rust/geoarrow-array/src/scalar/mod.rs
+++ b/rust/geoarrow-array/src/scalar/mod.rs
@@ -3,7 +3,7 @@
 //! For all "native" GeoArrow scalar types, (all types defined in this module) it is `O(1)` and
 //! allocation-free for any coordinate access.
 //!
-//! For "serialized" scalars emitted from the [`WkbArray`][crate::array::WkbArray] and
+//! For "serialized" scalars emitted from the [`GenericWkbArray`][crate::array::GenericWkbArray] and
 //! [`WktArray`][crate::array::WktArray], there is an initial parsing step when accessing the
 //! scalar from the [`ArrayAccessor`][crate::ArrayAccessor] trait.
 //!

--- a/rust/geoarrow-array/src/trait_.rs
+++ b/rust/geoarrow-array/src/trait_.rs
@@ -227,8 +227,8 @@ pub trait GeoArrowArray: Debug + Send + Sync {
 /// Accessing a geometry from a "native" array, such as `PointArray`, `MultiPolygonArray` or
 /// `GeometryArray` will always be constant-time and zero-copy.
 ///
-/// Accessing a geometry from a "serialized" array such as `WkbArray` or `WktArray` will trigger
-/// some amount of parsing. In the case of `WkbArray`, accessing an item will read the WKB header
+/// Accessing a geometry from a "serialized" array such as `GenericWkbArray` or `WktArray` will trigger
+/// some amount of parsing. In the case of `GenericWkbArray`, accessing an item will read the WKB header
 /// and scan the buffer if needed to find internal geometry offsets, but will not copy any internal
 /// coordinates. This allows for later access to be constant-time (though not necessarily
 /// zero-copy, since WKB is not byte-aligned). In the case of `WktArray`, accessing a geometry will

--- a/rust/geoarrow-array/src/trait_.rs
+++ b/rust/geoarrow-array/src/trait_.rs
@@ -227,13 +227,13 @@ pub trait GeoArrowArray: Debug + Send + Sync {
 /// Accessing a geometry from a "native" array, such as `PointArray`, `MultiPolygonArray` or
 /// `GeometryArray` will always be constant-time and zero-copy.
 ///
-/// Accessing a geometry from a "serialized" array such as `GenericWkbArray` or `WktArray` will trigger
+/// Accessing a geometry from a "serialized" array such as `GenericWkbArray` or `GenericWktArray` will trigger
 /// some amount of parsing. In the case of `GenericWkbArray`, accessing an item will read the WKB header
 /// and scan the buffer if needed to find internal geometry offsets, but will not copy any internal
 /// coordinates. This allows for later access to be constant-time (though not necessarily
-/// zero-copy, since WKB is not byte-aligned). In the case of `WktArray`, accessing a geometry will
+/// zero-copy, since WKB is not byte-aligned). In the case of `GenericWktArray`, accessing a geometry will
 /// fully parse the WKT string and copy coordinates to a separate representation. This means that
-/// calling `.iter()` on a `WktArray` will transparently fully parse every row.
+/// calling `.iter()` on a `GenericWktArray` will transparently fully parse every row.
 ///
 /// # Validity
 ///

--- a/rust/geoarrow-geoparquet/src/reader/parse.rs
+++ b/rust/geoarrow-geoparquet/src/reader/parse.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use arrow_array::{Array, ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use geoarrow_array::array::{
-    LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray,
-    PolygonArray, WkbArray,
+    LargeWkbArray, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray,
+    PointArray, PolygonArray, WkbArray,
 };
 use geoarrow_array::cast::from_wkb;
 use geoarrow_array::{GeoArrowArray, GeoArrowType};
@@ -135,12 +135,12 @@ fn parse_array(array: ArrayRef, orig_field: &Field, target_field: &Field) -> Res
 fn parse_wkb_column(arr: &dyn Array, target_geo_data_type: GeoArrowType) -> Result<ArrayRef> {
     match arr.data_type() {
         DataType::Binary => {
-            let wkb_arr = WkbArray::<i32>::try_from((arr, WkbType::new(Default::default())))?;
+            let wkb_arr = WkbArray::try_from((arr, WkbType::new(Default::default())))?;
             let geom_arr = from_wkb(&wkb_arr, target_geo_data_type)?;
             Ok(geom_arr.to_array_ref())
         }
         DataType::LargeBinary => {
-            let wkb_arr = WkbArray::<i64>::try_from((arr, WkbType::new(Default::default())))?;
+            let wkb_arr = LargeWkbArray::try_from((arr, WkbType::new(Default::default())))?;
             let geom_arr = from_wkb(&wkb_arr, target_geo_data_type)?;
             Ok(geom_arr.to_array_ref())
         }

--- a/rust/geoarrow-geoparquet/src/test/geoarrow_data/example.rs
+++ b/rust/geoarrow-geoparquet/src/test/geoarrow_data/example.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use arrow_array::RecordBatchReader;
 use arrow_array::cast::AsArray;
 use arrow_schema::ArrowError;
-use geoarrow_array::array::{WktArray, from_arrow_array};
+use geoarrow_array::array::{GenericWktArray, WktArray, from_arrow_array};
 use geoarrow_array::builder::{
     GeometryCollectionBuilder, LineStringBuilder, MultiLineStringBuilder, MultiPointBuilder,
     MultiPolygonBuilder, PointBuilder, PolygonBuilder,
@@ -75,7 +75,7 @@ fn geoparquet_filepath(data_type: GeoArrowType, suffix: &str) -> PathBuf {
 }
 
 /// Read a GeoParquet file and return the WKT and geometry arrays; columns 0 and 1.
-fn read_gpq_file(path: impl AsRef<Path>) -> (WktArray<i32>, Arc<dyn GeoArrowArray>) {
+fn read_gpq_file(path: impl AsRef<Path>) -> (GenericWktArray<i32>, Arc<dyn GeoArrowArray>) {
     println!("reading path: {:?}", path.as_ref());
     let file = File::open(path).unwrap();
     let reader = GeoParquetRecordBatchReaderBuilder::try_new(file)

--- a/rust/geoarrow-geos/src/import/array/wkb.rs
+++ b/rust/geoarrow-geos/src/import/array/wkb.rs
@@ -1,5 +1,5 @@
 use arrow_array::OffsetSizeTrait;
-use geoarrow_array::array::WkbArray;
+use geoarrow_array::array::GenericWkbArray;
 use geoarrow_array::builder::WkbBuilder;
 use geoarrow_array::error::Result;
 use geoarrow_schema::WkbType;
@@ -22,7 +22,7 @@ impl<O: OffsetSizeTrait> FromGEOS for WkbBuilder<O> {
     }
 }
 
-impl<O: OffsetSizeTrait> FromGEOS for WkbArray<O> {
+impl<O: OffsetSizeTrait> FromGEOS for GenericWkbArray<O> {
     type GeoArrowType = WkbType;
 
     fn from_geos(

--- a/rust/geodatafusion/src/udf/native/io/wkt.rs
+++ b/rust/geodatafusion/src/udf/native/io/wkt.rs
@@ -8,7 +8,7 @@ use datafusion::logical_expr::{
     ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     Volatility,
 };
-use geoarrow_array::array::{WktArray, from_arrow_array};
+use geoarrow_array::array::{LargeWktArray, WktArray, from_arrow_array};
 use geoarrow_array::cast::{from_wkt, to_wkt};
 use geoarrow_array::{GeoArrowArray, GeoArrowType};
 use geoarrow_schema::{CoordType, GeometryType, WktType};
@@ -115,14 +115,10 @@ impl GeomFromText {
         let field = args.arg_fields[0];
         let to_type = GeoArrowType::try_from(args.return_field)?;
         let geom_arr = match field.data_type() {
-            DataType::Utf8 => from_wkt(
-                &WktArray::<i32>::try_from((array.as_ref(), field))?,
-                to_type,
-            ),
-            DataType::LargeUtf8 => from_wkt(
-                &WktArray::<i64>::try_from((array.as_ref(), field))?,
-                to_type,
-            ),
+            DataType::Utf8 => from_wkt(&WktArray::try_from((array.as_ref(), field))?, to_type),
+            DataType::LargeUtf8 => {
+                from_wkt(&LargeWktArray::try_from((array.as_ref(), field))?, to_type)
+            }
             _ => unreachable!(),
         }?;
 


### PR DESCRIPTION
### Change list

- Rename `WkbArray` to `GenericWkbArray`
- Rename `WktArray` to `GenericWktArray`
- Add type aliases for `WkbArray`, `LargeWkbArray`, `WktArray`, `LargeWktArray`

Closes https://github.com/geoarrow/geoarrow-rs/issues/1110