### PR TITLE
ci(Python): Remove Windows x86 build

### DIFF
--- a/.github/workflows/python-core-wheels.yml
+++ b/.github/workflows/python-core-wheels.yml
@@ -98,8 +98,6 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
-          - runner: windows-latest
-            target: x86
         module:
           - geoarrow-core
           - geoarrow-compute

--- a/.github/workflows/python-io-wheels.yml
+++ b/.github/workflows/python-io-wheels.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64, x86]
+        target: [x64]
     steps:
       - uses: actions/checkout@v4
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [0.5.2] - 2025-09-12
 
 - fix(geoarrow-array): Fix persisting CRS when creating GeometryArray from Field #1326. This also fixes an internal error when downcasting a GeometryArray with a CRS.
+- ci(Python): Remove Windows x86 build #1329
 
 ## [0.5.1] - 2025-08-11
 


### PR DESCRIPTION
To fix the broken python wheel build: https://github.com/geoarrow/geoarrow-rs/actions/runs/17688206370/job/50277114526