### PR TITLE
Reduce dead code in geoarrow-array

### DIFF
--- a/rust/geoarrow-array/src/array/coord/combined.rs
+++ b/rust/geoarrow-array/src/array/coord/combined.rs
@@ -86,12 +86,6 @@ impl CoordBuffer {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn with_coords(self, coords: CoordBuffer) -> Self {
-        assert_eq!(coords.len(), self.len());
-        coords
-    }
-
     /// Convert this coordinate array into the given [CoordType]
     ///
     /// This is a no-op if the coord_type matches the existing coord type. Otherwise a full clone

--- a/rust/geoarrow-array/src/array/coord/interleaved.rs
+++ b/rust/geoarrow-array/src/array/coord/interleaved.rs
@@ -54,12 +54,6 @@ impl InterleavedCoordBuffer {
         Ok(Self { coords, dim })
     }
 
-    // Currently used by a test
-    #[allow(dead_code)]
-    pub(crate) fn from_vec(coords: Vec<f64>, dim: Dimension) -> Result<Self> {
-        Self::try_new(coords.into(), dim)
-    }
-
     /// Construct from an iterator of coordinates.
     pub fn from_coords<'a>(
         coords: impl ExactSizeIterator<Item = &'a (impl CoordTrait<T = f64> + 'a)>,

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -103,11 +103,6 @@ impl LineStringArray {
         &self.coords
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn into_inner(self) -> (CoordBuffer, OffsetBuffer<i32>, Option<NullBuffer>) {
-        (self.coords, self.geom_offsets, self.nulls)
-    }
-
     /// Access the underlying geometry offsets buffer
     pub fn geom_offsets(&self) -> &OffsetBuffer<i32> {
         &self.geom_offsets

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -107,11 +107,6 @@ impl MultiPointArray {
         &self.coords
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn into_inner(self) -> (CoordBuffer, OffsetBuffer<i32>, Option<NullBuffer>) {
-        (self.coords, self.geom_offsets, self.nulls)
-    }
-
     /// Access the underlying geometry offsets buffer
     pub fn geom_offsets(&self) -> &OffsetBuffer<i32> {
         &self.geom_offsets

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -160,23 +160,6 @@ impl MultiPolygonArray {
         &self.coords
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn into_inner(
-        self,
-    ) -> (
-        CoordBuffer,
-        OffsetBuffer<i32>,
-        OffsetBuffer<i32>,
-        OffsetBuffer<i32>,
-    ) {
-        (
-            self.coords,
-            self.geom_offsets,
-            self.polygon_offsets,
-            self.ring_offsets,
-        )
-    }
-
     /// Access the underlying geometry offsets buffer
     pub fn geom_offsets(&self) -> &OffsetBuffer<i32> {
         &self.geom_offsets

--- a/rust/geoarrow-array/src/capacity/mod.rs
+++ b/rust/geoarrow-array/src/capacity/mod.rs
@@ -23,6 +23,5 @@ pub(crate) use mixed::MixedCapacity;
 pub use multilinestring::MultiLineStringCapacity;
 pub use multipoint::MultiPointCapacity;
 pub use multipolygon::MultiPolygonCapacity;
-pub use point::PointCapacity;
 pub use polygon::PolygonCapacity;
 pub use wkb::WkbCapacity;

--- a/rust/geoarrow-array/src/capacity/multipoint.rs
+++ b/rust/geoarrow-array/src/capacity/multipoint.rs
@@ -77,12 +77,6 @@ impl MultiPointCapacity {
         Ok(())
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn add_point_capacity(&mut self, point_capacity: usize) {
-        self.coord_capacity += point_capacity;
-        self.geom_capacity += point_capacity;
-    }
-
     /// The coordinate buffer capacity
     pub fn coord_capacity(&self) -> usize {
         self.coord_capacity

--- a/rust/geoarrow-array/src/util.rs
+++ b/rust/geoarrow-array/src/util.rs
@@ -19,32 +19,6 @@ pub(crate) fn offsets_buffer_i64_to_i32(offsets: &OffsetBuffer<i64>) -> Result<O
     Ok(unsafe { OffsetBuffer::new_unchecked(i32_offsets.into()) })
 }
 
-#[allow(dead_code)]
-pub(crate) fn offsets_buffer_to_i64<O: OffsetSizeTrait>(
-    offsets: &OffsetBuffer<O>,
-) -> OffsetBuffer<i64> {
-    let i64_offsets = offsets
-        .iter()
-        .map(|x| x.to_i64().unwrap())
-        .collect::<Vec<_>>();
-    unsafe { OffsetBuffer::new_unchecked(i64_offsets.into()) }
-}
-
-#[allow(dead_code)]
-pub(crate) fn offsets_buffer_to_i32<O: OffsetSizeTrait>(
-    offsets: &OffsetBuffer<O>,
-) -> Result<OffsetBuffer<i32>> {
-    // TODO: raise nicer error. Ref:
-    // https://github.com/jorgecarleitao/arrow2/blob/6a4b53169a48cbd234cecde6ab6a98f84146fca2/src/offset.rs#L492
-    i32::try_from(offsets.last().as_usize()).unwrap();
-
-    let i32_offsets = offsets
-        .iter()
-        .map(|x| x.to_usize().unwrap() as i32)
-        .collect::<Vec<_>>();
-    Ok(unsafe { OffsetBuffer::new_unchecked(i32_offsets.into()) })
-}
-
 /// Offsets utils that I miss from arrow2
 pub(crate) trait OffsetBufferUtils<O: OffsetSizeTrait> {
     /// Returns the length an array with these offsets would be.

--- a/rust/geodatafusion/src/udf/native/measurement/area.rs
+++ b/rust/geodatafusion/src/udf/native/measurement/area.rs
@@ -1,10 +1,11 @@
 use std::any::Any;
 use std::sync::{Arc, OnceLock};
 
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Field};
 use datafusion::logical_expr::scalar_doc_sections::DOC_SECTION_OTHER;
-use datafusion::logical_expr::{ColumnarValue, Documentation, ScalarUDFImpl, Signature};
-use geoarrow::algorithm::geo::Area as _Area;
+use datafusion::logical_expr::{
+    ColumnarValue, Documentation, ReturnFieldArgs, ScalarUDFImpl, Signature,
+};
 
 use crate::data_types::{any_single_geometry_type_input, parse_to_native_array};
 use crate::error::GeoDataFusionResult;
@@ -41,8 +42,15 @@ impl ScalarUDFImpl for Area {
         Ok(DataType::Float64)
     }
 
-    fn invoke(&self, args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
-        Ok(area_impl(args)?)
+    // fn invoke(&self, args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+    //     Ok(area_impl(args)?)
+    // }
+
+    fn invoke_with_args(
+        &self,
+        args: datafusion::logical_expr::ScalarFunctionArgs,
+    ) -> datafusion::error::Result<ColumnarValue> {
+        todo!()
     }
 
     fn documentation(&self) -> Option<&Documentation> {

--- a/rust/geodatafusion/src/udf/native/measurement/area.rs
+++ b/rust/geodatafusion/src/udf/native/measurement/area.rs
@@ -1,11 +1,10 @@
 use std::any::Any;
 use std::sync::{Arc, OnceLock};
 
-use arrow_schema::{DataType, Field};
+use arrow_schema::DataType;
 use datafusion::logical_expr::scalar_doc_sections::DOC_SECTION_OTHER;
-use datafusion::logical_expr::{
-    ColumnarValue, Documentation, ReturnFieldArgs, ScalarUDFImpl, Signature,
-};
+use datafusion::logical_expr::{ColumnarValue, Documentation, ScalarUDFImpl, Signature};
+use geoarrow::algorithm::geo::Area as _Area;
 
 use crate::data_types::{any_single_geometry_type_input, parse_to_native_array};
 use crate::error::GeoDataFusionResult;
@@ -42,15 +41,8 @@ impl ScalarUDFImpl for Area {
         Ok(DataType::Float64)
     }
 
-    // fn invoke(&self, args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
-    //     Ok(area_impl(args)?)
-    // }
-
-    fn invoke_with_args(
-        &self,
-        args: datafusion::logical_expr::ScalarFunctionArgs,
-    ) -> datafusion::error::Result<ColumnarValue> {
-        todo!()
+    fn invoke(&self, args: &[ColumnarValue]) -> datafusion::error::Result<ColumnarValue> {
+        Ok(area_impl(args)?)
     }
 
     fn documentation(&self) -> Option<&Documentation> {


### PR DESCRIPTION
### Change list

- Reduce dead code
- Remove remaining `into_inner` methods on arrays (closes https://github.com/geoarrow/geoarrow-rs/issues/1111)
- Remove `PointCapacity` from public API.