### PR TITLE
fix: Support `DataType::LargeBinary` in `create_output_field`

### DIFF
--- a/rust/geoparquet/src/writer/metadata.rs
+++ b/rust/geoparquet/src/writer/metadata.rs
@@ -533,8 +533,15 @@ fn create_output_field(column_info: &ColumnInfo, name: String, nullable: bool) -
     use GeoParquetColumnEncoding as Encoding;
 
     match column_info.encoding {
-        Encoding::WKB => Field::new(name, DataType::Binary, nullable)
-            .with_extension_type(WkbType::new(Default::default())),
+        Encoding::WKB => {
+            if column_info.large_offsets {
+                Field::new(name, DataType::LargeBinary, nullable)
+                    .with_extension_type(WkbType::new(Default::default()))
+            } else {
+                Field::new(name, DataType::Binary, nullable)
+                    .with_extension_type(WkbType::new(Default::default()))
+            }
+        }
         // A native encoding
         _ => {
             assert_eq!(column_info.geometry_types.len(), 1);

--- a/rust/geoparquet/src/writer/metadata.rs
+++ b/rust/geoparquet/src/writer/metadata.rs
@@ -534,13 +534,13 @@ fn create_output_field(column_info: &ColumnInfo, name: String, nullable: bool) -
 
     match column_info.encoding {
         Encoding::WKB => {
-            if column_info.large_offsets {
-                Field::new(name, DataType::LargeBinary, nullable)
-                    .with_extension_type(WkbType::new(Default::default()))
+            let data_type = if column_info.large_offsets {
+                DataType::LargeBinary
             } else {
-                Field::new(name, DataType::Binary, nullable)
-                    .with_extension_type(WkbType::new(Default::default()))
-            }
+                DataType::Binary
+            };
+            Field::new(name, data_type, nullable)
+                .with_extension_type(WkbType::new(Default::default()))
         }
         // A native encoding
         _ => {


### PR DESCRIPTION
Following up on #1447 , this is another place in the codebase I believe we need to switch on `large_offsets`. I am pretty sure there has to be logic here to support `DataType::LargeBinary` otherwise even if you specify `large_offsets` for the column, geoarrow will try to write a `Binary` type with i32 offsets causing either a schema mismatch error or the potential for overflow.

I tested running this with a very large dataset using `large_offsets` and it completed without issue properly this time. 