### PR TITLE
Reduce public API surface of WkbBuilder, GeometryBuilder, and GeometryCollectionBuilder

### DIFF
--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -296,9 +296,9 @@ mod test {
 
     fn wkb_data<O: OffsetSizeTrait>() -> GenericWkbArray<O> {
         let mut builder = WkbBuilder::new(WkbType::new(Default::default()));
-        builder.push_point(Some(&point::p0()));
-        builder.push_point(Some(&point::p1()));
-        builder.push_point(Some(&point::p2()));
+        builder.push_geometry(Some(&point::p0()));
+        builder.push_geometry(Some(&point::p1()));
+        builder.push_geometry(Some(&point::p2()));
         builder.finish()
     }
 

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -331,7 +331,7 @@ impl<'a> GeometryBuilder {
     /// If `self.prefer_multi` is `true`, it will be stored in the `MultiPointBuilder` child
     /// array. Otherwise, it will be stored in the `PointBuilder` child array.
     #[inline]
-    pub fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
+    fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
         if let Some(point) = value {
             let dim: Dimension = point.dim().try_into().unwrap();
             let array_idx = dim.order();
@@ -397,10 +397,7 @@ impl<'a> GeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_line_string(
-        &mut self,
-        value: Option<&impl LineStringTrait<T = f64>>,
-    ) -> Result<()> {
+    fn push_line_string(&mut self, value: Option<&impl LineStringTrait<T = f64>>) -> Result<()> {
         if let Some(line_string) = value {
             let dim: Dimension = line_string.dim().try_into().unwrap();
             let array_idx = dim.order();
@@ -455,7 +452,7 @@ impl<'a> GeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
+    fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
         if let Some(polygon) = value {
             let dim: Dimension = polygon.dim().try_into().unwrap();
             let array_idx = dim.order();
@@ -507,10 +504,7 @@ impl<'a> GeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_point(
-        &mut self,
-        value: Option<&impl MultiPointTrait<T = f64>>,
-    ) -> Result<()> {
+    fn push_multi_point(&mut self, value: Option<&impl MultiPointTrait<T = f64>>) -> Result<()> {
         if let Some(multi_point) = value {
             let dim: Dimension = multi_point.dim().try_into().unwrap();
             let array_idx = dim.order();
@@ -547,7 +541,7 @@ impl<'a> GeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_line_string(
+    fn push_multi_line_string(
         &mut self,
         value: Option<&impl MultiLineStringTrait<T = f64>>,
     ) -> Result<()> {
@@ -587,7 +581,7 @@ impl<'a> GeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_multi_polygon(
+    fn push_multi_polygon(
         &mut self,
         value: Option<&impl MultiPolygonTrait<T = f64>>,
     ) -> Result<()> {
@@ -663,7 +657,7 @@ impl<'a> GeometryBuilder {
     ///
     /// This function errors iff the new last item is larger than what O supports.
     #[inline]
-    pub fn push_geometry_collection(
+    fn push_geometry_collection(
         &mut self,
         value: Option<&impl GeometryCollectionTrait<T = f64>>,
     ) -> Result<()> {

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -141,7 +141,7 @@ impl<'a> GeometryCollectionBuilder {
 
     /// Push a Point onto the end of this builder
     #[inline]
-    pub fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
+    fn push_point(&mut self, value: Option<&impl PointTrait<T = f64>>) -> Result<()> {
         if let Some(geom) = value {
             self.geoms.push_point(geom)?;
             self.geom_offsets.try_push_usize(1)?;
@@ -154,10 +154,7 @@ impl<'a> GeometryCollectionBuilder {
 
     /// Push a LineString onto the end of this builder
     #[inline]
-    pub fn push_line_string(
-        &mut self,
-        value: Option<&impl LineStringTrait<T = f64>>,
-    ) -> Result<()> {
+    fn push_line_string(&mut self, value: Option<&impl LineStringTrait<T = f64>>) -> Result<()> {
         if let Some(geom) = value {
             self.geoms.push_line_string(geom)?;
             self.geom_offsets.try_push_usize(1)?;
@@ -170,7 +167,7 @@ impl<'a> GeometryCollectionBuilder {
 
     /// Push a Polygon onto the end of this builder
     #[inline]
-    pub fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
+    fn push_polygon(&mut self, value: Option<&impl PolygonTrait<T = f64>>) -> Result<()> {
         if let Some(geom) = value {
             self.geoms.push_polygon(geom)?;
             self.geom_offsets.try_push_usize(1)?;
@@ -183,10 +180,7 @@ impl<'a> GeometryCollectionBuilder {
 
     /// Push a MultiPoint onto the end of this builder
     #[inline]
-    pub fn push_multi_point(
-        &mut self,
-        value: Option<&impl MultiPointTrait<T = f64>>,
-    ) -> Result<()> {
+    fn push_multi_point(&mut self, value: Option<&impl MultiPointTrait<T = f64>>) -> Result<()> {
         if let Some(geom) = value {
             self.geoms.push_multi_point(geom)?;
             self.geom_offsets.try_push_usize(1)?;
@@ -199,7 +193,7 @@ impl<'a> GeometryCollectionBuilder {
 
     /// Push a MultiLineString onto the end of this builder
     #[inline]
-    pub fn push_multi_line_string(
+    fn push_multi_line_string(
         &mut self,
         value: Option<&impl MultiLineStringTrait<T = f64>>,
     ) -> Result<()> {
@@ -215,7 +209,7 @@ impl<'a> GeometryCollectionBuilder {
 
     /// Push a MultiPolygon onto the end of this builder
     #[inline]
-    pub fn push_multi_polygon(
+    fn push_multi_polygon(
         &mut self,
         value: Option<&impl MultiPolygonTrait<T = f64>>,
     ) -> Result<()> {

--- a/rust/geoarrow-array/src/builder/wkb.rs
+++ b/rust/geoarrow-array/src/builder/wkb.rs
@@ -1,15 +1,9 @@
 use arrow_array::OffsetSizeTrait;
 use arrow_array::builder::GenericBinaryBuilder;
-use geo_traits::{
-    GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
-    MultiPolygonTrait, PointTrait, PolygonTrait,
-};
+use geo_traits::GeometryTrait;
 use geoarrow_schema::WkbType;
 use wkb::Endianness;
-use wkb::writer::{
-    write_geometry, write_geometry_collection, write_line_string, write_multi_line_string,
-    write_multi_point, write_multi_polygon, write_point, write_polygon,
-};
+use wkb::writer::write_geometry;
 
 use crate::array::GenericWkbArray;
 use crate::capacity::WkbCapacity;
@@ -52,91 +46,11 @@ impl<O: OffsetSizeTrait> WkbBuilder<O> {
     // pub fn reserve(&mut self, capacity: WkbCapacity) {
     // }
 
-    /// Push a Point onto the end of this builder
-    #[inline]
-    pub fn push_point(&mut self, geom: Option<&impl PointTrait<T = f64>>) {
-        if let Some(geom) = geom {
-            write_point(&mut self.0, geom, Endianness::LittleEndian).unwrap();
-            self.0.append_value("")
-        } else {
-            self.0.append_null();
-        }
-    }
-
-    /// Push a LineString onto the end of this builder
-    #[inline]
-    pub fn push_line_string(&mut self, geom: Option<&impl LineStringTrait<T = f64>>) {
-        if let Some(geom) = geom {
-            write_line_string(&mut self.0, geom, Endianness::LittleEndian).unwrap();
-            self.0.append_value("")
-        } else {
-            self.0.append_null()
-        }
-    }
-
-    /// Push a Polygon onto the end of this builder
-    #[inline]
-    pub fn push_polygon(&mut self, geom: Option<&impl PolygonTrait<T = f64>>) {
-        if let Some(geom) = geom {
-            write_polygon(&mut self.0, geom, Endianness::LittleEndian).unwrap();
-            self.0.append_value("")
-        } else {
-            self.0.append_null()
-        }
-    }
-
-    /// Push a MultiPoint onto the end of this builder
-    #[inline]
-    pub fn push_multi_point(&mut self, geom: Option<&impl MultiPointTrait<T = f64>>) {
-        if let Some(geom) = geom {
-            write_multi_point(&mut self.0, geom, Endianness::LittleEndian).unwrap();
-            self.0.append_value("")
-        } else {
-            self.0.append_null()
-        }
-    }
-
-    /// Push a MultiLineString onto the end of this builder
-    #[inline]
-    pub fn push_multi_line_string(&mut self, geom: Option<&impl MultiLineStringTrait<T = f64>>) {
-        if let Some(geom) = geom {
-            write_multi_line_string(&mut self.0, geom, Endianness::LittleEndian).unwrap();
-            self.0.append_value("")
-        } else {
-            self.0.append_null()
-        }
-    }
-
-    /// Push a MultiPolygon onto the end of this builder
-    #[inline]
-    pub fn push_multi_polygon(&mut self, geom: Option<&impl MultiPolygonTrait<T = f64>>) {
-        if let Some(geom) = geom {
-            write_multi_polygon(&mut self.0, geom, Endianness::LittleEndian).unwrap();
-            self.0.append_value("")
-        } else {
-            self.0.append_null()
-        }
-    }
-
     /// Push a Geometry onto the end of this builder
     #[inline]
     pub fn push_geometry(&mut self, geom: Option<&impl GeometryTrait<T = f64>>) {
         if let Some(geom) = geom {
             write_geometry(&mut self.0, geom, Endianness::LittleEndian).unwrap();
-            self.0.append_value("")
-        } else {
-            self.0.append_null()
-        }
-    }
-
-    /// Push a GeometryCollection onto the end of this builder
-    #[inline]
-    pub fn push_geometry_collection(
-        &mut self,
-        geom: Option<&impl GeometryCollectionTrait<T = f64>>,
-    ) {
-        if let Some(geom) = geom {
-            write_geometry_collection(&mut self.0, geom, Endianness::LittleEndian).unwrap();
             self.0.append_value("")
         } else {
             self.0.append_null()

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -508,14 +508,20 @@ mod test {
             CoordType::Interleaved,
             Default::default(),
         ));
-        builder.push_point(Some(&crate::test::point::p0())).unwrap();
-        builder.push_point(Some(&crate::test::point::p1())).unwrap();
-        builder.push_point(Some(&crate::test::point::p2())).unwrap();
         builder
-            .push_multi_line_string(Some(&crate::test::multilinestring::ml0()))
+            .push_geometry(Some(&crate::test::point::p0()))
             .unwrap();
         builder
-            .push_multi_line_string(Some(&crate::test::multilinestring::ml1()))
+            .push_geometry(Some(&crate::test::point::p1()))
+            .unwrap();
+        builder
+            .push_geometry(Some(&crate::test::point::p2()))
+            .unwrap();
+        builder
+            .push_geometry(Some(&crate::test::multilinestring::ml0()))
+            .unwrap();
+        builder
+            .push_geometry(Some(&crate::test::multilinestring::ml1()))
             .unwrap();
         let geom_array = builder.finish();
         let field = geom_array.data_type.to_field("geometry", true);


### PR DESCRIPTION
With geo-traits 0.3, all geometries _must_ also implement `GeometryTrait`. Therefore, when the overhead of going through `geo_traits::GeometryTrait` is small enough and when going through `push_geometry` is infallible, we might as well clean up the builder interface by only exposing a `push_geometry` instead of also all the other `push*` functions.

Closes https://github.com/geoarrow/geoarrow-rs/issues/1113