### PR TITLE
feat(geodatafusion-geojson): Add GeoJSON table provider to write to line-delimited GeoJSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "geodatafusion-geojson"
+version = "0.1.0-dev"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "async-trait",
+ "datafusion",
+ "datafusion-datasource",
+ "geo-traits",
+ "geoarrow-array",
+ "geoarrow-geojson",
+ "geoarrow-schema",
+ "geodatafusion",
+ "geojson",
+ "object_store",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "wkt 0.14.0",
+]
+
+[[package]]
 name = "geographiclib-rs"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "rust/geoarrow-test",
     "rust/geodatafusion",
     "rust/geodatafusion-flatgeobuf",
+    "rust/geodatafusion-geojson",
     "rust/geoparquet",
     "rust/pyo3-geoarrow",
 ]
@@ -54,7 +55,7 @@ geoarrow-array = { path = "rust/geoarrow-array", version = "0.5" }
 geoarrow-cast = { path = "rust/geoarrow-cast", version = "0.5" }
 geoarrow-flatgeobuf = { path = "rust/geoarrow-flatgeobuf", version = "0.5" }
 geoarrow-geo = { path = "rust/geoarrow-geo", version = "0.5" }
-geoarrow-geojson = { path = "rust/geoarrow-geojson", version = "0.5" }
+geoarrow-geojson = { path = "rust/geoarrow-geojson" }
 geoarrow-schema = { path = "rust/geoarrow-schema", version = "0.5" }
 geoarrow-test = { path = "rust/geoarrow-test", version = "0.5" }
 geodatafusion = { path = "rust/geodatafusion" }

