### PR TITLE
fix(geoparquet): Fix crate publish for 0.4

### DIFF
--- a/rust/geoparquet/src/writer/encode.rs
+++ b/rust/geoparquet/src/writer/encode.rs
@@ -101,7 +101,7 @@ pub(super) fn encode_record_batch(
         output_columns[*column_idx] = Some(encoded_column);
 
         if let Some(covering_field_idx) = column_info.covering_field_idx {
-            let covering = bounding_rect(&from_arrow_array(array, field)?)?;
+            let covering = bounding_rect(from_arrow_array(array, field)?.as_ref())?;
             output_columns[covering_field_idx] = Some(covering.into_array_ref());
         }
 


### PR DESCRIPTION
It's weird but I got
```
Compiling geoparquet v0.4.0 (/Users/kyle/github/geoarrow/geoarrow-rs/target/package/geoparquet-0.4.0)
error[E0277]: the trait bound `Arc<dyn GeoArrowArray>: GeoArrowArray` is not satisfied
   --> src/writer/encode.rs:104:42
    |
104 |             let covering = bounding_rect(&from_arrow_array(array, field)?)?;
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `GeoArrowArray` is not implemented for `Arc<dyn GeoArrowArray>`
    |
    = help: the following other types implement trait `GeoArrowArray`:
              GenericWkbArray<O>
              GenericWktArray<O>
              GeometryArray
              GeometryCollectionArray
              LineStringArray
              MultiLineStringArray
              MultiPointArray
              MultiPolygonArray
            and 5 others
    = note: required for the cast from `&Arc<dyn GeoArrowArray>` to `&dyn GeoArrowArray`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `geoparquet` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

only when trying to publish the package. Why wouldn't this error in one of our checks on CI?

With this change, `cargo publish -p geoparquet --dry-run` succeeds.