### PR TITLE
fix(geodatafusion-flatgeobuf): make `http-range-client` dependency non-optional

### DIFF
--- a/rust/geodatafusion-flatgeobuf/Cargo.toml
+++ b/rust/geodatafusion-flatgeobuf/Cargo.toml
@@ -17,7 +17,7 @@ flatgeobuf = { workspace = true }
 futures = { workspace = true }
 geoarrow-flatgeobuf = { workspace = true, features = ["object_store"] }
 geoarrow-schema = { workspace = true }
-http-range-client = { workspace = true, optional = true, default-features = false }
+http-range-client = { workspace = true, default-features = false }
 object_store = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- fix geodatafusion-flatgeobuf Cargo.toml to include http-range-client dependency

## Testing
- `cargo test --workspace` *(fails: ObjectStore(Generic { store: "HTTP", source: RetryError ... }))*


------
https://chatgpt.com/codex/tasks/task_e_689505c7ed788328bd27b8f3db4e0c90