### PR TITLE
chore(python): Prepare version 0.4.1

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## [0.4.1] - 2025-07-17
+
+- Added `path` property to `GeoParquetFile` class so information about each fragment of a `GeoParquetDataset` can be associated back to the original file.
+
 ## [0.4.0] - 2025-07-01
 
 This release contains the Python bindings for more or less a **full rewrite** of the GeoArrow Rust library.

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-rust-compute"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-rust-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "geoarrow-array",
  "geoarrow-schema",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-rust-io"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "bytes",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 homepage = "https://geoarrow.org/geoarrow-rs/"
 repository = "https://github.com/geoarrow/geoarrow-rs"


### PR DESCRIPTION
Pretty much just includes #1246 , but I want that for a Lonboard demo (https://github.com/developmentseed/lonboard/pull/822) 