--- a/rust/geodatafusion-geojson/Cargo.toml
+++ b/rust/geodatafusion-geojson/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "geodatafusion-geojson"
+version = "0.1.0-dev"
+authors = ["Kyle Barron <kylebarron2@gmail.com>"]
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "GeoJSON TableProvider for DataFusion"
+categories = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+arrow-schema = { workspace = true }
+async-trait = { workspace = true }
+datafusion = { workspace = true }
+datafusion-datasource = { workspace = true }
+geoarrow-geojson = { workspace = true }
+object_store = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+arrow-array = { workspace = true }
+geo-traits = { workspace = true }
+geoarrow-array = { workspace = true, features = ["test-data"] }
+geoarrow-schema = { workspace = true }
+geodatafusion = { workspace = true }
+geojson = { workspace = true }
+object_store = { workspace = true, features = ["http"] }
+serde_json = "1.0"
+tokio = { workspace = true, features = ["macros", "fs", "rt-multi-thread"] }
+wkt = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/rust/geodatafusion-geojson/src/file_format.rs
+++ b/rust/geodatafusion-geojson/src/file_format.rs
@@ -1,0 +1,315 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt::{self, Debug, Formatter};
+use std::io::{BufWriter, Write};
+use std::sync::Arc;
+
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use datafusion::catalog::Session;
+use datafusion::common::runtime::SpawnedTask;
+use datafusion::common::{GetExt, Statistics};
+use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
+use datafusion::datasource::file_format::{FileFormat, FileFormatFactory};
+use datafusion::datasource::physical_plan::{FileScanConfig, FileSource};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::LexRequirement;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan};
+use datafusion_datasource::display::FileGroupDisplay;
+use datafusion_datasource::file_sink_config::{FileSink, FileSinkConfig};
+use datafusion_datasource::sink::{DataSink, DataSinkExec};
+use datafusion_datasource::write::ObjectWriterBuilder;
+use datafusion_datasource::write::demux::DemuxedStreamReceiver;
+use geoarrow_geojson::writer::GeoJsonLinesWriter;
+use object_store::{ObjectMeta, ObjectStore};
+use tempfile::NamedTempFile;
+use tokio::io::AsyncWriteExt;
+
+/// Factory used to create [`GeoJsonFormat`]
+///
+/// This always outputs newline-delimited GeoJSON.
+#[derive(Debug, Default)]
+pub struct GeoJsonFormatFactory {}
+
+impl GeoJsonFormatFactory {
+    /// Creates an instance of [`GeoJsonFormatFactory`]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl FileFormatFactory for GeoJsonFormatFactory {
+    fn create(
+        &self,
+        _state: &dyn Session,
+        _format_options: &HashMap<String, String>,
+    ) -> Result<Arc<dyn FileFormat>> {
+        Ok(Arc::new(GeoJsonFormat {}))
+    }
+
+    fn default(&self) -> Arc<dyn FileFormat> {
+        Arc::new(GeoJsonFormat {})
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl GetExt for GeoJsonFormatFactory {
+    fn get_ext(&self) -> String {
+        "geojsonl".to_string()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct GeoJsonFormat {}
+
+#[async_trait]
+impl FileFormat for GeoJsonFormat {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn get_ext(&self) -> String {
+        "geojsonl".to_string()
+    }
+
+    fn get_ext_with_compression(
+        &self,
+        file_compression_type: &FileCompressionType,
+    ) -> Result<String> {
+        let ext = self.get_ext();
+        Ok(format!("{}{}", ext, file_compression_type.get_ext()))
+    }
+
+    async fn infer_schema(
+        &self,
+        _state: &dyn Session,
+        _store: &Arc<dyn ObjectStore>,
+        _objects: &[ObjectMeta],
+    ) -> Result<SchemaRef> {
+        // GeoJSON files cannot be read by this implementation, only written
+        Err(DataFusionError::NotImplemented(
+            "Reading GeoJSON files is not currently supported. This format only supports writing."
+                .to_string(),
+        ))
+    }
+
+    async fn infer_stats(
+        &self,
+        _state: &dyn Session,
+        _store: &Arc<dyn ObjectStore>,
+        _table_schema: SchemaRef,
+        _object: &ObjectMeta,
+    ) -> Result<Statistics> {
+        Err(DataFusionError::NotImplemented(
+            "Reading GeoJSON files is not currently supported. This format only supports writing."
+                .to_string(),
+        ))
+    }
+
+    async fn create_physical_plan(
+        &self,
+        _state: &dyn Session,
+        _conf: FileScanConfig,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Err(DataFusionError::NotImplemented(
+            "Reading GeoJSON files is not currently supported. This format only supports writing."
+                .to_string(),
+        ))
+    }
+
+    async fn create_writer_physical_plan(
+        &self,
+        input: Arc<dyn ExecutionPlan>,
+        _state: &dyn Session,
+        conf: FileSinkConfig,
+        order_requirements: Option<LexRequirement>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let sink = Arc::new(GeoJsonSink::new(conf));
+        Ok(Arc::new(DataSinkExec::new(input, sink, order_requirements)))
+    }
+
+    fn file_source(&self) -> Arc<dyn FileSource> {
+        // Not implemented for reading
+        unimplemented!("GeoJSON format only supports writing")
+    }
+
+    /// Returns whether this instance uses compression if applicable
+    fn compression_type(&self) -> Option<FileCompressionType> {
+        Some(FileCompressionType::UNCOMPRESSED)
+    }
+}
+
+#[derive(Debug)]
+pub struct GeoJsonSink {
+    config: FileSinkConfig,
+}
+
+impl GeoJsonSink {
+    pub fn new(config: FileSinkConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl DisplayAs for GeoJsonSink {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter<'_>) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "GeoJsonSink(file_groups=")?;
+                FileGroupDisplay(&self.config.file_group).fmt_as(t, f)?;
+                write!(f, ")")
+            }
+            DisplayFormatType::TreeRender => {
+                let format_name = "geojson-lines";
+                writeln!(f, "format: {}", format_name)?;
+                write!(f, "file={}", &self.config.original_url)
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl FileSink for GeoJsonSink {
+    fn config(&self) -> &FileSinkConfig {
+        &self.config
+    }
+
+    async fn spawn_writer_tasks_and_join(
+        &self,
+        _context: &Arc<TaskContext>,
+        demux_task: SpawnedTask<Result<()>>,
+        mut file_stream_rx: DemuxedStreamReceiver,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Result<u64> {
+        let mut total_rows: u64 = 0;
+        while let Some((path, mut rb_rx)) = file_stream_rx.recv().await {
+            // We create a tempfile on disk because the GeoJSON writers are sync only
+            let named_temp_file = NamedTempFile::new()?;
+            let output_file = BufWriter::new(named_temp_file);
+
+            let mut geojson_writer = GeoJsonLinesWriter::new(output_file);
+
+            // For each record batch received, write it to the GeoJSON writer
+            while let Some(batch) = rb_rx.recv().await {
+                total_rows += batch.num_rows() as u64;
+                geojson_writer
+                    .write(&batch)
+                    .map_err(|err| DataFusionError::External(Box::new(err)))?;
+            }
+
+            // Finalize the writer
+            let mut output_file = geojson_writer
+                .finish()
+                .map_err(|err| DataFusionError::External(Box::new(err)))?;
+            output_file.flush()?;
+
+            let named_temp_file = output_file
+                .into_inner()
+                .map_err(|err| DataFusionError::External(Box::new(err)))?;
+
+            // Upload temp file to object store
+            upload_temp_file_to_object_store(named_temp_file, &path, object_store.clone()).await?;
+        }
+
+        demux_task
+            .join()
+            .await
+            .map_err(|e| DataFusionError::Execution(e.to_string()))??;
+        Ok(total_rows)
+    }
+}
+
+#[async_trait]
+impl DataSink for GeoJsonSink {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> &SchemaRef {
+        self.config.output_schema()
+    }
+
+    async fn write_all(
+        &self,
+        data: datafusion::execution::SendableRecordBatchStream,
+        context: &Arc<TaskContext>,
+    ) -> Result<u64> {
+        FileSink::write_all(self, data, context).await
+    }
+}
+
+/// Helper function to upload a temp file to object store
+async fn upload_temp_file_to_object_store(
+    named_temp_file: tempfile::NamedTempFile,
+    path: &object_store::path::Path,
+    object_store: Arc<dyn ObjectStore>,
+) -> Result<()> {
+    use std::io::Read;
+
+    // Reopen the temp file for reading
+    let mut buf_reader = std::io::BufReader::new(std::fs::File::open(named_temp_file.path())?);
+
+    let mut object_writer = ObjectWriterBuilder::new(
+        FileCompressionType::UNCOMPRESSED,
+        path,
+        object_store.clone(),
+    )
+    .with_buffer_size(Some(20 * 1024 * 1024))
+    .build()?;
+
+    // Iterate over 20mb chunks of the output_file
+    let mut buf = vec![0u8; 20 * 1024 * 1024];
+    loop {
+        match buf_reader.read(&mut buf) {
+            Ok(0) => break, // End of file
+            Ok(size) => {
+                object_writer.write_all(&buf[..size]).await?;
+            }
+            Err(e) => return Err(DataFusionError::External(Box::new(e))),
+        }
+    }
+
+    object_writer.shutdown().await?;
+    Ok(())
+}
+
+/// Factory for creating GeoJSON file formats
+#[derive(Default, Debug)]
+pub struct GeoJsonFileFactory {
+    file_factory: GeoJsonFormatFactory,
+}
+
+impl GeoJsonFileFactory {
+    pub fn new() -> Self {
+        Self {
+            file_factory: GeoJsonFormatFactory::new(),
+        }
+    }
+}
+
+impl FileFormatFactory for GeoJsonFileFactory {
+    fn create(
+        &self,
+        state: &dyn Session,
+        format_options: &std::collections::HashMap<String, String>,
+    ) -> Result<Arc<dyn FileFormat>> {
+        self.file_factory.create(state, format_options)
+    }
+
+    fn default(&self) -> Arc<dyn FileFormat> {
+        self.file_factory.default()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl GetExt for GeoJsonFileFactory {
+    fn get_ext(&self) -> String {
+        self.file_factory.get_ext()
+    }
+}

--- a/rust/geodatafusion-geojson/src/lib.rs
+++ b/rust/geodatafusion-geojson/src/lib.rs
@@ -1,0 +1,183 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![doc(
+    html_logo_url = "https://github.com/geoarrow.png",
+    html_favicon_url = "https://github.com/geoarrow.png?size=32"
+)]
+
+pub mod file_format;
+
+pub use file_format::{GeoJsonFileFactory, GeoJsonFormat, GeoJsonFormatFactory};
+
+#[cfg(test)]
+mod tests {
+    use std::env::temp_dir;
+    use std::fs;
+    use std::sync::Arc;
+
+    use arrow_array::{Int32Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::catalog::MemTable;
+    use datafusion::execution::SessionStateBuilder;
+    use datafusion::prelude::SessionContext;
+    use geoarrow_array::GeoArrowArray;
+    use geoarrow_array::builder::PointBuilder;
+    use geoarrow_schema::{Dimension, PointType};
+    use wkt::wkt;
+
+    use super::*;
+
+    fn sample_table() -> (Vec<RecordBatch>, Arc<Schema>) {
+        let mut builder = PointBuilder::new(PointType::new(Dimension::XY, Default::default()));
+        builder.push_point(Some(&wkt!(POINT(1.0 2.0))));
+        builder.push_point(Some(&wkt!(POINT(3.0 4.0))));
+        let geometry = builder.finish();
+
+        let fields = vec![
+            Arc::new(Field::new("id", DataType::Int32, false)),
+            Arc::new(Field::new("name", DataType::Utf8, false)),
+            Arc::new(geometry.data_type().to_field("geometry", true)),
+        ];
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])) as _,
+                Arc::new(StringArray::from(vec!["Point A", "Point B"])) as _,
+                geometry.into_array_ref(),
+            ],
+        )
+        .unwrap();
+
+        (vec![batch], schema)
+    }
+
+    #[tokio::test]
+    async fn test_write_geojsonlines_sink() {
+        let file_format = Arc::new(GeoJsonFileFactory::new()); // Lines format
+        let state = SessionStateBuilder::new()
+            .with_file_formats(vec![file_format])
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+
+        let (batches, schema) = sample_table();
+        let mem_table = Arc::new(MemTable::try_new(schema.clone(), vec![batches]).unwrap());
+        ctx.register_table("mem_table", mem_table).unwrap();
+
+        let file_path = temp_dir().join("test_geojsonlines_sink.geojsonl");
+
+        ctx.sql(&format!("COPY mem_table TO '{}';", file_path.display()))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        // Read the file and verify it's valid GeoJSON Lines
+        let contents = fs::read_to_string(&file_path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+
+        // Should have 2 lines for 2 features
+        assert_eq!(lines.len(), 2);
+
+        // Parse each line as a GeoJSON Feature
+        for (i, line) in lines.iter().enumerate() {
+            let feature: geojson::Feature = line.parse().unwrap();
+            let expected_id = i + 1;
+            let expected_name = format!("Point {}", if i == 0 { "A" } else { "B" });
+
+            assert_eq!(
+                feature.id,
+                Some(geojson::feature::Id::Number(serde_json::Number::from(
+                    expected_id
+                )))
+            );
+            assert_eq!(
+                feature.properties.as_ref().unwrap().get("name").unwrap(),
+                &serde_json::Value::String(expected_name)
+            );
+
+            // Check geometry
+            if let Some(ref geometry) = feature.geometry {
+                if let geojson::Value::Point(coords) = &geometry.value {
+                    let expected_x = if i == 0 { 1.0 } else { 3.0 };
+                    let expected_y = if i == 0 { 2.0 } else { 4.0 };
+                    assert_eq!(coords[0], expected_x);
+                    assert_eq!(coords[1], expected_y);
+                } else {
+                    panic!("Expected Point geometry");
+                }
+            } else {
+                panic!("Expected geometry");
+            }
+        }
+
+        fs::remove_file(&file_path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_geojson_with_id_column() {
+        // Test with explicit ID column
+        let mut builder = PointBuilder::new(PointType::new(Dimension::XY, Default::default()));
+        builder.push_point(Some(&wkt!(POINT(5.0 6.0))));
+        let geometry = builder.finish();
+
+        let fields = vec![
+            Arc::new(Field::new("id", DataType::Int32, false)),
+            Arc::new(geometry.data_type().to_field("geometry", true)),
+            Arc::new(Field::new("value", DataType::Int32, false)),
+        ];
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![42])) as _,
+                geometry.into_array_ref(),
+                Arc::new(Int32Array::from(vec![100])) as _,
+            ],
+        )
+        .unwrap();
+
+        let file_format = Arc::new(GeoJsonFileFactory::new());
+        let state = SessionStateBuilder::new()
+            .with_file_formats(vec![file_format])
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+
+        let mem_table = Arc::new(MemTable::try_new(schema, vec![vec![batch]]).unwrap());
+        ctx.register_table("mem_table", mem_table).unwrap();
+
+        let file_path = temp_dir().join("test_geojson_with_id.geojsonl");
+
+        ctx.sql(&format!("COPY mem_table TO '{}';", file_path.display()))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        // Read and validate - should be a single line since it's one feature
+        let contents = fs::read_to_string(&file_path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 1);
+
+        // Parse the single line as a GeoJSON Feature
+        let feature: geojson::Feature = lines[0].parse().unwrap();
+
+        // Check the id field is at feature level
+        assert_eq!(
+            feature.id,
+            Some(geojson::feature::Id::Number(serde_json::Number::from(42)))
+        );
+
+        // Check properties only contains "value", not "id"
+        let props = feature.properties.as_ref().unwrap();
+        assert_eq!(
+            props.get("value").unwrap(),
+            &serde_json::Value::Number(serde_json::Number::from(100))
+        );
+        assert!(props.get("id").is_none()); // id should not be in properties
+
+        fs::remove_file(&file_path).unwrap();
+    }
+}


### PR DESCRIPTION
### Change list

- New `geodatafusion-geojson` crate with GeoJSON table provider.
- Currently this table provider only supports writing, not reading.