### PR TITLE
fix: Add a public setter method for `large_offsets` in the options builder

### DIFF
--- a/rust/geoparquet/src/writer/options.rs
+++ b/rust/geoparquet/src/writer/options.rs
@@ -115,6 +115,12 @@ impl GeoParquetWriterOptionsBuilder {
         self
     }
 
+    /// Use large offsets when writing as WKB for a specific geometry column.
+    pub fn set_large_offsets(mut self, col: String) -> Self {
+        self.get_mut_props(col).large_offsets = true;
+        self
+    }
+
     /// Finalizes the configuration and returns immutable writer options struct.
     pub fn build(self) -> GeoParquetWriterOptions {
         GeoParquetWriterOptions {


### PR DESCRIPTION
In #1447 I mistakenly missed the fact that fields in the `GeoParquetWriterOptionsBuilder` struct are all private so there needs to be a public setter in some capacity in `impl GeoParquetWriterOptionsBuilder`. There might be some other way to set this but I think this is most idiomatic regardless.

I only added a method to change the `large_offset` value for one column at a time to ensure that this is opt-in and strictly applied to only the necessary geometry columns, not all at once. 