### PR TITLE
Cargo fmt group imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           components: rustfmt
       - name: Fmt
-        run: cargo +nightly fmt -- --check --unstable-features --config imports_granularity=Module,group_imports=StdExternalCrate
+        run: cargo +nightly-2025-05-14 fmt -- --check --unstable-features --config imports_granularity=Module,group_imports=StdExternalCrate
 
   docs-no-warnings:
     name: Lint and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,9 @@ jobs:
         with:
           submodules: "recursive"
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain
         with:
+          toolchain: nightly-2025-05-14
           components: rustfmt
       - name: Fmt
         run: cargo +nightly-2025-05-14 fmt -- --check --unstable-features --config imports_granularity=Module,group_imports=StdExternalCrate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,26 @@ jobs:
         run: |
           echo "PKG_CONFIG_PATH=$(pwd)/build/.pixi/envs/default/lib/pkgconfig" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$(pwd)/build/.pixi/envs/default/lib" >> "$GITHUB_ENV"
-      - name: Fmt
-        run: cargo fmt -- --check
       - name: Clippy
         run: cargo clippy --all-features --tests -- -D warnings
       - name: Check
         run: cargo check --all-features
       - name: Test
         run: cargo test --all-features
+
+  fmt:
+    name: Fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - name: Fmt
+        run: cargo +nightly fmt -- --check --unstable-features --config imports_granularity=Module,group_imports=StdExternalCrate
 
   docs-no-warnings:
     name: Lint and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: Install Rust
-        uses: dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-05-14
           components: rustfmt

--- a/rust/geoarrow-array/src/array/coord/separated.rs
+++ b/rust/geoarrow-array/src/array/coord/separated.rs
@@ -5,12 +5,12 @@ use arrow_array::types::Float64Type;
 use arrow_array::{ArrayRef, Float64Array, StructArray};
 use arrow_buffer::ScalarBuffer;
 use arrow_schema::{DataType, Field};
+use geo_traits::CoordTrait;
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, Dimension, PointType};
 
 use crate::builder::SeparatedCoordBufferBuilder;
 use crate::scalar::SeparatedCoord;
