### PR TITLE
chore: Bump python package version to 0.8.0

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Kyle Barron <kylebarron2@gmail.com>"]
-version = "0.6.1"
+version = "0.8.0"
 edition = "2024"
 homepage = "https://geoarrow.org/geoarrow-rs/"
 repository = "https://github.com/geoarrow/geoarrow-rs"


### PR DESCRIPTION
- It seems the version is out of sync for rust and python package.
- This PR fixes the downstream packaging issue [for nixpkgs](https://github.com/NixOS/nixpkgs/pull/519849#discussion_r3244894484), where we are overwriting it with rust version. 