### PR TITLE
perf(geoarrow-array): Improve perf of `from_wkb`/`from_wkt` when parsing to WKB/WKT output types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,7 @@ dependencies = [
  "arrow-array",
  "arrow-csv",
  "arrow-schema",
+ "geo-traits",
  "geoarrow-array",
  "geoarrow-schema",
 ]

--- a/rust/geoarrow-array/CHANGELOG.md
+++ b/rust/geoarrow-array/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Unreleased
 
 - New `GeozeroRecordBatchWriter` to allow for an iterative push-based API for writing to geozero-based data sinks.
-- perf(geoarrow-array): Improve perf of from_wkb/from_wkt when parsing to WKB/WKT output types
+- perf(geoarrow-array): Improve perf of from_wkb/from_wkt when parsing to WKB/WKT output types https://github.com/geoarrow/geoarrow-rs/pull/1313
 
 ## 0.5.0 - 2025-08-07
 

--- a/rust/geoarrow-array/CHANGELOG.md
+++ b/rust/geoarrow-array/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - New `GeozeroRecordBatchWriter` to allow for an iterative push-based API for writing to geozero-based data sinks.
+- perf(geoarrow-array): Improve perf of from_wkb/from_wkt when parsing to WKB/WKT output types
 
 ## 0.5.0 - 2025-08-07
 


### PR DESCRIPTION
Avoid actually materializing `geoms` unless needed.