### PR TITLE
fix(geoarrow-array)!: WkbBuilder should return result when appending geometries

### DIFF
--- a/rust/geoarrow-array/src/array/wkb.rs
+++ b/rust/geoarrow-array/src/array/wkb.rs
@@ -300,9 +300,9 @@ mod test {
 
     fn wkb_data<O: OffsetSizeTrait>() -> GenericWkbArray<O> {
         let mut builder = WkbBuilder::new(WkbType::new(Default::default()));
-        builder.push_geometry(Some(&point::p0()));
-        builder.push_geometry(Some(&point::p1()));
-        builder.push_geometry(Some(&point::p2()));
+        builder.push_geometry(Some(&point::p0())).unwrap();
+        builder.push_geometry(Some(&point::p1())).unwrap();
+        builder.push_geometry(Some(&point::p2())).unwrap();
         builder.finish()
     }
 

--- a/rust/geoarrow-array/src/builder/wkb.rs
+++ b/rust/geoarrow-array/src/builder/wkb.rs
@@ -2,6 +2,7 @@ use arrow_array::OffsetSizeTrait;
 use arrow_array::builder::GenericBinaryBuilder;
 use geo_traits::GeometryTrait;
 use geoarrow_schema::WkbType;
+use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use wkb::Endianness;
 use wkb::writer::{WriteOptions, write_geometry};
 
@@ -38,37 +39,43 @@ impl<O: OffsetSizeTrait> WkbBuilder<O> {
 
     /// Push a Geometry onto the end of this builder
     #[inline]
-    pub fn push_geometry(&mut self, geom: Option<&impl GeometryTrait<T = f64>>) {
+    pub fn push_geometry(
+        &mut self,
+        geom: Option<&impl GeometryTrait<T = f64>>,
+    ) -> GeoArrowResult<()> {
         if let Some(geom) = geom {
             let wkb_options = WriteOptions {
                 endianness: Endianness::LittleEndian,
             };
-            write_geometry(&mut self.0, geom, &wkb_options).unwrap();
+            write_geometry(&mut self.0, geom, &wkb_options)
+                .map_err(|err| GeoArrowError::Wkb(err.to_string()))?;
             self.0.append_value("")
         } else {
             self.0.append_null()
-        }
+        };
+        Ok(())
     }
 
     /// Extend this builder from an iterator of Geometries.
     pub fn extend_from_iter<'a>(
         &mut self,
         geoms: impl Iterator<Item = Option<&'a (impl GeometryTrait<T = f64> + 'a)>>,
-    ) {
+    ) -> GeoArrowResult<()> {
         geoms
             .into_iter()
-            .for_each(|maybe_geom| self.push_geometry(maybe_geom));
+            .try_for_each(|maybe_geom| self.push_geometry(maybe_geom))?;
+        Ok(())
     }
 
     /// Create this builder from a slice of nullable Geometries.
     pub fn from_nullable_geometries(
         geoms: &[Option<impl GeometryTrait<T = f64>>],
         typ: WkbType,
-    ) -> Self {
+    ) -> GeoArrowResult<Self> {
         let capacity = WkbCapacity::from_geometries(geoms.iter().map(|x| x.as_ref()));
         let mut array = Self::with_capacity(typ, capacity);
-        array.extend_from_iter(geoms.iter().map(|x| x.as_ref()));
-        array
+        array.extend_from_iter(geoms.iter().map(|x| x.as_ref()))?;
+        Ok(array)
     }
 
     /// Consume this builder and convert to a [GenericWkbArray].

--- a/rust/geoarrow-array/src/cast.rs
+++ b/rust/geoarrow-array/src/cast.rs
@@ -371,7 +371,7 @@ fn impl_to_wkb<'a, O: OffsetSizeTrait>(
         .map(|x| x.transpose())
         .collect::<GeoArrowResult<Vec<_>>>()?;
     let wkb_type = WkbType::new(geo_arr.data_type().metadata().clone());
-    Ok(WkbBuilder::from_nullable_geometries(geoms.as_slice(), wkb_type).finish())
+    Ok(WkbBuilder::from_nullable_geometries(geoms.as_slice(), wkb_type)?.finish())
 }
 
 /// Convert a [GeoArrowArray] to a [`WkbViewArray`].
@@ -1256,7 +1256,7 @@ mod test {
             .collect::<std::result::Result<Vec<_>, _>>()
             .unwrap();
         let wkb_type = WkbType::new(geo_arr.data_type().metadata().clone());
-        Ok(WkbBuilder::from_nullable_geometries(geoms.as_slice(), wkb_type).finish())
+        Ok(WkbBuilder::from_nullable_geometries(geoms.as_slice(), wkb_type)?.finish())
     }
 
     // Verify that this compiles with the macro

--- a/rust/geoarrow-geos/src/import/array/wkb.rs
+++ b/rust/geoarrow-geos/src/import/array/wkb.rs
@@ -18,7 +18,7 @@ impl<O: OffsetSizeTrait> FromGEOS for WkbBuilder<O> {
             .into_iter()
             .map(|geom| geom.map(GEOSGeometry::new))
             .collect::<Vec<_>>();
-        Ok(Self::from_nullable_geometries(&geoms, typ))
+        Self::from_nullable_geometries(&geoms, typ)
     }
 }
 


### PR DESCRIPTION
### Change list

- Currently the WkbBuilder uses `unwrap` when adding geometries to the builder. This should not panic.