### PR TITLE
feat: use LazyLock for constructing union types

### DIFF
--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -996,6 +996,154 @@ static SEPARATED_XYZM: LazyLock<DataType> = LazyLock::new(|| {
     )
 });
 
+/* TODO: see if these would actually help with mixed_data_type()
+static GEOMETRY_UNION_XY: LazyLock<Vec<Field>> = LazyLock::new(|| {
+    vec![
+        Field::new(
+            "point_xy",
+            PointType::new(Dimension::XY, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "linestring_xy",
+            LineStringType::new(Dimension::XY, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "polygon_xy",
+            PolygonType::new(Dimension::XY, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multipoint_xy",
+            MultiPointType::new(Dimension::XY, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multilinestring_xy",
+            MultiLineStringType::new(Dimension::XY, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multipolygon_xy",
+            MultiPolygonType::new(Dimension::XY, Default::default()).data_type(),
+            true,
+        ),
+    ]
+}
+);
+
+static GEOMETRY_UNION_XYZ: LazyLock<Vec<Field>> = LazyLock::new(|| {
+    vec![
+        Field::new(
+            "point_xyz",
+            PointType::new(Dimension::XYZ, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "linestring_xyz",
+            LineStringType::new(Dimension::XYZ, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "polygon_xyz",
+            PolygonType::new(Dimension::XYZ, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multipoint_xyz",
+            MultiPointType::new(Dimension::XYZ, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multilinestring_xyz",
+            MultiLineStringType::new(Dimension::XYZ, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multipolygon_xyz",
+            MultiPolygonType::new(Dimension::XYZ, Default::default()).data_type(),
+            true,
+        ),
+    ]
+}
+);
+
+static GEOMETRY_UNION_XYM: LazyLock<Vec<Field>> = LazyLock::new(|| {
+    vec![
+        Field::new(
+            "point_xym",
+            PointType::new(Dimension::XYM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "linestring_xym",
+            LineStringType::new(Dimension::XYM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "polygon_xym",
+            PolygonType::new(Dimension::XYM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multipoint_xym",
+            MultiPointType::new(Dimension::XYM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multilinestring_xym",
+            MultiLineStringType::new(Dimension::XYM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multipolygon_xym",
+            MultiPolygonType::new(Dimension::XYM, Default::default()).data_type(),
+            true,
+        ),
+    ]
+}
+);
+
+static GEOMETRY_UNION_XYZM : LazyLock<Vec<Field>> = LazyLock::new(|| {
+vec![
+        Field::new(
+            "point_xyzm",
+            PointType::new(Dimension::XYZM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "linestring_xyzm",
+LineStringType::new(Dimension::XYZM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "polygon_xyzm",
+            PolygonType::new(Dimension::XYZM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multipoint_xyzm",
+            MultiPointType::new(Dimension::XYZM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multilinestring_xyzm",
+            MultiLineStringType::new(Dimension::XYZM, Default::default()).data_type(),
+            true,
+        ),
+        Field::new(
+            "multipolygon_xyzm",
+            MultiPolygonType::new(Dimension::XYZM, Default::default()).data_type(),
+            true,
+        ),
+    ]
+}
+);
+*/
+
+ 
+
 /// A GeoArrow Geometry type.
 ///
 /// Refer to the [GeoArrow

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1,8 +1,8 @@
+use std::collections::HashSet;
+use std::sync::{Arc, LazyLock};
+
 use arrow_schema::extension::ExtensionType;
 use arrow_schema::{ArrowError, DataType, Field, UnionFields, UnionMode};
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::sync::LazyLock;
 
 use crate::error::GeoArrowError;
 use crate::metadata::Metadata;

--- a/rust/geoarrow-schema/src/type.rs
+++ b/rust/geoarrow-schema/src/type.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
-use std::sync::Arc;
-
 use arrow_schema::extension::ExtensionType;
 use arrow_schema::{ArrowError, DataType, Field, UnionFields, UnionMode};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::LazyLock;
 
 use crate::error::GeoArrowError;
 use crate::metadata::Metadata;
@@ -932,6 +932,70 @@ fn parse_geometry_collection(data_type: &DataType) -> Result<(CoordType, Dimensi
     }
 }
 
