### PR TITLE
feat: contains fn 

### DIFF
--- a/rust/geoarrow-geo/src/contains.rs
+++ b/rust/geoarrow-geo/src/contains.rs
@@ -33,7 +33,7 @@ fn _contains_impl<'a>(
                 let result = left_geom.contains(&right_geom);
                 builder.append_value(result);
             }
-            (None, _) | (_, None) => {
+            ( _, _) => {
                 builder.append_null();
             }
         }

--- a/rust/geoarrow-geo/src/contains.rs
+++ b/rust/geoarrow-geo/src/contains.rs
@@ -33,7 +33,7 @@ pub fn contains<'a>(
 
 #[cfg(test)]
 mod tests {
-    use geo::{Geometry, line_string, polygon, point};
+    use geo::{Geometry, line_string, point, polygon};
     use geoarrow_array::builder::GeometryBuilder;
     use geoarrow_schema::{CoordType, GeometryType};
 
@@ -111,15 +111,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "Arrays must have the same length")]
     fn test_contains_length_mismatch() {
-        let geoms_left = vec![
-            Some(Geometry::from(polygon![
-                (x: 1.0, y: 1.0),
-                (x: 2.0, y: 1.0),
-                (x: 2.0, y: 2.0),
-                (x: 1.0, y: 2.0)
-            ])),
-        ];
-        let geoms_right: Vec<Option<Geometry>>  = vec![];
+        let geoms_left = vec![Some(Geometry::from(polygon![
+            (x: 1.0, y: 1.0),
+            (x: 2.0, y: 1.0),
+            (x: 2.0, y: 2.0),
+            (x: 1.0, y: 2.0)
+        ]))];
+        let geoms_right: Vec<Option<Geometry>> = vec![];
 
         let typ = GeometryType::new(Default::default()).with_coord_type(CoordType::Interleaved);
         let left_array = GeometryBuilder::from_nullable_geometries(&geoms_left, typ.clone())

--- a/rust/geoarrow-geo/src/contains.rs
+++ b/rust/geoarrow-geo/src/contains.rs
@@ -1,6 +1,5 @@
 use arrow_array::BooleanArray;
 use geo::contains::Contains;
-use geo::point;
 use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::GeoArrowArrayAccessor;
 use geoarrow_schema::error::GeoArrowResult;
@@ -33,10 +32,12 @@ pub fn contains<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use geo::point;
     use geo::{Geometry, line_string, polygon};
     use geoarrow_array::builder::GeometryBuilder;
     use geoarrow_schema::{CoordType, GeometryType};
+
+    use super::*;
 
     #[test]
     fn test_contains() {

--- a/rust/geoarrow-geo/src/contains.rs
+++ b/rust/geoarrow-geo/src/contains.rs
@@ -33,7 +33,7 @@ fn _contains_impl<'a>(
                 let result = left_geom.contains(&right_geom);
                 builder.append_value(result);
             }
-            ( _, _) => {
+            (_, _) => {
                 builder.append_null();
             }
         }

--- a/rust/geoarrow-geo/src/contains.rs
+++ b/rust/geoarrow-geo/src/contains.rs
@@ -1,0 +1,109 @@
+use arrow_array::BooleanArray;
+use geo::contains::Contains;
+use geo::point;
+use geo_traits::to_geo::ToGeoGeometry;
+use geoarrow_array::GeoArrowArrayAccessor;
+use geoarrow_schema::error::GeoArrowResult;
+pub fn contains<'a>(
+    left_array: &'a impl GeoArrowArrayAccessor<'a>,
+    right_array: &'a impl GeoArrowArrayAccessor<'a>,
+) -> GeoArrowResult<BooleanArray> {
+    assert_eq!(
+        left_array.len(),
+        right_array.len(),
+        "Arrays must have the same length"
+    );
+    let mut builder = BooleanArray::builder(left_array.len());
+
+    for (canidate_left, canidate_right) in left_array.iter().zip(right_array.iter()) {
+        match (canidate_left, canidate_right) {
+            (Some(left), Some(right)) => {
+                let left_geom = left?.to_geometry();
+                let right_geom = right?.to_geometry();
+                let result = left_geom.contains(&right_geom);
+                builder.append_value(result);
+            }
+            (None, _) | (_, None) => {
+                builder.append_null();
+            }
+        }
+    }
+    Ok(builder.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::{Geometry, line_string, polygon};
+    use geoarrow_array::builder::GeometryBuilder;
+    use geoarrow_schema::{CoordType, GeometryType};
+
+    #[test]
+    fn test_contains() {
+        let test_pairs = [
+            //Right is contained in left
+            vec![
+                Some(Geometry::from(polygon![
+                    (x: 1.0, y: 1.0),
+                    (x: 2.0, y: 1.0),
+                    (x: 2.0, y: 2.0),
+                    (x: 1.0, y: 2.0)
+                ])),
+                Some(Geometry::from(polygon![
+                    (x: 1.5, y: 1.5),
+                    (x: 1.75, y: 1.5),
+                    (x: 1.75, y: 1.75),
+                    (x: 1.5, y: 1.75)
+                ])),
+            ],
+            //Right is not contained in left
+            vec![
+                Some(Geometry::from(polygon![
+                    (x: 1.0, y: 1.0),
+                    (x: 2.0, y: 1.0),
+                    (x: 2.0, y: 2.0),
+                    (x: 1.0, y: 2.0)
+                ])),
+                Some(Geometry::from(polygon![
+                    (x: 4.5, y: 4.5),
+                    (x: 5.5, y: 4.5),
+                    (x: 5.5, y: 5.5),
+                    (x: 3.5, y: 5.5),
+                ])),
+            ],
+            //Mixed geometry
+            vec![
+                Some(Geometry::from(line_string![
+                    (x: 0., y: 0.),
+                    (x: 2., y: 0.),
+                    (x: 2., y: 2.),
+                    (x: 0., y: 2.),
+                    (x: 0., y: 0.),
+                ])),
+                Some(Geometry::from(point!(x: 2., y: 0.))),
+            ],
+        ];
+
+        let geoms_left = test_pairs
+            .iter()
+            .map(|pair| pair[0].clone())
+            .collect::<Vec<_>>();
+        let geoms_right = test_pairs
+            .iter()
+            .map(|pair| pair[1].clone())
+            .collect::<Vec<_>>();
+
+        let typ = GeometryType::new(Default::default()).with_coord_type(CoordType::Interleaved);
+        let left_array = GeometryBuilder::from_nullable_geometries(&geoms_left, typ.clone())
+            .unwrap()
+            .finish();
+        let right_array = GeometryBuilder::from_nullable_geometries(&geoms_right, typ)
+            .unwrap()
+            .finish();
+
+        let result = contains(&left_array, &right_array).unwrap();
+        let expected = BooleanArray::from(vec![Some(true), Some(false), Some(true)]);
+
+        assert_eq!(result, expected, "Contains test failed");
+    }
+}

--- a/rust/geoarrow-geo/src/lib.rs
+++ b/rust/geoarrow-geo/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod area;
 mod centroid;
+mod contains;
 mod convex_hull;
 mod intersects;
 mod relate;
@@ -10,6 +11,7 @@ pub(crate) mod util;
 
 pub use area::{signed_area, unsigned_area};
 pub use centroid::centroid;
+pub use contains::contains;
 pub use convex_hull::convex_hull;
 pub use intersects::intersects;
 pub use relate::relate_boolean;


### PR DESCRIPTION
Addresses #1205 , Follows #1207 example for DE-9IM predicates  and added `contains`. Used [geo's](https://docs.rs/geo/latest/geo/algorithm/contains/trait.Contains.html) `contain` method. 


Tests right now are right polygon contained in left, two polygons that don't contain one another, and mixed geometry of line and point being contained in line.
Please let me know if more tests should be added. 
