### PR TITLE
feat: Remove `General` variant of `GeoArrowError`

### DIFF
--- a/rust/geoarrow-array/src/array/coord/combined.rs
+++ b/rust/geoarrow-array/src/array/coord/combined.rs
@@ -128,8 +128,8 @@ impl CoordBuffer {
                     InterleavedCoordBuffer::from_arrow(downcasted, dim)?,
                 ))
             }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
+            _ => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected coord buffer type: {:?}",
                 value.data_type()
             ))),
         }

--- a/rust/geoarrow-array/src/array/coord/interleaved.rs
+++ b/rust/geoarrow-array/src/array/coord/interleaved.rs
@@ -22,7 +22,7 @@ pub struct InterleavedCoordBuffer {
 
 fn check(coords: &ScalarBuffer<f64>, dim: Dimension) -> GeoArrowResult<()> {
     if coords.len() % dim.size() != 0 {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "Length of interleaved coordinate buffer must be a multiple of the dimension size"
                 .to_string(),
         ));
@@ -127,7 +127,7 @@ impl InterleavedCoordBuffer {
 
     pub(crate) fn from_arrow(array: &FixedSizeListArray, dim: Dimension) -> GeoArrowResult<Self> {
         if array.value_length() != dim.size() as i32 {
-            return Err(GeoArrowError::General(format!(
+            return Err(GeoArrowError::InvalidGeoArrow(format!(
                 "Expected the FixedSizeListArray to match the dimension. Array length is {}, dimension is: {:?} have size 2",
                 array.value_length(),
                 dim

--- a/rust/geoarrow-array/src/array/coord/separated.rs
+++ b/rust/geoarrow-array/src/array/coord/separated.rs
@@ -38,7 +38,7 @@ fn check(buffers: &[ScalarBuffer<f64>; 4], dim: Dimension) -> GeoArrowResult<()>
     };
 
     if !all_same_length {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "all buffers must have the same length".to_string(),
         ));
     }
@@ -66,7 +66,7 @@ impl SeparatedCoordBuffer {
     /// equal the dimension size.
     pub fn from_vec(buffers: Vec<ScalarBuffer<f64>>, dim: Dimension) -> GeoArrowResult<Self> {
         if buffers.len() != dim.size() {
-            return Err(GeoArrowError::General(
+            return Err(GeoArrowError::InvalidGeoArrow(
                 "Buffers must match dimension length ".into(),
             ));
         }

--- a/rust/geoarrow-array/src/array/geometry.rs
+++ b/rust/geoarrow-array/src/array/geometry.rs
@@ -663,8 +663,8 @@ impl TryFrom<(&UnionArray, GeometryType)> for GeometryArray {
                             );
                         }
                         _ => {
-                            return Err(GeoArrowError::General(format!(
-                                "Unexpected type_id {}",
+                            return Err(GeoArrowError::InvalidGeoArrow(format!(
+                                "Unexpected type_id when converting to GeometryArray {}",
                                 type_id
                             )));
                         }
@@ -672,10 +672,9 @@ impl TryFrom<(&UnionArray, GeometryType)> for GeometryArray {
                 }
             }
             _ => {
-                return Err(ArrowError::CastError(
+                return Err(GeoArrowError::InvalidGeoArrow(
                     "expected union type when converting to GeometryArray".to_string(),
-                )
-                .into());
+                ));
             }
         };
 
@@ -803,9 +802,9 @@ impl TryFrom<(&dyn Array, GeometryType)> for GeometryArray {
     fn try_from((value, typ): (&dyn Array, GeometryType)) -> GeoArrowResult<Self> {
         match value.data_type() {
             DataType::Union(_, _) => (value.as_union(), typ).try_into(),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected GeometryArray DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/geometrycollection.rs
+++ b/rust/geoarrow-array/src/array/geometrycollection.rs
@@ -237,9 +237,9 @@ impl TryFrom<(&dyn Array, GeometryCollectionType)> for GeometryCollectionArray {
         match value.data_type() {
             DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
             DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected GeometryCollection Arrow DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/linestring.rs
+++ b/rust/geoarrow-array/src/array/linestring.rs
@@ -39,13 +39,13 @@ pub(super) fn check(
     geom_offsets: &OffsetBuffer<i32>,
 ) -> GeoArrowResult<()> {
     if validity_len.is_some_and(|len| len != geom_offsets.len_proxy()) {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "nulls mask length must match the number of values".to_string(),
         ));
     }
 
     if *geom_offsets.last() as usize != coords.len() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest geometry offset must match coords length".to_string(),
         ));
     }
@@ -277,9 +277,9 @@ impl TryFrom<(&dyn Array, LineStringType)> for LineStringArray {
         match value.data_type() {
             DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
             DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected LineString DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/multilinestring.rs
+++ b/rust/geoarrow-array/src/array/multilinestring.rs
@@ -43,19 +43,19 @@ pub(super) fn check(
     validity_len: Option<usize>,
 ) -> GeoArrowResult<()> {
     if validity_len.is_some_and(|len| len != geom_offsets.len_proxy()) {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "nulls mask length must match the number of values".to_string(),
         ));
     }
 
     if *ring_offsets.last() as usize != coords.len() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest ring offset must match coords length".to_string(),
         ));
     }
 
     if *geom_offsets.last() as usize != ring_offsets.len_proxy() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest geometry offset must match ring offsets length".to_string(),
         ));
     }
@@ -338,9 +338,9 @@ impl TryFrom<(&dyn Array, MultiLineStringType)> for MultiLineStringArray {
         match value.data_type() {
             DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
             DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected MultiLineString DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/multipoint.rs
+++ b/rust/geoarrow-array/src/array/multipoint.rs
@@ -39,13 +39,13 @@ pub(super) fn check(
     geom_offsets: &OffsetBuffer<i32>,
 ) -> GeoArrowResult<()> {
     if validity_len.is_some_and(|len| len != geom_offsets.len_proxy()) {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "nulls mask length must match the number of values".to_string(),
         ));
     }
 
     if *geom_offsets.last() as usize != coords.len() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest geometry offset must match coords length".to_string(),
         ));
     }
@@ -280,9 +280,9 @@ impl TryFrom<(&dyn Array, MultiPointType)> for MultiPointArray {
         match value.data_type() {
             DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
             DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected MultiPoint DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/multipolygon.rs
+++ b/rust/geoarrow-array/src/array/multipolygon.rs
@@ -47,24 +47,24 @@ pub(super) fn check(
     validity_len: Option<usize>,
 ) -> GeoArrowResult<()> {
     if validity_len.is_some_and(|len| len != geom_offsets.len_proxy()) {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "nulls mask length must match the number of values".to_string(),
         ));
     }
     if *ring_offsets.last() as usize != coords.len() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest ring offset must match coords length".to_string(),
         ));
     }
 
     if *polygon_offsets.last() as usize != ring_offsets.len_proxy() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest polygon offset must match ring offsets length".to_string(),
         ));
     }
 
     if *geom_offsets.last() as usize != polygon_offsets.len_proxy() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest geometry offset must match polygon offsets length".to_string(),
         ));
     }
