### PR TITLE
feat(geoarrow-schema): Set `CoordType::Separated` as default

### DIFF
--- a/rust/geoarrow-schema/src/coord_type.rs
+++ b/rust/geoarrow-schema/src/coord_type.rs
@@ -3,7 +3,7 @@
 /// GeoArrow permits coordinate types to either be "Interleaved", where the X and Y coordinates are
 /// in a single buffer as `XYXYXY` or "Separated", where the X and Y coordinates are in multiple
 /// buffers as `XXXX` and `YYYY`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CoordType {
     /// Interleaved coordinates.
     ///
@@ -25,5 +25,6 @@ pub enum CoordType {
     /// ```notest
     /// Struct<x: double, y: double, [z: double, [m: double>]]
     /// ```
+    #[default]
     Separated,
 }

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -928,7 +928,7 @@ fn parse_geometry_collection(data_type: &DataType) -> Result<(CoordType, Dimensi
 ///
 /// Refer to the [GeoArrow
 /// specification](https://github.com/geoarrow/geoarrow/blob/main/format.md#geometry).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct GeometryType {
     coord_type: CoordType,
     metadata: Arc<Metadata>,


### PR DESCRIPTION
Pending https://github.com/geoarrow/geoarrow/pull/88, cc @paleolimbot 