### PR TITLE
feat: Use `LazyLock` for constructing coordinate `DataType` instances

### DIFF
--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1,8 +1,8 @@
+use std::collections::HashSet;
+use std::sync::{Arc, LazyLock};
+
 use arrow_schema::extension::ExtensionType;
 use arrow_schema::{ArrowError, DataType, Field, UnionFields, UnionMode};
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::sync::LazyLock;
 
 use crate::error::GeoArrowError;
 use crate::metadata::Metadata;


### PR DESCRIPTION
addresses #1412 by allocating static `LazyLock` instances for each coord/dimension combo within `coord_to_data_type()` . This will cache these different types and hopefully improve performance when calling `coord_to_data_type()`.

--------------

- Added 8 `LazyLock`s for each type combinations (interleaved_xy, seperated_xy etc...)
- Matches these to corrosponding combos in `coord_to_data_type()`

------------
TODO:

- Benchmarking for performance
- Lazylock allocs for union field structs/GeometryCollection (point, linestrings etc...)