### PR TITLE
fix(js/scripts/build.sh): fix wasm init problem when run build in vite(#1393)

### DIFF
--- a/js/scripts/build.sh
+++ b/js/scripts/build.sh
@@ -59,7 +59,7 @@ echo '{"type": "module"}' > pkg/esm/package.json
 # Update files array in package.json using JQ
 # Set module field to bundler/arrow1.js
 # Set types field to bundler/arrow1.d.ts
-jq ".files = [\"*\"] | .module=\"bundler/index.js\" | .types=\"bundler/index.d.ts\" | .name=\"$NAME\"" pkg/package.json > pkg/package.json.tmp
+jq ".files = [\"*\"] | .module=\"bundler/index.js\" | .types=\"bundler/index.d.ts\" | .name=\"$NAME\"" | .sideEffects=[\"*/index.js\",\"./snippets/*\"] pkg/package.json > pkg/package.json.tmp
 
 # Overwrite existing package.json file
 mv pkg/package.json.tmp pkg/package.json


### PR DESCRIPTION
Added sideEffects field to package.json update.

Closes https://github.com/geoarrow/geoarrow-rs/issues/1393