### PR TITLE
feat: New API for WKB builder to push bytes/str directly

### DIFF
--- a/rust/geoarrow-array/src/builder/wkb.rs
+++ b/rust/geoarrow-array/src/builder/wkb.rs
@@ -92,6 +92,7 @@ impl<O: OffsetSizeTrait> WkbBuilder<O> {
     ///
     /// ```
     /// use geoarrow_array::builder::WkbBuilder;
+    /// use geoarrow_array::GeoArrowArray;
     /// use geoarrow_schema::WkbType;
     ///
     /// let mut builder = WkbBuilder::<i32>::new(WkbType::default());
@@ -143,6 +144,7 @@ impl<O: OffsetSizeTrait> WkbBuilder<O> {
     ///
     /// ```
     /// use geoarrow_array::builder::WkbBuilder;
+    /// use geoarrow_array::GeoArrowArray;
     /// use geoarrow_schema::WkbType;
     ///
     /// let mut builder = WkbBuilder::<i32>::new(WkbType::default());


### PR DESCRIPTION

> Currently builder methods only take geometry objects, which require fully parsing the bytes/str input and repacking. It would be nicer to be able to write a bytes/str directly to the underlying builder.
>
> There can be a "safe" variant that validates that the input is valid WKB/WKT and a "unsafe"/"unchecked" variant that pushes the bytes/str directly


Closes https://github.com/geoarrow/geoarrow-rs/issues/1349

I forgot I don't have a WKT builder right now