### PR TITLE
feat(geoarrow-array): Add `GeoArrowArrayReader` trait and `GeoArrowArrayIterator` struct

### DIFF
--- a/rust/geoarrow-array/src/lib.rs
+++ b/rust/geoarrow-array/src/lib.rs
@@ -13,7 +13,9 @@ pub mod scalar;
 mod trait_;
 pub(crate) mod util;
 
-pub use trait_::{GeoArrowArray, GeoArrowArrayAccessor, IntoArrow};
+pub use trait_::{
+    GeoArrowArray, GeoArrowArrayAccessor, GeoArrowArrayIterator, GeoArrowArrayReader, IntoArrow,
+};
 
 #[cfg(any(test, feature = "test-data"))]
 #[allow(missing_docs)]


### PR DESCRIPTION
This parallels https://docs.rs/pyo3-arrow/latest/pyo3_arrow/ffi/trait.ArrayReader.html and https://docs.rs/pyo3-arrow/latest/pyo3_arrow/ffi/struct.ArrayIterator.html.

It's quite useful to have an iterator of GeoArrow arrays with a known geometry type in advance.