### PR TITLE
chore: Bump Datafusion to 48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,8 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6cb8c2c81eada072059983657d6c9caf3fddefc43b4a65551d243253254a96"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -806,7 +807,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7be8d1b627843af62e447396db08fe1372d882c0eb8d0ea655fd1fbc33120ee"
 dependencies = [
  "arrow",
  "async-trait",
@@ -831,7 +833,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ab16c5ae43f65ee525fc493ceffbc41f40dee38b01f643dfcfc12959e92038"
 dependencies = [
  "arrow",
  "async-trait",
@@ -853,7 +856,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d56b2ac9f476b93ca82e4ef5fb00769c8a3f248d12b4965af7e27635fa7e12"
 dependencies = [
  "ahash",
  "arrow",
@@ -876,7 +880,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16015071202d6133bc84d72756176467e3e46029f3ce9ad2cb788f9b1ff139b2"
 dependencies = [
  "futures",
  "log",
@@ -886,7 +891,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b77523c95c89d2a7eb99df14ed31390e04ab29b43ff793e562bdc1716b07e17b"
 dependencies = [
  "arrow",
  "async-compression",
@@ -921,7 +927,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d25c5e2c0ebe8434beeea997b8e88d55b3ccc0d19344293f2373f65bc524fc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -945,7 +952,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc6959e1155741ab35369e1dc7673ba30fc45ed568fad34c01b7cb1daeb4d4c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -969,7 +977,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a6afdfe358d70f4237f60eaef26ae5a1ce7cb2c469d02d5fc6c7fd5d84e58b"
 dependencies = [
  "arrow",
  "async-trait",
@@ -999,12 +1008,14 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bcd8a3e3e3d02ea642541be23d44376b5d5c37c2938cce39b3873cdf7186eea"
 
 [[package]]
 name = "datafusion-execution"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670da1d45d045eee4c2319b8c7ea57b26cf48ab77b630aaa50b779e406da476a"
 dependencies = [
  "arrow",
  "dashmap",
@@ -1022,7 +1033,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a577f64bdb7e2cc4043cd97f8901d8c504711fde2dbcb0887645b00d7c660b"
 dependencies = [
  "arrow",
  "chrono",
@@ -1042,7 +1054,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b7916806ace3e9f41884f230f7f38ebf0e955dfbd88266da1826f29a0b9a6a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1054,7 +1067,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb31c9dc73d3e0c365063f91139dc273308f8a8e124adda9898db8085d68357"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1082,7 +1096,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb72c6940697eaaba9bd1f746a697a07819de952b817e3fb841fb75331ad5d4"
 dependencies = [
  "ahash",
  "arrow",
@@ -1102,7 +1117,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fdc54656659e5ecd49bf341061f4156ab230052611f4f3609612a0da259696"
 dependencies = [
  "ahash",
  "arrow",
@@ -1114,7 +1130,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad94598e3374938ca43bca6b675febe557e7a14eb627d617db427d70d65118b"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1134,7 +1151,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2fc6c2946da5cab8364fb28b5cac3115f0f3a87960b235ed031c3f7e2e639b"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1149,7 +1167,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5746548a8544870a119f556543adcd88fe0ba6b93723fe78ad0439e0fbb8b4"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1166,7 +1185,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbe9404382cda257c434f22e13577bee7047031dfdb6216dd5e841b9465e6fe"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1175,7 +1195,8 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dce50e3b637dab0d25d04d2fe79dfdca2b257eabd76790bffd22c7f90d700c8"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -1185,7 +1206,8 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cfaacf06445dc3bbc1e901242d2a44f2cae99a744f49f3fefddcee46240058"
 dependencies = [
  "arrow",
  "chrono",
@@ -1203,7 +1225,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1908034a89d7b2630898e06863583ae4c00a0dd310c1589ca284195ee3f7f8a6"
 dependencies = [
  "ahash",
  "arrow",
@@ -1224,7 +1247,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b7a12dd59ea07614b67dbb01d85254fbd93df45bcffa63495e11d3bdf847df"
 dependencies = [
  "ahash",
  "arrow",
@@ -1237,7 +1261,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4371cc4ad33978cc2a8be93bd54a232d3f2857b50401a14631c0705f3f910aae"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1255,7 +1280,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc47bc33025757a5c11f2cd094c5b6b5ed87f46fa33c023e6fdfa25fcbfade23"
 dependencies = [
  "ahash",
  "arrow",
@@ -1284,7 +1310,8 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7485da32283985d6b45bd7d13a65169dcbe8c869e25d01b2cfbc425254b4b49"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1307,7 +1334,8 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "48.0.0"
-source = "git+https://github.com/apache/datafusion?rev=0f83c1d233499e80fd9b0baf89dd624099c1d1ba#0f83c1d233499e80fd9b0baf89dd624099c1d1ba"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a466b15632befddfeac68c125f0260f569ff315c6831538cbb40db754134e0df"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 bytes = "1.10.0"
 chrono = { version = "0.4.41", default-features = false }
-# https://github.com/apache/datafusion/pull/15646
-datafusion = { git = "https://github.com/apache/datafusion", rev = "0f83c1d233499e80fd9b0baf89dd624099c1d1ba" }
+datafusion = { version = "48.0.0" }
 flatgeobuf = { version = "4.6", default-features = false }
 futures = "0.3"
 geo = "0.30.0"


### PR DESCRIPTION
Bumped Datafusion to 48.
No changes in code were necessary, as extension types were already used.