### PR TITLE
Rename `GeometryArrayBuilder` to `GeoArrowArrayBuilder`

### DIFF
--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -16,7 +16,7 @@ use crate::builder::{
 };
 use crate::capacity::GeometryCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
 
 pub(crate) const DEFAULT_PREFER_MULTI: bool = false;
 
@@ -372,7 +372,7 @@ impl<'a> GeometryBuilder {
 
     #[inline]
     fn add_type(
-        child: &mut dyn GeometryArrayBuilder,
+        child: &mut dyn GeoArrowArrayBuilder,
         offsets: &mut Vec<i32>,
         types: &mut Vec<i8>,
         type_id: i8,
@@ -760,7 +760,7 @@ impl<'a> GeometryBuilder {
     /// Flush any deferred nulls to the desired array builder.
     fn flush_deferred_nulls(
         deferred_nulls: &mut usize,
-        child: &mut dyn GeometryArrayBuilder,
+        child: &mut dyn GeoArrowArrayBuilder,
         offsets: &mut Vec<i32>,
         types: &mut Vec<i8>,
         type_id: i8,
@@ -822,7 +822,7 @@ impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, GeometryType)> for Geometr
     }
 }
 
-impl GeometryArrayBuilder for GeometryBuilder {
+impl GeoArrowArrayBuilder for GeometryBuilder {
     fn len(&self) -> usize {
         self.types.len()
     }

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -12,7 +12,7 @@ use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapp
 use crate::builder::{MixedGeometryBuilder, OffsetsBuilder};
 use crate::capacity::GeometryCollectionCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<GeometryCollection>>`: a mutable collection of
 /// GeometryCollections.
@@ -353,7 +353,7 @@ impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, GeometryCollectionType)>
     }
 }
 
-impl GeometryArrayBuilder for GeometryCollectionBuilder {
+impl GeoArrowArrayBuilder for GeometryCollectionBuilder {
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -10,7 +10,7 @@ use crate::builder::{
 };
 use crate::capacity::LineStringCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<LineString>>`: a mutable collection of LineStrings.
 ///
@@ -268,7 +268,7 @@ impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, LineStringType)> for LineS
     }
 }
 
-impl GeometryArrayBuilder for LineStringBuilder {
+impl GeoArrowArrayBuilder for LineStringBuilder {
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -12,7 +12,7 @@ use crate::builder::{
 };
 use crate::capacity::MixedCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::GeometryArrayBuilder;
+use crate::trait_::GeoArrowArrayBuilder;
 
 pub(crate) const DEFAULT_PREFER_MULTI: bool = false;
 

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -10,7 +10,7 @@ use crate::builder::{
 };
 use crate::capacity::MultiLineStringCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiLineString>>`: a mutable collection of
 /// MultiLineStrings.
@@ -368,7 +368,7 @@ impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiLineStringType)>
     }
 }
 
-impl GeometryArrayBuilder for MultiLineStringBuilder {
+impl GeoArrowArrayBuilder for MultiLineStringBuilder {
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -10,7 +10,7 @@ use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiPoint>>`: a mutable collection of MultiPoints.
 ///
@@ -271,7 +271,7 @@ impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiPointType)> for Multi
     }
 }
 
-impl GeometryArrayBuilder for MultiPointBuilder {
+impl GeoArrowArrayBuilder for MultiPointBuilder {
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -12,7 +12,7 @@ use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiPolygon>>`: a mutable collection of MultiPolygons.
 ///
@@ -387,7 +387,7 @@ impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, MultiPolygonType)> for Mul
     }
 }
 
-impl GeometryArrayBuilder for MultiPolygonBuilder {
+impl GeoArrowArrayBuilder for MultiPolygonBuilder {
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -9,7 +9,7 @@ use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
 
 /// The GeoArrow equivalent to `Vec<Option<Point>>`: a mutable collection of Points.
 ///
@@ -237,7 +237,7 @@ impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, PointType)> for PointBuild
     }
 }
 
-impl GeometryArrayBuilder for PointBuilder {
+impl GeoArrowArrayBuilder for PointBuilder {
     fn len(&self) -> usize {
         self.coords.len()
     }

--- a/rust/geoarrow-array/src/builder/polygon.rs
+++ b/rust/geoarrow-array/src/builder/polygon.rs
@@ -13,7 +13,7 @@ use crate::builder::{
 };
 use crate::capacity::PolygonCapacity;
 use crate::error::{GeoArrowError, Result};
-use crate::trait_::{GeoArrowArrayAccessor, GeometryArrayBuilder};
+use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
 
 pub type MutablePolygonParts = (
     CoordBufferBuilder,
@@ -349,7 +349,7 @@ impl<O: OffsetSizeTrait> TryFrom<(GenericWkbArray<O>, PolygonType)> for PolygonB
     }
 }
 
-impl GeometryArrayBuilder for PolygonBuilder {
+impl GeoArrowArrayBuilder for PolygonBuilder {
     fn len(&self) -> usize {
         self.geom_offsets.len_proxy()
     }

--- a/rust/geoarrow-array/src/geozero/import/geometry.rs
+++ b/rust/geoarrow-array/src/geozero/import/geometry.rs
@@ -7,7 +7,7 @@ use geozero::{GeomProcessor, GeozeroGeometry};
 
 use crate::array::GeometryArray;
 use crate::builder::GeometryBuilder;
-use crate::trait_::GeometryArrayBuilder;
+use crate::trait_::GeoArrowArrayBuilder;
 
 /// GeoZero trait to convert to GeoArrow [`GeometryArray`].
 ///
@@ -222,7 +222,7 @@ impl GeomProcessor for GeometryStreamBuilder {
     }
 }
 
-impl GeometryArrayBuilder for GeometryStreamBuilder {
+impl GeoArrowArrayBuilder for GeometryStreamBuilder {
     fn len(&self) -> usize {
         self.builder.len()
     }

--- a/rust/geoarrow-array/src/trait_.rs
+++ b/rust/geoarrow-array/src/trait_.rs
@@ -399,13 +399,13 @@ pub trait GeoArrowArrayAccessor<'a>: GeoArrowArray {
 /// thereby making them useful to perform numeric operations without allocations.
 /// As in [`NativeArray`], concrete arrays (such as
 /// [`PointBuilder`][crate::array::PointBuilder]) implement how they are mutated.
-pub trait GeometryArrayBuilder: Debug + Send + Sync {
+pub trait GeoArrowArrayBuilder: Debug + Send + Sync {
     /// Returns the length of the array.
     ///
     /// # Examples
     ///
     /// ```ignore
-    /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
+    /// use geoarrow::{array::PointBuilder, trait_::GeoArrowArrayBuilder};
     /// use geoarrow_schema::Dimension;
     ///
     /// let mut builder = PointBuilder::new(Dimension::XY);
@@ -420,7 +420,7 @@ pub trait GeometryArrayBuilder: Debug + Send + Sync {
     /// # Examples
     ///
     /// ```ignore
-    /// use geoarrow::{array::PointBuilder, trait_::GeometryArrayBuilder};
+    /// use geoarrow::{array::PointBuilder, trait_::GeoArrowArrayBuilder};
     /// use geoarrow_schema::Dimension;
     ///
     /// let mut builder = PointBuilder::new(Dimension::XY);


### PR DESCRIPTION
The term `Geometry` should only be used for the concrete geometry type `Geometry`.

Any generic trait should be prefixed with `GeoArrow`

Closes https://github.com/geoarrow/geoarrow-rs/issues/1119