### PR TITLE
docs: add note about cmake build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These smaller crates are designed to mimic the upstream `arrow` crates as much a
 - `geoarrow-array`: Pretty stable
 - `geoarrow-cast`: Pretty stable
 - `geoarrow-flatgeobuf`: Somewhat stable.
-- `geoparquet`: Somewhat stable. A decently large refactor is expected in https://github.com/geoarrow/geoarrow-rs/pull/1089.
+- `geoparquet`: Somewhat stable. A decently large refactor is expected in <https://github.com/geoarrow/geoarrow-rs/pull/1089>.
 - Other Rust crates: unstable
 - Python bindings: unstable
 - JS bindings: unstable
@@ -55,3 +55,35 @@ These smaller crates are designed to mimic the upstream `arrow` crates as much a
 - [GeoArrow and GeoParquet in deck.gl](https://observablehq.com/@kylebarron/geoarrow-and-geoparquet-in-deck-gl) gives an overview of what GeoArrow's memory layout looks like under the hood, even though it's focused on how to render the data on a map.
 - [Thoughts on GEOS in WebAssembly](https://kylebarron.dev/blog/geos-wasm) introduces why I think GeoRust + GeoArrow on the web has significant potential.
 - [Zero-copy Apache Arrow with WebAssembly](https://observablehq.com/@kylebarron/zero-copy-apache-arrow-with-webassembly) explains how the JavaScript bindings are able to move memory between JavaScript and WebAssembly so efficiently.
+
+## Contributing
+
+```shell
+git clone git@github.com:geoarrow/geoarrow-rs.git
+cd geoarrow-rs
+cargo test --all-features
+```
+
+### Build issues
+
+If you get the following error:
+
+```text
+  CMake Error at cmake/Ccache.cmake:10 (cmake_minimum_required):
+    Compatibility with CMake < 3.5 has been removed from CMake.
+
+    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+    to tell CMake that the project requires at least <min> but has been updated
+    to work with policies introduced by <max> or earlier.
+
+    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+  Call Stack (most recent call first):
+    CMakeLists.txt:130 (include)
+```
+
+Fix by following those instructions:
+
+```shell
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+cargo test --all-features
+```


### PR DESCRIPTION
Closes #1060 as "document the fix" since I couldn't figure an automatic workaround.