### PR TITLE
docs: include constructor docs in the table of contents

### DIFF
--- a/python/mkdocs.yml
+++ b/python/mkdocs.yml
@@ -29,7 +29,7 @@ nav:
           - api/core/geometry_type.md
           - api/core/geometry/scalar.md
           # - api/core/geometry/type.md
-          # - api/core/constructors.md
+          - api/core/constructors.md
           - api/core/functions.md
           - api/core/enums.md
           - api/core/types.md


### PR DESCRIPTION
- [x] closes #1346

`mkdocs` warns about a couple more files that are built but not included in the "nav" configuration:
- api/compute/enums.md
- api/compute/functions.md
- api/compute/types.md
- api/core/geometry/type.md
- api/io/gdal.md
- ecosystem/geopandas.md