### PR TITLE
chore(python): Refactor to use upstream GeoArrowArrayReader trait

### DIFF
--- a/rust/pyo3-geoarrow/src/array_reader.rs
+++ b/rust/pyo3-geoarrow/src/array_reader.rs
@@ -1,12 +1,13 @@
-use arrow_schema::FieldRef;
+use std::sync::{Arc, Mutex};
+
 use geoarrow_array::array::from_arrow_array;
+use geoarrow_array::{GeoArrowArrayIterator, GeoArrowArrayReader};
 use geoarrow_schema::GeoArrowType;
-use pyo3::exceptions::{PyIOError, PyStopIteration};
+use pyo3::exceptions::{PyIOError, PyStopIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyType};
 use pyo3_arrow::PyArrayReader;
 use pyo3_arrow::error::PyArrowResult;
-use pyo3_arrow::export::Arro3ArrayReader;
 use pyo3_arrow::ffi::{ArrayIterator, ArrayReader, to_schema_pycapsule, to_stream_pycapsule};
 use pyo3_arrow::input::AnyArray;
 
@@ -22,52 +23,52 @@ use crate::{PyGeoArray, PyGeoArrowError, PyGeoArrowResult, PyGeoChunkedArray};
     subclass,
     frozen
 )]
-pub struct PyGeoArrayReader(PyArrayReader, GeoArrowType);
+pub struct PyGeoArrayReader {
+    iter: Mutex<Option<Box<dyn GeoArrowArrayReader + Send>>>,
+    data_type: GeoArrowType,
+}
 
 impl PyGeoArrayReader {
-    /// Construct a new [PyArrayReader] from an existing [ArrayReader].
-    pub fn try_new(reader: PyArrayReader) -> PyGeoArrowResult<Self> {
-        let field = reader.field_ref()?;
-        let data_type = GeoArrowType::try_from(field.as_ref())?;
-        Ok(Self(reader, data_type))
+    pub fn new(reader: Box<dyn GeoArrowArrayReader + Send>) -> Self {
+        let data_type = reader.data_type();
+        Self {
+            iter: Mutex::new(Some(reader)),
+            data_type,
+        }
     }
 
     /// Import from a raw Arrow C Stream capsule
     pub fn from_arrow_pycapsule(capsule: &Bound<PyCapsule>) -> PyGeoArrowResult<Self> {
         let reader = PyArrayReader::from_arrow_pycapsule(capsule)?;
-        Self::try_new(reader)
+        Ok(Self::new(array_reader_to_geoarrow_array_reader(
+            reader.into_reader()?,
+        )?))
     }
 
-    pub fn into_inner(self) -> (PyArrayReader, GeoArrowType) {
-        (self.0, self.1)
-    }
+    // pub fn into_inner(self) -> (PyArrayReader, GeoArrowType) {
+    //     (self.iter, self.data_type)
+    // }
 
     pub fn data_type(&self) -> &GeoArrowType {
-        &self.1
+        &self.data_type
     }
 
     /// Consume this reader and convert into a [ArrayReader].
     ///
     /// The reader can only be consumed once. Calling `into_reader`
-    pub fn into_reader(self) -> PyResult<Box<dyn ArrayReader + Send>> {
-        self.0.into_reader()
+    pub fn into_reader(self) -> PyResult<Box<dyn GeoArrowArrayReader + Send>> {
+        let stream = self
+            .iter
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or(PyIOError::new_err("Cannot read from closed stream."))?;
+        Ok(stream)
     }
 
     /// Consume this reader and create a [PyGeoChunkedArray] object
     pub fn into_chunked_array(self) -> PyGeoArrowResult<PyGeoChunkedArray> {
         self.read_all()
-    }
-
-    /// Access the [FieldRef] of this ArrayReader.
-    ///
-    /// If the stream has already been consumed, this method will error.
-    pub fn field_ref(&self) -> PyResult<FieldRef> {
-        self.0.field_ref()
-    }
-
-    /// Export this to a Python `arro3.core.ArrayReader`.
-    pub fn into_arro3(self) -> Arro3ArrayReader {
-        self.0.into()
     }
 }
 
@@ -75,7 +76,7 @@ impl TryFrom<Box<dyn ArrayReader + Send>> for PyGeoArrayReader {
     type Error = PyGeoArrowError;
 
     fn try_from(value: Box<dyn ArrayReader + Send>) -> Result<Self, Self::Error> {
-        Self::try_new(value.into())
+        Ok(Self::new(array_reader_to_geoarrow_array_reader(value)?))
     }
 }
 
@@ -83,14 +84,15 @@ impl TryFrom<PyArrayReader> for PyGeoArrayReader {
     type Error = PyGeoArrowError;
 
     fn try_from(value: PyArrayReader) -> Result<Self, Self::Error> {
-        Self::try_new(value)
+        value.into_reader()?.try_into()
     }
 }
 
 #[pymethods]
 impl PyGeoArrayReader {
     fn __arrow_c_schema__<'py>(&'py self, py: Python<'py>) -> PyArrowResult<Bound<'py, PyCapsule>> {
-        to_schema_pycapsule(py, self.field_ref()?.as_ref())
+        let field = self.data_type.to_field("", true);
+        to_schema_pycapsule(py, field)
     }
 
     #[pyo3(signature = (requested_schema=None))]
@@ -98,15 +100,15 @@ impl PyGeoArrayReader {
         &'py self,
         py: Python<'py>,
         requested_schema: Option<Bound<'py, PyCapsule>>,
-    ) -> PyArrowResult<Bound<'py, PyCapsule>> {
-        let array_reader = self
-            .0
-            .as_ref()
+    ) -> PyGeoArrowResult<Bound<'py, PyCapsule>> {
+        let geoarray_reader = self
+            .iter
             .lock()
             .unwrap()
             .take()
             .ok_or(PyIOError::new_err("Cannot read from closed stream"))?;
-        to_stream_pycapsule(py, array_reader, requested_schema)
+        let array_reader = geoarrow_array_reader_to_array_reader(geoarray_reader)?;
+        Ok(to_stream_pycapsule(py, array_reader, requested_schema)?)
     }
 
     // Return self
@@ -125,7 +127,7 @@ impl PyGeoArrayReader {
 
     #[getter]
     fn closed(&self) -> bool {
-        self.0.as_ref().lock().unwrap().is_none()
+        self.iter.lock().unwrap().is_none()
     }
 
     #[classmethod]
@@ -148,46 +150,61 @@ impl PyGeoArrayReader {
         r#type: PyGeoType,
         arrays: Vec<PyGeoArray>,
     ) -> PyGeoArrowResult<Self> {
+        let typ = r#type.into_inner();
         let arrays = arrays
             .into_iter()
-            .map(|array| array.into_inner().to_array_ref())
-            .collect::<Vec<_>>();
+            .map(|array| {
+                let array = array.into_inner();
+                if array.data_type() != typ {
+                    return Err(PyValueError::new_err(format!(
+                        "Array data type does not match expected type: got {:?}, expected {:?}",
+                        array.data_type(),
+                        typ
+                    )));
+                }
+                Ok(array.to_array_ref())
+            })
+            .collect::<PyResult<Vec<_>>>()?;
         PyArrayReader::new(Box::new(ArrayIterator::new(
             arrays.into_iter().map(Ok),
-            r#type.into_inner().to_field("", true).into(),
+            typ.to_field("", true).into(),
         )))
         .try_into()
     }
 
     #[classmethod]
-    fn from_stream(_cls: &Bound<PyType>, reader: PyArrayReader) -> PyGeoArrowResult<Self> {
-        Self::try_new(reader)
+    fn from_stream(_cls: &Bound<PyType>, reader: Self) -> Self {
+        reader
     }
 
     #[getter]
     fn r#type(&self) -> PyGeoType {
-        self.1.clone().into()
+        self.data_type.clone().into()
     }
 
     fn read_all(&self) -> PyGeoArrowResult<PyGeoChunkedArray> {
-        let (chunks, field) = self.0.to_chunked_array()?.into_inner();
-        let geo_arrays = chunks
-            .iter()
-            .map(|array| from_arrow_array(array, &field))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(PyGeoChunkedArray::new(geo_arrays, self.1.clone()))
+        let stream = self
+            .iter
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or(PyIOError::new_err("Cannot read from closed stream."))?;
+        let data_type = stream.data_type();
+        let mut arrays = vec![];
+        for array in stream {
+            arrays.push(array?);
+        }
+        Ok(PyGeoChunkedArray::try_new(arrays, data_type)?)
     }
 
     fn read_next_array(&self) -> PyGeoArrowResult<PyGeoArray> {
-        let mut inner = self.0.as_ref().lock().unwrap();
+        let mut inner = self.iter.lock().unwrap();
         let stream = inner
             .as_mut()
             .ok_or(PyIOError::new_err("Cannot read from closed stream."))?;
 
         if let Some(next_array) = stream.next() {
-            let array = from_arrow_array(&next_array?, &self.1.to_field("", true))?;
-            Ok(PyGeoArray::new(array))
+            Ok(PyGeoArray::new(next_array?))
         } else {
             Err(PyStopIteration::new_err("").into())
         }
@@ -196,6 +213,30 @@ impl PyGeoArrayReader {
 
 impl<'a> FromPyObject<'a> for PyGeoArrayReader {
     fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
-        Ok(Self::try_new(ob.extract()?)?)
+        let reader = ob.extract::<PyArrayReader>()?;
+        Ok(Self::new(array_reader_to_geoarrow_array_reader(
+            reader.into_reader()?,
+        )?))
     }
+}
+
+fn array_reader_to_geoarrow_array_reader(
+    reader: Box<dyn ArrayReader + Send>,
+) -> PyGeoArrowResult<Box<dyn GeoArrowArrayReader + Send>> {
+    let field = reader.field();
+    let data_type = GeoArrowType::try_from(field.as_ref())?;
+    let iter = reader
+        .into_iter()
+        .map(move |array| from_arrow_array(array?.as_ref(), field.as_ref()));
+    Ok(Box::new(GeoArrowArrayIterator::new(iter, data_type)))
+}
+
+fn geoarrow_array_reader_to_array_reader(
+    reader: Box<dyn GeoArrowArrayReader + Send>,
+) -> PyGeoArrowResult<Box<dyn ArrayReader + Send>> {
+    let field = Arc::new(reader.data_type().to_field("", true));
+    let iter = reader
+        .into_iter()
+        .map(move |array| Ok(array?.to_array_ref()));
+    Ok(Box::new(ArrayIterator::new(iter, field)))
 }

--- a/rust/pyo3-geoarrow/src/array_reader.rs
+++ b/rust/pyo3-geoarrow/src/array_reader.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use geoarrow_array::array::from_arrow_array;
 use geoarrow_array::{GeoArrowArrayIterator, GeoArrowArrayReader};
 use geoarrow_schema::GeoArrowType;
+use geoarrow_schema::error::GeoArrowResult;
 use pyo3::exceptions::{PyIOError, PyStopIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyType};
@@ -190,10 +191,7 @@ impl PyGeoArrayReader {
             .take()
             .ok_or(PyIOError::new_err("Cannot read from closed stream."))?;
         let data_type = stream.data_type();
-        let mut arrays = vec![];
-        for array in stream {
-            arrays.push(array?);
-        }
+        let arrays = stream.collect::<GeoArrowResult<_>>()?;
         Ok(PyGeoChunkedArray::try_new(arrays, data_type)?)
     }
 


### PR DESCRIPTION
### Change list

- Hold `Box<dyn GeoArrowArrayReader>` directly inside the `PyGeoArrayReader`
- Implement conversions between `Box<dyn GeoArrowArrayReader>` and `Box<dyn ArrayReader>`
- Validation when constructing a new `PyGeoChunkedArray` that all arrays have the same GeoArrowType.