### PR TITLE
feat(geoarrow-flatgeobuf): Improved schema inference & expose more from header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,6 +1765,7 @@ dependencies = [
  "geoarrow-schema",
  "geozero",
  "http-range-client",
+ "indexmap 2.10.0",
  "object_store",
  "tokio",
  "wkt 0.14.0",

--- a/rust/geoarrow-flatgeobuf/Cargo.toml
+++ b/rust/geoarrow-flatgeobuf/Cargo.toml
@@ -33,6 +33,7 @@ geoarrow-array = { workspace = true, features = ["geozero"] }
 geoarrow-schema = { workspace = true }
 geozero = { workspace = true }
 http-range-client = { workspace = true, optional = true, default-features = false }
+indexmap = { workspace = true }
 object_store = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/rust/geoarrow-flatgeobuf/src/lib.rs
+++ b/rust/geoarrow-flatgeobuf/src/lib.rs
@@ -1,5 +1,6 @@
 //! Read from and write to [FlatGeobuf](https://flatgeobuf.org/) files.
 
+#![warn(missing_docs)]
 #![cfg_attr(not(test), deny(unused_crate_dependencies))]
 
 pub mod reader;

--- a/rust/geoarrow-flatgeobuf/src/reader/async.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/async.rs
@@ -47,7 +47,10 @@ impl<T: AsyncHttpRangeClient + Unpin + Send + 'static> FlatGeobufRecordBatchStre
             selection,
             geometry_type: header.geometry_type().clone(),
             batch_size: options.batch_size,
-            properties_schema: header.properties_schema().clone(),
+            properties_schema: header
+                .properties_schema()
+                .expect("todo: handle unknown properties schema")
+                .clone(),
             num_rows_remaining,
             read_geometry: options.read_geometry,
         })

--- a/rust/geoarrow-flatgeobuf/src/reader/async.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/async.rs
@@ -22,7 +22,7 @@ struct FlatGeobufRecordBatchStreamInner<T: AsyncHttpRangeClient> {
     geometry_type: GeoArrowType,
     batch_size: usize,
     properties_schema: SchemaRef,
-    num_rows_remaining: Option<usize>,
+    num_rows_remaining: usize,
     read_geometry: bool,
 }
 