@@ -392,9 +392,9 @@ impl TryFrom<(&dyn Array, MultiPolygonType)> for MultiPolygonArray {
         match value.data_type() {
             DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
             DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected MultiPolygon DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/point.rs
+++ b/rust/geoarrow-array/src/array/point.rs
@@ -30,7 +30,7 @@ pub struct PointArray {
 /// - Validity mask must have the same length as the coordinates.
 pub(super) fn check(coords: &CoordBuffer, validity_len: Option<usize>) -> GeoArrowResult<()> {
     if validity_len.is_some_and(|len| len != coords.len()) {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "validity mask length must match the number of values".to_string(),
         ));
     }
@@ -246,9 +246,10 @@ impl TryFrom<(&dyn Array, PointType)> for PointArray {
         match value.data_type() {
             DataType::FixedSizeList(_, _) => (value.as_fixed_size_list(), typ).try_into(),
             DataType::Struct(_) => (value.as_struct(), typ).try_into(),
-            _ => Err(GeoArrowError::General(
-                "Invalid data type for PointArray".to_string(),
-            )),
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected Point DataType: {:?}",
+                dt
+            ))),
         }
     }
 }

--- a/rust/geoarrow-array/src/array/polygon.rs
+++ b/rust/geoarrow-array/src/array/polygon.rs
@@ -45,19 +45,19 @@ pub(super) fn check(
     validity_len: Option<usize>,
 ) -> GeoArrowResult<()> {
     if validity_len.is_some_and(|len| len != geom_offsets.len_proxy()) {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "nulls mask length must match the number of values".to_string(),
         ));
     }
 
     if *ring_offsets.last() as usize != coords.len() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest ring offset must match coords length".to_string(),
         ));
     }
 
     if *geom_offsets.last() as usize != ring_offsets.len_proxy() {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::InvalidGeoArrow(
             "largest geometry offset must match ring offsets length".to_string(),
         ));
     }
@@ -335,9 +335,9 @@ impl TryFrom<(&dyn Array, PolygonType)> for PolygonArray {
         match value.data_type() {
             DataType::List(_) => (value.as_list::<i32>(), typ).try_into(),
             DataType::LargeList(_) => (value.as_list::<i64>(), typ).try_into(),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected Polygon DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/rect.rs
+++ b/rust/geoarrow-array/src/array/rect.rs
@@ -189,7 +189,7 @@ impl TryFrom<(&StructArray, BoxType)> for RectArray {
         let nulls = value.nulls();
         let columns = value.columns();
         if columns.len() != dim.size() * 2 {
-            return Err(GeoArrowError::General(format!(
+            return Err(GeoArrowError::InvalidGeoArrow(format!(
                 "Invalid number of columns for RectArray: expected {} but got {}",
                 dim.size() * 2,
                 columns.len()
@@ -223,9 +223,10 @@ impl TryFrom<(&dyn Array, BoxType)> for RectArray {
     fn try_from((value, dim): (&dyn Array, BoxType)) -> GeoArrowResult<Self> {
         match value.data_type() {
             DataType::Struct(_) => (value.as_struct(), dim).try_into(),
-            _ => Err(GeoArrowError::General(
-                "Invalid data type for RectArray".to_string(),
-            )),
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected Rect DataType: {:?}",
+                dt
+            ))),
         }
     }
 }

--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -179,9 +179,9 @@ impl TryFrom<(&dyn Array, WkbType)> for GenericWkbArray<i32> {
                     (value.as_binary::<i64>().clone(), typ).into();
                 geom_array.try_into()
             }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected GenericWkbArray DataType: {:?}",
+                dt
             ))),
         }
     }
@@ -197,9 +197,9 @@ impl TryFrom<(&dyn Array, WkbType)> for GenericWkbArray<i64> {
                 Ok(geom_array.into())
             }
             DataType::LargeBinary => Ok((value.as_binary::<i64>().clone(), typ).into()),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected GenericWkbArray DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/wkb_view.rs
+++ b/rust/geoarrow-array/src/array/wkb_view.rs
@@ -146,9 +146,9 @@ impl TryFrom<(&dyn Array, WkbType)> for WkbViewArray {
     fn try_from((value, typ): (&dyn Array, WkbType)) -> GeoArrowResult<Self> {
         match value.data_type() {
             DataType::BinaryView => Ok((value.as_binary_view().clone(), typ).into()),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected WkbView DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/wkt.rs
+++ b/rust/geoarrow-array/src/array/wkt.rs
@@ -129,7 +129,7 @@ impl<'a, O: OffsetSizeTrait> GeoArrowArrayAccessor<'a> for GenericWktArray<O> {
 
     unsafe fn value_unchecked(&'a self, index: usize) -> GeoArrowResult<Self::Item> {
         let s = unsafe { self.array.value_unchecked(index) };
-        Wkt::from_str(s).map_err(GeoArrowError::WktStrError)
+        Wkt::from_str(s).map_err(|err| GeoArrowError::Wkt(err.to_string()))
     }
 }
 
@@ -167,9 +167,9 @@ impl TryFrom<(&dyn Array, WktType)> for GenericWktArray<i32> {
                     (value.as_string::<i64>().clone(), typ).into();
                 geom_array.try_into()
             }
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected WktArray DataType: {:?}",
+                dt
             ))),
         }
     }
@@ -186,9 +186,9 @@ impl TryFrom<(&dyn Array, WktType)> for GenericWktArray<i64> {
                 Ok(geom_array.into())
             }
             DataType::LargeUtf8 => Ok((value.as_string::<i64>().clone(), typ).into()),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected WktArray DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/array/wkt_view.rs
+++ b/rust/geoarrow-array/src/array/wkt_view.rs
@@ -120,7 +120,7 @@ impl<'a> GeoArrowArrayAccessor<'a> for WktViewArray {
 
     unsafe fn value_unchecked(&'a self, index: usize) -> GeoArrowResult<Self::Item> {
         let s = unsafe { self.array.value_unchecked(index) };
-        Wkt::from_str(s).map_err(GeoArrowError::WktStrError)
+        Wkt::from_str(s).map_err(|err| GeoArrowError::Wkt(err.to_string()))
     }
 }
 