+static INTERLEAVED_XY: LazyLock<DataType> = LazyLock::new(|| {
+    let values_field = Field::new("xy", DataType::Float64, false);
+    DataType::FixedSizeList(Arc::new(values_field), 2)
+});
+
+static INTERLEAVED_XYZ: LazyLock<DataType> = LazyLock::new(|| {
+    let values_field = Field::new("xyz", DataType::Float64, false);
+    DataType::FixedSizeList(Arc::new(values_field), 3)
+});
+
+static INTERLEAVED_XYM: LazyLock<DataType> = LazyLock::new(|| {
+    let values_field = Field::new("xym", DataType::Float64, false);
+    DataType::FixedSizeList(Arc::new(values_field), 3)
+});
+
+static INTERLEAVED_XYZM: LazyLock<DataType> = LazyLock::new(|| {
+    let values_field = Field::new("xyzm", DataType::Float64, false);
+    DataType::FixedSizeList(Arc::new(values_field), 4)
+});
+
+static SEPARATED_XY: LazyLock<DataType> = LazyLock::new(|| {
+    DataType::Struct(
+        vec![
+            Field::new("x", DataType::Float64, false),
+            Field::new("y", DataType::Float64, false),
+        ]
+        .into(),
+    )
+});
+
+static SEPARATED_XYZ: LazyLock<DataType> = LazyLock::new(|| {
+    DataType::Struct(
+        vec![
+            Field::new("x", DataType::Float64, false),
+            Field::new("y", DataType::Float64, false),
+            Field::new("z", DataType::Float64, false),
+        ]
+        .into(),
+    )
+});
+
+static SEPARATED_XYM: LazyLock<DataType> = LazyLock::new(|| {
+    DataType::Struct(
+        vec![
+            Field::new("x", DataType::Float64, false),
+            Field::new("y", DataType::Float64, false),
+            Field::new("m", DataType::Float64, false),
+        ]
+        .into(),
+    )
+});
+
+static SEPARATED_XYZM: LazyLock<DataType> = LazyLock::new(|| {
+    DataType::Struct(
+        vec![
+            Field::new("x", DataType::Float64, false),
+            Field::new("y", DataType::Float64, false),
+            Field::new("z", DataType::Float64, false),
+            Field::new("m", DataType::Float64, false),
+        ]
+        .into(),
+    )
+});
+
 /// A GeoArrow Geometry type.
 ///
 /// Refer to the [GeoArrow
@@ -1452,54 +1516,16 @@ impl ExtensionType for WktType {
 
 fn coord_type_to_data_type(coord_type: CoordType, dim: Dimension) -> DataType {
     match (coord_type, dim) {
-        (CoordType::Interleaved, Dimension::XY) => {
-            let values_field = Field::new("xy", DataType::Float64, false);
-            DataType::FixedSizeList(Arc::new(values_field), 2)
-        }
-        (CoordType::Interleaved, Dimension::XYZ) => {
-            let values_field = Field::new("xyz", DataType::Float64, false);
-            DataType::FixedSizeList(Arc::new(values_field), 3)
-        }
-        (CoordType::Interleaved, Dimension::XYM) => {
-            let values_field = Field::new("xym", DataType::Float64, false);
-            DataType::FixedSizeList(Arc::new(values_field), 3)
-        }
-        (CoordType::Interleaved, Dimension::XYZM) => {
-            let values_field = Field::new("xyzm", DataType::Float64, false);
-            DataType::FixedSizeList(Arc::new(values_field), 4)
-        }
-        (CoordType::Separated, Dimension::XY) => {
-            let values_fields = vec![
-                Field::new("x", DataType::Float64, false),
-                Field::new("y", DataType::Float64, false),
-            ];
-            DataType::Struct(values_fields.into())
-        }
-        (CoordType::Separated, Dimension::XYZ) => {
-            let values_fields = vec![
-                Field::new("x", DataType::Float64, false),
-                Field::new("y", DataType::Float64, false),
-                Field::new("z", DataType::Float64, false),
-            ];
-            DataType::Struct(values_fields.into())
-        }
-        (CoordType::Separated, Dimension::XYM) => {
-            let values_fields = vec![
-                Field::new("x", DataType::Float64, false),
-                Field::new("y", DataType::Float64, false),
-                Field::new("m", DataType::Float64, false),
-            ];
-            DataType::Struct(values_fields.into())
-        }
-        (CoordType::Separated, Dimension::XYZM) => {
-            let values_fields = vec![
-                Field::new("x", DataType::Float64, false),
-                Field::new("y", DataType::Float64, false),
-                Field::new("z", DataType::Float64, false),
-                Field::new("m", DataType::Float64, false),
-            ];
-            DataType::Struct(values_fields.into())
-        }
+        (CoordType::Interleaved, Dimension::XY) => INTERLEAVED_XY.clone(),
+
+        (CoordType::Interleaved, Dimension::XYZ) => INTERLEAVED_XYZ.clone(),
+
+        (CoordType::Interleaved, Dimension::XYM) => INTERLEAVED_XYM.clone(),
+        (CoordType::Interleaved, Dimension::XYZM) => INTERLEAVED_XYZM.clone(),
+        (CoordType::Separated, Dimension::XY) => SEPARATED_XY.clone(),
+        (CoordType::Separated, Dimension::XYZ) => SEPARATED_XYZ.clone(),
+        (CoordType::Separated, Dimension::XYM) => SEPARATED_XYM.clone(),
+        (CoordType::Separated, Dimension::XYZM) => SEPARATED_XYZM.clone(),
     }
 }
 


### PR DESCRIPTION
- Static `LazyLocks` for caching mixed union types
- Static `LazyLocks` for `GeometryType`
- `mixed_data_type` is now indexed lookup at `MIXED_UNION_TYPES`
- `GeometryType::data_type()` is indexed lookup at `GEOMETRY_UNION_TYPES`

Closes https://github.com/geoarrow/geoarrow-rs/issues/1412