### PR TITLE
chore: Bump to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "geoarrow-array",
  "geoarrow-schema",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-array"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-cast"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-schema",
  "geo-traits",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-csv"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-array",
  "arrow-csv",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-expr-geo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-expr-geos"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-flatgeobuf"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-geojson"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-array",
  "arrow-json",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-schema"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-schema",
  "geo-traits",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-test"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "wkt 0.14.0",
 ]
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "geoparquet"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-geoarrow"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["js"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/rust/pyo3-geoarrow/CHANGELOG.md
+++ b/rust/pyo3-geoarrow/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ## [Unreleased]
 
+## 0.6.1 - 2025-10-16
+
 - docs(pyo3-geoarrow): Improve docs #1377
 - refactor(pyo3-geoarrow): Move Python data type constructors out of pyo3-geoarrow (deprecating existing constructors) #1379


### PR DESCRIPTION
Publishing the improved pyo3-geoarrow docs (#1376 )