### PR TITLE
feat(flatgeobuf): push down bbox filters

### DIFF
--- a/rust/geodatafusion-flatgeobuf/src/source.rs
+++ b/rust/geodatafusion-flatgeobuf/src/source.rs
@@ -5,12 +5,17 @@ use std::sync::Arc;
 
 use arrow_schema::SchemaRef;
 use datafusion::common::Statistics;
+use datafusion::config::ConfigOptions;
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::physical_plan::{
     FileMeta, FileOpenFuture, FileOpener, FileScanConfig, FileSource,
 };
 use datafusion::error::{DataFusionError, Result};
+use datafusion::physical_expr::expressions::Literal;
+use datafusion::physical_expr::{PhysicalExpr, ScalarFunctionExpr};
+use datafusion::physical_plan::filter_pushdown::{FilterPushdownPropagation, PushedDown};
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
+use datafusion::scalar::ScalarValue;
 use futures::StreamExt;
 use geoarrow_flatgeobuf::reader::{FlatGeobufReaderOptions, FlatGeobufRecordBatchStream};
 use object_store::ObjectStore;
@@ -24,6 +29,7 @@ pub struct FlatGeobufSource {
     projection: Option<Vec<usize>>,
     metrics: ExecutionPlanMetricsSet,
     projected_statistics: Option<Statistics>,
+    bbox: Option<[f64; 4]>,
 }
 
 impl FlatGeobufSource {
@@ -34,6 +40,7 @@ impl FlatGeobufSource {
             projection: None,
             metrics: ExecutionPlanMetricsSet::new(),
             projected_statistics: None,
+            bbox: None,
         }
     }
 }
@@ -96,6 +103,56 @@ impl FileSource for FlatGeobufSource {
     fn file_type(&self) -> &str {
         "flatgeobuf"
     }
+
+    fn try_pushdown_filters(
+        &self,
+        filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn FileSource>>> {
+        let bbox = filters.iter().find_map(extract_bbox);
+
+        let mut result: FilterPushdownPropagation<Arc<dyn FileSource>> =
+            FilterPushdownPropagation::with_parent_pushdown_result(vec![
+                PushedDown::No;
+                filters.len()
+            ]);
+
+        if let Some(bbox) = bbox {
+            let mut conf = self.clone();
+            conf.bbox = Some(bbox);
+            result = result.with_updated_node(Arc::new(conf) as Arc<dyn FileSource>);
+        }
+
+        Ok(result)
+    }
+}
+
+fn extract_bbox(expr: &Arc<dyn PhysicalExpr>) -> Option<[f64; 4]> {
+    let func = expr.as_any().downcast_ref::<ScalarFunctionExpr>()?;
+    if !func.name().eq_ignore_ascii_case("st_intersects") || func.args().len() != 2 {
+        return None;
+    }
+    let geom_expr = &func.args()[1];
+    let env_func = geom_expr.as_any().downcast_ref::<ScalarFunctionExpr>()?;
+    if !env_func.name().eq_ignore_ascii_case("st_makeenvelope") || env_func.args().len() < 4 {
+        return None;
+    }
+    let x_min = value_as_f64(&env_func.args()[0])?;
+    let y_min = value_as_f64(&env_func.args()[1])?;
+    let x_max = value_as_f64(&env_func.args()[2])?;
+    let y_max = value_as_f64(&env_func.args()[3])?;
+    Some([x_min, y_min, x_max, y_max])
+}
+
+fn value_as_f64(expr: &Arc<dyn PhysicalExpr>) -> Option<f64> {
+    let lit = expr.as_any().downcast_ref::<Literal>()?;
+    match lit.value() {
+        ScalarValue::Float64(Some(v)) => Some(*v),
+        ScalarValue::Float32(Some(v)) => Some(*v as f64),
+        ScalarValue::Int64(Some(v)) => Some(*v as f64),
+        ScalarValue::Int32(Some(v)) => Some(*v as f64),
+        _ => None,
+    }
 }
 
 pub struct FlatGeobufOpener {
@@ -131,10 +188,17 @@ impl FileOpener for FlatGeobufOpener {
                 .with_batch_size(config.batch_size.unwrap_or(1024));
 
             let fgb_reader = open_flatgeobuf_reader(store, file_meta.location().clone()).await?;
-            let selection = fgb_reader
-                .select_all()
-                .await
-                .map_err(|err| DataFusionError::External(Box::new(err)))?;
+            let selection = if let Some([minx, miny, maxx, maxy]) = config.bbox {
+                fgb_reader
+                    .select_bbox(minx, miny, maxx, maxy)
+                    .await
+                    .map_err(|err| DataFusionError::External(Box::new(err)))?
+            } else {
+                fgb_reader
+                    .select_all()
+                    .await
+                    .map_err(|err| DataFusionError::External(Box::new(err)))?
+            };
             let stream = FlatGeobufRecordBatchStream::try_new(selection, options)
                 .map_err(|err| DataFusionError::External(Box::new(err)))?;
             Ok(stream.boxed())


### PR DESCRIPTION
## Summary
- parse ST_Intersects filters for bounding boxes
- forward bbox to FlatGeobuf reader via `select_bbox`

## Testing
- `cargo test -p geodatafusion-flatgeobuf` *(failed: ObjectStore(Generic { store: "HTTP", source: RetryError(RetryErrorImpl { method: HEAD, uri: Some(https://flatgeobuf.org/test/data/countries.fgb), retries: 10, max_retries: 10, elapsed: 3.066506823s, retry_timeout: 180s, inner: Http(HttpError { kind: Connect, source: reqwest::Error { kind: Request, source: hyper_util::client::legacy::Error(Connect, TunnelUnsuccessful) } }) }) }))`

------
https://chatgpt.com/codex/tasks/task_e_6895104696a483288f5b9d1a04e64355