@@ -152,9 +152,9 @@ impl TryFrom<(&dyn Array, WktType)> for WktViewArray {
     fn try_from((value, typ): (&dyn Array, WktType)) -> GeoArrowResult<Self> {
         match value.data_type() {
             DataType::Utf8View => Ok((value.as_string_view().clone(), typ).into()),
-            _ => Err(GeoArrowError::General(format!(
-                "Unexpected type: {:?}",
-                value.data_type()
+            dt => Err(GeoArrowError::InvalidGeoArrow(format!(
+                "Unexpected WktView DataType: {:?}",
+                dt
             ))),
         }
     }

--- a/rust/geoarrow-array/src/builder/coord/interleaved.rs
+++ b/rust/geoarrow-array/src/builder/coord/interleaved.rs
@@ -98,7 +98,7 @@ impl InterleavedCoordBufferBuilder {
             Dimension::XY => match coord.dim() {
                 geo_traits::Dimensions::Xy | geo_traits::Dimensions::Unknown(2) => {}
                 d => {
-                    return Err(GeoArrowError::General(format!(
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
                         "coord dimension must be XY for this buffer; got {d:?}."
                     )));
                 }
@@ -106,7 +106,7 @@ impl InterleavedCoordBufferBuilder {
             Dimension::XYZ => match coord.dim() {
                 geo_traits::Dimensions::Xyz | geo_traits::Dimensions::Unknown(3) => {}
                 d => {
-                    return Err(GeoArrowError::General(format!(
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
                         "coord dimension must be XYZ for this buffer; got {d:?}."
                     )));
                 }
@@ -114,7 +114,7 @@ impl InterleavedCoordBufferBuilder {
             Dimension::XYM => match coord.dim() {
                 geo_traits::Dimensions::Xym | geo_traits::Dimensions::Unknown(3) => {}
                 d => {
-                    return Err(GeoArrowError::General(format!(
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
                         "coord dimension must be XYM for this buffer; got {d:?}."
                     )));
                 }
@@ -122,7 +122,7 @@ impl InterleavedCoordBufferBuilder {
             Dimension::XYZM => match coord.dim() {
                 geo_traits::Dimensions::Xyzm | geo_traits::Dimensions::Unknown(4) => {}
                 d => {
-                    return Err(GeoArrowError::General(format!(
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
                         "coord dimension must be XYZM for this buffer; got {d:?}."
                     )));
                 }

--- a/rust/geoarrow-array/src/builder/coord/separated.rs
+++ b/rust/geoarrow-array/src/builder/coord/separated.rs
@@ -112,7 +112,7 @@ impl SeparatedCoordBufferBuilder {
             Dimension::XY => match coord.dim() {
                 geo_traits::Dimensions::Xy | geo_traits::Dimensions::Unknown(2) => {}
                 d => {
-                    return Err(GeoArrowError::General(format!(
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
                         "coord dimension must be XY for this buffer; got {d:?}."
                     )));
                 }
@@ -120,7 +120,7 @@ impl SeparatedCoordBufferBuilder {
             Dimension::XYZ => match coord.dim() {
                 geo_traits::Dimensions::Xyz | geo_traits::Dimensions::Unknown(3) => {}
                 d => {
-                    return Err(GeoArrowError::General(format!(
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
                         "coord dimension must be XYZ for this buffer; got {d:?}."
                     )));
                 }
@@ -128,7 +128,7 @@ impl SeparatedCoordBufferBuilder {
             Dimension::XYM => match coord.dim() {
                 geo_traits::Dimensions::Xym | geo_traits::Dimensions::Unknown(3) => {}
                 d => {
-                    return Err(GeoArrowError::General(format!(
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
                         "coord dimension must be XYM for this buffer; got {d:?}."
                     )));
                 }
@@ -136,7 +136,7 @@ impl SeparatedCoordBufferBuilder {
             Dimension::XYZM => match coord.dim() {
                 geo_traits::Dimensions::Xyzm | geo_traits::Dimensions::Unknown(4) => {}
                 d => {
-                    return Err(GeoArrowError::General(format!(
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
                         "coord dimension must be XYZM for this buffer; got {d:?}."
                     )));
                 }

--- a/rust/geoarrow-array/src/builder/geo_trait_wrappers.rs
+++ b/rust/geoarrow-array/src/builder/geo_trait_wrappers.rs
@@ -19,10 +19,11 @@ impl<'a, T: WktNum, R: RectTrait<T = T>> RectWrapper<'a, T, R> {
     pub(crate) fn try_new(rect: &'a R) -> GeoArrowResult<Self> {
         match rect.dim() {
             geo_traits::Dimensions::Xy | geo_traits::Dimensions::Unknown(2) => {}
-            _ => {
-                return Err(GeoArrowError::General(
-                    "Only 2d rect supported when pushing to polygon.".to_string(),
-                ));
+            dim => {
+                return Err(GeoArrowError::IncorrectGeometryType(format!(
+                    "Only 2d rects supported when pushing to polygon. Got dimension: {:?}",
+                    dim
+                )));
             }
         };
 

--- a/rust/geoarrow-array/src/builder/linestring.rs
+++ b/rust/geoarrow-array/src/builder/linestring.rs
@@ -14,6 +14,7 @@ use crate::builder::{
 };
 use crate::capacity::LineStringCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
+use crate::util::GeometryTypeName;
 
 /// The GeoArrow equivalent to `Vec<Option<LineString>>`: a mutable collection of LineStrings.
 ///
@@ -211,11 +212,19 @@ impl LineStringBuilder {
                     } else if num_line_strings == 1 {
                         self.push_line_string(Some(&ml.line_string(0).unwrap()))?
                     } else {
-                        return Err(GeoArrowError::General("Incorrect type".to_string()));
+                        return Err(GeoArrowError::IncorrectGeometryType(format!(
+                            "Expected MultiLineString with only one LineString in LineStringBuilder, got {} line strings",
+                            num_line_strings
+                        )));
                     }
                 }
                 GeometryType::Line(l) => self.push_line_string(Some(&LineWrapper(l)))?,
-                _ => return Err(GeoArrowError::General("Incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected LineString, got {}",
+                        gt.name()
+                    )));
+                }
             }
         } else {
             self.push_null();

--- a/rust/geoarrow-array/src/builder/mixed.rs
+++ b/rust/geoarrow-array/src/builder/mixed.rs
@@ -338,8 +338,8 @@ impl MixedGeometryBuilder {
                 if gc.num_geometries() == 1 {
                     self.push_geometry(&gc.geometry(0).unwrap())?
                 } else {
-                    return Err(GeoArrowError::General(
-                        "nested geometry collections not supported".to_string(),
+                    return Err(GeoArrowError::InvalidGeoArrow(
+                        "nested geometry collections not supported in GeoArrow".to_string(),
                     ));
                 }
             }

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -6,6 +6,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, Multi
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiLineStringType};
 
+use crate::util::GeometryTypeName;
 // use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiLineStringArray};
@@ -251,7 +252,12 @@ impl MultiLineStringBuilder {
             match value.as_type() {
                 GeometryType::LineString(g) => self.push_line_string(Some(g))?,
                 GeometryType::MultiLineString(g) => self.push_multi_line_string(Some(g))?,
-                _ => return Err(GeoArrowError::General("Incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected MultiLineString compatible geometry, got {}",
+                        gt.name()
+                    )));
+                }
             }
         } else {
             self.push_null();

--- a/rust/geoarrow-array/src/builder/multilinestring.rs
+++ b/rust/geoarrow-array/src/builder/multilinestring.rs
@@ -6,8 +6,6 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, Multi
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiLineStringType};
 
-use crate::util::GeometryTypeName;
-// use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiLineStringArray};
 use crate::builder::{
@@ -15,6 +13,7 @@ use crate::builder::{
 };
 use crate::capacity::MultiLineStringCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
+use crate::util::GeometryTypeName;
 
 /// The GeoArrow equivalent to `Vec<Option<MultiLineString>>`: a mutable collection of
 /// MultiLineStrings.

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -6,8 +6,6 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, Point
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiPointType};
 
-use crate::util::GeometryTypeName;
-// use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiPointArray};
 use crate::builder::{
@@ -15,6 +13,7 @@ use crate::builder::{
 };
 use crate::capacity::MultiPointCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
+use crate::util::GeometryTypeName;
 
 /// The GeoArrow equivalent to `Vec<Option<MultiPoint>>`: a mutable collection of MultiPoints.
 ///

--- a/rust/geoarrow-array/src/builder/multipoint.rs
+++ b/rust/geoarrow-array/src/builder/multipoint.rs
@@ -6,6 +6,7 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, Point
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiPointType};
 
+use crate::util::GeometryTypeName;
 // use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiPointArray};
@@ -173,7 +174,12 @@ impl MultiPointBuilder {
             match value.as_type() {
                 GeometryType::Point(g) => self.push_point(Some(g))?,
                 GeometryType::MultiPoint(g) => self.push_multi_point(Some(g))?,
-                _ => return Err(GeoArrowError::General("Incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected MultiPoint compatible geometry, got {}",
+                        gt.name()
+                    )));
+                }
             }
         } else {
             self.push_null();

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -8,6 +8,7 @@ use geo_traits::{
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiPolygonType};
 
+use crate::util::GeometryTypeName;
 // use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiPolygonArray};
@@ -232,7 +233,12 @@ impl MultiPolygonBuilder {
                 GeometryType::Polygon(g) => self.push_polygon(Some(g))?,
                 GeometryType::MultiPolygon(g) => self.push_multi_polygon(Some(g))?,
                 // TODO: support rect
-                _ => return Err(GeoArrowError::General("Incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected MultiPolygon compatible geometry, got {}",
+                        gt.name()
+                    )));
+                }
             }
         } else {
             self.push_null();

--- a/rust/geoarrow-array/src/builder/multipolygon.rs
+++ b/rust/geoarrow-array/src/builder/multipolygon.rs
@@ -8,8 +8,6 @@ use geo_traits::{
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, MultiPolygonType};
 
-use crate::util::GeometryTypeName;
-// use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, MultiPolygonArray};
 use crate::builder::{
@@ -17,6 +15,7 @@ use crate::builder::{
 };
 use crate::capacity::MultiPolygonCapacity;
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
+use crate::util::GeometryTypeName;
 
 /// The GeoArrow equivalent to `Vec<Option<MultiPolygon>>`: a mutable collection of MultiPolygons.
 ///

--- a/rust/geoarrow-array/src/builder/point.rs
+++ b/rust/geoarrow-array/src/builder/point.rs
@@ -6,13 +6,13 @@ use geo_traits::{CoordTrait, GeometryTrait, GeometryType, MultiPointTrait, Point
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, PointType};
 
-// use super::array::check;
 use crate::GeoArrowArray;
 use crate::array::{GenericWkbArray, PointArray};
 use crate::builder::{
     CoordBufferBuilder, InterleavedCoordBufferBuilder, SeparatedCoordBufferBuilder,
 };
 use crate::trait_::{GeoArrowArrayAccessor, GeoArrowArrayBuilder};
+use crate::util::GeometryTypeName;
 
 /// The GeoArrow equivalent to `Vec<Option<Point>>`: a mutable collection of Points.
 ///
@@ -171,10 +171,18 @@ impl PointBuilder {
                     } else if num_points == 1 {
                         self.push_point(Some(&mp.point(0).unwrap()))
                     } else {
-                        return Err(GeoArrowError::General("Incorrect type".to_string()));
+                        return Err(GeoArrowError::IncorrectGeometryType(format!(
+                            "Expected MultiPoint with only one point in PointBuilder, got {} points",
+                            num_points
+                        )));
                     }
                 }
-                _ => return Err(GeoArrowError::General("Incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected point, got {}",
+                        gt.name()
+                    )));
+                }
             }
         } else {
             self.push_null()

--- a/rust/geoarrow-array/src/builder/rect.rs
+++ b/rust/geoarrow-array/src/builder/rect.rs
@@ -78,7 +78,7 @@ impl RectBuilder {
         data_type: BoxType,
     ) -> GeoArrowResult<Self> {
         if lower.len() != upper.len() {
-            return Err(GeoArrowError::General(
+            return Err(GeoArrowError::InvalidGeoArrow(
                 "Lower and upper lengths must match".to_string(),
             ));
         }

--- a/rust/geoarrow-array/src/capacity/linestring.rs
+++ b/rust/geoarrow-array/src/capacity/linestring.rs
@@ -3,6 +3,8 @@ use std::ops::Add;
 use geo_traits::{GeometryTrait, GeometryType, LineStringTrait};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
+use crate::util::GeometryTypeName;
+
 /// A counter for the buffer sizes of a [`LineStringArray`][crate::array::LineStringArray].
 ///
 /// This can be used to reduce allocations by allocating once for exactly the array size you need.
@@ -55,7 +57,12 @@ impl LineStringCapacity {
         if let Some(g) = value {
             match g.as_type() {
                 GeometryType::LineString(p) => self.add_valid_line_string(p),
-                _ => return Err(GeoArrowError::General("incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected LineString, got {}",
+                        gt.name()
+                    )));
+                }
             }
         };
         Ok(())

--- a/rust/geoarrow-array/src/capacity/mixed.rs
+++ b/rust/geoarrow-array/src/capacity/mixed.rs
@@ -121,8 +121,8 @@ impl MixedCapacity {
             geo_traits::GeometryType::MultiLineString(p) => self.add_multi_line_string(p),
             geo_traits::GeometryType::MultiPolygon(p) => self.add_multi_polygon(p),
             geo_traits::GeometryType::GeometryCollection(_) => {
-                return Err(GeoArrowError::General(
-                    "nested geometry collections not supported".to_string(),
+                return Err(GeoArrowError::InvalidGeoArrow(
+                    "nested geometry collections not supported in GeoArrow".to_string(),
                 ));
             }
             geo_traits::GeometryType::Rect(r) => self.add_polygon(&RectWrapper::try_new(r)?),

--- a/rust/geoarrow-array/src/capacity/multilinestring.rs
+++ b/rust/geoarrow-array/src/capacity/multilinestring.rs
@@ -4,6 +4,7 @@ use geo_traits::{GeometryTrait, GeometryType, LineStringTrait, MultiLineStringTr
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::capacity::LineStringCapacity;
+use crate::util::GeometryTypeName;
 
 /// A counter for the buffer sizes of a
 /// [`MultiLineStringArray`][crate::array::MultiLineStringArray].
@@ -86,7 +87,12 @@ impl MultiLineStringCapacity {
             match geom.as_type() {
                 GeometryType::LineString(g) => self.add_line_string(Some(g)),
                 GeometryType::MultiLineString(g) => self.add_multi_line_string(Some(g)),
-                _ => return Err(GeoArrowError::General("Incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected LineString or MultiLineString, got {}",
+                        gt.name()
+                    )));
+                }
             }
         } else {
             self.geom_capacity += 1;

--- a/rust/geoarrow-array/src/capacity/multipoint.rs
+++ b/rust/geoarrow-array/src/capacity/multipoint.rs
@@ -3,6 +3,8 @@ use std::ops::{Add, AddAssign};
 use geo_traits::{GeometryTrait, GeometryType, MultiPointTrait, PointTrait};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
+use crate::util::GeometryTypeName;
+
 /// A counter for the buffer sizes of a [`MultiPointArray`][crate::array::MultiPointArray].
 ///
 /// This can be used to reduce allocations by allocating once for exactly the array size you need.
@@ -71,7 +73,12 @@ impl MultiPointCapacity {
             match g.as_type() {
                 GeometryType::Point(p) => self.add_valid_point(p),
                 GeometryType::MultiPoint(p) => self.add_valid_multi_point(p),
-                _ => return Err(GeoArrowError::General("incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected Point or MultiPoint, got {}",
+                        gt.name()
+                    )));
+                }
             }
         };
         Ok(())

--- a/rust/geoarrow-array/src/capacity/multipolygon.rs
+++ b/rust/geoarrow-array/src/capacity/multipolygon.rs
@@ -4,6 +4,7 @@ use geo_traits::{GeometryTrait, GeometryType, LineStringTrait, MultiPolygonTrait
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::capacity::PolygonCapacity;
+use crate::util::GeometryTypeName;
 
 /// A counter for the buffer sizes of a [`MultiPolygonArray`][crate::array::MultiPolygonArray].
 ///
@@ -126,7 +127,12 @@ impl MultiPolygonCapacity {
             match geom.as_type() {
                 GeometryType::Polygon(g) => self.add_polygon(Some(g)),
                 GeometryType::MultiPolygon(g) => self.add_multi_polygon(Some(g)),
-                _ => return Err(GeoArrowError::General("Incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected MultiPolygon, got {}",
+                        gt.name()
+                    )));
+                }
             }
         } else {
             self.geom_capacity += 1;

--- a/rust/geoarrow-array/src/capacity/point.rs
+++ b/rust/geoarrow-array/src/capacity/point.rs
@@ -42,7 +42,11 @@ impl PointCapacity {
             match g.as_type() {
                 GeometryType::Point(p) => self.add_point(Some(p)),
 
-                _ => return Err(GeoArrowError::General("incorrect type".to_string())),
+                _ => {
+                    return Err(GeoArrowError::IncorrectGeometryType(
+                        "Expected point in PointCapacity".to_string(),
+                    ));
+                }
             }
         } else {
             self.geom_capacity += 1;

--- a/rust/geoarrow-array/src/capacity/polygon.rs
+++ b/rust/geoarrow-array/src/capacity/polygon.rs
@@ -3,6 +3,8 @@ use std::ops::Add;
 use geo_traits::{GeometryTrait, GeometryType, LineStringTrait, PolygonTrait, RectTrait};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
+use crate::util::GeometryTypeName;
+
 /// A counter for the buffer sizes of a [`PolygonArray`][crate::array::PolygonArray].
 ///
 /// This can be used to reduce allocations by allocating once for exactly the array size you need.
@@ -89,7 +91,12 @@ impl PolygonCapacity {
             match geom.as_type() {
                 GeometryType::Polygon(g) => self.add_polygon(Some(g)),
                 GeometryType::Rect(g) => self.add_rect(Some(g)),
-                _ => return Err(GeoArrowError::General("Incorrect type".to_string())),
+                gt => {
+                    return Err(GeoArrowError::IncorrectGeometryType(format!(
+                        "Expected polygon, got {}",
+                        gt.name()
+                    )));
+                }
             }
         } else {
             self.geom_capacity += 1;

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -462,8 +462,8 @@ pub fn from_wkb<'a, A: GenericWkbArrayType<'a>>(
             Arc::new(GeometryCollectionBuilder::from_nullable_geometries(&geoms, typ)?.finish())
         }
         Rect(_) => {
-            return Err(GeoArrowError::General(format!(
-                "Invalid data type in from_wkb {:?}",
+            return Err(GeoArrowError::IncorrectGeometryType(format!(
+                "Cannot decode WKB geometries to Rect geometry type in from_wkb {:?}",
                 to_type,
             )));
         }
@@ -645,8 +645,8 @@ pub fn from_wkt<A: GenericWktArrayType>(
             Arc::new(GeometryCollectionBuilder::from_nullable_geometries(&geoms, typ)?.finish())
         }
         Rect(_) => {
-            return Err(GeoArrowError::General(format!(
-                "Invalid data type in from_wkt {:?}",
+            return Err(GeoArrowError::IncorrectGeometryType(format!(
+                "Cannot decode WKT geometries to Rect geometry type in from_wkt {:?}",
                 to_type,
             )));
         }

--- a/rust/geoarrow-array/src/datatypes.rs
+++ b/rust/geoarrow-array/src/datatypes.rs
@@ -317,7 +317,12 @@ impl TryFrom<&Field> for GeoArrowType {
     fn try_from(field: &Field) -> GeoArrowResult<Self> {
         // TODO: should we make Metadata::deserialize public?
         let metadata: Metadata = if let Some(ext_meta) = field.extension_type_metadata() {
-            serde_json::from_str(ext_meta)?
+            serde_json::from_str(ext_meta).map_err(|err| {
+                GeoArrowError::InvalidGeoArrow(format!(
+                    "Failed to deserialize GeoArrow metadata: {}",
+                    err
+                ))
+            })?
         } else {
             Default::default()
         };

--- a/rust/geoarrow-array/src/util.rs
+++ b/rust/geoarrow-array/src/util.rs
@@ -1,5 +1,3 @@
-//! Note: This entire mod is a candidate to upstream into arrow-rs.
-
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::OffsetBuffer;
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
@@ -58,5 +56,40 @@ impl<O: OffsetSizeTrait> OffsetBufferUtils<O> for OffsetBuffer<O> {
     #[inline]
     fn last(&self) -> &O {
         self.as_ref().last().unwrap()
+    }
+}
+
+pub(crate) trait GeometryTypeName {
+    /// Returns the name of the geometry type.
+    fn name(&self) -> String;
+}
+
+impl<'a, P, LS, Y, MP, ML, MY, GC, R, T, L> GeometryTypeName
+    for geo_traits::GeometryType<'a, P, LS, Y, MP, ML, MY, GC, R, T, L>
+where
+    P: geo_traits::PointTrait,
+    LS: geo_traits::LineStringTrait,
+    Y: geo_traits::PolygonTrait,
+    MP: geo_traits::MultiPointTrait,
+    ML: geo_traits::MultiLineStringTrait,
+    MY: geo_traits::MultiPolygonTrait,
+    GC: geo_traits::GeometryCollectionTrait,
+    R: geo_traits::RectTrait,
+    T: geo_traits::TriangleTrait,
+    L: geo_traits::LineTrait,
+{
+    fn name(&self) -> String {
+        match self {
+            Self::Point(_) => "Point".to_string(),
+            Self::LineString(_) => "LineString".to_string(),
+            Self::Polygon(_) => "Polygon".to_string(),
+            Self::MultiPoint(_) => "MultiPoint".to_string(),
+            Self::MultiLineString(_) => "MultiLineString".to_string(),
+            Self::MultiPolygon(_) => "MultiPolygon".to_string(),
+            Self::GeometryCollection(_) => "GeometryCollection".to_string(),
+            Self::Rect(_) => "Rect".to_string(),
+            Self::Triangle(_) => "Triangle".to_string(),
+            Self::Line(_) => "Line".to_string(),
+        }
     }
 }

--- a/rust/geoarrow-cast/src/downcast.rs
+++ b/rust/geoarrow-cast/src/downcast.rs
@@ -24,9 +24,10 @@ pub fn infer_downcast_type<'a>(
     }
 
     if type_ids.is_empty() {
-        return Err(GeoArrowError::General(
-            "Cannot infer type from empty sequence of arrays".to_string(),
-        ));
+        return Err(ArrowError::CastError(
+            "Empty iterator of arrays passed to infer_downcast_type".to_string(),
+        )
+        .into());
     }
 
     infer_from_native_type_and_dimension(type_ids)

--- a/rust/geoarrow-flatgeobuf/src/writer.rs
+++ b/rust/geoarrow-flatgeobuf/src/writer.rs
@@ -124,7 +124,7 @@ pub fn write_flatgeobuf_with_options<W: Write, S: Into<GeozeroRecordBatchReader>
     let fields = &schema.fields;
     let geom_col_idxs = geometry_columns(schema.as_ref());
     if geom_col_idxs.len() != 1 {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::FlatGeobuf(
             "Only one geometry column currently supported in FlatGeobuf writer".to_string(),
         ));
     }
@@ -151,7 +151,7 @@ fn infer_flatgeobuf_geometry_type(schema: &Schema) -> GeoArrowResult<flatgeobuf:
     let fields = &schema.fields;
     let geom_col_idxs = geometry_columns(schema);
     if geom_col_idxs.len() != 1 {
-        return Err(GeoArrowError::General(
+        return Err(GeoArrowError::FlatGeobuf(
             "Only one geometry column currently supported in FlatGeobuf writer".to_string(),
         ));
     }

--- a/rust/geoarrow-geos/src/import/scalar/geometrycollection.rs
+++ b/rust/geoarrow-geos/src/import/scalar/geometrycollection.rs
@@ -15,7 +15,7 @@ impl GEOSGeometryCollection {
         if matches!(geom.geometry_type(), GeometryTypes::GeometryCollection) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be geometry collection".to_string(),
             ))
         }

--- a/rust/geoarrow-geos/src/import/scalar/linearring.rs
+++ b/rust/geoarrow-geos/src/import/scalar/linearring.rs
@@ -16,7 +16,7 @@ impl<'a> GEOSConstLinearRing<'a> {
         if matches!(geom.geometry_type(), GeometryTypes::LinearRing) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be linear ring".to_string(),
             ))
         }

--- a/rust/geoarrow-geos/src/import/scalar/linestring.rs
+++ b/rust/geoarrow-geos/src/import/scalar/linestring.rs
@@ -14,7 +14,7 @@ impl GEOSLineString {
         if matches!(geom.geometry_type(), GeometryTypes::LineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be line string".to_string(),
             ))
         }
@@ -81,7 +81,7 @@ impl<'a> GEOSConstLineString<'a> {
         if matches!(geom.geometry_type(), GeometryTypes::LineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be line string".to_string(),
             ))
         }

--- a/rust/geoarrow-geos/src/import/scalar/multilinestring.rs
+++ b/rust/geoarrow-geos/src/import/scalar/multilinestring.rs
@@ -17,7 +17,7 @@ impl GEOSMultiLineString {
         if matches!(geom.geometry_type(), GeometryTypes::MultiLineString) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be multi line string".to_string(),
             ))
         }

--- a/rust/geoarrow-geos/src/import/scalar/multipoint.rs
+++ b/rust/geoarrow-geos/src/import/scalar/multipoint.rs
@@ -16,7 +16,7 @@ impl GEOSMultiPoint {
         if matches!(geom.geometry_type(), GeometryTypes::MultiPoint) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be multi point".to_string(),
             ))
         }

--- a/rust/geoarrow-geos/src/import/scalar/multipolygon.rs
+++ b/rust/geoarrow-geos/src/import/scalar/multipolygon.rs
@@ -16,7 +16,7 @@ impl GEOSMultiPolygon {
         if matches!(geom.geometry_type(), GeometryTypes::MultiPolygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be multi polygon".to_string(),
             ))
         }

--- a/rust/geoarrow-geos/src/import/scalar/point.rs
+++ b/rust/geoarrow-geos/src/import/scalar/point.rs
@@ -15,7 +15,7 @@ impl GEOSPoint {
         if matches!(geom.geometry_type(), GeometryTypes::Point) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be point".to_string(),
             ))
         }
@@ -81,7 +81,7 @@ impl<'a> GEOSConstPoint<'a> {
         if matches!(geom.geometry_type(), GeometryTypes::Point) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be point".to_string(),
             ))
         }

--- a/rust/geoarrow-geos/src/import/scalar/polygon.rs
+++ b/rust/geoarrow-geos/src/import/scalar/polygon.rs
@@ -16,7 +16,7 @@ impl GEOSPolygon {
         if matches!(geom.geometry_type(), GeometryTypes::Polygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be polygon".to_string(),
             ))
         }
@@ -98,7 +98,7 @@ impl<'a> GEOSConstPolygon<'a> {
         if matches!(geom.geometry_type(), GeometryTypes::Polygon) {
             Ok(Self(geom))
         } else {
-            Err(GeoArrowError::General(
+            Err(GeoArrowError::IncorrectGeometryType(
                 "Geometry type must be polygon".to_string(),
             ))
         }

--- a/rust/geoarrow-schema/src/error.rs
+++ b/rust/geoarrow-schema/src/error.rs
@@ -14,9 +14,13 @@ pub enum GeoArrowError {
     #[error("External error: {0}")]
     External(#[from] Box<dyn Error + Send + Sync>),
 
-    /// General error.
-    #[error("General error: {0}")]
-    General(String),
+    /// Invalid data not conforming to GeoArrow specification
+    #[error("Data not conforming to GeoArrow specification: {0}")]
+    InvalidGeoArrow(String),
+
+    /// Incorrect geometry type for operation
+    #[error("Incorrect geometry type for operation: {0}")]
+    IncorrectGeometryType(String),
 
     /// Whenever pushing to a container fails because it does not support more entries.
     ///
@@ -36,9 +40,13 @@ pub enum GeoArrowError {
     #[error(transparent)]
     SerdeJsonError(#[from] serde_json::Error),
 
-    /// [wkt::error::Error]
+    /// WKB Error
+    #[error("WKB error: {0}")]
+    Wkb(String),
+
+    /// WKT Error
     #[error("WKT error: {0}")]
-    WktStrError(&'static str),
+    Wkt(String),
 }
 
 /// Crate-specific result type.

--- a/rust/geoarrow-schema/src/error.rs
+++ b/rust/geoarrow-schema/src/error.rs
@@ -10,9 +10,29 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum GeoArrowError {
+    /// [ArrowError]
+    #[error(transparent)]
+    Arrow(#[from] ArrowError),
+
+    /// CRS error
+    #[error("CRS related error: {0}")]
+    Crs(String),
+
     /// Wraps an external error.
     #[error("External error: {0}")]
     External(#[from] Box<dyn Error + Send + Sync>),
+
+    /// FlatGeobuf error
+    #[error("FlatGeobuf error: {0}")]
+    FlatGeobuf(String),
+
+    /// GeoParquet error
+    #[error("GeoParquet error: {0}")]
+    GeoParquet(String),
+
+    /// [std::io::Error]
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
 
     /// Invalid data not conforming to GeoArrow specification
     #[error("Data not conforming to GeoArrow specification: {0}")]
@@ -27,14 +47,6 @@ pub enum GeoArrowError {
     /// The solution is usually to use a higher-capacity container-backing type.
     #[error("Overflow")]
     Overflow,
-
-    /// [ArrowError]
-    #[error(transparent)]
-    Arrow(#[from] ArrowError),
-
-    /// [std::io::Error]
-    #[error(transparent)]
-    IOError(#[from] std::io::Error),
 
     /// [serde_json::Error]
     #[error(transparent)]

--- a/rust/geoarrow-schema/src/error.rs
+++ b/rust/geoarrow-schema/src/error.rs
@@ -48,10 +48,6 @@ pub enum GeoArrowError {
     #[error("Overflow")]
     Overflow,
 
-    /// [serde_json::Error]
-    #[error(transparent)]
-    SerdeJsonError(#[from] serde_json::Error),
-
     /// WKB Error
     #[error("WKB error: {0}")]
     Wkb(String),

--- a/rust/geoparquet/src/metadata.rs
+++ b/rust/geoparquet/src/metadata.rs
@@ -529,7 +529,8 @@ impl GeoParquetMetadata {
             for kv in metadata {
                 if kv.key == "geo" {
                     if let Some(value) = &kv.value {
-                        return Ok(serde_json::from_str(value)?);
+                        return serde_json::from_str(value)
+                            .map_err(|err| GeoArrowError::GeoParquet(err.to_string()));
                     }
                 }
             }

--- a/rust/geoparquet/src/reader/metadata.rs
+++ b/rust/geoparquet/src/reader/metadata.rs
@@ -143,13 +143,14 @@ impl GeoParquetReaderMetadata {
         let paths = if let Some(paths) = paths {
             paths
         } else {
-            let geo_meta = self
-                .geo_meta
-                .as_ref()
-                .ok_or(GeoArrowError::General("No geospatial metadata".to_string()))?;
-            &geo_meta.bbox_covering(None)?.ok_or(GeoArrowError::General(
-                "No covering metadata found".to_string(),
-            ))?
+            let geo_meta = self.geo_meta.as_ref().ok_or(GeoArrowError::GeoParquet(
+                "No geospatial metadata".to_string(),
+            ))?;
+            &geo_meta
+                .bbox_covering(None)?
+                .ok_or(GeoArrowError::GeoParquet(
+                    "No covering metadata found".to_string(),
+                ))?
         };
 
         let geo_statistics = ParquetBboxStatistics::try_new(self.meta.parquet_schema(), paths)?;
@@ -168,13 +169,14 @@ impl GeoParquetReaderMetadata {
         let paths = if let Some(paths) = paths {
             paths
         } else {
-            let geo_meta = self
-                .geo_meta
-                .as_ref()
-                .ok_or(GeoArrowError::General("No geospatial metadata".to_string()))?;
-            &geo_meta.bbox_covering(None)?.ok_or(GeoArrowError::General(
-                "No covering metadata found".to_string(),
-            ))?
+            let geo_meta = self.geo_meta.as_ref().ok_or(GeoArrowError::GeoParquet(
+                "No geospatial metadata".to_string(),
+            ))?;
+            &geo_meta
+                .bbox_covering(None)?
+                .ok_or(GeoArrowError::GeoParquet(
+                    "No covering metadata found".to_string(),
+                ))?
         };
 
         let geo_statistics = ParquetBboxStatistics::try_new(self.meta.parquet_schema(), paths)?;
@@ -199,13 +201,14 @@ impl GeoParquetReaderMetadata {
     pub fn file_bbox(&self, column_name: Option<&str>) -> GeoArrowResult<Option<&[f64]>> {
         if let Some(geo_meta) = self.geo_metadata() {
             let column_name = column_name.unwrap_or(geo_meta.primary_column.as_str());
-            let column_meta = geo_meta
-                .columns
-                .get(column_name)
-                .ok_or(GeoArrowError::General(format!(
-                    "Column {} not found in GeoParquet metadata",
-                    column_name
-                )))?;
+            let column_meta =
+                geo_meta
+                    .columns
+                    .get(column_name)
+                    .ok_or(GeoArrowError::GeoParquet(format!(
+                        "Column {} not found in GeoParquet metadata",
+                        column_name
+                    )))?;
             Ok(column_meta.bbox.as_deref())
         } else {
             Ok(None)
@@ -216,13 +219,14 @@ impl GeoParquetReaderMetadata {
     pub fn crs(&self, column_name: Option<&str>) -> GeoArrowResult<Option<&Value>> {
         if let Some(geo_meta) = self.geo_metadata() {
             let column_name = column_name.unwrap_or(geo_meta.primary_column.as_str());
-            let column_meta = geo_meta
-                .columns
-                .get(column_name)
-                .ok_or(GeoArrowError::General(format!(
-                    "Column {} not found in GeoParquet metadata",
-                    column_name
-                )))?;
+            let column_meta =
+                geo_meta
+                    .columns
+                    .get(column_name)
+                    .ok_or(GeoArrowError::GeoParquet(format!(
+                        "Column {} not found in GeoParquet metadata",
+                        column_name
+                    )))?;
             Ok(column_meta.crs.as_ref())
         } else {
             Ok(None)
@@ -260,7 +264,7 @@ impl GeoParquetDatasetMetadata {
     /// Construct dataset metadata from a key-value map of [ArrowReaderMetadata].
     pub fn from_files(metas: HashMap<String, ArrowReaderMetadata>) -> GeoArrowResult<Self> {
         if metas.is_empty() {
-            return Err(GeoArrowError::General("No files provided".to_string()));
+            return Err(GeoArrowError::GeoParquet("No files provided".to_string()));
         }
 
         let mut schema: Option<SchemaRef> = None;
@@ -330,13 +334,14 @@ impl GeoParquetDatasetMetadata {
     pub fn file_bbox(&self, column_name: Option<&str>) -> GeoArrowResult<Option<&[f64]>> {
         if let Some(geo_meta) = self.geo_metadata() {
             let column_name = column_name.unwrap_or(geo_meta.primary_column.as_str());
-            let column_meta = geo_meta
-                .columns
-                .get(column_name)
-                .ok_or(GeoArrowError::General(format!(
-                    "Column {} not found in GeoParquet metadata",
-                    column_name
-                )))?;
+            let column_meta =
+                geo_meta
+                    .columns
+                    .get(column_name)
+                    .ok_or(GeoArrowError::GeoParquet(format!(
+                        "Column {} not found in GeoParquet metadata",
+                        column_name
+                    )))?;
             Ok(column_meta.bbox.as_deref())
         } else {
             Ok(None)
@@ -350,13 +355,14 @@ impl GeoParquetDatasetMetadata {
     pub fn crs(&self, column_name: Option<&str>) -> GeoArrowResult<Option<&Value>> {
         if let Some(geo_meta) = self.geo_metadata() {
             let column_name = column_name.unwrap_or(geo_meta.primary_column.as_str());
-            let column_meta = geo_meta
-                .columns
-                .get(column_name)
-                .ok_or(GeoArrowError::General(format!(
-                    "Column {} not found in GeoParquet metadata",
-                    column_name
-                )))?;
+            let column_meta =
+                geo_meta
+                    .columns
+                    .get(column_name)
+                    .ok_or(GeoArrowError::GeoParquet(format!(
+                        "Column {} not found in GeoParquet metadata",
+                        column_name
+                    )))?;
             Ok(column_meta.crs.as_ref())
         } else {
             Ok(None)

--- a/rust/geoparquet/src/reader/options.rs
+++ b/rust/geoparquet/src/reader/options.rs
@@ -164,12 +164,14 @@ impl GeoParquetReaderOptions {
             let bbox_paths = if let Some(paths) = bbox_paths {
                 paths
             } else {
-                let geo_meta = geo_meta
-                    .as_ref()
-                    .ok_or(GeoArrowError::General("No geospatial metadata".to_string()))?;
-                geo_meta.bbox_covering(None)?.ok_or(GeoArrowError::General(
-                    "No covering metadata found".to_string(),
-                ))?
+                let geo_meta = geo_meta.as_ref().ok_or(GeoArrowError::GeoParquet(
+                    "No geospatial metadata".to_string(),
+                ))?;
+                geo_meta
+                    .bbox_covering(None)?
+                    .ok_or(GeoArrowError::GeoParquet(
+                        "No covering metadata found".to_string(),
+                    ))?
             };
 
             let bbox_cols = ParquetBboxStatistics::try_new(builder.parquet_schema(), &bbox_paths)?;

--- a/rust/geoparquet/src/reader/parse.rs
+++ b/rust/geoparquet/src/reader/parse.rs
@@ -124,9 +124,9 @@ fn parse_array(
         DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {
             parse_wkb_column(array.as_ref(), target_field.try_into()?)
         }
-        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Err(GeoArrowError::General(
-            "WKT input not supported in GeoParquet.".to_string(),
-        )),
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Err(
+            GeoArrowError::GeoParquet("WKT input not supported in GeoParquet.".to_string()),
+        ),
         _ => match target_type {
             GeoArrowType::Point(typ) => parse_point_column(&array, typ),
             GeoArrowType::LineString(typ) => parse_line_string_column(&array, typ),
@@ -154,7 +154,7 @@ fn parse_wkb_column(
             let geom_arr = from_wkb(&wkb_arr, target_geo_data_type)?;
             Ok(geom_arr.to_array_ref())
         }
-        dt => Err(GeoArrowError::General(format!(
+        dt => Err(GeoArrowError::GeoParquet(format!(
             "Expected WKB array to have binary data type, got {}",
             dt
         ))),

--- a/rust/geoparquet/src/reader/spatial_filter.rs
+++ b/rust/geoparquet/src/reader/spatial_filter.rs
@@ -94,28 +94,28 @@ impl<'a> ParquetBboxStatistics<'a> {
         }
 
         if minx_col.is_none() {
-            return Err(GeoArrowError::General(format!(
+            return Err(GeoArrowError::GeoParquet(format!(
                 "Unable to find xmin_path: {:?}",
                 paths.xmin
             )));
         }
 
         if miny_col.is_none() {
-            return Err(GeoArrowError::General(format!(
+            return Err(GeoArrowError::GeoParquet(format!(
                 "Unable to find ymin_path: {:?}",
                 paths.ymin
             )));
         }
 
         if maxx_col.is_none() {
-            return Err(GeoArrowError::General(format!(
+            return Err(GeoArrowError::GeoParquet(format!(
                 "Unable to find xmax_path: {:?}",
                 paths.xmax
             )));
         }
 
         if maxy_col.is_none() {
-            return Err(GeoArrowError::General(format!(
+            return Err(GeoArrowError::GeoParquet(format!(
                 "Unable to find ymax_path: {:?}",
                 paths.ymax
             )));
@@ -280,7 +280,7 @@ fn construct_bbox_columns_predicate(
     column_types.insert(parquet_schema.column(bbox_cols.maxx_col).physical_type());
     column_types.insert(parquet_schema.column(bbox_cols.maxy_col).physical_type());
     if column_types.len() != 1 {
-        return Err(GeoArrowError::General(format!(
+        return Err(GeoArrowError::GeoParquet(format!(
             "Expected one column type for GeoParquet bbox columns, got {:?}",
             column_types
         )));
@@ -290,7 +290,7 @@ fn construct_bbox_columns_predicate(
     if !(matches!(column_type, parquet::basic::Type::FLOAT)
         || matches!(column_type, parquet::basic::Type::DOUBLE))
     {
-        return Err(GeoArrowError::General(format!(
+        return Err(GeoArrowError::GeoParquet(format!(
             "Expected column type for GeoParquet bbox column to be FLOAT or DOUBLE, got {:?}",
             column_type
         )));
@@ -398,7 +398,7 @@ fn path_equals<T: AsRef<str> + Debug>(a: &[T], b: &ColumnPath) -> bool {
 fn parse_statistics_f64(column_meta: &ColumnChunkMetaData) -> GeoArrowResult<(f64, f64)> {
     let stats = column_meta
         .statistics()
-        .ok_or(GeoArrowError::General(format!(
+        .ok_or(GeoArrowError::GeoParquet(format!(
             "No statistics for column {}",
             column_meta.column_path()
         )))?;
@@ -411,7 +411,7 @@ fn parse_statistics_f64(column_meta: &ColumnChunkMetaData) -> GeoArrowResult<(f6
             *typed_stats.min_opt().unwrap() as f64,
             *typed_stats.max_opt().unwrap() as f64,
         )),
-        st => Err(GeoArrowError::General(format!(
+        st => Err(GeoArrowError::GeoParquet(format!(
             "Unexpected statistics type: {:?}",
             st
         ))),

--- a/rust/geoparquet/src/writer/async.rs
+++ b/rust/geoparquet/src/writer/async.rs
@@ -75,7 +75,11 @@ impl<W: AsyncFileWriter> GeoParquetWriterAsync<W> {
     /// All the data in the inner buffer will be force flushed.
     pub async fn finish(mut self) -> GeoArrowResult<()> {
         if let Some(geo_meta) = self.metadata_builder.finish() {
-            let kv_metadata = KeyValue::new("geo".to_string(), serde_json::to_string(&geo_meta)?);
+            let kv_metadata = KeyValue::new(
+                "geo".to_string(),
+                serde_json::to_string(&geo_meta)
+                    .map_err(|err| GeoArrowError::GeoParquet(err.to_string()))?,
+            );
             self.writer.append_key_value_metadata(kv_metadata);
         }
 

--- a/rust/geoparquet/src/writer/sync.rs
+++ b/rust/geoparquet/src/writer/sync.rs
@@ -75,7 +75,11 @@ impl<W: Write + Send> GeoParquetWriter<W> {
     /// All the data in the inner buffer will be force flushed.
     pub fn finish(mut self) -> GeoArrowResult<()> {
         if let Some(geo_meta) = self.metadata_builder.finish() {
-            let kv_metadata = KeyValue::new("geo".to_string(), serde_json::to_string(&geo_meta)?);
+            let kv_metadata = KeyValue::new(
+                "geo".to_string(),
+                serde_json::to_string(&geo_meta)
+                    .map_err(|err| GeoArrowError::GeoParquet(err.to_string()))?,
+            );
             self.writer.append_key_value_metadata(kv_metadata);
         }
 

--- a/rust/pyo3-geoarrow/src/crs.rs
+++ b/rust/pyo3-geoarrow/src/crs.rs
@@ -161,14 +161,14 @@ impl CrsTransform for PyprojCRSTransform {
     fn _convert_to_projjson(&self, crs: &Crs) -> GeoArrowResult<Option<Value>> {
         let crs = PyCrs::from(crs.clone());
         let projjson = Python::with_gil(|py| crs.to_projjson(py))
-            .map_err(|err| GeoArrowError::General(err.to_string()))?;
+            .map_err(|err| GeoArrowError::Crs(err.to_string()))?;
         Ok(projjson)
     }
 
     fn _convert_to_wkt(&self, crs: &Crs) -> GeoArrowResult<Option<String>> {
         let crs = PyCrs::from(crs.clone());
         let wkt = Python::with_gil(|py| crs.to_wkt(py))
-            .map_err(|err| GeoArrowError::General(err.to_string()))?;
+            .map_err(|err| GeoArrowError::Crs(err.to_string()))?;
         Ok(wkt)
     }
 }


### PR DESCRIPTION
Enforces better error handling than grouping everything into "General"