### PR TITLE
feat(geodatafusion): Allow loading WKB from BinaryView columns

### DIFF
--- a/rust/geodatafusion/src/udf/native/io/wkb.rs
+++ b/rust/geodatafusion/src/udf/native/io/wkb.rs
@@ -9,7 +9,7 @@ use datafusion::logical_expr::{
     Volatility,
 };
 use geoarrow_array::GeoArrowArray;
-use geoarrow_array::array::{LargeWkbArray, WkbArray, from_arrow_array};
+use geoarrow_array::array::{LargeWkbArray, WkbArray, from_arrow_array, WkbViewArray};
 use geoarrow_array::cast::{from_wkb, to_wkb};
 use geoarrow_schema::{CoordType, GeoArrowType, GeometryType, WkbType};
 
@@ -100,7 +100,7 @@ impl GeomFromWKB {
         Self {
             signature: Signature::uniform(
                 1,
-                vec![DataType::Binary, DataType::LargeBinary],
+                vec![DataType::Binary, DataType::LargeBinary, DataType::BinaryView],
                 Volatility::Immutable,
             ),
             coord_type,
@@ -118,6 +118,10 @@ impl GeomFromWKB {
             ),
             DataType::LargeBinary => from_wkb(
                 &LargeWkbArray::try_from((array.as_ref(), field.as_ref()))?,
+                to_type,
+            ),
+            DataType::BinaryView => from_wkb(
+                &WkbViewArray::try_from((array.as_ref(), field.as_ref()))?,
                 to_type,
             ),
             _ => unreachable!(),

--- a/rust/geodatafusion/src/udf/native/io/wkb.rs
+++ b/rust/geodatafusion/src/udf/native/io/wkb.rs
@@ -9,7 +9,7 @@ use datafusion::logical_expr::{
     Volatility,
 };
 use geoarrow_array::GeoArrowArray;
-use geoarrow_array::array::{LargeWkbArray, WkbArray, from_arrow_array, WkbViewArray};
+use geoarrow_array::array::{LargeWkbArray, WkbArray, WkbViewArray, from_arrow_array};
 use geoarrow_array::cast::{from_wkb, to_wkb};
 use geoarrow_schema::{CoordType, GeoArrowType, GeometryType, WkbType};
 
@@ -100,7 +100,11 @@ impl GeomFromWKB {
         Self {
             signature: Signature::uniform(
                 1,
-                vec![DataType::Binary, DataType::LargeBinary, DataType::BinaryView],
+                vec![
+                    DataType::Binary,
+                    DataType::LargeBinary,
+                    DataType::BinaryView,
+                ],
                 Volatility::Immutable,
             ),
             coord_type,


### PR DESCRIPTION
`ST_GeomFromWKB` currently only works with a subset of the standard binary types. Most users on the latest DataFusion release probably won't have an issue with this today, but I'm currently using the `main` branch of DataFusion for several reasons and this defaults to using the view types (`BinaryView`, `Utf8View`, etc.) instead of `Binary`, `Utf8`, and so on.

This PR adds support for loading WKB geometries from a `BinaryView` column, which is how geoparquet geometry fields seem to be interpreted by default in the upcoming release.