### PR TITLE
fix(geoarrow-geo): Fix compilation error when converting geo-traits to `geo` geometries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6cb8c2c81eada072059983657d6c9caf3fddefc43b4a65551d243253254a96"
+checksum = "8a11e19a7ccc5bb979c95c1dceef663eab39c9061b3bbf8d1937faf0f03bf41f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -805,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7be8d1b627843af62e447396db08fe1372d882c0eb8d0ea655fd1fbc33120ee"
+checksum = "94985e67cab97b1099db2a7af11f31a45008b282aba921c1e1d35327c212ec18"
 dependencies = [
  "arrow",
  "async-trait",
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ab16c5ae43f65ee525fc493ceffbc41f40dee38b01f643dfcfc12959e92038"
+checksum = "e002df133bdb7b0b9b429d89a69aa77b35caeadee4498b2ce1c7c23a99516988"
 dependencies = [
  "arrow",
  "async-trait",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d56b2ac9f476b93ca82e4ef5fb00769c8a3f248d12b4965af7e27635fa7e12"
+checksum = "e13242fc58fd753787b0a538e5ae77d356cb9d0656fa85a591a33c5f106267f6"
 dependencies = [
  "ahash",
  "arrow",
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16015071202d6133bc84d72756176467e3e46029f3ce9ad2cb788f9b1ff139b2"
+checksum = "d2239f964e95c3a5d6b4a8cde07e646de8995c1396a7fd62c6e784f5341db499"
 dependencies = [
  "futures",
  "log",
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b77523c95c89d2a7eb99df14ed31390e04ab29b43ff793e562bdc1716b07e17b"
+checksum = "2cf792579bc8bf07d1b2f68c2d5382f8a63679cce8fbebfd4ba95742b6e08864"
 dependencies = [
  "arrow",
  "async-compression",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d25c5e2c0ebe8434beeea997b8e88d55b3ccc0d19344293f2373f65bc524fc"
+checksum = "cfc114f9a1415174f3e8d2719c371fc72092ef2195a7955404cfe6b2ba29a706"
 dependencies = [
  "arrow",
  "async-trait",
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc6959e1155741ab35369e1dc7673ba30fc45ed568fad34c01b7cb1daeb4d4c"
+checksum = "d88dd5e215c420a52362b9988ecd4cefd71081b730663d4f7d886f706111fc75"
 dependencies = [
  "arrow",
  "async-trait",
@@ -975,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a6afdfe358d70f4237f60eaef26ae5a1ce7cb2c469d02d5fc6c7fd5d84e58b"
+checksum = "33692acdd1fbe75280d14f4676fe43f39e9cb36296df56575aa2cac9a819e4cf"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1006,15 +1006,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bcd8a3e3e3d02ea642541be23d44376b5d5c37c2938cce39b3873cdf7186eea"
+checksum = "e0e7b648387b0c1937b83cb328533c06c923799e73a9e3750b762667f32662c0"
 
 [[package]]
 name = "datafusion-execution"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670da1d45d045eee4c2319b8c7ea57b26cf48ab77b630aaa50b779e406da476a"
+checksum = "9609d83d52ff8315283c6dad3b97566e877d8f366fab4c3297742f33dcd636c7"
 dependencies = [
  "arrow",
  "dashmap",
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a577f64bdb7e2cc4043cd97f8901d8c504711fde2dbcb0887645b00d7c660b"
+checksum = "e75230cd67f650ef0399eb00f54d4a073698f2c0262948298e5299fc7324da63"
 dependencies = [
  "arrow",
  "chrono",
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b7916806ace3e9f41884f230f7f38ebf0e955dfbd88266da1826f29a0b9a6a"
+checksum = "70fafb3a045ed6c49cfca0cd090f62cf871ca6326cc3355cb0aaf1260fa760b6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1065,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb31c9dc73d3e0c365063f91139dc273308f8a8e124adda9898db8085d68357"
+checksum = "cdf9a9cf655265861a20453b1e58357147eab59bdc90ce7f2f68f1f35104d3bb"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb72c6940697eaaba9bd1f746a697a07819de952b817e3fb841fb75331ad5d4"
+checksum = "7f07e49733d847be0a05235e17b884d326a2fd402c97a89fe8bcf0bfba310005"
 dependencies = [
  "ahash",
  "arrow",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fdc54656659e5ecd49bf341061f4156ab230052611f4f3609612a0da259696"
+checksum = "4512607e10d72b0b0a1dc08f42cb5bd5284cb8348b7fea49dc83409493e32b1b"
 dependencies = [
  "ahash",
  "arrow",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad94598e3374938ca43bca6b675febe557e7a14eb627d617db427d70d65118b"
+checksum = "2ab331806e34f5545e5f03396e4d5068077395b1665795d8f88c14ec4f1e0b7a"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2fc6c2946da5cab8364fb28b5cac3115f0f3a87960b235ed031c3f7e2e639b"
+checksum = "d4ac2c0be983a06950ef077e34e0174aa0cb9e346f3aeae459823158037ade37"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5746548a8544870a119f556543adcd88fe0ba6b93723fe78ad0439e0fbb8b4"
+checksum = "36f3d92731de384c90906941d36dcadf6a86d4128409a9c5cd916662baed5f53"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbe9404382cda257c434f22e13577bee7047031dfdb6216dd5e841b9465e6fe"
+checksum = "c679f8bf0971704ec8fd4249fcbb2eb49d6a12cc3e7a840ac047b4928d3541b5"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1193,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dce50e3b637dab0d25d04d2fe79dfdca2b257eabd76790bffd22c7f90d700c8"
+checksum = "2821de7cb0362d12e75a5196b636a59ea3584ec1e1cc7dc6f5e34b9e8389d251"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfaacf06445dc3bbc1e901242d2a44f2cae99a744f49f3fefddcee46240058"
+checksum = "1594c7a97219ede334f25347ad8d57056621e7f4f35a0693c8da876e10dd6a53"
 dependencies = [
  "arrow",
  "chrono",
@@ -1223,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1908034a89d7b2630898e06863583ae4c00a0dd310c1589ca284195ee3f7f8a6"
+checksum = "dc6da0f2412088d23f6b01929dedd687b5aee63b19b674eb73d00c3eb3c883b7"
 dependencies = [
  "ahash",
  "arrow",
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b7a12dd59ea07614b67dbb01d85254fbd93df45bcffa63495e11d3bdf847df"
+checksum = "dcb0dbd9213078a593c3fe28783beaa625a4e6c6a6c797856ee2ba234311fb96"
 dependencies = [
  "ahash",
  "arrow",
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4371cc4ad33978cc2a8be93bd54a232d3f2857b50401a14631c0705f3f910aae"
+checksum = "6d140854b2db3ef8ac611caad12bfb2e1e1de827077429322a6188f18fc0026a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc47bc33025757a5c11f2cd094c5b6b5ed87f46fa33c023e6fdfa25fcbfade23"
+checksum = "b46cbdf21a01206be76d467f325273b22c559c744a012ead5018dfe79597de08"
 dependencies = [
  "ahash",
  "arrow",
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7485da32283985d6b45bd7d13a65169dcbe8c869e25d01b2cfbc425254b4b49"
+checksum = "3a72733766ddb5b41534910926e8da5836622316f6283307fd9fb7e19811a59c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1332,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "48.0.0"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a466b15632befddfeac68c125f0260f569ff315c6831538cbb40db754134e0df"
+checksum = "c5162338cdec9cc7ea13a0e6015c361acad5ec1d88d83f7c86301f789473971f"
 dependencies = [
  "arrow",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 bytes = "1.10.0"
 chrono = { version = "0.4.41", default-features = false }
-datafusion = { version = "48.0.0" }
+datafusion = { version = "48.0.1" }
 flatgeobuf = { git = "https://github.com/kylebarron/flatgeobuf", rev = "ea7749d5b209972389f73f9a93dd1d860f3467a1", default-features = false }
 futures = "0.3"
 geo = "0.30.0"

--- a/rust/geoarrow-geo/src/area.rs
+++ b/rust/geoarrow-geo/src/area.rs
@@ -2,10 +2,11 @@ use arrow_array::Float64Array;
 use arrow_array::builder::Float64Builder;
 use arrow_buffer::NullBuffer;
 use geo::Area;
-use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, downcast_geoarrow_array};
 use geoarrow_schema::GeoArrowType;
 use geoarrow_schema::error::GeoArrowResult;
+
+use crate::util::to_geo::geometry_to_geo;
 
 pub fn unsigned_area(array: &dyn GeoArrowArray) -> GeoArrowResult<Float64Array> {
     downcast_geoarrow_array!(array, _unsigned_area_impl)
@@ -52,7 +53,7 @@ fn _area_impl<'a, F: Fn(&geo::Geometry) -> f64>(
 
     for item in array.iter() {
         if let Some(geom) = item {
-            let geo_geom = geom?.to_geometry();
+            let geo_geom = geometry_to_geo(&geom?)?;
             builder.append_value(area_fn(&geo_geom));
         } else {
             builder.append_null();

--- a/rust/geoarrow-geo/src/centroid.rs
+++ b/rust/geoarrow-geo/src/centroid.rs
@@ -1,10 +1,11 @@
 use geo::Centroid;
-use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::array::PointArray;
 use geoarrow_array::builder::PointBuilder;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, downcast_geoarrow_array};
-use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
+use geoarrow_schema::error::GeoArrowResult;
 use geoarrow_schema::{CoordType, Dimension, PointType};
+
+use crate::util::to_geo::geometry_to_geo;
 
 pub fn centroid(array: &dyn GeoArrowArray, coord_type: CoordType) -> GeoArrowResult<PointArray> {
     downcast_geoarrow_array!(array, _centroid_impl, coord_type)
@@ -20,11 +21,7 @@ fn _centroid_impl<'a>(
 
     for item in array.iter() {
         if let Some(geom) = item {
-            let geo_geom = geom?
-                .try_to_geometry()
-                .ok_or(GeoArrowError::IncorrectGeometryType(
-                    "geo crate does not support empty points.".to_string(),
-                ))?;
+            let geo_geom = geometry_to_geo(&geom?)?;
             let centroid = geo_geom.centroid();
             builder.push_point(centroid.as_ref());
         } else {

--- a/rust/geoarrow-geo/src/contains.rs
+++ b/rust/geoarrow-geo/src/contains.rs
@@ -1,10 +1,10 @@
 use arrow_array::BooleanArray;
 use geo::contains::Contains;
-use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::util::downcast::downcast_geoarrow_array_two_args;
+use crate::util::to_geo::geometry_to_geo;
 
 pub fn contains(
     left_array: &dyn GeoArrowArray,
@@ -28,8 +28,8 @@ fn _contains_impl<'a>(
     for (canidate_left, canidate_right) in left_array.iter().zip(right_array.iter()) {
         match (canidate_left, canidate_right) {
             (Some(left), Some(right)) => {
-                let left_geom = left?.to_geometry();
-                let right_geom = right?.to_geometry();
+                let left_geom = geometry_to_geo(&left?)?;
+                let right_geom = geometry_to_geo(&right?)?;
                 let result = left_geom.contains(&right_geom);
                 builder.append_value(result);
             }

--- a/rust/geoarrow-geo/src/convex_hull.rs
+++ b/rust/geoarrow-geo/src/convex_hull.rs
@@ -1,10 +1,11 @@
 use geo::ConvexHull;
-use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::array::PolygonArray;
 use geoarrow_array::builder::PolygonBuilder;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, downcast_geoarrow_array};
 use geoarrow_schema::error::GeoArrowResult;
 use geoarrow_schema::{Dimension, PolygonType};
+
+use crate::util::to_geo::geometry_to_geo;
 
 pub fn convex_hull(array: &dyn GeoArrowArray) -> GeoArrowResult<PolygonArray> {
     downcast_geoarrow_array!(array, convex_hull_impl)
@@ -18,7 +19,7 @@ fn convex_hull_impl<'a>(array: &'a impl GeoArrowArrayAccessor<'a>) -> GeoArrowRe
 
     for item in array.iter() {
         if let Some(geom) = item {
-            let geo_geom = geom?.to_geometry();
+            let geo_geom = geometry_to_geo(&geom?)?;
             let poly = geo_geom.convex_hull();
             builder.push_polygon(Some(&poly))?;
         } else {

--- a/rust/geoarrow-geo/src/intersects.rs
+++ b/rust/geoarrow-geo/src/intersects.rs
@@ -1,10 +1,10 @@
 use arrow_array::BooleanArray;
 use geo::intersects::Intersects;
-use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::util::downcast::downcast_geoarrow_array_two_args;
+use crate::util::to_geo::geometry_to_geo;
 
 pub fn intersects(
     left_array: &dyn GeoArrowArray,
@@ -28,18 +28,8 @@ fn _intersects_impl<'a>(
     for (maybe_left, maybe_right) in left_array.iter().zip(right_array.iter()) {
         match (maybe_left, maybe_right) {
             (Some(left), Some(right)) => {
-                let left_geom =
-                    left?
-                        .try_to_geometry()
-                        .ok_or(GeoArrowError::IncorrectGeometryType(
-                            "geo crate does not support empty points.".to_string(),
-                        ))?;
-                let right_geom =
-                    right?
-                        .try_to_geometry()
-                        .ok_or(GeoArrowError::IncorrectGeometryType(
-                            "geo crate does not support empty points.".to_string(),
-                        ))?;
+                let left_geom = geometry_to_geo(&left?)?;
+                let right_geom = geometry_to_geo(&right?)?;
                 let intersects = left_geom.intersects(&right_geom);
                 builder.append_value(intersects);
             }

--- a/rust/geoarrow-geo/src/lib.rs
+++ b/rust/geoarrow-geo/src/lib.rs
@@ -7,7 +7,7 @@ mod convex_hull;
 mod intersects;
 mod relate;
 mod simplify;
-pub(crate) mod util;
+pub mod util;
 
 pub use area::{signed_area, unsigned_area};
 pub use centroid::centroid;

--- a/rust/geoarrow-geo/src/relate.rs
+++ b/rust/geoarrow-geo/src/relate.rs
@@ -1,11 +1,11 @@
 use arrow_array::BooleanArray;
 use geo::Relate;
 use geo::relate::IntersectionMatrix;
-use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 use crate::util::downcast::downcast_geoarrow_array_two_args;
+use crate::util::to_geo::geometry_to_geo;
 
 pub fn relate_boolean(
     left_array: &dyn GeoArrowArray,
@@ -31,18 +31,8 @@ fn _relate_impl<'a>(
     for (maybe_left, maybe_right) in left_array.iter().zip(right_array.iter()) {
         match (maybe_left, maybe_right) {
             (Some(left), Some(right)) => {
-                let left_geom =
-                    left?
-                        .try_to_geometry()
-                        .ok_or(GeoArrowError::IncorrectGeometryType(
-                            "geo crate does not support empty points.".to_string(),
-                        ))?;
-                let right_geom =
-                    right?
-                        .try_to_geometry()
-                        .ok_or(GeoArrowError::IncorrectGeometryType(
-                            "geo crate does not support empty points.".to_string(),
-                        ))?;
+                let left_geom = geometry_to_geo(&left?)?;
+                let right_geom = geometry_to_geo(&right?)?;
                 let matrix = left_geom.relate(&right_geom);
                 builder.append_value(relate_cb(matrix));
             }

--- a/rust/geoarrow-geo/src/util/mod.rs
+++ b/rust/geoarrow-geo/src/util/mod.rs
@@ -1,2 +1,2 @@
 pub(crate) mod downcast;
-pub(crate) mod to_geo;
+pub mod to_geo;

--- a/rust/geoarrow-geo/src/util/mod.rs
+++ b/rust/geoarrow-geo/src/util/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod downcast;
+pub(crate) mod to_geo;

--- a/rust/geoarrow-geo/src/util/to_geo.rs
+++ b/rust/geoarrow-geo/src/util/to_geo.rs
@@ -1,4 +1,4 @@
-//! Convert structs that implement geo-traits to [geo] objects.
+//! Convert structs that implement [geo_traits] to [geo] objects.
 //!
 //! Note that this is the same underlying implementation as upstream [geo] in
 //! <https://github.com/georust/geo/pull/1255>. However, the trait-based implementation hits this
@@ -20,7 +20,7 @@ use geo_traits::to_geo::{
 use geo_traits::{GeometryCollectionTrait, GeometryTrait, GeometryType};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
-/// Convert any [geo-traits] Geometry to a [`geo::Geometry`].
+/// Convert any [geo_traits] Geometry to a [`geo::Geometry`].
 ///
 /// Only the first two dimensions will be kept.
 pub fn geometry_to_geo<T: CoordNum>(

--- a/rust/geoarrow-geo/src/util/to_geo.rs
+++ b/rust/geoarrow-geo/src/util/to_geo.rs
@@ -18,37 +18,50 @@ use geo_traits::to_geo::{
     ToGeoPoint, ToGeoPolygon, ToGeoRect, ToGeoTriangle,
 };
 use geo_traits::{GeometryCollectionTrait, GeometryTrait, GeometryType};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
 /// Convert any Geometry to a [`Geometry`].
 ///
 /// Only the first two dimensions will be kept.
-pub fn geometry_to_geo<T: CoordNum>(geometry: &impl GeometryTrait<T = T>) -> Geometry<T> {
+pub fn geometry_to_geo<T: CoordNum>(
+    geometry: &impl GeometryTrait<T = T>,
+) -> GeoArrowResult<Geometry<T>> {
     use GeometryType::*;
 
     match geometry.as_type() {
-        Point(geom) => Geometry::Point(geom.to_point()),
-        LineString(geom) => Geometry::LineString(geom.to_line_string()),
-        Polygon(geom) => Geometry::Polygon(geom.to_polygon()),
-        MultiPoint(geom) => Geometry::MultiPoint(geom.to_multi_point()),
-        MultiLineString(geom) => Geometry::MultiLineString(geom.to_multi_line_string()),
-        MultiPolygon(geom) => Geometry::MultiPolygon(geom.to_multi_polygon()),
-        GeometryCollection(geom) => Geometry::GeometryCollection(geometry_collection_to_geo(geom)),
-        Rect(geom) => Geometry::Rect(geom.to_rect()),
-        Line(geom) => Geometry::Line(geom.to_line()),
-        Triangle(geom) => Geometry::Triangle(geom.to_triangle()),
+        Point(geom) => Ok(Geometry::Point(geom.try_to_point().ok_or(
+            GeoArrowError::IncorrectGeometryType(
+                "geo crate does not support empty points.".to_string(),
+            ),
+        )?)),
+        LineString(geom) => Ok(Geometry::LineString(geom.to_line_string())),
+        Polygon(geom) => Ok(Geometry::Polygon(geom.to_polygon())),
+        MultiPoint(geom) => Ok(Geometry::MultiPoint(geom.try_to_multi_point().ok_or(
+            GeoArrowError::IncorrectGeometryType(
+                "geo crate does not support empty points.".to_string(),
+            ),
+        )?)),
+        MultiLineString(geom) => Ok(Geometry::MultiLineString(geom.to_multi_line_string())),
+        MultiPolygon(geom) => Ok(Geometry::MultiPolygon(geom.to_multi_polygon())),
+        GeometryCollection(geom) => Ok(Geometry::GeometryCollection(geometry_collection_to_geo(
+            geom,
+        )?)),
+        Rect(geom) => Ok(Geometry::Rect(geom.to_rect())),
+        Line(geom) => Ok(Geometry::Line(geom.to_line())),
+        Triangle(geom) => Ok(Geometry::Triangle(geom.to_triangle())),
     }
 }
 
 /// Convert any GeometryCollection to a [`GeometryCollection`].
 ///
 /// Only the first two dimensions will be kept.
-pub fn geometry_collection_to_geo<T: CoordNum>(
+fn geometry_collection_to_geo<T: CoordNum>(
     geometry_collection: &impl GeometryCollectionTrait<T = T>,
-) -> GeometryCollection<T> {
-    GeometryCollection::new_from(
+) -> GeoArrowResult<GeometryCollection<T>> {
+    Ok(GeometryCollection::new_from(
         geometry_collection
             .geometries()
             .map(|geometry| geometry_to_geo(&geometry))
-            .collect(),
-    )
+            .collect::<GeoArrowResult<_>>()?,
+    ))
 }

--- a/rust/geoarrow-geo/src/util/to_geo.rs
+++ b/rust/geoarrow-geo/src/util/to_geo.rs
@@ -1,4 +1,4 @@
-//! Convert structs that implement geo-traits to [geo-types] objects.
+//! Convert structs that implement geo-traits to [geo] objects.
 //!
 //! Note that this is the same underlying implementation as upstream [geo] in
 //! <https://github.com/georust/geo/pull/1255>. However, the trait-based implementation hits this
@@ -20,7 +20,7 @@ use geo_traits::to_geo::{
 use geo_traits::{GeometryCollectionTrait, GeometryTrait, GeometryType};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 
-/// Convert any Geometry to a [`Geometry`].
+/// Convert any [geo-traits] Geometry to a [`geo::Geometry`].
 ///
 /// Only the first two dimensions will be kept.
 pub fn geometry_to_geo<T: CoordNum>(

--- a/rust/geoarrow-geo/src/util/to_geo.rs
+++ b/rust/geoarrow-geo/src/util/to_geo.rs
@@ -12,7 +12,6 @@
 //! Other traits can use the upstream impls.
 
 use geo::{CoordNum, Geometry, GeometryCollection};
-
 use geo_traits::to_geo::{
     ToGeoLine, ToGeoLineString, ToGeoMultiLineString, ToGeoMultiPoint, ToGeoMultiPolygon,
     ToGeoPoint, ToGeoPolygon, ToGeoRect, ToGeoTriangle,

--- a/rust/geodatafusion/src/udf/geo/relationships/topological/intersects.rs
+++ b/rust/geodatafusion/src/udf/geo/relationships/topological/intersects.rs
@@ -10,7 +10,6 @@ use datafusion::logical_expr::{
     ColumnarValue, Documentation, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 use geo::{PreparedGeometry, Relate};
-use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::array::from_arrow_array;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, downcast_geoarrow_array};
 use geoarrow_schema::error::GeoArrowResult;

--- a/rust/geodatafusion/src/udf/geo/relationships/topological/relate.rs
+++ b/rust/geodatafusion/src/udf/geo/relationships/topological/relate.rs
@@ -13,6 +13,7 @@ use geo::relate::IntersectionMatrix;
 use geo::{PreparedGeometry, Relate};
 use geoarrow_array::array::from_arrow_array;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, downcast_geoarrow_array};
+use geoarrow_geo::util::to_geo::geometry_to_geo;
 use geoarrow_schema::error::GeoArrowResult;
 
 use crate::error::GeoDataFusionResult;
@@ -222,8 +223,7 @@ fn _to_geo_scalar_impl<'a>(
     arr: &'a impl GeoArrowArrayAccessor<'a>,
 ) -> GeoArrowResult<Option<geo::Geometry>> {
     if let Some(geom) = arr.iter().next().unwrap() {
-        let geom = geom?;
-        Ok(geom.try_to_geometry())
+        Some(geometry_to_geo(&geom?)).transpose()
     } else {
         Ok(None)
     }
@@ -246,7 +246,7 @@ fn _relate_prepared_geometry_impl<'a>(
 
     for item in arr.iter() {
         if let Some(geom) = item {
-            let geo_geom = geom?.to_geometry();
+            let geo_geom = geometry_to_geo(&geom?)?;
             builder.append_value(relate_cb(geo_geom.relate(prepared)));
         } else {
             builder.append_null();

--- a/rust/geodatafusion/src/udf/geo/relationships/topological/relate.rs
+++ b/rust/geodatafusion/src/udf/geo/relationships/topological/relate.rs
@@ -11,7 +11,6 @@ use datafusion::logical_expr::{
 };
 use geo::relate::IntersectionMatrix;
 use geo::{PreparedGeometry, Relate};
-use geo_traits::to_geo::ToGeoGeometry;
 use geoarrow_array::array::from_arrow_array;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, downcast_geoarrow_array};
 use geoarrow_schema::error::GeoArrowResult;


### PR DESCRIPTION
@ianthetechie brought up in https://github.com/geoarrow/geoarrow-rs/discussions/1238 that geoarrow-geo no longer compiled on latest Rust stable on main. I'd forgotten that in the original `geoarrow` code I overrode how to convert how to convert to `geo` objects. There's something about trait objects that causes the compilation failure. Pure functions are fine to use recursion in this way.

Closes https://github.com/geoarrow/geoarrow-rs/issues/1240