### PR TITLE
ci(python): fix wheel builds on Windows

### DIFF
--- a/.github/workflows/python-core-wheels.yml
+++ b/.github/workflows/python-core-wheels.yml
@@ -116,7 +116,16 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.x
+          # Every interpreter passed to `-i` below must be installed: on
+          # Windows, maturin can't build for a missing interpreter without
+          # pyo3's generate-import-lib feature.
+          python-version: |
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            3.14
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/python-io-wheels.yml
+++ b/.github/workflows/python-io-wheels.yml
@@ -108,7 +108,16 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          # Every interpreter passed to `-i` below must be installed: on
+          # Windows, maturin can't build for a missing interpreter without
+          # pyo3's generate-import-lib feature.
+          python-version: |
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            3.14
           architecture: ${{ matrix.target }}
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
_Description written by claude code_

The windows wheel jobs pass -i 3.9 through -i 3.14 to maturin but only installed a single Python. maturin can't build for a missing interpreter on Windows without pyo3's generate-import-lib feature, failing the py-v0.6.3 release builds. Install every requested interpreter via setup-python's multi-version support, matching arro3.