### PR TITLE
chore: Rust 1.95 cleanup

### DIFF
--- a/.github/workflows/python-core-wheels.yml
+++ b/.github/workflows/python-core-wheels.yml
@@ -186,10 +186,14 @@ jobs:
         module:
           - geoarrow-core
         include:
-          # Pyodide's pinned toolchain for Python 3.13 (nightly-2025-02-01,
-          # rustc 1.86) is very old. We override with a newer nightly
+          # Pyodide's pinned toolchain for Python 3.13 is (nightly-2025-02-01,
+          # rustc 1.86). It requires nightly, so we bump to a newer version.
           - python-version: "3.13"
             rust-toolchain-override: nightly-2026-06-01
+          # Pyodide's pinned toolchain for Python 3.14 is 1.93.0.
+          # The 3.14 toolchain can use stable, so we bump to our MSRV.
+          - python-version: "3.14"
+            rust-toolchain-override: 1.95
     steps:
       - uses: actions/checkout@v7
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ authors = ["Kyle Barron <kylebarron2@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/geoarrow/geoarrow-rs"
-rust-version = "1.85"
+rust-version = "1.95"
 categories = ["science::geo"]
 
 [workspace.dependencies]

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["webassembly", "arrow", "geospatial"]
 categories = ["wasm", "science::geo"]
-rust-version = { workspace = true }
+rust-version = "1.95"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/js/Cargo.toml
+++ b/js/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["webassembly", "arrow", "geospatial"]
 categories = ["wasm", "science::geo"]
-rust-version = "1.85"
+rust-version = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -710,12 +710,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "earcutr"
-version = "0.4.3"
+name = "earcut"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
 dependencies = [
- "itertools 0.11.0",
  "num-traits",
 ]
 
@@ -818,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "float_next_after"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
 
 [[package]]
 name = "fnv"
@@ -961,19 +960,22 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.31.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
 dependencies = [
- "earcutr",
+ "earcut",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
  "i_overlay",
  "log",
  "num-traits",
+ "rand 0.10.1",
+ "rand_pcg",
  "robust",
  "rstar 0.12.2",
+ "sif-itree",
  "spade",
 ]
 
@@ -988,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
@@ -1001,6 +1003,7 @@ dependencies = [
  "rstar 0.8.4",
  "rstar 0.9.3",
  "serde",
+ "spade",
 ]
 
 [[package]]
@@ -1487,24 +1490,27 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010025c2c532c8d82e42d0b8bb5184afa449fa6f06c709ea9adcb16c49ae405b"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "i_key_sort"
-version = "0.6.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9190f86706ca38ac8add223b2aed8b1330002b5cdbbce28fb58b10914d38fc27"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "i_overlay"
-version = "4.0.7"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413183068e6e0289e18d7d0a1f661b81546e6918d5453a44570b9ab30cbed1b3"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -1515,18 +1521,18 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.14.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea154b742f7d43dae2897fcd5ead86bc7b5eefcedd305a7ebf9f69d44d61082"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
 dependencies = [
  "i_float",
 ]
 
 [[package]]
 name = "i_tree"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "iana-time-zone"
@@ -1709,15 +1715,6 @@ checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2034,12 +2031,12 @@ dependencies = [
  "httparse",
  "humantime",
  "hyper",
- "itertools 0.14.0",
+ "itertools",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "ring",
  "rustls-pki-types",
@@ -2409,7 +2406,7 @@ dependencies = [
  "futures",
  "http",
  "humantime",
- "itertools 0.14.0",
+ "itertools",
  "object_store",
  "percent-encoding",
  "pyo3",
@@ -2459,7 +2456,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2513,7 +2510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2523,7 +2529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2533,6 +2539,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3016,6 +3037,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
 name = "simd-adler32"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "arrow", "geospatial"]
 categories = ["wasm", "science::geo"]
-rust-version = { workspace = true }
+rust-version = "1.95"
 
 [workspace.dependencies]
 arrow = "58"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/geoarrow/geoarrow-rs"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "arrow", "geospatial"]
 categories = ["wasm", "science::geo"]
-rust-version = "1.85"
+rust-version = { workspace = true }
 
 [workspace.dependencies]
 arrow = "58"

--- a/python/geoarrow-io/src/input/mod.rs
+++ b/python/geoarrow-io/src/input/mod.rs
@@ -80,11 +80,10 @@ pub fn construct_reader(
     // If the user's path is a "known" URL (i.e. http(s)) then construct an object store
     // instance for them.
     #[cfg(feature = "async")]
-    if let Ok(path_or_url) = file.extract::<PyBackedStr>() {
-        if path_or_url.starts_with("http") {
+    if let Ok(path_or_url) = file.extract::<PyBackedStr>()
+        && path_or_url.starts_with("http") {
             return Ok(AnyFileReader::Async(default_http_store(&path_or_url)?));
         }
-    }
 
     Ok(AnyFileReader::Sync(file.extract()?))
 }

--- a/python/geoarrow-io/src/input/mod.rs
+++ b/python/geoarrow-io/src/input/mod.rs
@@ -81,9 +81,10 @@ pub fn construct_reader(
     // instance for them.
     #[cfg(feature = "async")]
     if let Ok(path_or_url) = file.extract::<PyBackedStr>()
-        && path_or_url.starts_with("http") {
-            return Ok(AnyFileReader::Async(default_http_store(&path_or_url)?));
-        }
+        && path_or_url.starts_with("http")
+    {
+        return Ok(AnyFileReader::Async(default_http_store(&path_or_url)?));
+    }
 
     Ok(AnyFileReader::Sync(file.extract()?))
 }

--- a/rust/geoarrow-array/src/array/coord/interleaved.rs
+++ b/rust/geoarrow-array/src/array/coord/interleaved.rs
@@ -21,7 +21,7 @@ pub struct InterleavedCoordBuffer {
 }
 
 fn check(coords: &ScalarBuffer<f64>, dim: Dimension) -> GeoArrowResult<()> {
-    if coords.len() % dim.size() != 0 {
+    if !coords.len().is_multiple_of(dim.size()) {
         return Err(GeoArrowError::InvalidGeoArrow(
             "Length of interleaved coordinate buffer must be a multiple of the dimension size"
                 .to_string(),

--- a/rust/geoarrow-cast/src/cast.rs
+++ b/rust/geoarrow-cast/src/cast.rs
@@ -60,13 +60,13 @@ pub fn cast(
     // We want to error if the dimensions aren't compatible, but allow conversions to
     // `GeometryArray`, `WKB`, etc where the target array isn't parameterized by a specific
     // dimension.
-    if let (Some(from_dim), Some(to_dim)) = (array.data_type().dimension(), to_type.dimension()) {
-        if from_dim != to_dim {
-            return Err(ArrowError::CastError(format!(
-                "Cannot cast from {from_dim:?} to {to_dim:?}: incompatible dimensions",
-            ))
-            .into());
-        }
+    if let (Some(from_dim), Some(to_dim)) = (array.data_type().dimension(), to_type.dimension())
+        && from_dim != to_dim
+    {
+        return Err(ArrowError::CastError(format!(
+            "Cannot cast from {from_dim:?} to {to_dim:?}: incompatible dimensions",
+        ))
+        .into());
     }
 
     if array.data_type().metadata() != to_type.metadata() {

--- a/rust/geoarrow-expr-geos/src/import/scalar/mod.rs
+++ b/rust/geoarrow-expr-geos/src/import/scalar/mod.rs
@@ -21,20 +21,20 @@ pub use polygon::{GEOSConstPolygon, GEOSPolygon};
 
 /// Determine the [`geo_traits::Dimensions`] of a GEOS geometry.
 pub(crate) fn dimensions_from_geom(geom: &impl geos::Geom) -> geo_traits::Dimensions {
-    #[cfg(not(feature = "geos-3_14"))]
-    {
-        match geom.get_coordinate_dimension().unwrap() {
-            geos::CoordDimensions::TwoD => geo_traits::Dimensions::Xy,
-            geos::CoordDimensions::ThreeD => geo_traits::Dimensions::Xyz,
+    cfg_select! {
+        feature = "geos-3_14" => {
+            match (geom.has_z().unwrap(), geom.has_m().unwrap()) {
+                (false, false) => geo_traits::Dimensions::Xy,
+                (true, false) => geo_traits::Dimensions::Xyz,
+                (false, true) => geo_traits::Dimensions::Xym,
+                (true, true) => geo_traits::Dimensions::Xyzm,
+            }
         }
-    }
-    #[cfg(feature = "geos-3_14")]
-    {
-        match (geom.has_z().unwrap(), geom.has_m().unwrap()) {
-            (false, false) => geo_traits::Dimensions::Xy,
-            (true, false) => geo_traits::Dimensions::Xyz,
-            (false, true) => geo_traits::Dimensions::Xym,
-            (true, true) => geo_traits::Dimensions::Xyzm,
+        _ => {
+            match geom.get_coordinate_dimension().unwrap() {
+                geos::CoordDimensions::TwoD => geo_traits::Dimensions::Xy,
+                geos::CoordDimensions::ThreeD => geo_traits::Dimensions::Xyz,
+            }
         }
     }
 }

--- a/rust/geoarrow-flatgeobuf/src/reader/schema.rs
+++ b/rust/geoarrow-flatgeobuf/src/reader/schema.rs
@@ -114,10 +114,10 @@ impl FlatGeobufSchemaScanner {
                 .map_err(|err| GeoArrowError::External(Box::new(err)))?;
 
             num_features_processed += 1;
-            if let Some(max_scan_records) = max_scan_records {
-                if num_features_processed >= max_scan_records {
-                    return Ok(());
-                }
+            if let Some(max_scan_records) = max_scan_records
+                && num_features_processed >= max_scan_records
+            {
+                return Ok(());
             }
         }
         Ok(())

--- a/rust/geoarrow-schema/src/crs.rs
+++ b/rust/geoarrow-schema/src/crs.rs
@@ -193,12 +193,11 @@ pub trait CrsTransform: Debug {
     /// If the CRS is already stored as WKT, this will return that. Otherwise it will call
     /// [`Self::_convert_to_wkt`].
     fn extract_wkt(&self, crs: &Crs) -> GeoArrowResult<Option<String>> {
-        if let (Some(crs), Some(crs_type)) = (crs.crs_value(), crs.crs_type()) {
-            if crs_type == CrsType::Wkt2_2019 {
-                if let Value::String(inner) = crs {
-                    return Ok::<_, GeoArrowError>(Some(inner.clone()));
-                }
-            }
+        if let (Some(crs), Some(crs_type)) = (crs.crs_value(), crs.crs_type())
+            && crs_type == CrsType::Wkt2_2019
+            && let Value::String(inner) = crs
+        {
+            return Ok::<_, GeoArrowError>(Some(inner.clone()));
         }
 
         self._convert_to_wkt(crs)

--- a/rust/geoparquet/src/metadata.rs
+++ b/rust/geoparquet/src/metadata.rs
@@ -609,12 +609,12 @@ impl GeoParquetMetadata {
                 )));
             }
 
-            if let (Some(left_bbox), Some(right_bbox)) = (&left.bbox, &right.bbox) {
-                if left_bbox.len() != right_bbox.len() {
-                    return Err(GeoArrowError::GeoParquet(format!(
-                        "Different bbox dimensions for column {key}",
-                    )));
-                }
+            if let (Some(left_bbox), Some(right_bbox)) = (&left.bbox, &right.bbox)
+                && left_bbox.len() != right_bbox.len()
+            {
+                return Err(GeoArrowError::GeoParquet(format!(
+                    "Different bbox dimensions for column {key}",
+                )));
             }
 
             match (left.crs.as_ref(), right.crs.as_ref()) {

--- a/rust/geoparquet/src/total_bounds.rs
+++ b/rust/geoparquet/src/total_bounds.rs
@@ -80,10 +80,10 @@ impl BoundingRect {
         if y < self.miny {
             self.miny = y;
         }
-        if let Some(z) = z {
-            if z < self.minz {
-                self.minz = z;
-            }
+        if let Some(z) = z
+            && z < self.minz
+        {
+            self.minz = z;
         }
 
         if x > self.maxx {
@@ -92,10 +92,10 @@ impl BoundingRect {
         if y > self.maxy {
             self.maxy = y;
         }
-        if let Some(z) = z {
-            if z > self.maxz {
-                self.maxz = z;
-            }
+        if let Some(z) = z
+            && z > self.maxz
+        {
+            self.maxz = z;
         }
     }
 


### PR DESCRIPTION
Follow-up to #1455:

* Bumps the MSRV to 1.95 ~~(and unifies around the workspace value)~~.
* Refactors dimensions_from_geom to use `cfg_select!`, which I think will make future maintenance less error-prone.