-use geo_traits::CoordTrait;
 
 /// An array of coordinates stored in separate buffers of the same length.
 ///

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -278,9 +278,8 @@ mod test {
     use geoarrow_schema::{CoordType, Dimension};
     use geoarrow_test::raw;
 
-    use crate::test::geometrycollection;
-
     use super::*;
+    use crate::test::geometrycollection;
 
     #[test]
     fn try_from_arrow() {

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -1,5 +1,12 @@
 use std::sync::Arc;
 
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
+use arrow_buffer::{NullBuffer, OffsetBuffer};
+use arrow_schema::{DataType, Field};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
+use geoarrow_schema::{CoordType, LineStringType, Metadata};
+
 use crate::array::{CoordBuffer, GenericWkbArray};
 use crate::builder::LineStringBuilder;
 use crate::capacity::LineStringCapacity;
@@ -8,13 +15,6 @@ use crate::eq::offset_buffer_eq;
 use crate::scalar::LineString;
 use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{OffsetBufferUtils, offsets_buffer_i64_to_i32};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
-
-use arrow_array::cast::AsArray;
-use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
-use arrow_buffer::{NullBuffer, OffsetBuffer};
-use arrow_schema::{DataType, Field};
-use geoarrow_schema::{CoordType, LineStringType, Metadata};
 
 /// An immutable array of LineString geometries.
 ///
@@ -316,9 +316,8 @@ mod test {
     use geo_traits::to_geo::ToGeoLineString;
     use geoarrow_schema::{CoordType, Dimension};
 
-    use crate::test::linestring;
-
     use super::*;
+    use crate::test::linestring;
 
     #[test]
     fn geo_round_trip() {

--- a/rust/geoarrow-array/src/array/mod.rs
+++ b/rust/geoarrow-array/src/array/mod.rs
@@ -18,7 +18,12 @@ mod wkb_view;
 mod wkt;
 mod wkt_view;
 
+use std::sync::Arc;
+
+use arrow_array::Array;
+use arrow_schema::Field;
 pub use coord::{CoordBuffer, InterleavedCoordBuffer, SeparatedCoordBuffer};
+use geoarrow_schema::error::GeoArrowResult;
 pub(crate) use geometry::DimensionIndex;
 pub use geometry::GeometryArray;
 pub use geometrycollection::GeometryCollectionArray;
@@ -34,12 +39,6 @@ pub use wkb::{GenericWkbArray, LargeWkbArray, WkbArray};
 pub use wkb_view::WkbViewArray;
 pub use wkt::{GenericWktArray, LargeWktArray, WktArray};
 pub use wkt_view::WktViewArray;
-
-use std::sync::Arc;
-
-use arrow_array::Array;
-use arrow_schema::Field;
-use geoarrow_schema::error::GeoArrowResult;
 
 use crate::{GeoArrowArray, GeoArrowType};
 

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -399,9 +399,8 @@ mod test {
     use geo_traits::to_geo::ToGeoMultiLineString;
     use geoarrow_schema::{CoordType, Dimension};
 
-    use crate::test::multilinestring;
-
     use super::*;
+    use crate::test::multilinestring;
 
     #[test]
     fn geo_round_trip() {

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -336,9 +336,8 @@ mod test {
     use geo_traits::to_geo::ToGeoMultiPoint;
     use geoarrow_schema::{CoordType, Dimension};
 
-    use crate::test::multipoint;
-
     use super::*;
+    use crate::test::multipoint;
 
     #[test]
     fn geo_round_trip() {

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -454,9 +454,8 @@ mod test {
     use geo_traits::to_geo::ToGeoMultiPolygon;
     use geoarrow_schema::{CoordType, Dimension};
 
-    use crate::test::multipolygon;
-
     use super::*;
+    use crate::test::multipolygon;
 
     #[test]
     fn geo_round_trip() {

--- a/rust/geoarrow-array/src/array/point.rs
+++ b/rust/geoarrow-array/src/array/point.rs
@@ -298,10 +298,9 @@ mod test {
     use geo_traits::to_geo::ToGeoPoint;
     use geoarrow_schema::{CoordType, Dimension};
 
+    use super::*;
     use crate::builder::PointBuilder;
     use crate::test::point;
-
-    use super::*;
 
     #[test]
     fn geo_round_trip() {

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
-use arrow_array::{Array, OffsetSizeTrait};
-use arrow_array::{ArrayRef, GenericListArray};
+use arrow_array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait};
 use arrow_buffer::{NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
@@ -407,9 +406,8 @@ mod test {
     use geo_traits::to_geo::ToGeoPolygon;
     use geoarrow_schema::{CoordType, Dimension};
 
-    use crate::test::polygon;
-
     use super::*;
+    use crate::test::polygon;
 
     #[test]
     fn geo_round_trip() {

--- a/rust/geoarrow-array/src/array/rect.rs
+++ b/rust/geoarrow-array/src/array/rect.rs
@@ -254,10 +254,9 @@ mod test {
     use geo_traits::to_geo::ToGeoRect;
     use geoarrow_schema::Dimension;
 
+    use super::*;
     use crate::builder::RectBuilder;
     use crate::test::rect;
-
-    use super::*;
 
     #[test]
     fn geo_round_trip() {

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -7,6 +7,7 @@ use arrow_array::{
 };
 use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{Metadata, WkbType};
 use wkb::reader::Wkb;
 
@@ -15,7 +16,6 @@ use crate::capacity::WkbCapacity;
 use crate::datatypes::GeoArrowType;
 use crate::trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
 use crate::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// An immutable array of WKB geometries.
 ///
@@ -291,11 +291,10 @@ pub type LargeWkbArray = GenericWkbArray<i64>;
 mod test {
     use arrow_array::builder::{BinaryBuilder, LargeBinaryBuilder};
 
+    use super::*;
     use crate::GeoArrowArray;
     use crate::builder::WkbBuilder;
     use crate::test::point;
-
-    use super::*;
 
     fn wkb_data<O: OffsetSizeTrait>() -> GenericWkbArray<O> {
         let mut builder = WkbBuilder::new(WkbType::new(Default::default()));

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -8,6 +8,7 @@ use arrow_array::{
 };
 use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{Metadata, WktType};
 use wkt::Wkt;
 
@@ -16,7 +17,6 @@ use crate::array::WktViewArray;
 use crate::datatypes::GeoArrowType;
 use crate::trait_::{GeoArrowArray, IntoArrow};
 use crate::util::{offsets_buffer_i32_to_i64, offsets_buffer_i64_to_i32};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// An immutable array of WKT geometries using GeoArrow's in-memory representation.
 ///
@@ -279,11 +279,10 @@ mod test {
     use arrow_array::builder::{LargeStringBuilder, StringBuilder};
     use geoarrow_schema::{CoordType, Dimension};
 
+    use super::*;
     use crate::GeoArrowArray;
     use crate::cast::to_wkt;
     use crate::test::point;
-
-    use super::*;
 
     fn wkt_data<O: OffsetSizeTrait>() -> GenericWktArray<O> {
         to_wkt(&point::array(CoordType::Interleaved, Dimension::XY)).unwrap()

--- a/rust/geoarrow-array/src/array/wkt_view.rs
+++ b/rust/geoarrow-array/src/array/wkt_view.rs
@@ -6,12 +6,12 @@ use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, OffsetSizeTrait, StringViewArray};
 use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{Metadata, WktType};
 use wkt::Wkt;
 
 use crate::array::GenericWktArray;
 use crate::{GeoArrowArray, GeoArrowArrayAccessor, GeoArrowType, IntoArrow};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// An immutable array of WKT geometries.
 ///

--- a/rust/geoarrow-array/src/builder/coord/combined.rs
+++ b/rust/geoarrow-array/src/builder/coord/combined.rs
@@ -1,11 +1,11 @@
 use core::f64;
 
 use geo_traits::{CoordTrait, PointTrait};
+use geoarrow_schema::error::GeoArrowResult;
 use geoarrow_schema::{CoordType, Dimension};
 
 use crate::array::CoordBuffer;
 use crate::builder::{InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder};
-use geoarrow_schema::error::GeoArrowResult;
 
 /// The GeoArrow equivalent to `Vec<Coord>`: a mutable collection of coordinates.
 ///

--- a/rust/geoarrow-array/src/builder/coord/interleaved.rs
+++ b/rust/geoarrow-array/src/builder/coord/interleaved.rs
@@ -2,9 +2,9 @@ use core::f64;
 
 use geo_traits::{CoordTrait, PointTrait};
 use geoarrow_schema::Dimension;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::array::InterleavedCoordBuffer;
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Coord>`: a mutable collection of coordinates.
 ///

--- a/rust/geoarrow-array/src/builder/coord/separated.rs
+++ b/rust/geoarrow-array/src/builder/coord/separated.rs
@@ -1,8 +1,8 @@
 use geo_traits::{CoordTrait, PointTrait};
 use geoarrow_schema::Dimension;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::array::SeparatedCoordBuffer;
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<Coord>>`: a mutable collection of coordinates.
 ///

--- a/rust/geoarrow-array/src/builder/geo_trait_wrappers.rs
+++ b/rust/geoarrow-array/src/builder/geo_trait_wrappers.rs
@@ -10,9 +10,8 @@ use geo_traits::{
     UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
     UnimplementedPoint, UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
 };
-use wkt::WktNum;
-
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
+use wkt::WktNum;
 
 pub(crate) struct RectWrapper<'a, T: WktNum, R: RectTrait<T = T>>(&'a R);
 

--- a/rust/geoarrow-array/src/builder/geometry.rs
+++ b/rust/geoarrow-array/src/builder/geometry.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use arrow_array::OffsetSizeTrait;
 use geo_traits::*;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{
     Dimension, GeometryCollectionType, GeometryType, LineStringType, Metadata, MultiLineStringType,
     MultiPointType, MultiPolygonType, PointType, PolygonType,
@@ -16,7 +17,6 @@ use crate::builder::{
 };
 use crate::capacity::GeometryCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 pub(crate) const DEFAULT_PREFER_MULTI: bool = false;
 
@@ -848,9 +848,8 @@ mod test {
     use geoarrow_schema::CoordType;
     use wkt::wkt;
 
-    use crate::GeoArrowArray;
-
     use super::*;
+    use crate::GeoArrowArray;
 
     #[test]
     fn all_items_null() {

--- a/rust/geoarrow-array/src/builder/geometrycollection.rs
+++ b/rust/geoarrow-array/src/builder/geometrycollection.rs
@@ -7,6 +7,7 @@ use geo_traits::{
     MultiPolygonTrait, PointTrait, PolygonTrait,
 };
 use geoarrow_schema::GeometryCollectionType;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, GeometryCollectionArray};
@@ -14,7 +15,6 @@ use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapp
 use crate::builder::{MixedGeometryBuilder, OffsetsBuilder};
 use crate::capacity::GeometryCollectionCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<GeometryCollection>>`: a mutable collection of
 /// GeometryCollections.

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, LineStringType};
 
 use crate::GeoArrowArray;
@@ -13,7 +14,6 @@ use crate::builder::{
 };
 use crate::capacity::LineStringCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<LineString>>`: a mutable collection of LineStrings.
 ///

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -1,4 +1,5 @@
 use geo_traits::*;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{
     CoordType, Dimension, LineStringType, MultiLineStringType, MultiPointType, MultiPolygonType,
     PointType, PolygonType,
@@ -12,7 +13,6 @@ use crate::builder::{
 };
 use crate::capacity::MixedCapacity;
 use crate::trait_::GeoArrowArrayBuilder;
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 pub(crate) const DEFAULT_PREFER_MULTI: bool = false;
 

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiLineStringType};
-// use super::array::check;
 
+// use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiLineStringArray};
 use crate::builder::{
@@ -13,7 +14,6 @@ use crate::builder::{
 };
 use crate::capacity::MultiLineStringCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiLineString>>`: a mutable collection of
 /// MultiLineStrings.

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -3,17 +3,17 @@ use std::sync::Arc;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiPointType};
 
-use crate::capacity::MultiPointCapacity;
 // use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiPointArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
+use crate::capacity::MultiPointCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiPoint>>`: a mutable collection of MultiPoints.
 ///

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -5,17 +5,17 @@ use arrow_buffer::NullBufferBuilder;
 use geo_traits::{
     CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait,
 };
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiPolygonType};
 
-use crate::capacity::MultiPolygonCapacity;
 // use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiPolygonArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, OffsetsBuilder, SeparatedCoordBufferBuilder,
 };
+use crate::capacity::MultiPolygonCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<MultiPolygon>>`: a mutable collection of MultiPolygons.
 ///

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, PointType};
 
 // use super::array::check;
@@ -12,7 +13,6 @@ use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<Point>>`: a mutable collection of Points.
 ///

--- a/rust/geoarrow-array/src/builder/polygon.rs
+++ b/rust/geoarrow-array/src/builder/polygon.rs
@@ -6,6 +6,7 @@ use geo_traits::{
     CoordTrait, GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait,
     RectTrait,
 };
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, PolygonType};
 
 use crate::GeoArrowArray;
@@ -16,7 +17,6 @@ use crate::builder::{
 };
 use crate::capacity::PolygonCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<Polygon>>`: a mutable collection of Polygons.
 ///

--- a/rust/geoarrow-array/src/builder/rect.rs
+++ b/rust/geoarrow-array/src/builder/rect.rs
@@ -1,11 +1,11 @@
 use arrow_buffer::NullBufferBuilder;
 use geo_traits::{CoordTrait, RectTrait};
 use geoarrow_schema::BoxType;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::array::RectArray;
 use crate::builder::SeparatedCoordBufferBuilder;
 use crate::scalar::Rect;
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// The GeoArrow equivalent to `Vec<Option<Rect>>`: a mutable collection of Rects.
 ///

--- a/rust/geoarrow-array/src/capacity/geometry.rs
+++ b/rust/geoarrow-array/src/capacity/geometry.rs
@@ -2,6 +2,7 @@ use std::ops::AddAssign;
 
 use geo_traits::*;
 use geoarrow_schema::Dimension;
+use geoarrow_schema::error::GeoArrowResult;
 use wkt::WktNum;
 
 use crate::array::DimensionIndex;
@@ -10,7 +11,6 @@ use crate::capacity::{
     GeometryCollectionCapacity, LineStringCapacity, MultiLineStringCapacity, MultiPointCapacity,
     MultiPolygonCapacity, PolygonCapacity,
 };
-use geoarrow_schema::error::GeoArrowResult;
 
 /// A counter for the buffer sizes of a [`GeometryArray`][crate::array::GeometryArray].
 ///

--- a/rust/geoarrow-array/src/capacity/geometrycollection.rs
+++ b/rust/geoarrow-array/src/capacity/geometrycollection.rs
@@ -1,13 +1,14 @@
 use std::ops::Add;
 
-use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapper};
-use crate::capacity::MixedCapacity;
 use geo_traits::{
     GeometryCollectionTrait, GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait,
     MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
 };
 use geoarrow_schema::error::GeoArrowResult;
 use wkt::WktNum;
+
+use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapper};
+use crate::capacity::MixedCapacity;
 
 /// A counter for the buffer sizes of a
 /// [`GeometryCollectionArray`][crate::array::GeometryCollectionArray].

--- a/rust/geoarrow-array/src/capacity/mixed.rs
+++ b/rust/geoarrow-array/src/capacity/mixed.rs
@@ -1,6 +1,7 @@
 use std::ops::Add;
 
 use geo_traits::*;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use wkt::WktNum;
 
 use crate::builder::geo_trait_wrappers::{LineWrapper, RectWrapper, TriangleWrapper};
@@ -8,7 +9,6 @@ use crate::capacity::{
     LineStringCapacity, MultiLineStringCapacity, MultiPointCapacity, MultiPolygonCapacity,
     PolygonCapacity,
 };
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// A counter for the buffer sizes of a [`MixedGeometryArray`][crate::array::MixedGeometryArray].
 ///

--- a/rust/geoarrow-array/src/capacity/multilinestring.rs
+++ b/rust/geoarrow-array/src/capacity/multilinestring.rs
@@ -1,8 +1,9 @@
 use std::ops::{Add, AddAssign};
 
-use crate::capacity::LineStringCapacity;
 use geo_traits::{GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTrait};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
+
+use crate::capacity::LineStringCapacity;
 
 /// A counter for the buffer sizes of a
 /// [`MultiLineStringArray`][crate::array::MultiLineStringArray].

--- a/rust/geoarrow-array/src/capacity/multipolygon.rs
+++ b/rust/geoarrow-array/src/capacity/multipolygon.rs
@@ -1,8 +1,9 @@
 use std::ops::{Add, AddAssign};
 
-use crate::capacity::PolygonCapacity;
 use geo_traits::{GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait, PolygonTrait};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
+
+use crate::capacity::PolygonCapacity;
 
 /// A counter for the buffer sizes of a [`MultiPolygonArray`][crate::array::MultiPolygonArray].
 ///

--- a/rust/geoarrow-array/src/capacity/point.rs
+++ b/rust/geoarrow-array/src/capacity/point.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
+use std::ops::Add;
+
 use geo_traits::{GeometryTrait, GeometryType, PointTrait};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
-use std::ops::Add;
 
 /// A counter for the buffer sizes of a [`PointArray`][crate::array::PointArray].
 ///

--- a/rust/geoarrow-array/src/capacity/polygon.rs
+++ b/rust/geoarrow-array/src/capacity/polygon.rs
@@ -1,7 +1,6 @@
 use std::ops::Add;
 
 use geo_traits::{GeometryTrait, GeometryType, LineStringTrait, PolygonTrait, RectTrait};
-
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// A counter for the buffer sizes of a [`PolygonArray`][crate::array::PolygonArray].

--- a/rust/geoarrow-array/src/capacity/wkb.rs
+++ b/rust/geoarrow-array/src/capacity/wkb.rs
@@ -1,7 +1,6 @@
 use std::ops::Add;
 
 use arrow_array::OffsetSizeTrait;
-
 use geo_traits::GeometryTrait;
 use wkb::writer::geometry_wkb_size;
 

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -5,13 +5,12 @@ use std::sync::Arc;
 
 use arrow_schema::extension::ExtensionType;
 use arrow_schema::{DataType, Field};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{
     BoxType, CoordType, Dimension, GeometryCollectionType, GeometryType, LineStringType, Metadata,
     MultiLineStringType, MultiPointType, MultiPolygonType, PointType, PolygonType, WkbType,
     WktType,
 };
-
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// A type enum representing all possible GeoArrow geometry types, including both "native" and
 /// "serialized" encodings.

--- a/rust/geoarrow-array/src/geozero/export/data_source/mod.rs
+++ b/rust/geoarrow-array/src/geozero/export/data_source/mod.rs
@@ -1,7 +1,5 @@
 mod record_batch_reader;
 
-pub use record_batch_reader::GeozeroRecordBatchReader;
-
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -13,6 +11,7 @@ use arrow_json::writer::make_encoder;
 use arrow_schema::{DataType, Schema, TimeUnit};
 use geozero::error::GeozeroError;
 use geozero::{ColumnValue, FeatureProcessor, GeomProcessor, GeozeroDatasource, PropertyProcessor};
+pub use record_batch_reader::GeozeroRecordBatchReader;
 
 use crate::GeoArrowArray;
 use crate::array::from_arrow_array;

--- a/rust/geoarrow-array/src/geozero/import/point.rs
+++ b/rust/geoarrow-array/src/geozero/import/point.rs
@@ -156,10 +156,9 @@ mod test {
     use geo_types::{Geometry, GeometryCollection};
     use geoarrow_schema::{CoordType, Dimension};
 
+    use super::*;
     use crate::GeoArrowArrayAccessor;
     use crate::test::{linestring, point};
-
-    use super::*;
 
     #[test]
     fn from_geozero() {

--- a/rust/geoarrow-array/src/scalar/coord/interleaved.rs
+++ b/rust/geoarrow-array/src/scalar/coord/interleaved.rs
@@ -78,8 +78,9 @@ impl CoordTrait for &InterleavedCoord<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::array::{InterleavedCoordBuffer, SeparatedCoordBuffer};
     use geoarrow_schema::Dimension;
+
+    use crate::array::{InterleavedCoordBuffer, SeparatedCoordBuffer};
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/rust/geoarrow-array/src/scalar/coord/separated.rs
+++ b/rust/geoarrow-array/src/scalar/coord/separated.rs
@@ -76,8 +76,9 @@ impl CoordTrait for &SeparatedCoord<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::array::{InterleavedCoordBuffer, SeparatedCoordBuffer};
     use geoarrow_schema::Dimension;
+
+    use crate::array::{InterleavedCoordBuffer, SeparatedCoordBuffer};
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/rust/geoarrow-array/src/scalar/multilinestring.rs
+++ b/rust/geoarrow-array/src/scalar/multilinestring.rs
@@ -87,10 +87,11 @@ impl<G: MultiLineStringTrait<T = f64>> PartialEq<G> for MultiLineString<'_> {
 
 #[cfg(test)]
 mod test {
+    use geoarrow_schema::{CoordType, Dimension, MultiLineStringType};
+
     use crate::builder::MultiLineStringBuilder;
     use crate::test::multilinestring::{ml0, ml1};
     use crate::trait_::GeoArrowArrayAccessor;
-    use geoarrow_schema::{CoordType, Dimension, MultiLineStringType};
 
     /// Test Eq where the current index is true but another index is false
     #[test]

--- a/rust/geoarrow-array/src/test/point.rs
+++ b/rust/geoarrow-array/src/test/point.rs
@@ -1,5 +1,4 @@
 use geo_types::{Point, point};
-
 use geoarrow_schema::{CoordType, Dimension, PointType};
 use geoarrow_test::raw;
 

--- a/rust/geoarrow-array/src/test/rect.rs
+++ b/rust/geoarrow-array/src/test/rect.rs
@@ -1,8 +1,8 @@
 use geo_types::{Rect, coord};
+use geoarrow_schema::{BoxType, Dimension};
 
 use crate::array::RectArray;
 use crate::builder::RectBuilder;
-use geoarrow_schema::{BoxType, Dimension};
 
 pub(crate) fn r0() -> Rect {
     Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. })

--- a/rust/geoarrow-flatgeobuf/src/writer.rs
+++ b/rust/geoarrow-flatgeobuf/src/writer.rs
@@ -230,10 +230,11 @@ mod test {
         ];
         let schema = Arc::new(Schema::new(fields));
 
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![u8_array, string_array, point_array.into_array_ref()],
-        )
+        let batch = RecordBatch::try_new(schema.clone(), vec![
+            u8_array,
+            string_array,
+            point_array.into_array_ref(),
+        ])
         .unwrap();
 
         (vec![batch], schema)

--- a/rust/geoarrow-flatgeobuf/src/writer.rs
+++ b/rust/geoarrow-flatgeobuf/src/writer.rs
@@ -230,11 +230,10 @@ mod test {
         ];
         let schema = Arc::new(Schema::new(fields));
 
-        let batch = RecordBatch::try_new(schema.clone(), vec![
-            u8_array,
-            string_array,
-            point_array.into_array_ref(),
-        ])
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![u8_array, string_array, point_array.into_array_ref()],
+        )
         .unwrap();
 
         (vec![batch], schema)

--- a/rust/geoarrow-geos/src/import/array/geometry.rs
+++ b/rust/geoarrow-geos/src/import/array/geometry.rs
@@ -34,12 +34,12 @@ impl FromGEOS for GeometryArray {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::export::to_geos_geometry;
-
     use geoarrow_array::test::geometry::array;
     use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::CoordType;
+
+    use super::*;
+    use crate::export::to_geos_geometry;
 
     #[ignore = "GEOS doesn't support XYM, XYZM; need to add option to only construct specific dimensions in geometry test array"]
     #[test]

--- a/rust/geoarrow-geos/src/import/array/geometrycollection.rs
+++ b/rust/geoarrow-geos/src/import/array/geometrycollection.rs
@@ -34,12 +34,12 @@ impl FromGEOS for GeometryCollectionArray {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::export::to_geos_geometry;
-
     use geoarrow_array::test::geometrycollection::array;
     use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
+
+    use super::*;
+    use crate::export::to_geos_geometry;
 
     #[ignore = "geometry collection import from GEOS not yet implemented"]
     #[test]

--- a/rust/geoarrow-geos/src/import/array/linestring.rs
+++ b/rust/geoarrow-geos/src/import/array/linestring.rs
@@ -34,12 +34,12 @@ impl FromGEOS for LineStringArray {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::export::to_geos_geometry;
-
     use geoarrow_array::test::linestring::array;
     use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
+
+    use super::*;
+    use crate::export::to_geos_geometry;
 
     #[test]
     fn geos_round_trip() {

--- a/rust/geoarrow-geos/src/import/array/multilinestring.rs
+++ b/rust/geoarrow-geos/src/import/array/multilinestring.rs
@@ -34,12 +34,12 @@ impl FromGEOS for MultiLineStringArray {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::export::to_geos_geometry;
-
     use geoarrow_array::test::multilinestring::array;
     use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
+
+    use super::*;
+    use crate::export::to_geos_geometry;
 
     #[test]
     fn geos_round_trip() {

--- a/rust/geoarrow-geos/src/import/array/multipoint.rs
+++ b/rust/geoarrow-geos/src/import/array/multipoint.rs
@@ -34,12 +34,12 @@ impl FromGEOS for MultiPointArray {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::export::to_geos_geometry;
-
     use geoarrow_array::test::multipoint::array;
     use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
+
+    use super::*;
+    use crate::export::to_geos_geometry;
 
     #[test]
     fn geos_round_trip() {

--- a/rust/geoarrow-geos/src/import/array/multipolygon.rs
+++ b/rust/geoarrow-geos/src/import/array/multipolygon.rs
@@ -33,12 +33,12 @@ impl FromGEOS for MultiPolygonArray {
 }
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::export::to_geos_geometry;
-
     use geoarrow_array::test::multipolygon::array;
     use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
+
+    use super::*;
+    use crate::export::to_geos_geometry;
 
     #[test]
     fn geos_round_trip() {

--- a/rust/geoarrow-geos/src/import/array/point.rs
+++ b/rust/geoarrow-geos/src/import/array/point.rs
@@ -37,12 +37,12 @@ impl FromGEOS for PointArray {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::export::to_geos_geometry;
-
     use geoarrow_array::test::point::array;
     use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
+
+    use super::*;
+    use crate::export::to_geos_geometry;
 
     #[test]
     fn geos_round_trip() {

--- a/rust/geoarrow-geos/src/import/array/polygon.rs
+++ b/rust/geoarrow-geos/src/import/array/polygon.rs
@@ -34,12 +34,12 @@ impl FromGEOS for PolygonArray {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::export::to_geos_geometry;
-
     use geoarrow_array::test::polygon::array;
     use geoarrow_array::{GeoArrowArrayAccessor, IntoArrow};
     use geoarrow_schema::{CoordType, Dimension};
+
+    use super::*;
+    use crate::export::to_geos_geometry;
 
     #[test]
     fn geos_round_trip() {

--- a/rust/geoarrow-schema/src/crs.rs
+++ b/rust/geoarrow-schema/src/crs.rs
@@ -1,9 +1,10 @@
 //! Defines GeoArrow CRS metadata and CRS transforms used for writing GeoArrow data to file formats
 //! that require different CRS representations.
 
+use std::fmt::Debug;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::fmt::Debug;
 
 use crate::error::{GeoArrowError, GeoArrowResult};
 

--- a/rust/geoarrow-schema/src/error.rs
+++ b/rust/geoarrow-schema/src/error.rs
@@ -1,9 +1,10 @@
 //! Defines [`GeoArrowError`], representing all errors returned by this crate.
 
-use arrow_schema::ArrowError;
 use std::borrow::Cow;
 use std::error::Error;
 use std::fmt::Debug;
+
+use arrow_schema::ArrowError;
 use thiserror::Error;
 
 /// Enum with all errors in this crate.

--- a/rust/geoarrow-schema/src/metadata.rs
+++ b/rust/geoarrow-schema/src/metadata.rs
@@ -69,7 +69,8 @@ impl TryFrom<&Field> for Metadata {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, str::FromStr};
+    use std::collections::HashMap;
+    use std::str::FromStr;
 
     use arrow_schema::DataType;
     use serde_json::{Value, json};

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1509,12 +1509,11 @@ fn coord_type_to_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
 mod test {
     use std::sync::Arc;
 
-    use crate::crs::Crs;
-    use crate::edges::Edges;
+    use arrow_schema::{DataType, Field};
 
     use super::*;
-    use arrow_schema::DataType;
-    use arrow_schema::Field;
+    use crate::crs::Crs;
+    use crate::edges::Edges;
 
     #[test]
     fn test_point_interleaved_xy() {

--- a/rust/geodatafusion/src/error.rs
+++ b/rust/geodatafusion/src/error.rs
@@ -1,9 +1,10 @@
 //! Defines [`GeoArrowError`], representing all errors returned by this crate.
 
+use std::fmt::Debug;
+
 use arrow_schema::ArrowError;
 use datafusion::error::DataFusionError;
 use geoarrow_schema::error::GeoArrowError;
-use std::fmt::Debug;
 use thiserror::Error;
 
 /// Enum with all errors in this crate.

--- a/rust/geoparquet/src/reader/async.rs
+++ b/rust/geoparquet/src/reader/async.rs
@@ -166,9 +166,9 @@ impl<T: AsyncFileReader + Unpin + Send + 'static> GeoParquetRecordBatchStream<T>
 
 #[cfg(all(test, feature = "compression"))]
 mod test {
-    use super::*;
     use tokio::fs::File;
 
+    use super::*;
     use crate::metadata::GeoParquetBboxCovering;
     use crate::test::fixture_dir;
 

--- a/rust/geoparquet/src/reader/builder.rs
+++ b/rust/geoparquet/src/reader/builder.rs
@@ -168,11 +168,11 @@ impl RecordBatchReader for GeoParquetRecordBatchReader {
 
 #[cfg(all(test, feature = "compression"))]
 mod test {
+    use std::fs::File;
+
     use arrow_array::cast::AsArray;
 
     use super::*;
-    use std::fs::File;
-
     use crate::metadata::GeoParquetBboxCovering;
     use crate::test::fixture_dir;
 

--- a/rust/geoparquet/src/reader/metadata.rs
+++ b/rust/geoparquet/src/reader/metadata.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use arrow_schema::SchemaRef;
 use geoarrow_array::array::RectArray;
 use geoarrow_array::builder::RectBuilder;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{BoxType, CoordType, Dimension};
 use parquet::arrow::arrow_reader::ArrowReaderMetadata;
 #[cfg(feature = "async")]
@@ -19,7 +20,6 @@ use crate::metadata::{GeoParquetBboxCovering, GeoParquetMetadata};
 use crate::reader::parse::infer_target_schema;
 use crate::reader::spatial_filter::ParquetBboxStatistics;
 use crate::{GeoParquetReaderOptions, GeoParquetRecordBatchReaderBuilder};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// An extension trait
 trait ArrowReaderMetadataExt {

--- a/rust/geoparquet/src/reader/parse.rs
+++ b/rust/geoparquet/src/reader/parse.rs
@@ -11,6 +11,7 @@ use geoarrow_array::array::{
 };
 use geoarrow_array::cast::from_wkb;
 use geoarrow_array::{GeoArrowArray, GeoArrowType};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{
     CoordType, GeometryType, LineStringType, Metadata, MultiLineStringType, MultiPointType,
     MultiPolygonType, PointType, PolygonType, WkbType,
@@ -20,7 +21,6 @@ use crate::metadata::{
     GeoParquetColumnEncoding, GeoParquetColumnMetadata, GeoParquetGeometryTypeAndDimension,
     GeoParquetMetadata, infer_geo_data_type,
 };
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 pub fn infer_target_schema(
     existing_schema: &Schema,

--- a/rust/geoparquet/src/reader/spatial_filter.rs
+++ b/rust/geoparquet/src/reader/spatial_filter.rs
@@ -209,12 +209,15 @@ fn construct_native_predicate(
     bbox_cols: ParquetBboxStatistics,
     bbox_query: Rect,
 ) -> GeoArrowResult<Box<dyn ArrowPredicate>> {
-    let mask = ProjectionMask::leaves(parquet_schema, [
-        bbox_cols.minx_col,
-        bbox_cols.miny_col,
-        bbox_cols.maxx_col,
-        bbox_cols.maxy_col,
-    ]);
+    let mask = ProjectionMask::leaves(
+        parquet_schema,
+        [
+            bbox_cols.minx_col,
+            bbox_cols.miny_col,
+            bbox_cols.maxx_col,
+            bbox_cols.maxy_col,
+        ],
+    );
 
     let predicate = ArrowPredicateFn::new(mask, move |batch| {
         let array = batch.column(0);
@@ -258,12 +261,15 @@ fn construct_bbox_columns_predicate(
     bbox_cols: ParquetBboxStatistics,
     bbox_query: Rect,
 ) -> GeoArrowResult<Box<dyn ArrowPredicate>> {
-    let mask = ProjectionMask::leaves(parquet_schema, [
-        bbox_cols.minx_col,
-        bbox_cols.miny_col,
-        bbox_cols.maxx_col,
-        bbox_cols.maxy_col,
-    ]);
+    let mask = ProjectionMask::leaves(
+        parquet_schema,
+        [
+            bbox_cols.minx_col,
+            bbox_cols.miny_col,
+            bbox_cols.maxx_col,
+            bbox_cols.maxy_col,
+        ],
+    );
 
     // The GeoParquet spec allows the bounding box columns to be either Double or Float data type.
     // We need to know which type it is so that we can downcast the produced Arrow arrays to the

--- a/rust/geoparquet/src/reader/spatial_filter.rs
+++ b/rust/geoparquet/src/reader/spatial_filter.rs
@@ -209,15 +209,12 @@ fn construct_native_predicate(
     bbox_cols: ParquetBboxStatistics,
     bbox_query: Rect,
 ) -> GeoArrowResult<Box<dyn ArrowPredicate>> {
-    let mask = ProjectionMask::leaves(
-        parquet_schema,
-        [
-            bbox_cols.minx_col,
-            bbox_cols.miny_col,
-            bbox_cols.maxx_col,
-            bbox_cols.maxy_col,
-        ],
-    );
+    let mask = ProjectionMask::leaves(parquet_schema, [
+        bbox_cols.minx_col,
+        bbox_cols.miny_col,
+        bbox_cols.maxx_col,
+        bbox_cols.maxy_col,
+    ]);
 
     let predicate = ArrowPredicateFn::new(mask, move |batch| {
         let array = batch.column(0);
@@ -261,15 +258,12 @@ fn construct_bbox_columns_predicate(
     bbox_cols: ParquetBboxStatistics,
     bbox_query: Rect,
 ) -> GeoArrowResult<Box<dyn ArrowPredicate>> {
-    let mask = ProjectionMask::leaves(
-        parquet_schema,
-        [
-            bbox_cols.minx_col,
-            bbox_cols.miny_col,
-            bbox_cols.maxx_col,
-            bbox_cols.maxy_col,
-        ],
-    );
+    let mask = ProjectionMask::leaves(parquet_schema, [
+        bbox_cols.minx_col,
+        bbox_cols.miny_col,
+        bbox_cols.maxx_col,
+        bbox_cols.maxy_col,
+    ]);
 
     // The GeoParquet spec allows the bounding box columns to be either Double or Float data type.
     // We need to know which type it is so that we can downcast the produced Arrow arrays to the

--- a/rust/geoparquet/src/total_bounds.rs
+++ b/rust/geoparquet/src/total_bounds.rs
@@ -7,7 +7,6 @@ use geo_traits::{
     UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
     UnimplementedPoint, UnimplementedPolygon, UnimplementedTriangle,
 };
-
 use geo_types::Coord;
 use geoarrow_array::array::RectArray;
 use geoarrow_array::builder::RectBuilder;

--- a/rust/geoparquet/src/writer/async.rs
+++ b/rust/geoparquet/src/writer/async.rs
@@ -1,12 +1,13 @@
-use crate::writer::encode::encode_record_batch;
-use crate::writer::metadata::GeoParquetMetadataBuilder;
-use crate::writer::options::GeoParquetWriterOptions;
 use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_schema::Schema;
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use parquet::arrow::AsyncArrowWriter;
 use parquet::arrow::async_writer::AsyncFileWriter;
 use parquet::file::metadata::KeyValue;
+
+use crate::writer::encode::encode_record_batch;
+use crate::writer::metadata::GeoParquetMetadataBuilder;
+use crate::writer::options::GeoParquetWriterOptions;
 
 /// Write a [RecordBatchReader] to GeoParquet.
 pub async fn write_geoparquet_async<W: AsyncFileWriter>(

--- a/rust/geoparquet/src/writer/sync.rs
+++ b/rust/geoparquet/src/writer/sync.rs
@@ -1,13 +1,14 @@
 use std::io::Write;
 
-use crate::writer::encode::encode_record_batch;
-use crate::writer::metadata::GeoParquetMetadataBuilder;
-use crate::writer::options::GeoParquetWriterOptions;
 use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_schema::Schema;
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use parquet::arrow::ArrowWriter;
 use parquet::file::metadata::KeyValue;
+
+use crate::writer::encode::encode_record_batch;
+use crate::writer::metadata::GeoParquetMetadataBuilder;
+use crate::writer::options::GeoParquetWriterOptions;
 
 /// Write a [RecordBatchReader] to GeoParquet.
 pub fn write_geoparquet<W: Write + Send>(

--- a/rust/pyo3-geoarrow/src/array.rs
+++ b/rust/pyo3-geoarrow/src/array.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use geoarrow_array::array::from_arrow_array;
 // use geoarrow::ArrayBase;
 // use geoarrow::NativeArray;
 // use geoarrow::error::GeoArrowError;
 // use geoarrow::scalar::GeometryScalar;
 // use geoarrow::trait_::NativeArrayRef;
 use geoarrow_array::GeoArrowArray;
+use geoarrow_array::array::from_arrow_array;
 use geoarrow_cast::downcast::NativeType;
 use geoarrow_schema::{
     BoxType, GeometryCollectionType, LineStringType, MultiLineStringType, MultiPointType,

--- a/rust/pyo3-geoarrow/src/crs.rs
+++ b/rust/pyo3-geoarrow/src/crs.rs
@@ -53,12 +53,9 @@ impl PyCrs {
 
         let crs_obj = match self.0.crs_type() {
             Some(CrsType::Projjson) => {
-                let args = PyTuple::new(
-                    py,
-                    vec![serde_json::to_string(
-                        &self.0.crs_value().as_ref().unwrap(),
-                    )?],
-                )?;
+                let args = PyTuple::new(py, vec![serde_json::to_string(
+                    &self.0.crs_value().as_ref().unwrap(),
+                )?])?;
                 crs_class.call_method1(intern!(py, "from_json"), args)?
             }
             Some(CrsType::AuthorityCode) => match self.0.crs_value().as_ref().unwrap() {

--- a/rust/pyo3-geoarrow/src/crs.rs
+++ b/rust/pyo3-geoarrow/src/crs.rs
@@ -53,9 +53,12 @@ impl PyCrs {
 
         let crs_obj = match self.0.crs_type() {
             Some(CrsType::Projjson) => {
-                let args = PyTuple::new(py, vec![serde_json::to_string(
-                    &self.0.crs_value().as_ref().unwrap(),
-                )?])?;
+                let args = PyTuple::new(
+                    py,
+                    vec![serde_json::to_string(
+                        &self.0.crs_value().as_ref().unwrap(),
+                    )?],
+                )?;
                 crs_class.call_method1(intern!(py, "from_json"), args)?
             }
             Some(CrsType::AuthorityCode) => match self.0.crs_value().as_ref().unwrap() {

--- a/rust/pyo3-geoarrow/src/data_type.rs
+++ b/rust/pyo3-geoarrow/src/data_type.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use crate::error::{PyGeoArrowError, PyGeoArrowResult};
-use crate::{PyCoordType, PyCrs, PyDimension, PyEdges};
-
 use geoarrow_array::GeoArrowType;
 use geoarrow_schema::{
     BoxType, GeometryCollectionType, GeometryType, LineStringType, Metadata, MultiLineStringType,
@@ -12,6 +9,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyType};
 use pyo3_arrow::PyField;
 use pyo3_arrow::ffi::to_schema_pycapsule;
+
+use crate::error::{PyGeoArrowError, PyGeoArrowResult};
+use crate::{PyCoordType, PyCrs, PyDimension, PyEdges};
 
 #[pyclass(module = "geoarrow.rust.core", name = "GeoArrowType", subclass, frozen)]
 pub struct PyGeoArrowType(pub(crate) GeoArrowType);


### PR DESCRIPTION
Enforce import order in CI using cargo fmt.

See reference here: https://develop.sentry.dev/engineering-practices/rust/#import-order