@@ -31,18 +31,18 @@ impl<T: AsyncHttpRangeClient + Unpin + Send + 'static> FlatGeobufRecordBatchStre
         selection: AsyncFeatureIter<T>,
         options: FlatGeobufReaderOptions,
     ) -> GeoArrowResult<Self> {
-        let (geometry_type, properties_schema) = parse_header(
+        let header = parse_header(
             selection.header(),
             options.coord_type,
             options.prefer_view_types,
             options.columns.as_ref(),
         )?;
-        let num_rows_remaining = selection.features_count();
+        let num_rows_remaining = header.features_count().try_into().unwrap();
         Ok(Self {
             selection,
-            geometry_type,
+            geometry_type: header.geometry_type().clone(),
             batch_size: options.batch_size,
-            properties_schema,
+            properties_schema: header.properties_schema().clone(),
             num_rows_remaining,
             read_geometry: options.read_geometry,
         })
@@ -61,9 +61,7 @@ impl<T: AsyncHttpRangeClient + Unpin + Send + 'static> FlatGeobufRecordBatchStre
 
     async fn process_batch(&mut self) -> GeoArrowResult<Option<RecordBatch>> {
         let options = GeoArrowRecordBatchBuilderOptions {
-            batch_size: self
-                .num_rows_remaining
-                .map(|num_rows_remaining| num_rows_remaining.min(self.batch_size)),
+            batch_size: Some(self.num_rows_remaining.min(self.batch_size)),
             error_on_extra_columns: false,
             read_geometry: self.read_geometry,
         };

--- a/rust/geoarrow-flatgeobuf/src/reader/mod.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/mod.rs
@@ -1,3 +1,5 @@
+//! Read from [FlatGeobuf](https://flatgeobuf.org/) files.
+
 #[cfg(feature = "async")]
 mod r#async;
 mod common;

--- a/rust/geoarrow-flatgeobuf/src/reader/mod.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/mod.rs
@@ -3,6 +3,7 @@ mod r#async;
 mod common;
 #[cfg(feature = "object_store")]
 pub mod object_store;
+pub mod schema;
 mod sync;
 mod table_builder;
 

--- a/rust/geoarrow-flatgeobuf/src/reader/mod.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/mod.rs
@@ -8,5 +8,5 @@ mod table_builder;
 
 #[cfg(feature = "async")]
 pub use r#async::FlatGeobufRecordBatchStream;
-pub use common::{FlatGeobufReaderOptions, parse_header};
+pub use common::{Envelope, FlatGeobufReaderOptions, HeaderInfo, parse_header};
 pub use sync::FlatGeobufRecordBatchIterator;

--- a/rust/geoarrow-flatgeobuf/src/reader/object_store.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/object_store.rs
@@ -1,3 +1,5 @@
+//! Integration with the [`object_store`] crate.
+
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -6,12 +8,14 @@ use http_range_client::{AsyncHttpRangeClient, Result as HTTPRangeClientResult};
 use object_store::ObjectStore;
 use object_store::path::Path;
 
+/// A wrapper around an [`ObjectStore`] that implements the [`AsyncHttpRangeClient`] trait.
 pub struct ObjectStoreWrapper {
     store: Arc<dyn ObjectStore>,
     location: Path,
 }
 
 impl ObjectStoreWrapper {
+    /// Creates a new [`ObjectStoreWrapper`] with the given store and location.
     pub fn new(store: Arc<dyn ObjectStore>, location: Path) -> Self {
         Self { store, location }
     }

--- a/rust/geoarrow-flatgeobuf/src/reader/schema.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/schema.rs
@@ -1,3 +1,5 @@
+//! Helpers for inferring a schema from FlatGeobuf files.
+
 use std::io::{Read, Seek};
 use std::sync::Arc;
 
@@ -21,6 +23,9 @@ use indexmap::IndexMap;
 /// This currently only infers the properties schema, not the geometry schema. For FlatGeobuf files
 /// with unknown geometry, we currently always use the `Geometry` GeoArrow type, which allows for
 /// all geometry types.
+///
+/// This can be used to infer a joint schema for multiple FlatGeobuf files by passing successive
+/// files' data into the `process` method.
 #[derive(Debug, Clone)]
 pub struct FlatGeobufSchemaBuilder {
     fields: IndexMap<String, FieldRef>,
@@ -120,6 +125,7 @@ impl FlatGeobufSchemaBuilder {
 }
 
 impl FlatGeobufSchemaBuilder {
+    /// Finish the schema building process and return the resulting schema.
     pub fn finish(self) -> SchemaRef {
         Arc::new(Schema::new(self.fields.into_values().collect::<Vec<_>>()))
     }

--- a/rust/geoarrow-flatgeobuf/src/reader/schema.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/schema.rs
@@ -1,0 +1,200 @@
+use std::io::{Read, Seek};
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef, TimeUnit};
+use flatgeobuf::{
+    FallibleStreamingIterator, FeatureIter, FeatureProperties, NotSeekable, Seekable,
+};
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
+use geozero::PropertyProcessor;
+use indexmap::IndexMap;
+
+/// A scanner over FlatGeobuf files to infer a properties schema.
+///
+/// The FlatGeobuf specification allows for files that are [either homogeneous or
+/// heterogenerous](https://worace.works/2022/03/12/flatgeobuf-implementers-guide/) in schema. For
+/// homogeneous schemas, they usually have feature information in the file header, meaning that for
+/// GeoArrow we can easily infer the desired schema upfront. For heterogenerous files, however,
+/// there's no feature information in the header, so we must scan through actual data records in
+/// the file to infer the schema.
+///
+/// This currently only infers the properties schema, not the geometry schema. For FlatGeobuf files
+/// with unknown geometry, we currently always use the `Geometry` GeoArrow type, which allows for
+/// all geometry types.
+#[derive(Debug, Clone)]
+pub struct FlatGeobufSchemaBuilder {
+    fields: IndexMap<String, FieldRef>,
+    prefer_view_types: bool,
+}
+
+impl FlatGeobufSchemaBuilder {
+    /// Create a new FlatGeobuf schema builder.
+    pub fn new(prefer_view_types: bool) -> Self {
+        Self {
+            fields: IndexMap::new(),
+            prefer_view_types,
+        }
+    }
+}
+
+impl Default for FlatGeobufSchemaBuilder {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
+impl FlatGeobufSchemaBuilder {
+    /// Process the properties of a FlatGeobuf feature to build the schema.
+    pub fn process<R: Read + Seek>(
+        &mut self,
+        selection: FeatureIter<R, Seekable>,
+        max_read_records: Option<usize>,
+    ) -> GeoArrowResult<()> {
+        let mut selection = selection.take(max_read_records.unwrap_or(usize::MAX));
+
+        loop {
+            if let Some(feature) = selection
+                .next()
+                .map_err(|err| GeoArrowError::External(Box::new(err)))?
+            {
+                feature
+                    .process_properties(self)
+                    .map_err(|err| GeoArrowError::External(Box::new(err)))?;
+            } else {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Process the properties of a FlatGeobuf feature to build the schema without using seek.
+    pub fn process_seq<R: Read>(
+        &mut self,
+        selection: FeatureIter<R, NotSeekable>,
+        max_read_records: Option<usize>,
+    ) -> GeoArrowResult<()> {
+        let mut selection = selection.take(max_read_records.unwrap_or(usize::MAX));
+
+        loop {
+            if let Some(feature) = selection
+                .next()
+                .map_err(|err| GeoArrowError::External(Box::new(err)))?
+            {
+                feature
+                    .process_properties(self)
+                    .map_err(|err| GeoArrowError::External(Box::new(err)))?;
+            } else {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Process the properties of a FlatGeobuf feature to build the schema from an async source.
+    #[cfg(feature = "async")]
+    pub async fn process_async<
+        T: http_range_client::AsyncHttpRangeClient + Unpin + Send + 'static,
+    >(
+        &mut self,
+        mut selection: flatgeobuf::AsyncFeatureIter<T>,
+        max_read_records: Option<usize>,
+    ) -> GeoArrowResult<()> {
+        let mut num_features_processed = 0;
+
+        while let Some(feature) = selection
+            .next()
+            .await
+            .map_err(|err| GeoArrowError::External(Box::new(err)))?
+        {
+            feature
+                .process_properties(self)
+                .map_err(|err| GeoArrowError::External(Box::new(err)))?;
+
+            num_features_processed += 1;
+            if let Some(max_read_records) = max_read_records {
+                if num_features_processed >= max_read_records {
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl FlatGeobufSchemaBuilder {
+    pub fn finish(self) -> SchemaRef {
+        Arc::new(Schema::new(self.fields.into_values().collect::<Vec<_>>()))
+    }
+}
+
+impl PropertyProcessor for FlatGeobufSchemaBuilder {
+    fn property(
+        &mut self,
+        _idx: usize,
+        name: &str,
+        value: &geozero::ColumnValue,
+    ) -> geozero::error::Result<bool> {
+        if let Some(field) = self.fields.get(name) {
+            // We have already seen this field, so we skip it.
+            if field != &column_value_to_field(name, value, self.prefer_view_types) {
+                return Err(geozero::error::GeozeroError::Property(format!(
+                    "Inconsistent field for property '{}': expected {:?}, found {:?}",
+                    name,
+                    field,
+                    column_value_to_field(name, value, self.prefer_view_types),
+                )));
+            }
+        } else {
+            // We haven't seen this field yet, so we add it to the schema.
+            let field = column_value_to_field(name, value, self.prefer_view_types);
+            self.fields.insert(name.to_string(), field);
+        }
+
+        Ok(false)
+    }
+}
+
+fn column_value_to_field(
+    name: &str,
+    value: &geozero::ColumnValue,
+    prefer_view_types: bool,
+) -> FieldRef {
+    let data_type = match value {
+        geozero::ColumnValue::Bool(_) => DataType::Boolean,
+        geozero::ColumnValue::Byte(_) => DataType::Int8,
+        geozero::ColumnValue::Short(_) => DataType::Int16,
+        geozero::ColumnValue::Int(_) => DataType::Int32,
+        geozero::ColumnValue::Long(_) => DataType::Int64,
+        geozero::ColumnValue::UByte(_) => DataType::UInt8,
+        geozero::ColumnValue::UShort(_) => DataType::UInt16,
+        geozero::ColumnValue::UInt(_) => DataType::UInt32,
+        geozero::ColumnValue::ULong(_) => DataType::UInt64,
+        geozero::ColumnValue::Float(_) => DataType::Float32,
+        geozero::ColumnValue::Double(_) => DataType::Float64,
+        geozero::ColumnValue::String(_) => {
+            if prefer_view_types {
+                DataType::Utf8View
+            } else {
+                DataType::Utf8
+            }
+        }
+        geozero::ColumnValue::Binary(_) => {
+            if prefer_view_types {
+                DataType::BinaryView
+            } else {
+                DataType::Binary
+            }
+        }
+        geozero::ColumnValue::Json(_) => {
+            let data_type = if prefer_view_types {
+                DataType::Utf8View
+            } else {
+                DataType::Utf8
+            };
+            let field = Field::new(name, data_type, true)
+                .with_extension_type(arrow_schema::extension::Json::default());
+            return Arc::new(field);
+        }
+        geozero::ColumnValue::DateTime(_) => DataType::Timestamp(TimeUnit::Microsecond, None),
+    };
+
+    Arc::new(Field::new(name, data_type, true))
+}

--- a/rust/geoarrow-flatgeobuf/src/reader/sync.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/sync.rs
@@ -62,7 +62,10 @@ impl<R: Read, S> FlatGeobufRecordBatchIterator<R, S> {
             selection,
             geometry_type: header.geometry_type().clone(),
             batch_size: options.batch_size,
-            properties_schema: header.properties_schema().clone(),
+            properties_schema: header
+                .properties_schema()
+                .expect("todo: handle unknown properties schema")
+                .clone(),
             num_rows_remaining,
             read_geometry: options.read_geometry,
         })

--- a/rust/geoarrow-flatgeobuf/src/reader/sync.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/sync.rs
@@ -45,6 +45,8 @@ pub struct FlatGeobufRecordBatchIterator<R: Read, S> {
 }
 
 impl<R: Read, S> FlatGeobufRecordBatchIterator<R, S> {
+    /// Create a new FlatGeobuf record batch iterator from a feature iterator from the
+    /// [`flatgeobuf`] crate.
     pub fn try_new(
         selection: FeatureIter<R, S>,
         options: FlatGeobufReaderOptions,

--- a/rust/geoarrow-flatgeobuf/src/writer.rs
+++ b/rust/geoarrow-flatgeobuf/src/writer.rs
@@ -1,3 +1,5 @@
+//! Write to [FlatGeobuf](https://flatgeobuf.org/) files.
+
 use std::io::Write;
 
 use arrow_schema::Schema;

--- a/rust/geodatafusion-flatgeobuf/src/file_format.rs
+++ b/rust/geodatafusion-flatgeobuf/src/file_format.rs
@@ -125,7 +125,11 @@ impl FileFormat for FlatGeobufFormat {
             )
             .await?;
 
-            let mut fields = header.properties_schema().fields().to_vec();
+            let mut fields = header
+                .properties_schema()
+                .expect("todo: handle inferring schema")
+                .fields()
+                .to_vec();
             fields.push(Arc::new(header.geometry_type().to_field("geometry", true)));
             let schema = Schema::new(fields);
 

--- a/rust/geodatafusion-flatgeobuf/src/file_format.rs
+++ b/rust/geodatafusion-flatgeobuf/src/file_format.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -7,20 +7,19 @@ use arrow_schema::{Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::catalog::memory::DataSourceExec;
+use datafusion::common::stats::Precision;
 use datafusion::common::{GetExt, Statistics};
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
 use datafusion::datasource::file_format::{FileFormat, FileFormatFactory};
-use datafusion::datasource::physical_plan::{
-    FileScanConfig, FileScanConfigBuilder, FileSinkConfig, FileSource,
-};
+use datafusion::datasource::physical_plan::{FileScanConfig, FileScanConfigBuilder, FileSource};
 use datafusion::error::{DataFusionError, Result};
-use datafusion::physical_expr::LexRequirement;
 use datafusion::physical_plan::ExecutionPlan;
 use flatgeobuf::HttpFgbReader;
 use geoarrow_flatgeobuf::reader::object_store::ObjectStoreWrapper;
-use geoarrow_flatgeobuf::reader::parse_header;
+use geoarrow_flatgeobuf::reader::{HeaderInfo, parse_header};
 use geoarrow_schema::CoordType;
 use http_range_client::AsyncBufferedHttpRangeClient;
+use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore};
 
 use crate::source::FlatGeobufSource;
@@ -73,6 +72,23 @@ pub struct FlatGeobufFormat {
     coord_type: CoordType,
 }
 
+async fn read_flatgeobuf_header(
+    store: Arc<dyn ObjectStore>,
+    location: Path,
+    coord_type: CoordType,
+    prefer_view_types: bool,
+    projection: Option<&HashSet<String>>,
+) -> Result<HeaderInfo> {
+    let object_store_wrapper = ObjectStoreWrapper::new(store, location);
+    let async_client = AsyncBufferedHttpRangeClient::with(object_store_wrapper, "");
+    let reader = HttpFgbReader::new(async_client)
+        .await
+        .map_err(|err| DataFusionError::External(Box::new(err)))?;
+    let header = parse_header(reader.header(), coord_type, prefer_view_types, projection)
+        .map_err(|err| DataFusionError::External(Box::new(err)))?;
+    Ok(header)
+}
+
 #[async_trait]
 impl FileFormat for FlatGeobufFormat {
     fn as_any(&self) -> &dyn Any {
@@ -100,18 +116,17 @@ impl FileFormat for FlatGeobufFormat {
         let mut schemas = vec![];
 
         for object in objects {
-            let object_store_wrapper =
-                ObjectStoreWrapper::new(store.clone(), object.location.clone());
-            let async_client = AsyncBufferedHttpRangeClient::with(object_store_wrapper, "");
-            let reader = HttpFgbReader::new(async_client)
-                .await
-                .map_err(|err| DataFusionError::External(Box::new(err)))?;
-            let (geo_type, properties_schema) =
-                parse_header(reader.header(), self.coord_type, true, None)
-                    .map_err(|err| DataFusionError::External(Box::new(err)))?;
+            let header = read_flatgeobuf_header(
+                store.clone(),
+                object.location.clone(),
+                self.coord_type,
+                true,
+                None,
+            )
+            .await?;
 
-            let mut fields = properties_schema.fields().to_vec();
-            fields.push(Arc::new(geo_type.to_field("geometry", true)));
+            let mut fields = header.properties_schema().fields().to_vec();
+            fields.push(Arc::new(header.geometry_type().to_field("geometry", true)));
             let schema = Schema::new(fields);
 
             schemas.push(schema);
@@ -124,11 +139,24 @@ impl FileFormat for FlatGeobufFormat {
     async fn infer_stats(
         &self,
         _state: &dyn Session,
-        _store: &Arc<dyn ObjectStore>,
+        store: &Arc<dyn ObjectStore>,
         table_schema: SchemaRef,
-        _object: &ObjectMeta,
+        object: &ObjectMeta,
     ) -> Result<Statistics> {
-        Ok(Statistics::new_unknown(&table_schema))
+        let header = read_flatgeobuf_header(
+            store.clone(),
+            object.location.clone(),
+            self.coord_type,
+            true,
+            None,
+        )
+        .await?;
+
+        Ok(
+            Statistics::new_unknown(&table_schema).with_num_rows(Precision::Exact(
+                header.features_count().try_into().unwrap(),
+            )),
+        )
     }
 
     async fn create_physical_plan(
@@ -139,17 +167,8 @@ impl FileFormat for FlatGeobufFormat {
         let conf_builder = FileScanConfigBuilder::from(conf);
         let source = Arc::new(FlatGeobufSource::new());
         let config = conf_builder.with_source(source).build();
+        dbg!(&config);
         Ok(DataSourceExec::from_data_source(config))
-    }
-
-    async fn create_writer_physical_plan(
-        &self,
-        _input: Arc<dyn ExecutionPlan>,
-        _state: &dyn Session,
-        _conf: FileSinkConfig,
-        _order_requirements: Option<LexRequirement>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        todo!()
     }
 
     fn file_source(&self) -> Arc<dyn FileSource> {


### PR DESCRIPTION
# Change list

- Add schema scanner for inferring schema from dataset without known schema in header
- Require crate-wide docs
- Add HeaderInfo struct with full information from FlatGeobuf header


### Todo:

- Cleaner API for enabling schema inference. Right now, our public APIs have users pass in a bare FeatureIter, but if the schema isn't known, we have to exhaust the iterator just to infer the schema.