### PR TITLE
chore: Prepare Python 0.5.3 release

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## [0.5.3] - 2025-09-25
+
+- chore: Bump lockfiles to update wkb dependency
+
 ## [0.5.2] - 2025-09-12
 
 - fix(geoarrow-array): Fix persisting CRS when creating GeometryArray from Field #1326. This also fixes an internal error when downcasting a GeometryArray with a CRS.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [0.5.3] - 2025-09-25
 
-- chore: Bump lockfiles to update wkb dependency
+- chore: Bump lockfiles to update wkb dependency #1342
 
 ## [0.5.2] - 2025-09-12
 

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-rust-compute"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-rust-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-rust-io"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arrow",
  "bytes",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 homepage = "https://geoarrow.org/geoarrow-rs/"
 repository = "https://github.com/geoarrow/geoarrow-rs"


### PR DESCRIPTION
Update the lockfile to be able to build in release mode #1339 