### PR TITLE
feat(python): Stabilize GeoArrowType object

### DIFF
--- a/python/geoarrow-core/python/geoarrow/rust/core/_data_type.pyi
+++ b/python/geoarrow-core/python/geoarrow/rust/core/_data_type.pyi
@@ -24,13 +24,34 @@ __all__ = [
 ]
 
 class GeoArrowType:
+    """A GeoArrow data type.
+
+    This implements the [Arrow PyCapsule
+    interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html),
+    allowing it to be seamlessly converted to other Arrow implementations.
+
+    ### Converting to pyarrow
+
+    `geoarrow-types` is recommended to register GeoArrow extension types into the pyarrow type registry.
+
+    ```
+    from geoarrow.types.type_pyarrow import register_extension_types
+    from geoarrow.rust.core import point
+
+    pa.field(point("xy"))
+    # pyarrow.Field<: extension<geoarrow.point<PointType>>>
+
+    # You may want to set the name on the field upon importing:
+    pa.field(point("xy")).with_name("geometry")
+    # pyarrow.Field<geometry: extension<geoarrow.point<PointType>>>
+
+    # Because the extension types were registered from geoarrow-types,
+    # the resulting type is geoarrow-aware
+    pa.field(point("xy", crs="epsg:4326")).type.crs
+    # ProjJsonCrs(EPSG:4326)
+    ```
     """
 
