### PR TITLE
chore: Publish geoarrow-rs Python bindings version 0.6.1

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 homepage = "https://geoarrow.org/geoarrow-rs/"
 repository = "https://github.com/geoarrow/geoarrow-rs"


### PR DESCRIPTION
I published from this branch but it appears to have not included #1399 