### PR TITLE
ci(python): Bump pypy3.10 to pypy3.11 in io wheel builds

### DIFF
--- a/.github/workflows/python-io-wheels.yml
+++ b/.github/workflows/python-io-wheels.yml
@@ -43,7 +43,8 @@ jobs:
           version: "0.8.x"
 
       - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+        # pyo3 0.28 requires PyPy >= 3.11
+        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.11
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -51,7 +52,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           # As of Nov 2024, it was necessary to manually specify -i 3.13 to get
           # maturin to find the executable. --find-interpreter did not find it.
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i 3.14 -i pypy3.10 --manifest-path python/${{ matrix.module }}/Cargo.toml
+          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i 3.14 -i pypy3.11 --manifest-path python/${{ matrix.module }}/Cargo.toml
           sccache: "true"
           manylinux: ${{ matrix.platform.manylinux }}
 


### PR DESCRIPTION
pyo3 0.28 dropped support for PyPy 3.10 (minimum is now 3.11), which failed the linux io wheel builds for the py-v0.6.3 release with: 'the configured PyPy interpreter version (3.10) is lower than PyO3's minimum supported version (3.11)'. arro3 builds pypy3.11 wheels on the same target set with pyo3 0.28.