### PR TITLE
Add `push_geometry` method to `GeoArrowArrayBuilder` trait

### DIFF
--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -372,8 +372,8 @@ impl<'a> GeometryBuilder {
     }
 
     #[inline]
-    fn add_type(
-        child: &mut dyn GeoArrowArrayBuilder,
+    fn add_type<B: GeoArrowArrayBuilder>(
+        child: &mut B,
         offsets: &mut Vec<i32>,
         types: &mut Vec<i8>,
         type_id: i8,
@@ -759,9 +759,9 @@ impl<'a> GeometryBuilder {
     }
 
     /// Flush any deferred nulls to the desired array builder.
-    fn flush_deferred_nulls(
+    fn flush_deferred_nulls<B: GeoArrowArrayBuilder>(
         deferred_nulls: &mut usize,
-        child: &mut dyn GeoArrowArrayBuilder,
+        child: &mut B,
         offsets: &mut Vec<i32>,
         types: &mut Vec<i8>,
         type_id: i8,
@@ -830,6 +830,10 @@ impl GeoArrowArrayBuilder for GeometryBuilder {
 
     fn push_null(&mut self) {
         self.push_null();
+    }
+
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(geometry)
     }
 
     fn finish(self) -> Arc<dyn GeoArrowArray> {

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -365,6 +365,10 @@ impl GeoArrowArrayBuilder for GeometryCollectionBuilder {
         self.push_null();
     }
 
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(geometry)
+    }
+
     fn finish(self) -> Arc<dyn GeoArrowArray> {
         Arc::new(self.finish())
     }

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -280,6 +280,10 @@ impl GeoArrowArrayBuilder for LineStringBuilder {
         self.push_null();
     }
 
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(geometry)
+    }
+
     fn finish(self) -> Arc<dyn GeoArrowArray> {
         Arc::new(self.finish())
     }

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -380,6 +380,10 @@ impl GeoArrowArrayBuilder for MultiLineStringBuilder {
         self.push_null();
     }
 
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(geometry)
+    }
+
     fn finish(self) -> Arc<dyn GeoArrowArray> {
         Arc::new(self.finish())
     }

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -283,6 +283,10 @@ impl GeoArrowArrayBuilder for MultiPointBuilder {
         self.push_null();
     }
 
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(geometry)
+    }
+
     fn finish(self) -> Arc<dyn GeoArrowArray> {
         Arc::new(self.finish())
     }

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -399,6 +399,10 @@ impl GeoArrowArrayBuilder for MultiPolygonBuilder {
         self.push_null();
     }
 
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(geometry)
+    }
+
     fn finish(self) -> Arc<dyn GeoArrowArray> {
         Arc::new(self.finish())
     }

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -249,6 +249,10 @@ impl GeoArrowArrayBuilder for PointBuilder {
         self.push_null();
     }
 
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(geometry)
+    }
+
     fn finish(self) -> Arc<dyn GeoArrowArray> {
         Arc::new(self.finish())
     }

--- a/rust/geoarrow-array/src/builder/polygon.rs
+++ b/rust/geoarrow-array/src/builder/polygon.rs
@@ -361,6 +361,10 @@ impl GeoArrowArrayBuilder for PolygonBuilder {
         self.push_null();
     }
 
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()> {
+        self.push_geometry(geometry)
+    }
+
     fn finish(self) -> Arc<dyn GeoArrowArray> {
         Arc::new(self.finish())
     }

--- a/rust/geoarrow-array/src/geozero/import/geometry.rs
+++ b/rust/geoarrow-array/src/geozero/import/geometry.rs
@@ -233,6 +233,13 @@ impl GeoArrowArrayBuilder for GeometryStreamBuilder {
         self.builder.push_null()
     }
 
+    fn push_geometry(
+        &mut self,
+        geometry: Option<&impl geo_traits::GeometryTrait<T = f64>>,
+    ) -> crate::error::Result<()> {
+        self.builder.push_geometry(geometry)
+    }
+
     fn finish(self) -> Arc<dyn GeoArrowArray> {
         Arc::new(self.builder.finish())
     }

--- a/rust/geoarrow-array/src/trait_.rs
+++ b/rust/geoarrow-array/src/trait_.rs
@@ -399,7 +399,10 @@ pub trait GeoArrowArrayAccessor<'a>: GeoArrowArray {
 /// thereby making them useful to perform numeric operations without allocations.
 /// As in [`NativeArray`], concrete arrays (such as
 /// [`PointBuilder`][crate::array::PointBuilder]) implement how they are mutated.
-pub trait GeoArrowArrayBuilder: Debug + Send + Sync {
+//
+// Note: This trait is not yet publicly exported from this crate, as we're not sure how the API
+// should be, and in particular whether we need this trait to be dyn-compatible or not.
+pub(crate) trait GeoArrowArrayBuilder: Debug + Send + Sync {
     /// Returns the length of the array.
     ///
     /// # Examples
@@ -434,6 +437,10 @@ pub trait GeoArrowArrayBuilder: Debug + Send + Sync {
 
     /// Push a null value to this builder.
     fn push_null(&mut self);
+
+    /// Push a geometry to this builder.
+    #[allow(dead_code)]
+    fn push_geometry(&mut self, geometry: Option<&impl GeometryTrait<T = f64>>) -> Result<()>;
 
     /// Finish the builder and return an [`Arc`] to the resulting array.
     #[allow(dead_code)]


### PR DESCRIPTION
Note that adding `push_geometry` causes this trait to no longer be dyn-compatible, because there's a generic for `GeometryTrait` in `push_geometry`.

This is not yet exported publicly so that we can iterate on the design, and in particular decide whether we need dyn-compatibility or not. Hopefully when we implement more format parsers it'll be more clear.

Closes https://github.com/geoarrow/geoarrow-rs/issues/1118