### PR TITLE
feat: allow passing primary column to parquet writer

### DIFF
--- a/rust/geoparquet/src/writer/metadata.rs
+++ b/rust/geoparquet/src/writer/metadata.rs
@@ -196,7 +196,7 @@ impl GeoParquetMetadataBuilder {
 
         let output_schema = create_output_schema(schema, &columns);
         Ok(Self {
-            primary_column: None,
+            primary_column: options.primary_column.clone(),
             columns,
             output_schema,
         })

--- a/rust/geoparquet/src/writer/options.rs
+++ b/rust/geoparquet/src/writer/options.rs
@@ -22,6 +22,9 @@ pub struct GeoParquetWriterOptions {
     /// Set the type of encoding to use for writing to GeoParquet.
     pub encoding: GeoParquetWriterEncoding,
 
+    /// Set the primary geometry column name.
+    pub primary_column: Option<String>,
+
     /// The parquet [WriterProperties] to use for writing to file
     pub writer_properties: Option<WriterProperties>,
 


### PR DESCRIPTION
Needed to fix https://github.com/stac-utils/rustac/issues/755. https://github.com/geoarrow/geoarrow-rs/blob/42fbcdb53ce52ab7db2edec96c4fc4129474f311/rust/geoparquet/src/writer/metadata.rs#L229 is non-deterministic (because it's iterating over a `HashMap`).