### PR TITLE
ci: Fix Python CI

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -34,5 +34,3 @@ In order to obtain relevant modules, you should install them from PyPI directly,
 pip install geoarrow-rust-core geoarrow-rust-compute geoarrow-rust-io
 ```
 See [DEVELOP.md](DEVELOP.md) for more information on developing and building the Python bindings.
-
-tmp

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -13,7 +13,7 @@ dev-dependencies = [
     "geopandas>=1.0.1",
     "griffe-inherited-docstrings>=1.0.1",
     "ipykernel>=6.29.5",
-    "maturin==1.8.6",
+    "maturin>=1.7.4",
     "mkdocs>=1.6.1",
     "mkdocs-material[imaging]>=9.5.40",
     "pip>=24.2",


### PR DESCRIPTION
This PR reverts the Python lockfile to the state before https://github.com/geoarrow/geoarrow-rs/pull/1348

It appears that some Python lockfile update is causing spurious errors on ubuntu cu