-
-    GeoArrowType is a wrapper around the GeoArrowType C++ class.
-    """
-
-    def __init__(self, data: object) -> None: ...
     def __arrow_c_schema__(self) -> object: ...
     def __eq__(self, other: object) -> bool: ...
     def __repr__(self) -> str: ...
@@ -39,87 +60,282 @@ class GeoArrowType:
     @classmethod
     def from_arrow_pycapsule(cls, capsule: object) -> GeoArrowType: ...
     @property
-    def coord_type(self) -> CoordType: ...
+    def coord_type(self) -> CoordType | None:
+        """The coordinate type of the type.
+
+        This will only be set if the type is a "native" GeoArrow type with a known
+        coordinate type. Serialized arrays such as WKB/WKT arrays do not have a
+        coordinate type.
+        """
     @property
-    def dimension(self) -> Dimension:
-        """The dimension of the type."""
+    def dimension(self) -> Dimension | None:
+        """The dimension of the type.
+
+        This will only be set if the type is a "native" GeoArrow type with a known
+        dimension type. Geometry arrays and serialized arrays such as WKB/WKT arrays do
+        not have a statically-known dimension.
+        """
     @property
     def crs(self) -> CRS | None:
         """The CRS of the type."""
     @property
     def edges(self) -> Edges | None:
-        """The edge interpretation of this type."""
+        """The edge interpolation of this type."""
 
 def point(
     dimension: DimensionInput,
-    coord_type: CoordTypeInput,
+    *,
+    coord_type: CoordTypeInput = CoordType.SEPARATED,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow Point array.
+
+    Args:
+        dimension: The dimension of the array.
+
+    Keyword Args:
+        coord_type: The coordinate type of the array. Defaults to [`CoordType.SEPARATED`][geoarrow.rust.core.types.CoordType.SEPARATED].
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+
+    Examples:
+        ```py
+        from geoarrow.rust.core import point
+
+        point("xy")
+        # GeoArrowType(Point(dimension="XY", coord_type="separated"))
+
+        point("xy", coord_type="interleaved")
+        # GeoArrowType(Point(dimension="XY", coord_type="interleaved"))
+        ```
+
+    """
+
+def linestring(
+    dimension: DimensionInput,
+    *,
+    coord_type: CoordTypeInput = CoordType.SEPARATED,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow LineString array.
+
+    Args:
+        dimension: The dimension of the array.
+
+    Keyword Args:
+        coord_type: The coordinate type of the array. Defaults to [`CoordType.SEPARATED`][geoarrow.rust.core.types.CoordType.SEPARATED].
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def polygon(
+    dimension: DimensionInput,
+    *,
+    coord_type: CoordTypeInput = CoordType.SEPARATED,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow Polygon array.
+
+    Args:
+        dimension: The dimension of the array.
+
+    Keyword Args:
+        coord_type: The coordinate type of the array. Defaults to [`CoordType.SEPARATED`][geoarrow.rust.core.types.CoordType.SEPARATED].
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def multipoint(
+    dimension: DimensionInput,
+    *,
+    coord_type: CoordTypeInput = CoordType.SEPARATED,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow MultiPoint array.
+
+    Args:
+        dimension: The dimension of the array.
+
+    Keyword Args:
+        coord_type: The coordinate type of the array. Defaults to [`CoordType.SEPARATED`][geoarrow.rust.core.types.CoordType.SEPARATED].
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def multilinestring(
+    dimension: DimensionInput,
+    *,
+    coord_type: CoordTypeInput = CoordType.SEPARATED,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow MultiLineString array.
+
+    Args:
+        dimension: The dimension of the array.
+
+    Keyword Args:
+        coord_type: The coordinate type of the array. Defaults to [`CoordType.SEPARATED`][geoarrow.rust.core.types.CoordType.SEPARATED].
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def multipolygon(
+    dimension: DimensionInput,
+    *,
+    coord_type: CoordTypeInput = CoordType.SEPARATED,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow MultiPolygon array.
+
+    Args:
+        dimension: The dimension of the array.
+
+    Keyword Args:
+        coord_type: The coordinate type of the array. Defaults to [`CoordType.SEPARATED`][geoarrow.rust.core.types.CoordType.SEPARATED].
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def geometrycollection(
+    dimension: DimensionInput,
+    *,
+    coord_type: CoordTypeInput = CoordType.SEPARATED,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow GeometryCollection array.
+
+    Args:
+        dimension: The dimension of the array.
+
+    Keyword Args:
+        coord_type: The coordinate type of the array. Defaults to [`CoordType.SEPARATED`][geoarrow.rust.core.types.CoordType.SEPARATED].
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def geometry(
+    *,
+    coord_type: CoordType,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow Geometry array.
+
+    Keyword Args:
+        coord_type: The coordinate type of the array. Defaults to [`CoordType.SEPARATED`][geoarrow.rust.core.types.CoordType.SEPARATED].
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def box(
+    dimension: DimensionInput,
     *,
     crs: CRSInput | None = None,
     edges: EdgesInput | None = None,
 ) -> GeoArrowType:
-    """Create a new Arrow type for a GeoArrow Point array."""
+    """Create a new Arrow type for a GeoArrow Box array.
 
-def linestring(
-    dimension: DimensionInput,
-    coord_type: CoordTypeInput,
-    *,
-    crs: CRSInput | None = None,
-    edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
-def polygon(
-    dimension: DimensionInput,
-    coord_type: CoordTypeInput,
-    *,
-    crs: CRSInput | None = None,
-    edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
-def multipoint(
-    dimension: DimensionInput,
-    coord_type: CoordTypeInput,
-    *,
-    crs: CRSInput | None = None,
-    edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
-def multilinestring(
-    dimension: DimensionInput,
-    coord_type: CoordTypeInput,
-    *,
-    crs: CRSInput | None = None,
-    edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
-def multipolygon(
-    dimension: DimensionInput,
-    coord_type: CoordTypeInput,
-    *,
-    crs: CRSInput | None = None,
-    edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
-def geometrycollection(
-    dimension: DimensionInput,
-    coord_type: CoordTypeInput,
-    *,
-    crs: CRSInput | None = None,
-    edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
-def geometry(
-    coord_type: CoordType,
-    *,
-    crs: CRSInput | None = None,
-    edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
-def box(
-    dimension: DimensionInput,
-    *ICoordTypeInput,
-    crs: CRSInput | None = None,
-    edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
+    Args:
+        dimension: The dimension of the array.
+
+    Keyword Args:
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
 def wkb(
     *,
     crs: CRSInput | None = None,
     edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow WKB array.
+
+    This type is backed by an Arrow BinaryArray with `i32` offsets, allowing a maximum
+    array size of 2 GB per array chunk.
+
+    Args:
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def large_wkb(
+    *,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow WKB array.
+
+    This type is backed by an Arrow LargeBinaryArray with `i64` offsets, allowing more
+    than 2GB of data per array chunk.
+
+    Args:
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def wkb_view(
+    *,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow WKB array.
+
+    This type is backed by an Arrow [BinaryViewArray](https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-view-layout).
+
+    Args:
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
 def wkt(
     *,
     crs: CRSInput | None = None,
     edges: EdgesInput | None = None,
-) -> GeoArrowType: ...
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow WKT array.
+
+    This type is backed by an Arrow StringArray with `i32` offsets, allowing a maximum
+    array size of 2 GB per array chunk.
+
+    Args:
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def large_wkt(
+    *,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow WKT array.
+
+    This type is backed by an Arrow LargeString array with `i64` offsets, allowing more
+    than 2GB of data per array chunk.
+
+    Args:
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """
+
+def wkt_view(
+    *,
+    crs: CRSInput | None = None,
+    edges: EdgesInput | None = None,
+) -> GeoArrowType:
+    """Create a new Arrow type for a GeoArrow WKT array.
+
+    This type is backed by an Arrow
+    [StringView](https://arrow.apache.org/docs/format/Columnar.html#variable-size-binary-layout)
+    array.
+
+    Args:
+        crs: the CRS of the type. Defaults to None.
+        edges: the edge interpolation of the type. Defaults to None.
+    """

--- a/python/geoarrow-core/python/geoarrow/rust/core/_rust.pyi
+++ b/python/geoarrow-core/python/geoarrow/rust/core/_rust.pyi
@@ -17,6 +17,9 @@ try:
 except ImportError:
     pass
 
+from ._array import GeoArrowArray as GeoArrowArray
+from ._array_reader import GeoArrowArrayReader as GeoArrowArrayReader
+from ._chunked_array import ChunkedGeoArrowArray as ChunkedGeoArrowArray
 from ._constructors import CoordsInput as CoordsInput
 from ._constructors import linestrings as linestrings
 from ._constructors import multilinestrings as multilinestrings
@@ -24,24 +27,24 @@ from ._constructors import multipoints as multipoints
 from ._constructors import multipolygons as multipolygons
 from ._constructors import points as points
 from ._constructors import polygons as polygons
+from ._data_type import GeoArrowType as GeoArrowType
+from ._data_type import box as box
+from ._data_type import geometry as geometry
+from ._data_type import geometrycollection as geometrycollection
+from ._data_type import large_wkb as large_wkb
+from ._data_type import large_wkt as large_wkt
+from ._data_type import linestring as linestring
+from ._data_type import multilinestring as multilinestring
+from ._data_type import multipoint as multipoint
+from ._data_type import multipolygon as multipolygon
+from ._data_type import point as point
+from ._data_type import polygon as polygon
+from ._data_type import wkb as wkb
+from ._data_type import wkb_view as wkb_view
+from ._data_type import wkt as wkt
+from ._data_type import wkt_view as wkt_view
 from .enums import CoordType
 from .types import CRSInput
-
-from ._array import GeoArrowArray as GeoArrowArray
-from ._array_reader import GeoArrowArrayReader as GeoArrowArrayReader
-from ._chunked_array import ChunkedGeoArrowArray as ChunkedGeoArrowArray
-from ._data_type import GeoArrowType as GeoArrowType
-from ._data_type import point as point
-from ._data_type import linestring as linestring
-from ._data_type import polygon as polygon
-from ._data_type import multipoint as multipoint
-from ._data_type import multilinestring as multilinestring
-from ._data_type import multipolygon as multipolygon
-from ._data_type import geometrycollection as geometrycollection
-from ._data_type import geometry as geometry
-from ._data_type import box as box
-from ._data_type import wkb as wkb
-from ._data_type import wkt as wkt
 
 class Geometry:
     """

--- a/python/geoarrow-core/src/lib.rs
+++ b/python/geoarrow-core/src/lib.rs
@@ -41,22 +41,32 @@ fn _rust(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<pyo3_geoarrow::PyChunkedGeoArrowArray>()?;
     m.add_class::<pyo3_geoarrow::PyGeoArrowArray>()?;
     m.add_class::<pyo3_geoarrow::PyGeoArrowArrayReader>()?;
-    m.add_class::<pyo3_geoarrow::PyGeoArrowType>()?;
+    m.add_class::<pyo3_geoarrow::data_type::PyGeoArrowType>()?;
 
     // Type constructors
 
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::point, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::geometry, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::geometrycollection, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::linestring, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::multilinestring, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::multipoint, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::multipolygon, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::point, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::polygon, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::wkb, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::wkt, m)?)?;
-    m.add_function(wrap_pyfunction!(pyo3_geoarrow::r#box, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::point, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::geometry, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        pyo3_geoarrow::data_type::geometrycollection,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::linestring, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        pyo3_geoarrow::data_type::multilinestring,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::multipoint, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::multipolygon, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::point, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::polygon, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::wkb, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::large_wkb, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::wkb_view, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::wkt, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::large_wkt, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::wkt_view, m)?)?;
+    m.add_function(wrap_pyfunction!(pyo3_geoarrow::data_type::r#box, m)?)?;
 
     // Constructors
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,4 +26,5 @@ dev-dependencies = [
     "numpy",
     "obstore>=0.6.0",
     "lonboard>=0.10.4",
+    "geoarrow-types>=0.3.0",
 ]

--- a/python/tests/core/test_geoarrow_type.py
+++ b/python/tests/core/test_geoarrow_type.py
@@ -1,22 +1,27 @@
-from arro3.core import Field
+import pyarrow as pa
 import pyproj
 import pytest
-
+from arro3.core import DataType, Field
 from geoarrow.rust.core import (
     GeoArrowType,
-    point,
-    linestring,
-    polygon,
-    multipoint,
-    multilinestring,
-    multipolygon,
-    geometrycollection,
-    geometry,
     box,
+    geometry,
+    geometrycollection,
+    large_wkb,
+    large_wkt,
+    linestring,
+    multilinestring,
+    multipoint,
+    multipolygon,
+    point,
+    polygon,
     wkb,
+    wkb_view,
     wkt,
+    wkt_view,
 )
 from geoarrow.rust.core.enums import CoordType, Dimension, Edges
+from geoarrow.types.type_pyarrow import PointType, registered_extension_types
 
 ARROW_EXTENSION_NAME = "ARROW:extension:name"
 
@@ -44,7 +49,7 @@ def test_create_native_type(dim: Dimension, coord_type: CoordType):
         multipolygon,
         geometrycollection,
     ]:
-        t = constructor(dim, coord_type)
+        t = constructor(dim, coord_type=coord_type)
         assert isinstance(t, GeoArrowType)
         assert t.dimension == dim
         assert t.coord_type == coord_type
@@ -58,7 +63,7 @@ def test_create_native_type(dim: Dimension, coord_type: CoordType):
 
 @pytest.mark.parametrize("coord_type", [CoordType.INTERLEAVED, CoordType.SEPARATED])
 def test_create_geometry(coord_type: CoordType):
-    t = geometry(coord_type)
+    t = geometry(coord_type=coord_type)
     assert isinstance(t, GeoArrowType)
     assert t.dimension is None
     assert t.coord_type == coord_type
@@ -81,7 +86,29 @@ def test_create_wkt():
     assert isinstance(t, GeoArrowType)
     assert t.dimension is None
     assert t.coord_type is None
-    assert Field.from_arrow(t).metadata_str[ARROW_EXTENSION_NAME] == "geoarrow.wkt"
+    f = Field.from_arrow(t)
+    assert f.metadata_str[ARROW_EXTENSION_NAME] == "geoarrow.wkt"
+    assert f.type == DataType.string()
+
+
+def test_create_large_wkt():
+    t = large_wkt()
+    assert isinstance(t, GeoArrowType)
+    assert t.dimension is None
+    assert t.coord_type is None
+    f = Field.from_arrow(t)
+    assert f.metadata_str[ARROW_EXTENSION_NAME] == "geoarrow.wkt"
+    assert f.type == DataType.large_string()
+
+
+def test_create_wkt_view():
+    t = wkt_view()
+    assert isinstance(t, GeoArrowType)
+    assert t.dimension is None
+    assert t.coord_type is None
+    f = Field.from_arrow(t)
+    assert f.metadata_str[ARROW_EXTENSION_NAME] == "geoarrow.wkt"
+    assert f.type == DataType.string_view()
 
 
 def test_create_wkb():
@@ -89,17 +116,55 @@ def test_create_wkb():
     assert isinstance(t, GeoArrowType)
     assert t.dimension is None
     assert t.coord_type is None
-    assert Field.from_arrow(t).metadata_str[ARROW_EXTENSION_NAME] == "geoarrow.wkb"
+    f = Field.from_arrow(t)
+    assert f.metadata_str[ARROW_EXTENSION_NAME] == "geoarrow.wkb"
+    assert f.type == DataType.binary()
+
+
+def test_create_large_wkb():
+    t = large_wkb()
+    assert isinstance(t, GeoArrowType)
+    assert t.dimension is None
+    assert t.coord_type is None
+    f = Field.from_arrow(t)
+    assert f.metadata_str[ARROW_EXTENSION_NAME] == "geoarrow.wkb"
+    assert f.type == DataType.large_binary()
+
+
+def test_create_wkb_view():
+    t = wkb_view()
+    assert isinstance(t, GeoArrowType)
+    assert t.dimension is None
+    assert t.coord_type is None
+    f = Field.from_arrow(t)
+    assert f.metadata_str[ARROW_EXTENSION_NAME] == "geoarrow.wkb"
+    assert f.type == DataType.binary_view()
 
 
 def test_crs():
-    point_type = point(Dimension.XY, CoordType.INTERLEAVED, crs="EPSG:4326")
+    point_type = point("xy", crs="EPSG:4326")
     # Note: this is pyproj magic to compare a string to a pyproj CRS object
     assert point_type.crs == "EPSG:4326"
     assert isinstance(point_type.crs, pyproj.CRS)
 
 
 def test_edges():
-    point_type = point(Dimension.XY, CoordType.INTERLEAVED, edges=Edges.VINCENTY)
+    point_type = point(Dimension.XY, edges=Edges.VINCENTY)
     assert point_type.edges == Edges.VINCENTY
     assert isinstance(point_type.edges, Edges)
+
+
+def test_from_arrow():
+    ga_type = point("xy")
+    arro3_field = Field.from_arrow(ga_type)
+    assert ga_type == GeoArrowType.from_arrow(arro3_field)
+
+
+def test_from_geoarrow_pyarrow():
+    rust_type = point("xy")
+    with registered_extension_types():
+        field = pa.field(rust_type)
+        typ = field.type
+        assert isinstance(typ, PointType)
+
+        assert rust_type == GeoArrowType.from_arrow(typ)

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -686,6 +686,15 @@ wheels = [
 ]
 
 [[package]]
+name = "geoarrow-types"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/97/fa35f5d13a803b8f16e59c1f18f06607b9df5683c08bd7cd7a48a29ce988/geoarrow_types-0.3.0.tar.gz", hash = "sha256:82243e4be88b268fa978ae5bba6c6680c3556735e795965b2fe3e6fbfea9f9ee", size = 23708, upload-time = "2025-05-27T03:39:39.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/16/e37cb1b0894c9cf3f9b1c50ebcfab56a0d9fe7c3b6f97d5680a7eb27ca08/geoarrow_types-0.3.0-py3-none-any.whl", hash = "sha256:439df6101632080442beccc7393cac54d6c7f6965da897554349e94d2492f613", size = 19025, upload-time = "2025-05-27T03:39:38.652Z" },
+]
+
+[[package]]
 name = "geodatasets"
 version = "2024.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2098,6 +2107,7 @@ dev = [
     { name = "affine" },
     { name = "arro3-core" },
     { name = "black" },
+    { name = "geoarrow-types" },
     { name = "geodatasets" },
     { name = "geopandas", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "geopandas", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -2127,6 +2137,7 @@ dev = [
     { name = "affine", specifier = ">=2.4.0" },
     { name = "arro3-core", specifier = ">=0.5.0" },
     { name = "black", specifier = ">=24.10.0" },
+    { name = "geoarrow-types", specifier = ">=0.3.0" },
     { name = "geodatasets", specifier = ">=2024.8.0" },
     { name = "geopandas", specifier = ">=1.0.1" },
     { name = "griffe-inherited-docstrings", specifier = ">=1.0.1" },

--- a/rust/pyo3-geoarrow/src/array.rs
+++ b/rust/pyo3-geoarrow/src/array.rs
@@ -19,8 +19,9 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 use pyo3_arrow::PyArray;
 use pyo3_arrow::ffi::to_array_pycapsules;
 
+use crate::PyCoordType;
+use crate::data_type::PyGeoArrowType;
 use crate::error::{PyGeoArrowError, PyGeoArrowResult};
-use crate::{PyCoordType, PyGeoArrowType};
 
 #[pyclass(
     module = "geoarrow.rust.core",

--- a/rust/pyo3-geoarrow/src/array_reader.rs
+++ b/rust/pyo3-geoarrow/src/array_reader.rs
@@ -10,9 +10,8 @@ use pyo3_arrow::ffi::{ArrayIterator, ArrayReader, to_schema_pycapsule, to_stream
 use pyo3_arrow::input::AnyArray;
 use pyo3_arrow::{PyArray, PyArrayReader, PyField};
 
-use crate::{
-    PyChunkedGeoArrowArray, PyGeoArrowArray, PyGeoArrowError, PyGeoArrowResult, PyGeoArrowType,
-};
+use crate::data_type::PyGeoArrowType;
+use crate::{PyChunkedGeoArrowArray, PyGeoArrowArray, PyGeoArrowError, PyGeoArrowResult};
 
 /// A Python-facing GeoArrow array reader.
 ///

--- a/rust/pyo3-geoarrow/src/chunked_array.rs
+++ b/rust/pyo3-geoarrow/src/chunked_array.rs
@@ -15,8 +15,9 @@ use pyo3_arrow::ffi::{ArrayIterator, to_stream_pycapsule};
 use pyo3_arrow::input::AnyArray;
 use pyo3_arrow::{PyArrayReader, PyChunkedArray};
 
+use crate::data_type::PyGeoArrowType;
 use crate::error::{PyGeoArrowError, PyGeoArrowResult};
-use crate::{PyCoordType, PyGeoArrowArray, PyGeoArrowType};
+use crate::{PyCoordType, PyGeoArrowArray};
 
 #[pyclass(
     module = "geoarrow.rust.core",

--- a/rust/pyo3-geoarrow/src/lib.rs
+++ b/rust/pyo3-geoarrow/src/lib.rs
@@ -6,7 +6,7 @@ mod chunked_array;
 mod coord_buffer;
 mod coord_type;
 mod crs;
-mod data_type;
+pub mod data_type;
 mod dimension;
 mod edges;
 mod error;
@@ -21,10 +21,6 @@ pub use chunked_array::PyChunkedGeoArrowArray;
 pub use coord_buffer::PyCoordBuffer;
 pub use coord_type::PyCoordType;
 pub use crs::{PyCrs, PyprojCRSTransform};
-pub use data_type::{
-    PyGeoArrowType, r#box, geometry, geometrycollection, linestring, multilinestring, multipoint,
-    multipolygon, point, polygon, wkb, wkt,
-};
 pub use dimension::PyDimension;
 pub use edges::PyEdges;
 pub use error::{PyGeoArrowError, PyGeoArrowResult};


### PR DESCRIPTION
### Change list

- Add `large_wkb`, `wkb_view`, `large_wkt`, `wkt_view` constructors.
- Add tests for interop with pyarrow and geoarrow-types.
- Improved documentation
- Remove required coordinate type argument, defaulting to separated coord type.
- Improved repr that doesn't show the raw arrow-rs Field display

For https://github.com/geoarrow/geoarrow-rs/issues/1175