### PR TITLE
feat(geoparquet)!: error handling and 1.0/1.1/2.0-rc.1 version support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-ord",
  "arrow-schema",
+ "bytes",
  "futures",
  "geo-traits",
  "geo-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,12 +1915,26 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "parquet-geospatial",
  "paste",
  "seq-macro",
  "snap",
  "tokio",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parquet-geospatial"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93d4983a0d2df441b15070857a663e36de7be5a65b8bb70a0add6d3c4f231e5"
+dependencies = [
+ "arrow-schema",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "wkb",
 ]
 
 [[package]]

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `GeoParquetDataset.fragments` and dataset reads accept files without a `geo` key, using the dataset's merged geo metadata.
+- Errors from malformed GeoParquet files raise Python exceptions instead of panics.
+
 ## [0.6.3] - 2026-06-11
 
 ### What's Changed

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2094,6 +2094,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "object_store",
+ "parquet-geospatial",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -2101,6 +2102,19 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parquet-geospatial"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93d4983a0d2df441b15070857a663e36de7be5a65b8bb70a0add6d3c4f231e5"
+dependencies = [
+ "arrow-schema",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "wkb",
 ]
 
 [[package]]

--- a/python/geoarrow-io/src/parquet/async.rs
+++ b/python/geoarrow-io/src/parquet/async.rs
@@ -162,8 +162,8 @@ impl GeoParquetFile {
     }
 
     #[getter]
-    fn num_rows(&self) -> usize {
-        self.geoparquet_meta.num_rows()
+    fn num_rows(&self) -> PyGeoArrowResult<usize> {
+        Ok(self.geoparquet_meta.num_rows()?)
     }
 
     #[getter]
@@ -497,8 +497,8 @@ impl GeoParquetDataset {
     }
 
     #[getter]
-    fn num_rows(&self) -> usize {
-        self.meta.num_rows()
+    fn num_rows(&self) -> PyGeoArrowResult<usize> {
+        Ok(self.meta.num_rows()?)
     }
 
     #[getter]
@@ -527,7 +527,7 @@ impl GeoParquetDataset {
         if let Some(meta) = self.meta.files().get(path) {
             Ok(GeoParquetFile {
                 path: path.into(),
-                geoparquet_meta: GeoParquetReaderMetadata::from_arrow_meta(meta.clone()).unwrap(),
+                geoparquet_meta: GeoParquetReaderMetadata::from_arrow_meta(meta.clone())?,
                 store: self.store.clone(),
             })
         } else {
@@ -536,14 +536,16 @@ impl GeoParquetDataset {
     }
 
     #[getter]
-    fn fragments(&self) -> Vec<GeoParquetFile> {
+    fn fragments(&self) -> PyGeoArrowResult<Vec<GeoParquetFile>> {
         self.meta
             .files()
             .iter()
-            .map(|(path, meta)| GeoParquetFile {
-                path: path.clone().into(),
-                geoparquet_meta: GeoParquetReaderMetadata::from_arrow_meta(meta.clone()).unwrap(),
-                store: self.store.clone(),
+            .map(|(path, meta)| {
+                Ok(GeoParquetFile {
+                    path: path.clone().into(),
+                    geoparquet_meta: GeoParquetReaderMetadata::from_arrow_meta(meta.clone())?,
+                    store: self.store.clone(),
+                })
             })
             .collect()
     }

--- a/python/geoarrow-io/src/parquet/async.rs
+++ b/python/geoarrow-io/src/parquet/async.rs
@@ -12,6 +12,7 @@ use futures::TryStreamExt;
 use geo_traits::CoordTrait;
 use geoarrow_array::GeoArrowArray;
 use geoarrow_schema::error::GeoArrowError;
+use geoparquet::metadata::GeoParquetMetadata;
 use geoparquet::reader::{
     GeoParquetDatasetMetadata, GeoParquetReaderBuilder, GeoParquetReaderMetadata,
     GeoParquetRecordBatchStream,
@@ -382,6 +383,24 @@ pub struct GeoParquetDataset {
 }
 
 impl GeoParquetDataset {
+    /// Per-file reader metadata for one fragment of this dataset.
+    ///
+    /// A file without a `geo` key is a valid dataset member and gets the dataset's merged geo
+    /// metadata; the dataset schema check guarantees it carries the same columns.
+    // TODO: cache the parsed per-file metadata at open instead of re-parsing per call
+    fn file_reader_meta(
+        &self,
+        meta: &ArrowReaderMetadata,
+    ) -> PyGeoArrowResult<GeoParquetReaderMetadata> {
+        match GeoParquetMetadata::from_parquet_meta(meta.metadata().file_metadata()) {
+            Some(geo_meta) => Ok(GeoParquetReaderMetadata::new(meta.clone(), geo_meta?)),
+            None => Ok(GeoParquetReaderMetadata::new(
+                meta.clone(),
+                self.meta.geo_metadata().as_ref().clone(),
+            )),
+        }
+    }
+
     fn to_readers(
         &self,
         options: PyGeoParquetReadOptions,
@@ -392,8 +411,7 @@ impl GeoParquetDataset {
             .files()
             .iter()
             .map(|(path, meta)| {
-                // TODO: don't re-parse GeoParquet metadata
-                let geoparquet_meta = GeoParquetReaderMetadata::from_arrow_meta(meta.clone())?;
+                let geoparquet_meta = self.file_reader_meta(meta)?;
                 construct_file_stream(
                     path.clone().into(),
                     geoparquet_meta,
@@ -527,7 +545,7 @@ impl GeoParquetDataset {
         if let Some(meta) = self.meta.files().get(path) {
             Ok(GeoParquetFile {
                 path: path.into(),
-                geoparquet_meta: GeoParquetReaderMetadata::from_arrow_meta(meta.clone())?,
+                geoparquet_meta: self.file_reader_meta(meta)?,
                 store: self.store.clone(),
             })
         } else {
@@ -543,7 +561,7 @@ impl GeoParquetDataset {
             .map(|(path, meta)| {
                 Ok(GeoParquetFile {
                     path: path.clone().into(),
-                    geoparquet_meta: GeoParquetReaderMetadata::from_arrow_meta(meta.clone())?,
+                    geoparquet_meta: self.file_reader_meta(meta)?,
                     store: self.store.clone(),
                 })
             })

--- a/rust/geoparquet/CHANGELOG.md
+++ b/rust/geoparquet/CHANGELOG.md
@@ -11,7 +11,13 @@
 - Dataset schemas are compared by field name and data type; nullability merges as "nullable in any file".
 - The dataset metadata merge is order-independent per column: `geometry_types` union, and columns declared by only some files carry over.
 - Covering shape checks moved to the row-filter path; row-group pruning and bounds work for flat top-level coverings.
-- New `GeoParquetVersion` enum: `GeoParquetWriterOptions` takes a target version (default 1.1). Native encodings and coverings require 1.1, M or ZM geometries 2.0. `GeoParquetMetadata::known_version` interprets the file's version string.
+- New `GeoParquetVersion` enum: `GeoParquetWriterOptions` takes a target version (default 1.1). Native encodings require 1.1, coverings 1.1 or later, M or ZM geometries 2.0. `GeoParquetMetadata::known_version` interprets the file's version string.
+- GeoParquet 2.0 support targets 2.0.0-rc.1; the 2.0 reader and writer behavior can change until the specification is final.
+- The reader accepts files with GEOMETRY and GEOGRAPHY logical types and no `geo` key, as GeoParquet 2.0 expects, synthesizing metadata from the logical types: WKB, unknown geometry types, CRS from the `crs` property, edges from the GEOGRAPHY algorithm.
+- Row-group pruning and bounds fall back to the column's native geospatial statistics when no covering is declared.
+- The dataset merge no longer compares version strings, so datasets written across a specification transition read.
+- The `edges` metadata maps all five 2.0 edge algorithms and survives a missing CRS.
+- The writer emits GeoParquet 2.0 on request: WKB with the GEOMETRY or GEOGRAPHY logical type, via `GeoParquetRecordBatchEncoder::target_parquet_schema` and `ArrowWriterOptions::with_parquet_schema`. The parquet `geospatial` feature is enabled.
 
 ## 0.7.0 - 2026-01-04
 

--- a/rust/geoparquet/CHANGELOG.md
+++ b/rust/geoparquet/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## Unreleased
 
+- **Breaking:** the reader returns errors instead of panicking on malformed files; `num_rows` now returns `GeoArrowResult<usize>`.
+- Native-encoded columns take their geometry type from the encoding and layout, so an empty or inconsistent `geometry_types` list reads.
+- The reader validates the native coordinate struct: Float64 fields x, y, z, m in that order, at the encoding's nesting depth.
+- **Breaking:** the geo metadata `bbox` is a typed `GeoParquetBbox` (4, 6, or 8 elements), validated in deserialization.
+- Dataset schemas are compared by field name and data type; nullability merges as "nullable in any file".
+- The dataset metadata merge is order-independent per column: `geometry_types` union, and columns declared by only some files carry over.
+- Covering shape checks moved to the row-filter path; row-group pruning and bounds work for flat top-level coverings.
+
 ## 0.7.0 - 2026-01-04
 
 - chore: Bump to arrow 57 by @ddupg in https://github.com/geoarrow/geoarrow-rs/pull/1402

--- a/rust/geoparquet/CHANGELOG.md
+++ b/rust/geoparquet/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Dataset schemas are compared by field name and data type; nullability merges as "nullable in any file".
 - The dataset metadata merge is order-independent per column: `geometry_types` union, and columns declared by only some files carry over.
 - Covering shape checks moved to the row-filter path; row-group pruning and bounds work for flat top-level coverings.
+- New `GeoParquetVersion` enum: `GeoParquetWriterOptions` takes a target version (default 1.1). Native encodings and coverings require 1.1, M or ZM geometries 2.0. `GeoParquetMetadata::known_version` interprets the file's version string.
 
 ## 0.7.0 - 2026-01-04
 

--- a/rust/geoparquet/Cargo.toml
+++ b/rust/geoparquet/Cargo.toml
@@ -24,7 +24,7 @@ geo-types = { workspace = true }
 geoarrow-array = { workspace = true }
 geoarrow-schema = { workspace = true }
 indexmap = { workspace = true }
-parquet = { workspace = true, features = ["arrow"] }
+parquet = { workspace = true, features = ["arrow", "geospatial"] }
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/geoparquet/Cargo.toml
+++ b/rust/geoparquet/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = { workspace = true }
 wkt = { workspace = true }
 
 [dev-dependencies]
+bytes = { workspace = true }
 parquet = { workspace = true, features = [
     "async",
     "brotli",

--- a/rust/geoparquet/src/metadata.rs
+++ b/rust/geoparquet/src/metadata.rs
@@ -526,14 +526,24 @@ impl GeoParquetMetadata {
         None
     }
 
-    /// Update a GeoParquetMetadata from another file's metadata
+    /// Merge another file's metadata into this one
     ///
-    /// This will expand the bounding box of each geometry column to include the bounding box
-    /// defined in the other file's GeoParquet metadata
+    /// Expands each column's bbox, unions its geometry types, and carries over columns only
+    /// `other` declares. Apart from the version string, which keeps the first-seen file's
+    /// value, the merged column metadata is the same in any file order.
     pub fn try_update(&mut self, other: &GeoParquetMetadata) -> GeoArrowResult<()> {
         self.try_compatible_with(other)?;
         for (column_name, column_meta) in self.columns.iter_mut() {
-            let other_column_meta = other.columns.get(column_name.as_str()).unwrap();
+            let Some(other_column_meta) = other.columns.get(column_name.as_str()) else {
+                continue;
+            };
+
+            // Writers (e.g. GeoPandas) record per-file geometry_types, so two files of one
+            // dataset legitimately differ; the dataset-level list is their union.
+            column_meta
+                .geometry_types
+                .extend(other_column_meta.geometry_types.iter().cloned());
+
             match (column_meta.bbox.as_mut(), &other_column_meta.bbox) {
                 (Some(bbox), Some(other_bbox)) => {
                     bbox.expand_to_include(other_bbox).map_err(|_| {
@@ -547,6 +557,15 @@ impl GeoParquetMetadata {
                 }
                 // If the RHS doesn't have a bbox, we don't need to update
                 (_, None) => {}
+            }
+        }
+
+        // Carry over columns declared by only one file; the dataset reader's Arrow schema
+        // check guarantees the column exists physically in every file.
+        for (column_name, other_column_meta) in other.columns.iter() {
+            if !self.columns.contains_key(column_name) {
+                self.columns
+                    .insert(column_name.clone(), other_column_meta.clone());
             }
         }
         Ok(())
@@ -572,24 +591,16 @@ impl GeoParquetMetadata {
             ));
         }
 
-        for key in self.columns.keys() {
-            let left = self.columns.get(key).unwrap();
-            let right = other
-                .columns
-                .get(key)
-                .ok_or(GeoArrowError::GeoParquet(format!(
-                    "Other GeoParquet metadata missing column {key}",
-                )))?;
+        // Columns declared by only one side, and differing geometry_types, merge in
+        // try_update instead of failing here.
+        for (key, left) in self.columns.iter() {
+            let Some(right) = other.columns.get(key) else {
+                continue;
+            };
 
             if left.encoding != right.encoding {
                 return Err(GeoArrowError::GeoParquet(format!(
                     "Different GeoParquet encodings for column {key}",
-                )));
-            }
-
-            if left.geometry_types != right.geometry_types {
-                return Err(GeoArrowError::GeoParquet(format!(
-                    "Different GeoParquet geometry types for column {key}",
                 )));
             }
 
@@ -965,6 +976,51 @@ mod test {
             GeoParquetBbox::Xyzm([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
         );
         assert_eq!(serde_json::to_value(&bbox).unwrap(), xyzm);
+    }
+
+    #[test]
+    fn try_update_is_order_independent() {
+        let meta_a: GeoParquetMetadata = serde_json::from_value(serde_json::json!({
+            "version": "1.1.0",
+            "primary_column": "geom",
+            "columns": {
+                "geom": {
+                    "encoding": "WKB",
+                    "geometry_types": ["MultiPolygon"],
+                    "bbox": [0.0, 0.0, 1.0, 1.0]
+                }
+            }
+        }))
+        .unwrap();
+        let meta_b: GeoParquetMetadata = serde_json::from_value(serde_json::json!({
+            "version": "1.1.0",
+            "primary_column": "geom",
+            "columns": {
+                "geom": {
+                    "encoding": "WKB",
+                    "geometry_types": ["Polygon", "MultiPolygon"],
+                    "bbox": [-1.0, 0.5, 2.0, 0.75]
+                },
+                "geom2": {"encoding": "WKB", "geometry_types": ["Point"]}
+            }
+        }))
+        .unwrap();
+
+        let mut ab = meta_a.clone();
+        ab.try_update(&meta_b).unwrap();
+        let mut ba = meta_b.clone();
+        ba.try_update(&meta_a).unwrap();
+
+        for merged in [&ab, &ba] {
+            let geom = &merged.columns["geom"];
+            assert_eq!(geom.geometry_types.len(), 2);
+            assert_eq!(geom.bbox, Some(GeoParquetBbox::Xy([-1.0, 0.0, 2.0, 1.0])));
+            assert!(merged.columns.contains_key("geom2"));
+        }
+        assert_eq!(
+            ab.columns["geom"].geometry_types,
+            ba.columns["geom"].geometry_types
+        );
     }
 
     #[test]

--- a/rust/geoparquet/src/metadata.rs
+++ b/rust/geoparquet/src/metadata.rs
@@ -14,12 +14,17 @@ use geoarrow_schema::{
     LineStringType, Metadata, MultiLineStringType, MultiPointType, MultiPolygonType, PointType,
     PolygonType,
 };
-use parquet::file::metadata::FileMetaData;
+use parquet::basic::{EdgeInterpolationAlgorithm, LogicalType};
+use parquet::file::metadata::{FileMetaData, KeyValue};
+use parquet::schema::types::SchemaDescriptor;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 use crate::writer::GeoParquetWriterEncoding;
+
+// https://github.com/geoarrow/geoarrow-rs/pull/1159#issuecomment-2904610370
+pub(crate) const INFERRED_PRIMARY_COLUMN_NAMES: [&str; 2] = ["geometry", "geography"];
 
 /// The actual encoding of the geometry in the Parquet file.
 ///
@@ -531,6 +536,64 @@ impl GeoParquetMetadata {
         GeoParquetVersion::from_metadata_string(&self.version)
     }
 
+    /// Synthesize metadata from the Parquet GEOMETRY and GEOGRAPHY logical types.
+    ///
+    /// GeoParquet 2.0 expects readers to read files that carry only these types and no `geo`
+    /// key. Each top-level geometry-typed column becomes a WKB column with unknown geometry
+    /// types. Returns `None` when no such column exists.
+    ///
+    /// GeoParquet 2.0 is at release candidate 2.0.0-rc.1; this behavior can change until the
+    /// specification is final.
+    pub fn from_logical_types(
+        parquet_schema: &SchemaDescriptor,
+        key_value_metadata: Option<&Vec<KeyValue>>,
+    ) -> Option<GeoArrowResult<Self>> {
+        let mut columns: HashMap<String, GeoParquetColumnMetadata> = HashMap::new();
+        for field in parquet_schema.root_schema().get_fields() {
+            let Some(logical_type) = field.get_basic_info().logical_type_ref() else {
+                continue;
+            };
+            let (crs, edges) = match logical_type {
+                LogicalType::Geometry(geometry) => (geometry.crs.clone(), None),
+                LogicalType::Geography(geography) => {
+                    let edges = match geography.algorithm().map(edges_name_for_algorithm) {
+                        Some(Ok(name)) => Some(name),
+                        Some(Err(err)) => return Some(Err(err)),
+                        None => None,
+                    };
+                    (geography.crs.clone(), edges)
+                }
+                _ => continue,
+            };
+            let column = match synthesized_column(crs.as_deref(), edges, key_value_metadata) {
+                Ok(column) => column,
+                Err(err) => return Some(Err(err)),
+            };
+            columns.insert(field.name().to_string(), column);
+        }
+
+        if columns.is_empty() {
+            return None;
+        }
+
+        let primary_column = INFERRED_PRIMARY_COLUMN_NAMES
+            .iter()
+            .find(|name| columns.contains_key(**name))
+            .map(|name| name.to_string())
+            .unwrap_or_else(|| {
+                let mut names: Vec<&String> = columns.keys().collect();
+                names.sort();
+                names[0].clone()
+            });
+
+        Some(Ok(Self {
+            // Files carrying the geospatial logical types belong to the 2.0 ecosystem.
+            version: GeoParquetVersion::V2_0.as_str().to_string(),
+            primary_column,
+            columns,
+        }))
+    }
+
     /// Merge another file's metadata into this one
     ///
     /// Expands each column's bbox, unions its geometry types, and carries over columns only
@@ -584,12 +647,9 @@ impl GeoParquetMetadata {
 
     /// Assert that this metadata is compatible with another metadata instance, erroring if not
     pub fn try_compatible_with(&self, other: &GeoParquetMetadata) -> GeoArrowResult<()> {
-        if self.version.as_str() != other.version.as_str() {
-            return Err(GeoArrowError::GeoParquet(
-                "Different GeoParquet versions".to_string(),
-            ));
-        }
-
+        // The version string is deliberately not compared: a dataset written across a spec
+        // transition (1.1 files next to 2.0 files) merges on the per-column metadata, and the
+        // merged result keeps the first-seen version string.
         if self.primary_column.as_str() != other.primary_column.as_str() {
             return Err(GeoArrowError::GeoParquet(
                 "Different GeoParquet primary columns".to_string(),
@@ -678,7 +738,8 @@ pub enum GeoParquetVersion {
     V1_1,
     /// GeoParquet 2.0.0
     ///
-    /// The 2.0 specification is a release candidate. Writing 2.0 output is not implemented yet.
+    /// The 2.0 specification is at release candidate 2.0.0-rc.1; this crate's 2.0 behavior can
+    /// change until it is final.
     V2_0,
 }
 
@@ -889,21 +950,102 @@ impl GeoParquetColumnMetadata {
 
 impl From<GeoParquetColumnMetadata> for Metadata {
     fn from(value: GeoParquetColumnMetadata) -> Self {
-        let edges = if let Some(edges) = value.edges {
-            if edges.as_str() == "spherical" {
-                Some(Edges::Spherical)
-            } else {
-                None
-            }
-        } else {
-            None
+        let edges = value.edges.as_deref().and_then(edges_from_name);
+        let crs = match value.crs {
+            // A JSON string appears only in metadata synthesized from the Parquet logical
+            // types, where it carries an authority code.
+            Some(Value::String(authority_code)) => Crs::from_authority_code(authority_code),
+            Some(projjson) => Crs::from_projjson(projjson),
+            None => Crs::default(),
         };
-        if let Some(crs) = value.crs {
-            Metadata::new(Crs::from_projjson(crs), edges)
-        } else {
-            Metadata::default()
-        }
+        Metadata::new(crs, edges)
     }
+}
+
+/// The `geo` metadata `edges` names, aligned with the Parquet edge interpolation algorithms.
+fn edges_from_name(name: &str) -> Option<Edges> {
+    match name {
+        "spherical" => Some(Edges::Spherical),
+        "vincenty" => Some(Edges::Vincenty),
+        "thomas" => Some(Edges::Thomas),
+        "andoyer" => Some(Edges::Andoyer),
+        "karney" => Some(Edges::Karney),
+        _ => None,
+    }
+}
+
+fn edges_name_for_algorithm(algorithm: EdgeInterpolationAlgorithm) -> GeoArrowResult<&'static str> {
+    match algorithm {
+        EdgeInterpolationAlgorithm::SPHERICAL => Ok("spherical"),
+        EdgeInterpolationAlgorithm::VINCENTY => Ok("vincenty"),
+        EdgeInterpolationAlgorithm::THOMAS => Ok("thomas"),
+        EdgeInterpolationAlgorithm::ANDOYER => Ok("andoyer"),
+        EdgeInterpolationAlgorithm::KARNEY => Ok("karney"),
+        // Reading an unknown algorithm as planar would silently change geometry semantics.
+        other => Err(GeoArrowError::GeoParquet(format!(
+            "Unknown edge interpolation algorithm: {other:?}"
+        ))),
+    }
+}
+
+fn synthesized_column(
+    crs: Option<&str>,
+    edges: Option<&str>,
+    key_value_metadata: Option<&Vec<KeyValue>>,
+) -> GeoArrowResult<GeoParquetColumnMetadata> {
+    let mut column = serde_json::json!({
+        "encoding": "WKB",
+        // The empty list explicitly signals that the geometry types are not known.
+        "geometry_types": [],
+    });
+    if let Some(crs_value) = parquet_crs_to_geo_crs(crs, key_value_metadata)? {
+        column["crs"] = crs_value;
+    }
+    if let Some(edges) = edges {
+        column["edges"] = Value::String(edges.to_string());
+    }
+    serde_json::from_value(column).map_err(|err| GeoArrowError::GeoParquet(err.to_string()))
+}
+
+/// Interpret the Parquet logical-type `crs` property.
+///
+/// Four forms: inline PROJJSON, `projjson:<key>` naming a file metadata key that holds
+/// PROJJSON, `srid:<identifier>`, and `<authority>:<code>`. An `srid:` identifier is not
+/// resolvable without a CRS database and maps to no CRS; an authority code stays a JSON
+/// string for the [`Metadata`] conversion.
+fn parquet_crs_to_geo_crs(
+    crs: Option<&str>,
+    key_value_metadata: Option<&Vec<KeyValue>>,
+) -> GeoArrowResult<Option<Value>> {
+    // An absent crs property means OGC:CRS84, which is also the `geo` metadata default.
+    let Some(crs) = crs else { return Ok(None) };
+    let crs = crs.trim();
+    if crs.starts_with('{') {
+        let value = serde_json::from_str(crs).map_err(|err| {
+            GeoArrowError::GeoParquet(format!("Invalid PROJJSON in Parquet crs property: {err}"))
+        })?;
+        return Ok(Some(value));
+    }
+    if let Some(key) = crs.strip_prefix("projjson:") {
+        let value = key_value_metadata
+            .and_then(|kvs| kvs.iter().find(|kv| kv.key == key))
+            .and_then(|kv| kv.value.as_deref())
+            .ok_or_else(|| {
+                GeoArrowError::GeoParquet(format!(
+                    "Parquet crs property references missing file metadata key {key}"
+                ))
+            })?;
+        let value = serde_json::from_str(value).map_err(|err| {
+            GeoArrowError::GeoParquet(format!(
+                "Invalid PROJJSON under file metadata key {key}: {err}"
+            ))
+        })?;
+        return Ok(Some(value));
+    }
+    if crs.strip_prefix("srid:").is_some() {
+        return Ok(None);
+    }
+    Ok(Some(Value::String(crs.to_string())))
 }
 
 // TODO: deduplicate with `resolve_types` in `downcast.rs`
@@ -1041,6 +1183,54 @@ mod test {
             GeoParquetBbox::Xyzm([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
         );
         assert_eq!(serde_json::to_value(&bbox).unwrap(), xyzm);
+    }
+
+    #[test]
+    fn logical_types_synthesize_geo_metadata() {
+        let descr = crate::test::geometry_schema_descr(LogicalType::geography(
+            Some("EPSG:32633".to_string()),
+            Some(EdgeInterpolationAlgorithm::KARNEY),
+        ));
+        let meta = GeoParquetMetadata::from_logical_types(&descr, None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.version, "2.0.0");
+        assert_eq!(meta.primary_column, "geometry");
+        let column = &meta.columns["geometry"];
+        assert!(matches!(column.encoding, GeoParquetColumnEncoding::WKB));
+        assert!(column.geometry_types.is_empty());
+        assert_eq!(column.edges.as_deref(), Some("karney"));
+
+        let geoarrow_meta = Metadata::from(column.clone());
+        assert_eq!(geoarrow_meta.edges(), Some(Edges::Karney));
+        assert_eq!(
+            geoarrow_meta.crs(),
+            &Crs::from_authority_code("EPSG:32633".to_string())
+        );
+
+        let descr = crate::test::schema_descr("message schema { required binary name; }");
+        assert!(GeoParquetMetadata::from_logical_types(&descr, None).is_none());
+    }
+
+    #[test]
+    fn parquet_crs_property_forms() {
+        let inline = parquet_crs_to_geo_crs(Some(r#"{"type": "GeographicCRS"}"#), None).unwrap();
+        assert_eq!(inline, Some(serde_json::json!({"type": "GeographicCRS"})));
+
+        let kv = vec![KeyValue::new(
+            "my_crs".to_string(),
+            r#"{"a": 1}"#.to_string(),
+        )];
+        let referenced = parquet_crs_to_geo_crs(Some("projjson:my_crs"), Some(&kv)).unwrap();
+        assert_eq!(referenced, Some(serde_json::json!({"a": 1})));
+        assert!(parquet_crs_to_geo_crs(Some("projjson:absent"), Some(&kv)).is_err());
+
+        assert_eq!(parquet_crs_to_geo_crs(Some("srid:0"), None).unwrap(), None);
+        assert_eq!(parquet_crs_to_geo_crs(None, None).unwrap(), None);
+        assert_eq!(
+            parquet_crs_to_geo_crs(Some("EPSG:4326"), None).unwrap(),
+            Some(Value::String("EPSG:4326".to_string()))
+        );
     }
 
     #[test]

--- a/rust/geoparquet/src/metadata.rs
+++ b/rust/geoparquet/src/metadata.rs
@@ -74,6 +74,19 @@ impl GeoParquetColumnEncoding {
         };
         Ok(new_encoding)
     }
+
+    /// The geometry type a native encoding stores, or `None` for WKB.
+    pub(crate) fn native_geometry_type(&self) -> Option<GeoParquetGeometryType> {
+        match self {
+            Self::WKB => None,
+            Self::Point => Some(GeoParquetGeometryType::Point),
+            Self::LineString => Some(GeoParquetGeometryType::LineString),
+            Self::Polygon => Some(GeoParquetGeometryType::Polygon),
+            Self::MultiPoint => Some(GeoParquetGeometryType::MultiPoint),
+            Self::MultiLineString => Some(GeoParquetGeometryType::MultiLineString),
+            Self::MultiPolygon => Some(GeoParquetGeometryType::MultiPolygon),
+        }
+    }
 }
 
 impl Display for GeoParquetColumnEncoding {

--- a/rust/geoparquet/src/metadata.rs
+++ b/rust/geoparquet/src/metadata.rs
@@ -526,6 +526,11 @@ impl GeoParquetMetadata {
         None
     }
 
+    /// The declared specification version, or `None` for unknown version strings.
+    pub fn known_version(&self) -> Option<GeoParquetVersion> {
+        GeoParquetVersion::from_metadata_string(&self.version)
+    }
+
     /// Merge another file's metadata into this one
     ///
     /// Expands each column's bbox, unions its geometry types, and carries over columns only
@@ -657,6 +662,66 @@ impl GeoParquetMetadata {
                     )))?;
             Ok((&self.primary_column, column_meta))
         }
+    }
+}
+
+/// A GeoParquet specification version with version-specific writer rules.
+///
+/// The reader does not gate on the version: it stays layout-driven, and an unknown version
+/// string reads like any other file.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum GeoParquetVersion {
+    /// GeoParquet 1.0.0
+    V1_0,
+    /// GeoParquet 1.1.0
+    #[default]
+    V1_1,
+    /// GeoParquet 2.0.0
+    ///
+    /// The 2.0 specification is a release candidate. Writing 2.0 output is not implemented yet.
+    V2_0,
+}
+
+impl GeoParquetVersion {
+    /// The version string written to the `geo` metadata key.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::V1_0 => "1.0.0",
+            Self::V1_1 => "1.1.0",
+            Self::V2_0 => "2.0.0",
+        }
+    }
+
+    /// Interpret a file's version string, or `None` for unknown versions.
+    ///
+    /// Pre-release strings count as their release: `"1.0.0-beta.1"` is 1.0, `"2.0.0-rc.1"`
+    /// and the draft string `"2.0-dev"` are 2.0.
+    pub fn from_metadata_string(version: &str) -> Option<Self> {
+        match version {
+            v if v == "1.0.0" || v.starts_with("1.0.0-") => Some(Self::V1_0),
+            "1.1.0" => Some(Self::V1_1),
+            v if v == "2.0.0" || v.starts_with("2.0.0-") || v == "2.0-dev" => Some(Self::V2_0),
+            _ => None,
+        }
+    }
+
+    /// Native (GeoArrow) encodings exist only in GeoParquet 1.1; 1.0 and 2.0 are WKB-only.
+    pub fn supports_native_encoding(&self) -> bool {
+        matches!(self, Self::V1_1)
+    }
+
+    /// The bbox covering requires 1.1 or later.
+    ///
+    /// The covering is out of the 2.0 release candidate text, but the 1.1 form stays valid as
+    /// an extension and reinstatement is under discussion (opengeospatial/geoparquet#297).
+    /// This crate writes a covering into 2.0 output only on explicit request.
+    pub fn supports_covering(&self) -> bool {
+        matches!(self, Self::V1_1 | Self::V2_0)
+    }
+
+    /// M coordinates arrive with GeoParquet 2.0; 1.x forbids them.
+    pub fn supports_m_dimension(&self) -> bool {
+        matches!(self, Self::V2_0)
     }
 }
 
@@ -976,6 +1041,27 @@ mod test {
             GeoParquetBbox::Xyzm([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
         );
         assert_eq!(serde_json::to_value(&bbox).unwrap(), xyzm);
+    }
+
+    #[test]
+    fn version_strings_map_to_known_versions() {
+        use GeoParquetVersion::*;
+        for (string, expected) in [
+            ("1.0.0", Some(V1_0)),
+            ("1.0.0-beta.1", Some(V1_0)),
+            ("1.1.0", Some(V1_1)),
+            ("2.0.0", Some(V2_0)),
+            ("2.0.0-rc.1", Some(V2_0)),
+            ("2.0-dev", Some(V2_0)),
+            ("0.4.0", None),
+            ("3.0.0", None),
+        ] {
+            assert_eq!(
+                GeoParquetVersion::from_metadata_string(string),
+                expected,
+                "{string}"
+            );
+        }
     }
 
     #[test]

--- a/rust/geoparquet/src/metadata.rs
+++ b/rust/geoparquet/src/metadata.rs
@@ -536,40 +536,11 @@ impl GeoParquetMetadata {
             let other_column_meta = other.columns.get(column_name.as_str()).unwrap();
             match (column_meta.bbox.as_mut(), &other_column_meta.bbox) {
                 (Some(bbox), Some(other_bbox)) => {
-                    assert_eq!(bbox.len(), other_bbox.len());
-                    if bbox.len() == 4 {
-                        if other_bbox[0] < bbox[0] {
-                            bbox[0] = other_bbox[0];
-                        }
-                        if other_bbox[1] < bbox[1] {
-                            bbox[1] = other_bbox[1];
-                        }
-                        if other_bbox[2] > bbox[2] {
-                            bbox[2] = other_bbox[2];
-                        }
-                        if other_bbox[3] > bbox[3] {
-                            bbox[3] = other_bbox[3];
-                        }
-                    } else if bbox.len() == 6 {
-                        if other_bbox[0] < bbox[0] {
-                            bbox[0] = other_bbox[0];
-                        }
-                        if other_bbox[1] < bbox[1] {
-                            bbox[1] = other_bbox[1];
-                        }
-                        if other_bbox[2] < bbox[2] {
-                            bbox[2] = other_bbox[2];
-                        }
-                        if other_bbox[3] > bbox[3] {
-                            bbox[3] = other_bbox[3];
-                        }
-                        if other_bbox[4] > bbox[4] {
-                            bbox[4] = other_bbox[4];
-                        }
-                        if other_bbox[5] > bbox[5] {
-                            bbox[5] = other_bbox[5];
-                        }
-                    }
+                    bbox.expand_to_include(other_bbox).map_err(|_| {
+                        GeoArrowError::GeoParquet(format!(
+                            "Different bbox dimensions for column {column_name}",
+                        ))
+                    })?;
                 }
                 (None, Some(other_bbox)) => {
                     column_meta.bbox = Some(other_bbox.clone());
@@ -623,7 +594,7 @@ impl GeoParquetMetadata {
             }
 
             if let (Some(left_bbox), Some(right_bbox)) = (&left.bbox, &right.bbox)
-                && left_bbox.len() != right_bbox.len()
+                && std::mem::discriminant(left_bbox) != std::mem::discriminant(right_bbox)
             {
                 return Err(GeoArrowError::GeoParquet(format!(
                     "Different bbox dimensions for column {key}",
@@ -678,6 +649,75 @@ impl GeoParquetMetadata {
     }
 }
 
+/// A geo metadata bounding box, in the spec's flat-array form.
+///
+/// A 6-element bbox is always XYZ: GeoParquet has no 6-element XYM form
+/// (opengeospatial/geoparquet#300). The 8-element XYZM form arrives with GeoParquet 2.0.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "Vec<f64>", into = "Vec<f64>")]
+pub enum GeoParquetBbox {
+    /// `[xmin, ymin, xmax, ymax]`
+    Xy([f64; 4]),
+    /// `[xmin, ymin, zmin, xmax, ymax, zmax]`
+    Xyz([f64; 6]),
+    /// `[xmin, ymin, zmin, mmin, xmax, ymax, zmax, mmax]`
+    Xyzm([f64; 8]),
+}
+
+impl GeoParquetBbox {
+    /// The flat array: all minimums, then all maximums.
+    pub fn as_slice(&self) -> &[f64] {
+        match self {
+            Self::Xy(v) => v,
+            Self::Xyz(v) => v,
+            Self::Xyzm(v) => v,
+        }
+    }
+
+    /// Expand these bounds to also cover `other`.
+    ///
+    /// Errors if the two bboxes have different dimensions.
+    pub fn expand_to_include(&mut self, other: &GeoParquetBbox) -> GeoArrowResult<()> {
+        let (this, other) = match (self, other) {
+            (Self::Xy(a), Self::Xy(b)) => (a.as_mut_slice(), b.as_slice()),
+            (Self::Xyz(a), Self::Xyz(b)) => (a.as_mut_slice(), b.as_slice()),
+            (Self::Xyzm(a), Self::Xyzm(b)) => (a.as_mut_slice(), b.as_slice()),
+            _ => {
+                return Err(GeoArrowError::GeoParquet(
+                    "Different bbox dimensions".to_string(),
+                ));
+            }
+        };
+        let half = this.len() / 2;
+        for (bound, other_bound) in this[..half].iter_mut().zip(&other[..half]) {
+            *bound = bound.min(*other_bound);
+        }
+        for (bound, other_bound) in this[half..].iter_mut().zip(&other[half..]) {
+            *bound = bound.max(*other_bound);
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<Vec<f64>> for GeoParquetBbox {
+    type Error = String;
+
+    fn try_from(value: Vec<f64>) -> Result<Self, Self::Error> {
+        match value.len() {
+            4 => Ok(Self::Xy(value.try_into().unwrap())),
+            6 => Ok(Self::Xyz(value.try_into().unwrap())),
+            8 => Ok(Self::Xyzm(value.try_into().unwrap())),
+            len => Err(format!("Invalid bbox length {len}: expected 4, 6, or 8")),
+        }
+    }
+}
+
+impl From<GeoParquetBbox> for Vec<f64> {
+    fn from(value: GeoParquetBbox) -> Self {
+        value.as_slice().to_vec()
+    }
+}
+
 /// GeoParquet column metadata
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GeoParquetColumnMetadata {
@@ -726,7 +766,7 @@ pub struct GeoParquetColumnMetadata {
 
     /// Bounding Box of the geometries in the file, formatted according to RFC 7946, section 5.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bbox: Option<Vec<f64>>,
+    pub bbox: Option<GeoParquetBbox>,
 
     /// Coordinate epoch in case of a dynamic CRS, expressed as a decimal year.
     ///
@@ -882,6 +922,8 @@ pub(crate) fn infer_geo_data_type(
 
 #[cfg(test)]
 mod test {
+    use parquet::file::metadata::KeyValue;
+
     use super::*;
 
     // We want to ensure that extra keys in future GeoParquet versions do not break
@@ -901,5 +943,41 @@ mod test {
         );
 
         dbg!(&meta);
+    }
+
+    #[test]
+    fn bbox_serde_validates_length_and_round_trips() {
+        let err = serde_json::from_value::<GeoParquetMetadata>(serde_json::json!({
+            "version": "1.1.0",
+            "primary_column": "geom",
+            "columns": {
+                "geom": {"encoding": "WKB", "geometry_types": [], "bbox": [1.0, 2.0, 3.0]}
+            }
+        }))
+        .err()
+        .unwrap();
+        assert!(err.to_string().contains("bbox length"));
+
+        let xyzm = serde_json::json!([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+        let bbox: GeoParquetBbox = serde_json::from_value(xyzm.clone()).unwrap();
+        assert_eq!(
+            bbox,
+            GeoParquetBbox::Xyzm([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+        );
+        assert_eq!(serde_json::to_value(&bbox).unwrap(), xyzm);
+    }
+
+    #[test]
+    fn bbox_expand_to_include() {
+        let mut bbox = GeoParquetBbox::Xyz([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]);
+        bbox.expand_to_include(&GeoParquetBbox::Xyz([-1.0, 0.5, -2.0, 0.5, 3.0, 4.0]))
+            .unwrap();
+        assert_eq!(bbox, GeoParquetBbox::Xyz([-1.0, 0.0, -2.0, 1.0, 3.0, 4.0]));
+
+        let err = bbox
+            .expand_to_include(&GeoParquetBbox::Xy([0.0, 0.0, 1.0, 1.0]))
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("bbox dimensions"));
     }
 }

--- a/rust/geoparquet/src/reader/geo_ext.rs
+++ b/rust/geoparquet/src/reader/geo_ext.rs
@@ -6,7 +6,10 @@ use parquet::arrow::arrow_reader::{ArrowPredicate, ArrowReaderBuilder, RowFilter
 
 use crate::metadata::GeoParquetMetadata;
 use crate::reader::parse::infer_geoarrow_schema;
-use crate::reader::spatial_filter::{ParquetBboxStatistics, bbox_arrow_predicate, bbox_row_groups};
+use crate::reader::spatial_filter::{
+    ParquetBboxStatistics, bbox_arrow_predicate, bbox_row_groups, geometry_leaf_index,
+    native_bbox_row_groups,
+};
 
 /// A trait that extends the [`ArrowReaderBuilder`] with methods for reading GeoParquet files.
 ///
@@ -154,16 +157,14 @@ impl<T> GeoParquetReaderBuilder for ArrowReaderBuilder<T> {
         column_name: Option<&str>,
     ) -> GeoArrowResult<Vec<usize>> {
         let (column_name, column_meta) = geo_metadata.geometry_column(column_name)?;
-        let bbox_covering =
-            column_meta
-                .bbox_covering(column_name)
-                .ok_or(GeoArrowError::GeoParquet(format!(
-                    "No covering metadata found for column: {column_name}",
-                )))?;
-
-        let bbox_cols = ParquetBboxStatistics::try_new(self.parquet_schema(), &bbox_covering)?;
-
-        bbox_row_groups(self.metadata().row_groups(), &bbox_cols, bbox)
+        if let Some(bbox_covering) = column_meta.bbox_covering(column_name) {
+            let bbox_cols = ParquetBboxStatistics::try_new(self.parquet_schema(), &bbox_covering)?;
+            bbox_row_groups(self.metadata().row_groups(), &bbox_cols, bbox)
+        } else {
+            // Without a covering, fall back to the column's native geospatial statistics.
+            let leaf_idx = geometry_leaf_index(self.parquet_schema(), column_name)?;
+            native_bbox_row_groups(self.metadata().row_groups(), leaf_idx, bbox)
+        }
     }
 
     fn with_intersecting_row_groups(
@@ -199,6 +200,77 @@ mod test {
         buf.extend_from_slice(&x.to_le_bytes());
         buf.extend_from_slice(&y.to_le_bytes());
         buf
+    }
+
+    /// 2.0 round trip: the logical type survives, and pruning works from the native
+    /// statistics, because 2.0 output carries no covering by default.
+    #[test]
+    fn v2_roundtrip_prunes_from_native_statistics() {
+        use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
+        use parquet::arrow::arrow_writer::ArrowWriterOptions;
+        use parquet::basic::LogicalType;
+
+        use crate::metadata::GeoParquetVersion;
+        use crate::writer::{GeoParquetRecordBatchEncoder, GeoParquetWriterOptions};
+
+        let field = Field::new("geometry", DataType::Binary, false).with_metadata(
+            std::collections::HashMap::from([(
+                EXTENSION_TYPE_NAME_KEY.to_string(),
+                "geoarrow.wkb".to_string(),
+            )]),
+        );
+        let schema = Arc::new(Schema::new(vec![field]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(BinaryArray::from_iter_values([
+                wkb_point(1.0, 2.0),
+                wkb_point(3.0, 4.0),
+            ]))],
+        )
+        .unwrap();
+
+        let options = GeoParquetWriterOptions {
+            version: GeoParquetVersion::V2_0,
+            ..Default::default()
+        };
+        let mut encoder = GeoParquetRecordBatchEncoder::try_new(&schema, &options).unwrap();
+        let parquet_schema = encoder.target_parquet_schema().unwrap().unwrap();
+
+        let mut buf = Vec::new();
+        let writer_options = ArrowWriterOptions::new().with_parquet_schema(parquet_schema);
+        let mut writer =
+            ArrowWriter::try_new_with_options(&mut buf, encoder.target_schema(), writer_options)
+                .unwrap();
+        let encoded = encoder.encode_record_batch(&batch).unwrap();
+        writer.write(&encoded).unwrap();
+        writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+        writer.close().unwrap();
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(buf)).unwrap();
+        let geo_meta = builder.geoparquet_metadata().unwrap().unwrap();
+        assert_eq!(geo_meta.version, "2.0.0");
+        assert!(matches!(
+            builder.parquet_schema().columns()[0]
+                .self_type()
+                .get_basic_info()
+                .logical_type_ref(),
+            Some(LogicalType::Geometry(_))
+        ));
+
+        let hit = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 10.0 });
+        assert_eq!(
+            builder
+                .intersecting_row_groups(hit, &geo_meta, None)
+                .unwrap(),
+            vec![0]
+        );
+        let miss = Rect::new(coord! { x: 100.0, y: 100.0 }, coord! { x: 110.0, y: 110.0 });
+        assert!(
+            builder
+                .intersecting_row_groups(miss, &geo_meta, None)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     /// The filter must read each bound from the field the covering names, not an implied

--- a/rust/geoparquet/src/reader/geo_ext.rs
+++ b/rust/geoparquet/src/reader/geo_ext.rs
@@ -176,3 +176,115 @@ impl<T> GeoParquetReaderBuilder for ArrowReaderBuilder<T> {
         Ok(self.with_row_groups(row_groups))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::Int64Type;
+    use arrow_array::{BinaryArray, Float64Array, Int64Array, RecordBatch, StructArray};
+    use arrow_schema::{DataType, Field, Fields, Schema};
+    use bytes::Bytes;
+    use geo_types::coord;
+    use parquet::arrow::ArrowWriter;
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet::file::metadata::KeyValue;
+    use parquet::file::properties::WriterProperties;
+
+    use super::*;
+
+    fn wkb_point(x: f64, y: f64) -> Vec<u8> {
+        let mut buf = vec![0x01, 0x01, 0x00, 0x00, 0x00];
+        buf.extend_from_slice(&x.to_le_bytes());
+        buf.extend_from_slice(&y.to_le_bytes());
+        buf
+    }
+
+    /// The filter must read each bound from the field the covering names, not an implied
+    /// field order.
+    #[test]
+    fn bbox_row_filter_keeps_intersecting_rows() {
+        // Row i covers x in [10i, 10i + 1] and y in [10i + 100, 10i + 101].
+        let bbox_fields: Fields = vec![
+            Field::new("ymax", DataType::Float64, false),
+            Field::new("xmin", DataType::Float64, false),
+            Field::new("ymin", DataType::Float64, false),
+            Field::new("xmax", DataType::Float64, false),
+        ]
+        .into();
+        let child = |offset: f64| {
+            Arc::new(Float64Array::from_iter_values(
+                (0..4).map(|i| i as f64 * 10.0 + offset),
+            )) as _
+        };
+        let bbox = StructArray::new(
+            bbox_fields.clone(),
+            vec![child(101.0), child(0.0), child(100.0), child(1.0)],
+            None,
+        );
+        let geometry: BinaryArray = (0..4)
+            .map(|i| Some(wkb_point(i as f64 * 10.0 + 0.5, i as f64 * 10.0 + 100.5)))
+            .collect();
+        let ids = Int64Array::from_iter_values(0..4);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("geometry", DataType::Binary, false),
+            Field::new("bbox", DataType::Struct(bbox_fields), false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(ids), Arc::new(geometry), Arc::new(bbox)],
+        )
+        .unwrap();
+
+        let geo = serde_json::json!({
+            "version": "1.1.0",
+            "primary_column": "geometry",
+            "columns": {
+                "geometry": {
+                    "encoding": "WKB",
+                    "geometry_types": [],
+                    "covering": {
+                        "bbox": {
+                            "xmin": ["bbox", "xmin"],
+                            "ymin": ["bbox", "ymin"],
+                            "xmax": ["bbox", "xmax"],
+                            "ymax": ["bbox", "ymax"]
+                        }
+                    }
+                }
+            }
+        });
+        let props = WriterProperties::builder()
+            .set_key_value_metadata(Some(vec![KeyValue::new(
+                "geo".to_string(),
+                geo.to_string(),
+            )]))
+            .build();
+        let mut buf = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(buf)).unwrap();
+        let geo_meta = builder.geoparquet_metadata().unwrap().unwrap();
+        let query = Rect::new(coord! { x: 8.0, y: 108.0 }, coord! { x: 21.0, y: 121.0 });
+        let reader = builder
+            .with_intersecting_row_filter(query, &geo_meta, None)
+            .unwrap()
+            .build()
+            .unwrap();
+        let kept: Vec<i64> = reader
+            .flat_map(|batch| {
+                let batch = batch.unwrap();
+                batch
+                    .column(0)
+                    .as_primitive::<Int64Type>()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(kept, vec![1, 2]);
+    }
+}

--- a/rust/geoparquet/src/reader/metadata.rs
+++ b/rust/geoparquet/src/reader/metadata.rs
@@ -11,7 +11,9 @@ use parquet::schema::types::SchemaDescriptor;
 
 use crate::metadata::GeoParquetMetadata;
 use crate::reader::parse::infer_geoarrow_schema;
-use crate::reader::spatial_filter::ParquetBboxStatistics;
+use crate::reader::spatial_filter::{
+    ParquetBboxStatistics, geometry_leaf_index, native_stats_bbox, native_stats_bboxes,
+};
 
 /// An extension trait to DRY some code across the file and dataset metadata.
 trait ArrowReaderMetadataExt {
@@ -73,14 +75,22 @@ impl GeoParquetReaderMetadata {
     }
 
     /// Construct a new [GeoParquetReaderMetadata] from [ArrowReaderMetadata]
+    ///
+    /// The geo metadata comes from the `geo` key, or, for a file without one, is synthesized
+    /// from GEOMETRY and GEOGRAPHY logical types in the Parquet schema.
     pub fn from_arrow_meta(meta: ArrowReaderMetadata) -> GeoArrowResult<Self> {
-        let geo_meta = if let Some(geo_meta) =
-            GeoParquetMetadata::from_parquet_meta(meta.metadata().file_metadata())
+        let file_metadata = meta.metadata().file_metadata();
+        let geo_meta = if let Some(geo_meta) = GeoParquetMetadata::from_parquet_meta(file_metadata)
         {
+            Arc::new(geo_meta?)
+        } else if let Some(geo_meta) = GeoParquetMetadata::from_logical_types(
+            meta.parquet_schema(),
+            file_metadata.key_value_metadata(),
+        ) {
             Arc::new(geo_meta?)
         } else {
             return Err(GeoArrowError::GeoParquet(
-                "No `geo` key in Parquet metadata".to_string(),
+                "No `geo` key in Parquet metadata and no geometry-typed columns".to_string(),
             ));
         };
         Ok(Self { meta, geo_meta })
@@ -151,14 +161,6 @@ impl GeoParquetReaderMetadata {
         column_name: Option<&str>,
     ) -> GeoArrowResult<Option<geo_types::Rect>> {
         let (column_name, column_meta) = self.geo_meta.geometry_column(column_name)?;
-        let bbox_covering =
-            column_meta
-                .bbox_covering(column_name)
-                .ok_or(GeoArrowError::GeoParquet(format!(
-                    "No covering metadata found for column: {column_name}",
-                )))?;
-        let geo_statistics =
-            ParquetBboxStatistics::try_new(self.meta.parquet_schema(), &bbox_covering)?;
         let row_group_meta = self
             .meta
             .metadata()
@@ -170,7 +172,15 @@ impl GeoParquetReaderMetadata {
                     self.meta.metadata().num_row_groups()
                 ))
             })?;
-        Ok(Some(geo_statistics.get_bbox(row_group_meta)?))
+        if let Some(bbox_covering) = column_meta.bbox_covering(column_name) {
+            let geo_statistics =
+                ParquetBboxStatistics::try_new(self.meta.parquet_schema(), &bbox_covering)?;
+            Ok(Some(geo_statistics.get_bbox(row_group_meta)?))
+        } else {
+            // Without a covering, fall back to the column's native geospatial statistics.
+            let leaf_idx = geometry_leaf_index(self.meta.parquet_schema(), column_name)?;
+            Ok(Some(native_stats_bbox(row_group_meta, leaf_idx)?))
+        }
     }
 
     /// Get the bounds of all row groups.
@@ -179,19 +189,21 @@ impl GeoParquetReaderMetadata {
     /// in the metadata.
     pub fn row_groups_bounds(&self, column_name: Option<&str>) -> GeoArrowResult<RectArray> {
         let (column_name, column_meta) = self.geo_meta.geometry_column(column_name)?;
-        let bbox_covering =
-            column_meta
-                .bbox_covering(column_name)
-                .ok_or(GeoArrowError::GeoParquet(format!(
-                    "No covering metadata found for column: {column_name}",
-                )))?;
-
-        let geo_statistics =
-            ParquetBboxStatistics::try_new(self.meta.parquet_schema(), &bbox_covering)?;
-        geo_statistics.get_bboxes(
-            self.meta.metadata().row_groups(),
-            Arc::new(column_meta.clone().into()),
-        )
+        if let Some(bbox_covering) = column_meta.bbox_covering(column_name) {
+            let geo_statistics =
+                ParquetBboxStatistics::try_new(self.meta.parquet_schema(), &bbox_covering)?;
+            geo_statistics.get_bboxes(
+                self.meta.metadata().row_groups(),
+                Arc::new(column_meta.clone().into()),
+            )
+        } else {
+            let leaf_idx = geometry_leaf_index(self.meta.parquet_schema(), column_name)?;
+            native_stats_bboxes(
+                self.meta.metadata().row_groups(),
+                leaf_idx,
+                Arc::new(column_meta.clone().into()),
+            )
+        }
     }
 
     /// Access the bounding box of the given column for the entire file
@@ -259,10 +271,16 @@ impl GeoParquetDatasetMetadata {
                 None => schema = Some((meta.schema().clone(), path)),
             }
 
-            if let Some(new_geo_meta) =
-                GeoParquetMetadata::from_parquet_meta(meta.metadata().file_metadata())
-            {
-                let new_geo_meta = new_geo_meta?;
+            let file_metadata = meta.metadata().file_metadata();
+            let new_geo_meta = match GeoParquetMetadata::from_parquet_meta(file_metadata) {
+                Some(geo) => Some(geo?),
+                None => GeoParquetMetadata::from_logical_types(
+                    meta.parquet_schema(),
+                    file_metadata.key_value_metadata(),
+                )
+                .transpose()?,
+            };
+            if let Some(new_geo_meta) = new_geo_meta {
                 if let Some(geo_meta) = geo_meta.as_mut() {
                     geo_meta.try_update(&new_geo_meta)?;
                 } else {
@@ -431,6 +449,62 @@ mod test {
         let meta = GeoParquetReaderMetadata::new(arrow, geo_meta);
         let err = meta.row_group_bounds(0, None).unwrap_err();
         assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn row_group_bounds_from_native_geo_statistics() {
+        use parquet::basic::LogicalType;
+        use parquet::file::metadata::{
+            ColumnChunkMetaData, FileMetaData, ParquetMetaData, RowGroupMetaData,
+        };
+        use parquet::geospatial::bounding_box::BoundingBox;
+        use parquet::geospatial::statistics::GeospatialStatistics;
+
+        use crate::test::geometry_schema_descr;
+
+        let descr = geometry_schema_descr(LogicalType::geometry(None));
+        let geo_stats = GeospatialStatistics::new(Some(BoundingBox::new(1.0, 2.0, 3.0, 4.0)), None);
+        let geometry_column = ColumnChunkMetaData::builder(descr.column(0))
+            .set_geo_statistics(Box::new(geo_stats))
+            .build()
+            .unwrap();
+        let name_column = ColumnChunkMetaData::builder(descr.column(1))
+            .build()
+            .unwrap();
+        let row_group = RowGroupMetaData::builder(descr.clone())
+            .set_num_rows(10)
+            .set_column_metadata(vec![geometry_column, name_column])
+            .build()
+            .unwrap();
+        let file_meta = FileMetaData::new(1, 10, None, None, descr, None);
+        let parquet_meta = ParquetMetaData::new(file_meta, vec![row_group]);
+        let arrow =
+            ArrowReaderMetadata::try_new(Arc::new(parquet_meta), Default::default()).unwrap();
+
+        let meta = GeoParquetReaderMetadata::from_arrow_meta(arrow).unwrap();
+        let bounds = meta.row_group_bounds(0, None).unwrap().unwrap();
+        assert_eq!(
+            (
+                bounds.min().x,
+                bounds.max().x,
+                bounds.min().y,
+                bounds.max().y
+            ),
+            (1.0, 2.0, 3.0, 4.0)
+        );
+    }
+
+    #[test]
+    fn geo_less_file_with_geometry_logical_type_reads() {
+        use parquet::basic::LogicalType;
+
+        use crate::test::{arrow_meta_from_descr, geometry_schema_descr};
+
+        let descr = geometry_schema_descr(LogicalType::geometry(None));
+        let arrow = arrow_meta_from_descr(descr, 0, &[]);
+        let meta = GeoParquetReaderMetadata::from_arrow_meta(arrow).unwrap();
+        assert_eq!(meta.geo_metadata().primary_column, "geometry");
+        assert_eq!(meta.geo_metadata().version, "2.0.0");
     }
 
     #[test]

--- a/rust/geoparquet/src/reader/metadata.rs
+++ b/rust/geoparquet/src/reader/metadata.rs
@@ -205,7 +205,7 @@ impl GeoParquetReaderMetadata {
         column_name: Option<&'a str>,
     ) -> GeoArrowResult<Option<&'a [f64]>> {
         let (_, column_meta) = self.geo_meta.geometry_column(column_name)?;
-        Ok(column_meta.bbox.as_deref())
+        Ok(column_meta.bbox.as_ref().map(|bbox| bbox.as_slice()))
     }
 
     /// Access the GeoArrow [`Metadata`] from the provided geometry column.
@@ -335,7 +335,7 @@ impl GeoParquetDatasetMetadata {
         column_name: Option<&'a str>,
     ) -> GeoArrowResult<Option<&'a [f64]>> {
         let (_, column_meta) = self.geo_meta.geometry_column(column_name)?;
-        Ok(column_meta.bbox.as_deref())
+        Ok(column_meta.bbox.as_ref().map(|bbox| bbox.as_slice()))
     }
 
     /// Access the GeoArrow [`Metadata`] from the provided geometry column.

--- a/rust/geoparquet/src/reader/metadata.rs
+++ b/rust/geoparquet/src/reader/metadata.rs
@@ -18,15 +18,14 @@ trait ArrowReaderMetadataExt {
     /// Access the [ArrowReaderMetadata] of this builder.
     fn reader_metadata(&self) -> &ArrowReaderMetadata;
 
-    /// The number of rows in this file.
-    fn num_rows(&self) -> usize {
-        self.reader_metadata()
-            .metadata()
-            .row_groups()
-            .iter()
-            .fold(0, |acc, row_group_meta| {
-                acc + usize::try_from(row_group_meta.num_rows()).unwrap()
-            })
+    /// The number of rows in this file, erroring on an invalid footer row count.
+    fn num_rows(&self) -> GeoArrowResult<usize> {
+        let num_rows = self.reader_metadata().metadata().file_metadata().num_rows();
+        usize::try_from(num_rows).map_err(|_| {
+            GeoArrowError::GeoParquet(format!(
+                "Parquet footer reports an invalid row count {num_rows}"
+            ))
+        })
     }
 
     /// The number of row groups in this file.
@@ -132,8 +131,8 @@ impl GeoParquetReaderMetadata {
         )
     }
 
-    /// The number of rows in this file.
-    pub fn num_rows(&self) -> usize {
+    /// The number of rows in this file, erroring on an invalid footer row count.
+    pub fn num_rows(&self) -> GeoArrowResult<usize> {
         self.meta.num_rows()
     }
 
@@ -160,7 +159,17 @@ impl GeoParquetReaderMetadata {
                 )))?;
         let geo_statistics =
             ParquetBboxStatistics::try_new(self.meta.parquet_schema(), &bbox_covering)?;
-        let row_group_meta = self.meta.metadata().row_group(row_group_idx);
+        let row_group_meta = self
+            .meta
+            .metadata()
+            .row_groups()
+            .get(row_group_idx)
+            .ok_or_else(|| {
+                GeoArrowError::GeoParquet(format!(
+                    "Row group index {row_group_idx} out of range: file has {} row groups",
+                    self.meta.metadata().num_row_groups()
+                ))
+            })?;
         Ok(Some(geo_statistics.get_bbox(row_group_meta)?))
     }
 
@@ -282,11 +291,15 @@ impl GeoParquetDatasetMetadata {
         &self.geo_meta
     }
 
-    /// The total number of rows across all files.
-    pub fn num_rows(&self) -> usize {
-        self.files
-            .values()
-            .fold(0, |acc, file| acc + file.num_rows())
+    /// The total number of rows across all files, erroring on an invalid or overflowing count.
+    pub fn num_rows(&self) -> GeoArrowResult<usize> {
+        self.files.values().try_fold(0usize, |acc, file| {
+            acc.checked_add(file.num_rows()?).ok_or_else(|| {
+                GeoArrowError::GeoParquet(
+                    "Total num_rows across dataset files overflows usize".to_string(),
+                )
+            })
+        })
     }
 
     /// The total number of row groups across all files
@@ -333,5 +346,36 @@ impl GeoParquetDatasetMetadata {
     pub fn crs(&self, column_name: Option<&str>) -> GeoArrowResult<Crs> {
         let geoarrow_meta = self.geoarrow_metadata(column_name)?;
         Ok(geoarrow_meta.crs().clone())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::arrow_meta;
+
+    #[test]
+    fn num_rows_with_negative_footer_count_errors() {
+        let meta = arrow_meta("message schema { required double x; }", -5, &[]);
+        let err = ArrowReaderMetadataExt::num_rows(&meta).unwrap_err();
+        assert!(err.to_string().contains("invalid row count"));
+    }
+
+    #[test]
+    fn row_group_bounds_with_out_of_range_index_errors() {
+        let arrow = arrow_meta(
+            "message schema { required group geom { required double x; required double y; } }",
+            0,
+            &[],
+        );
+        let geo_meta: GeoParquetMetadata = serde_json::from_value(serde_json::json!({
+            "version": "1.1.0",
+            "primary_column": "geom",
+            "columns": {"geom": {"encoding": "point", "geometry_types": ["Point"]}}
+        }))
+        .unwrap();
+        let meta = GeoParquetReaderMetadata::new(arrow, geo_meta);
+        let err = meta.row_group_bounds(0, None).unwrap_err();
+        assert!(err.to_string().contains("out of range"));
     }
 }

--- a/rust/geoparquet/src/reader/metadata.rs
+++ b/rust/geoparquet/src/reader/metadata.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow_schema::SchemaRef;
+use arrow_schema::{Schema, SchemaRef};
 use geoarrow_array::array::RectArray;
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, Crs, Metadata};
@@ -249,13 +249,14 @@ impl GeoParquetDatasetMetadata {
             return Err(GeoArrowError::GeoParquet("No files provided".to_string()));
         }
 
-        let mut schema: Option<SchemaRef> = None;
+        let mut schema: Option<(SchemaRef, &str)> = None;
         let mut geo_meta: Option<GeoParquetMetadata> = None;
-        for meta in metas.values() {
-            if let Some(_prior_schema) = &schema {
-                // TODO: check that schemas are equivalent
-            } else {
-                schema = Some(meta.schema().clone());
+        for (path, meta) in metas.iter() {
+            match schema.as_mut() {
+                Some((merged, first_path)) => {
+                    *merged = merge_dataset_schemas(merged, first_path, meta.schema(), path)?;
+                }
+                None => schema = Some((meta.schema().clone(), path)),
             }
 
             if let Some(new_geo_meta) =
@@ -270,9 +271,10 @@ impl GeoParquetDatasetMetadata {
             }
         }
 
+        let (schema, _) = schema.unwrap();
         Ok(Self {
             files: metas,
-            schema: schema.unwrap(),
+            schema,
             geo_meta: geo_meta
                 .ok_or(GeoArrowError::GeoParquet(
                     "Expected GeoParquet dataset to have Geo metadata".to_string(),
@@ -349,6 +351,49 @@ impl GeoParquetDatasetMetadata {
     }
 }
 
+/// Check `schema` against the merged dataset schema and fold it in.
+///
+/// Field names and data types must match position by position. Nullability and field-level
+/// metadata legitimately differ between files of one dataset (a partition without nulls may
+/// be written non-nullable; writers differ in embedded `ARROW:schema` hints): nullability
+/// merges as "nullable in any file", field metadata keeps the first file's values.
+fn merge_dataset_schemas(
+    merged: &SchemaRef,
+    merged_path: &str,
+    schema: &SchemaRef,
+    path: &str,
+) -> GeoArrowResult<SchemaRef> {
+    if merged.fields().len() != schema.fields().len() {
+        return Err(GeoArrowError::GeoParquet(format!(
+            "Arrow schema of file {path} has {} columns but file {merged_path} has {}",
+            schema.fields().len(),
+            merged.fields().len()
+        )));
+    }
+
+    let mut fields = Vec::with_capacity(merged.fields().len());
+    for (merged_field, field) in merged.fields().iter().zip(schema.fields()) {
+        if merged_field.name() != field.name() || merged_field.data_type() != field.data_type() {
+            return Err(GeoArrowError::GeoParquet(format!(
+                "Arrow schema of file {path} does not match file {merged_path}: field {} ({}) vs field {} ({})",
+                field.name(),
+                field.data_type(),
+                merged_field.name(),
+                merged_field.data_type()
+            )));
+        }
+        if field.is_nullable() && !merged_field.is_nullable() {
+            fields.push(Arc::new(merged_field.as_ref().clone().with_nullable(true)));
+        } else {
+            fields.push(merged_field.clone());
+        }
+    }
+    Ok(Arc::new(Schema::new_with_metadata(
+        fields,
+        merged.metadata().clone(),
+    )))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -359,6 +404,15 @@ mod test {
         let meta = arrow_meta("message schema { required double x; }", -5, &[]);
         let err = ArrowReaderMetadataExt::num_rows(&meta).unwrap_err();
         assert!(err.to_string().contains("invalid row count"));
+    }
+
+    #[test]
+    fn dataset_with_mismatched_schemas_errors() {
+        let a = arrow_meta("message schema { required double x; }", 0, &[]);
+        let b = arrow_meta("message schema { required int64 y; }", 0, &[]);
+        let metas = IndexMap::from([("a".to_string(), a), ("b".to_string(), b)]);
+        let err = GeoParquetDatasetMetadata::from_files(metas).err().unwrap();
+        assert!(err.to_string().contains("does not match"));
     }
 
     #[test]
@@ -377,5 +431,25 @@ mod test {
         let meta = GeoParquetReaderMetadata::new(arrow, geo_meta);
         let err = meta.row_group_bounds(0, None).unwrap_err();
         assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn dataset_schemas_merge_over_benign_differences() {
+        use arrow_schema::{DataType, Field};
+
+        let merged: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("geom", DataType::Binary, true),
+        ]));
+        // The other file marks `name` nullable and carries writer-specific field metadata.
+        let other: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true)
+                .with_metadata([("PARQUET:field_id".to_string(), "1".to_string())].into()),
+            Field::new("geom", DataType::Binary, true),
+        ]));
+
+        let result = merge_dataset_schemas(&merged, "a.parquet", &other, "b.parquet").unwrap();
+        assert!(result.field(0).is_nullable());
+        assert!(result.field(0).metadata().is_empty());
     }
 }

--- a/rust/geoparquet/src/reader/parse.rs
+++ b/rust/geoparquet/src/reader/parse.rs
@@ -13,12 +13,12 @@ use geoarrow_array::array::{
 use geoarrow_array::cast::from_wkb;
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{
-    CoordType, GeoArrowType, GeometryType, LineStringType, Metadata, MultiLineStringType,
-    MultiPointType, MultiPolygonType, PointType, PolygonType, WkbType,
+    CoordType, Dimension, GeoArrowType, GeometryType, LineStringType, Metadata,
+    MultiLineStringType, MultiPointType, MultiPolygonType, PointType, PolygonType, WkbType,
 };
 
 use crate::metadata::{
-    GeoParquetColumnEncoding, GeoParquetColumnMetadata, GeoParquetGeometryTypeAndDimension,
+    GeoParquetColumnMetadata, GeoParquetGeometryType, GeoParquetGeometryTypeAndDimension,
     GeoParquetMetadata, infer_geo_data_type,
 };
 
@@ -63,26 +63,90 @@ fn infer_target_field(
 ) -> GeoArrowResult<FieldRef> {
     let metadata = Arc::new(Metadata::from(column_meta.clone()));
 
-    let target_geo_data_type: GeoArrowType = match column_meta.encoding {
-        GeoParquetColumnEncoding::WKB => {
-            if parse_to_native {
-                infer_target_wkb_type(&column_meta.geometry_types, coord_type, metadata)?
-            } else {
-                GeoArrowType::Wkb(WkbType::new(metadata))
-            }
-        }
-        // For native encodings there should only be one geometry type
-        _ => {
-            assert_eq!(column_meta.geometry_types.len(), 1);
-            let gpq_type = column_meta.geometry_types.iter().next().unwrap();
-            gpq_type.to_data_type(coord_type, metadata)
-        }
-    };
+    // For native encodings the encoding and layout, not `geometry_types`, are authoritative:
+    // the spec allows an empty list, and GeoPandas writes ["Polygon", "MultiPolygon"] for
+    // mixed data promoted to a multipolygon layout.
+    let target_geo_data_type: GeoArrowType =
+        if let Some(geometry_type) = column_meta.encoding.native_geometry_type() {
+            let dimension = native_dimension(existing_field.data_type(), geometry_type)?;
+            GeoParquetGeometryTypeAndDimension::new(geometry_type, dimension)
+                .to_data_type(coord_type, metadata)
+        } else if parse_to_native {
+            infer_target_wkb_type(&column_meta.geometry_types, coord_type, metadata)?
+        } else {
+            GeoArrowType::Wkb(WkbType::new(metadata))
+        };
 
     Ok(Arc::new(target_geo_data_type.to_field(
         existing_field.name(),
         existing_field.is_nullable(),
     )))
+}
+
+/// Derive the dimension of a native-encoded geometry column from its coordinate struct.
+///
+/// The reader binds coordinate buffers by position, so the Float64 fields must be x, y and
+/// optionally z and/or m, in that order; a reordered struct would silently swap axes if only
+/// the names were checked.
+fn native_dimension(
+    data_type: &DataType,
+    geometry_type: GeoParquetGeometryType,
+) -> GeoArrowResult<Dimension> {
+    let mut current = data_type;
+    for _ in 0..native_list_nesting_depth(geometry_type)? {
+        match current {
+            DataType::List(inner) | DataType::LargeList(inner) => current = inner.data_type(),
+            dt => {
+                return Err(GeoArrowError::GeoParquet(format!(
+                    "Invalid data type for native {geometry_type:?} encoding: expected a list, got {dt:?}"
+                )));
+            }
+        }
+    }
+
+    let DataType::Struct(fields) = current else {
+        return Err(GeoArrowError::GeoParquet(format!(
+            "Invalid data type for native {geometry_type:?} encoding: expected a coordinate struct, got {current:?}"
+        )));
+    };
+
+    let names: Vec<&str> = fields.iter().map(|f| f.name().as_str()).collect();
+    let dimension = match names.as_slice() {
+        ["x", "y"] => Dimension::XY,
+        ["x", "y", "z"] => Dimension::XYZ,
+        ["x", "y", "m"] => Dimension::XYM,
+        ["x", "y", "z", "m"] => Dimension::XYZM,
+        _ => {
+            return Err(GeoArrowError::GeoParquet(format!(
+                "Invalid coordinate struct for native encoding: expected fields x, y, z, m in that order, got {names:?}"
+            )));
+        }
+    };
+
+    for field in fields {
+        if field.data_type() != &DataType::Float64 {
+            return Err(GeoArrowError::GeoParquet(format!(
+                "Invalid coordinate struct for native encoding: field {} must be Float64, got {:?}",
+                field.name(),
+                field.data_type()
+            )));
+        }
+    }
+
+    Ok(dimension)
+}
+
+/// The list nesting depth of a native encoding's separated layout, above the coordinate struct.
+fn native_list_nesting_depth(geometry_type: GeoParquetGeometryType) -> GeoArrowResult<usize> {
+    match geometry_type {
+        GeoParquetGeometryType::Point => Ok(0),
+        GeoParquetGeometryType::LineString | GeoParquetGeometryType::MultiPoint => Ok(1),
+        GeoParquetGeometryType::Polygon | GeoParquetGeometryType::MultiLineString => Ok(2),
+        GeoParquetGeometryType::MultiPolygon => Ok(3),
+        GeoParquetGeometryType::GeometryCollection => Err(GeoArrowError::GeoParquet(
+            "GeometryCollection has no native GeoParquet encoding".to_string(),
+        )),
+    }
 }
 
 fn infer_target_wkb_type(
@@ -184,7 +248,9 @@ fn parse_array(
             GeoArrowType::MultiPoint(typ) => parse_multi_point_column(&array, typ),
             GeoArrowType::MultiLineString(typ) => parse_multi_line_string_column(&array, typ),
             GeoArrowType::MultiPolygon(typ) => parse_multi_polygon_column(&array, typ),
-            _ => unreachable!(),
+            _ => Err(GeoArrowError::GeoParquet(format!(
+                "Cannot parse native-encoded GeoParquet column to target type {target_type:?}",
+            ))),
         },
     }
 }
@@ -243,3 +309,95 @@ impl_parse_fn!(
     MultiPolygonArray,
     MultiPolygonType
 );
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use super::*;
+
+    fn xy_struct() -> DataType {
+        DataType::Struct(
+            vec![
+                Field::new("x", DataType::Float64, false),
+                Field::new("y", DataType::Float64, false),
+            ]
+            .into(),
+        )
+    }
+
+    fn column_meta(encoding: &str, geometry_types: &[&str]) -> GeoParquetColumnMetadata {
+        serde_json::from_value(json!({
+            "encoding": encoding,
+            "geometry_types": geometry_types
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn native_encoding_infers_type_and_dimension_from_layout() {
+        let meta = column_meta("point", &[]);
+        let xyz = DataType::Struct(
+            vec![
+                Field::new("x", DataType::Float64, false),
+                Field::new("y", DataType::Float64, false),
+                Field::new("z", DataType::Float64, false),
+            ]
+            .into(),
+        );
+        let field = Field::new("geometry", xyz, true);
+        let target = infer_target_field(&field, &meta, true, CoordType::Separated).unwrap();
+        let target_type = GeoArrowType::try_from(target.as_ref()).unwrap();
+        assert!(matches!(target_type, GeoArrowType::Point(t) if t.dimension() == Dimension::XYZ));
+    }
+
+    #[test]
+    fn native_encoding_overrides_geometry_types() {
+        let meta = column_meta("multipolygon", &["Polygon", "MultiPolygon"]);
+        let coords = DataType::List(Arc::new(Field::new(
+            "item",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::List(Arc::new(Field::new("item", xy_struct(), false))),
+                false,
+            ))),
+            false,
+        )));
+        let field = Field::new("geometry", coords, true);
+        let target = infer_target_field(&field, &meta, true, CoordType::Separated).unwrap();
+        let target_type = GeoArrowType::try_from(target.as_ref()).unwrap();
+        assert!(matches!(target_type, GeoArrowType::MultiPolygon(_)));
+    }
+
+    #[test]
+    fn native_encoding_layout_error_paths() {
+        let point = column_meta("point", &["Point"]);
+        let target_err = |meta: &GeoParquetColumnMetadata, data_type: DataType| {
+            let field = Field::new("geometry", data_type, true);
+            infer_target_field(&field, meta, true, CoordType::Separated)
+                .unwrap_err()
+                .to_string()
+        };
+
+        let coords = |fields: &[(&str, DataType)]| {
+            DataType::Struct(
+                fields
+                    .iter()
+                    .map(|(name, dt)| Field::new(*name, dt.clone(), false))
+                    .collect(),
+            )
+        };
+
+        // A 'point'-encoded column wrapped in a list has the wrong nesting depth.
+        let listed = DataType::List(Arc::new(Field::new("item", xy_struct(), false)));
+        assert!(target_err(&point, listed).contains("expected a coordinate struct"));
+        let linestring = column_meta("linestring", &["LineString"]);
+        assert!(target_err(&linestring, xy_struct()).contains("expected a list"));
+
+        let yx = coords(&[("y", DataType::Float64), ("x", DataType::Float64)]);
+        assert!(target_err(&point, yx).contains("in that order"));
+
+        let f32s = coords(&[("x", DataType::Float32), ("y", DataType::Float32)]);
+        assert!(target_err(&point, f32s).contains("Float64"));
+    }
+}

--- a/rust/geoparquet/src/reader/spatial_filter.rs
+++ b/rust/geoparquet/src/reader/spatial_filter.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -7,6 +6,7 @@ use arrow_array::types::{Float32Type, Float64Type};
 use arrow_array::{Array, Float32Array, Float64Array, Scalar};
 use arrow_buffer::ScalarBuffer;
 use arrow_ord::cmp::{gt_eq, lt_eq};
+use arrow_schema::ArrowError;
 use geo_traits::{CoordTrait, RectTrait};
 use geo_types::{CoordNum, Rect, coord};
 use geoarrow_array::GeoArrowArrayAccessor;
@@ -60,6 +60,9 @@ impl<'a> ParquetBboxStatistics<'a> {
         parquet_schema: &SchemaDescriptor,
         bbox_covering: &'a GeoParquetBboxCovering,
     ) -> GeoArrowResult<Self> {
+        // No structural requirements here: the statistics-only consumers (row-group pruning
+        // and bounds) work with any resolvable paths, including spec-noncompliant flat
+        // columns. The row-filter path checks its stricter shape itself.
         let mut minx_col: Option<usize> = None;
         let mut miny_col: Option<usize> = None;
         let mut maxx_col: Option<usize> = None;
@@ -238,15 +241,15 @@ fn construct_native_predicate(
 
         // Perform bbox comparison
         // TODO: do this in one pass instead of four?
-        let minx_cmp = gt_eq(&xmax_col, &minx_scalar).unwrap();
-        let miny_cmp = gt_eq(&ymax_col, &miny_scalar).unwrap();
-        let maxx_cmp = lt_eq(&xmin_col, &maxx_scalar).unwrap();
-        let maxy_cmp = lt_eq(&ymin_col, &maxy_scalar).unwrap();
+        let minx_cmp = gt_eq(&xmax_col, &minx_scalar)?;
+        let miny_cmp = gt_eq(&ymax_col, &miny_scalar)?;
+        let maxx_cmp = lt_eq(&xmin_col, &maxx_scalar)?;
+        let maxy_cmp = lt_eq(&ymin_col, &maxy_scalar)?;
 
         // AND together the results
-        let first = arrow_arith::boolean::and(&minx_cmp, &miny_cmp).unwrap();
-        let second = arrow_arith::boolean::and(&first, &maxx_cmp).unwrap();
-        let third = arrow_arith::boolean::and(&second, &maxy_cmp).unwrap();
+        let first = arrow_arith::boolean::and(&minx_cmp, &miny_cmp)?;
+        let second = arrow_arith::boolean::and(&first, &maxx_cmp)?;
+        let third = arrow_arith::boolean::and(&second, &maxy_cmp)?;
 
         Ok(third)
     });
@@ -260,95 +263,90 @@ fn construct_bbox_columns_predicate(
     bbox_cols: ParquetBboxStatistics,
     bbox_query: Rect,
 ) -> GeoArrowResult<Box<dyn ArrowPredicate>> {
-    let mask = ProjectionMask::leaves(
-        parquet_schema,
-        [
-            bbox_cols.minx_col,
-            bbox_cols.miny_col,
-            bbox_cols.maxx_col,
-            bbox_cols.maxy_col,
-        ],
-    );
-
-    // The GeoParquet spec allows the bounding box columns to be either Double or Float data type.
-    // We need to know which type it is so that we can downcast the produced Arrow arrays to the
-    // correct type.
-    let mut column_types = HashSet::with_capacity(4);
-    column_types.insert(parquet_schema.column(bbox_cols.minx_col).physical_type());
-    column_types.insert(parquet_schema.column(bbox_cols.miny_col).physical_type());
-    column_types.insert(parquet_schema.column(bbox_cols.maxx_col).physical_type());
-    column_types.insert(parquet_schema.column(bbox_cols.maxy_col).physical_type());
-    if column_types.len() != 1 {
-        return Err(GeoArrowError::GeoParquet(format!(
-            "Expected one column type for GeoParquet bbox columns, got {column_types:?}",
-        )));
-    }
-
-    let column_type = column_types.drain().next().unwrap();
-    if !(matches!(column_type, parquet::basic::Type::FLOAT)
-        || matches!(column_type, parquet::basic::Type::DOUBLE))
+    // The predicate projects one root column and reads batch.column(0) as a struct of the
+    // projected leaves, so the covering must be a GeoParquet 1.1 bounding box column: one
+    // top-level struct, every path [column, field], four distinct fields.
+    let root = bbox_cols.minx_col_path.first();
+    if bbox_cols.miny_col_path.first() != root
+        || bbox_cols.maxx_col_path.first() != root
+        || bbox_cols.maxy_col_path.first() != root
     {
         return Err(GeoArrowError::GeoParquet(format!(
-            "Expected column type for GeoParquet bbox column to be FLOAT or DOUBLE, got {column_type:?}",
+            "GeoParquet bbox covering paths must share the same root column, got {:?}, {:?}, {:?}, {:?}",
+            bbox_cols.minx_col_path,
+            bbox_cols.miny_col_path,
+            bbox_cols.maxx_col_path,
+            bbox_cols.maxy_col_path
         )));
     }
 
-    // Note: the GeoParquet specification declares that these columns MUST be named xmin, ymin,
-    // xmax, ymax. But the Overture data does not yet comply with this, so we follow the user
-    // input.
-    let minx_struct_field_name = bbox_cols.minx_col_path.last().unwrap().clone();
-    let miny_struct_field_name = bbox_cols.miny_col_path.last().unwrap().clone();
-    let maxx_struct_field_name = bbox_cols.maxx_col_path.last().unwrap().clone();
-    let maxy_struct_field_name = bbox_cols.maxy_col_path.last().unwrap().clone();
+    for path in [
+        bbox_cols.minx_col_path,
+        bbox_cols.miny_col_path,
+        bbox_cols.maxx_col_path,
+        bbox_cols.maxy_col_path,
+    ] {
+        if path.len() != 2 {
+            return Err(GeoArrowError::GeoParquet(format!(
+                "Expected a GeoParquet bbox covering path of the form [column, field], got {path:?}",
+            )));
+        }
+    }
+
+    let leaf_columns = [
+        bbox_cols.minx_col,
+        bbox_cols.miny_col,
+        bbox_cols.maxx_col,
+        bbox_cols.maxy_col,
+    ];
+
+    // Legitimate leaf sharing (native encoding) routes to construct_native_predicate, so a
+    // duplicate leaf here means the covering maps one field onto two roles.
+    if (1..leaf_columns.len()).any(|i| leaf_columns[..i].contains(&leaf_columns[i])) {
+        return Err(GeoArrowError::GeoParquet(format!(
+            "GeoParquet bbox covering paths must name four distinct fields, got {:?}, {:?}, {:?}, {:?}",
+            bbox_cols.minx_col_path,
+            bbox_cols.miny_col_path,
+            bbox_cols.maxx_col_path,
+            bbox_cols.maxy_col_path
+        )));
+    }
+
+    // The GeoParquet spec allows the bounding box columns to be either Double or Float data type.
+    for column in leaf_columns {
+        let column_type = parquet_schema.column(column).physical_type();
+        if !matches!(
+            column_type,
+            parquet::basic::Type::FLOAT | parquet::basic::Type::DOUBLE
+        ) {
+            return Err(GeoArrowError::GeoParquet(format!(
+                "Expected column type for GeoParquet bbox column to be FLOAT or DOUBLE, got {column_type:?}",
+            )));
+        }
+    }
+
+    let mask = ProjectionMask::leaves(parquet_schema, leaf_columns);
+
+    // The projected batch is one struct column whose children are the projected leaves in
+    // parquet schema order, so each role's child index is the rank of its leaf index.
+    let [
+        xmin_struct_idx,
+        ymin_struct_idx,
+        xmax_struct_idx,
+        ymax_struct_idx,
+    ] = leaf_columns.map(|column| leaf_columns.iter().filter(|&&other| other < column).count());
 
     let predicate = ArrowPredicateFn::new(mask, move |batch| {
-        let struct_col = batch.column(0).as_struct();
+        let struct_col = batch.column(0).as_struct_opt().ok_or_else(|| {
+            ArrowError::ComputeError(
+                "GeoParquet bbox covering root column is not a struct".to_string(),
+            )
+        })?;
 
-        let struct_fields = struct_col.fields();
-        let (xmin_struct_idx, _) = struct_fields.find(&minx_struct_field_name).unwrap();
-        let (ymin_struct_idx, _) = struct_fields.find(&miny_struct_field_name).unwrap();
-        let (xmax_struct_idx, _) = struct_fields.find(&maxx_struct_field_name).unwrap();
-        let (ymax_struct_idx, _) = struct_fields.find(&maxy_struct_field_name).unwrap();
-
-        let (xmin_col, ymin_col, xmax_col, ymax_col) = match column_type {
-            parquet::basic::Type::FLOAT => {
-                let minx_col = struct_col
-                    .column(xmin_struct_idx)
-                    .as_primitive::<Float32Type>();
-                let miny_col = struct_col
-                    .column(ymin_struct_idx)
-                    .as_primitive::<Float32Type>();
-                let maxx_col = struct_col
-                    .column(xmax_struct_idx)
-                    .as_primitive::<Float32Type>();
-                let maxy_col = struct_col
-                    .column(ymax_struct_idx)
-                    .as_primitive::<Float32Type>();
-
-                (
-                    &upcast_float_array(minx_col),
-                    &upcast_float_array(miny_col),
-                    &upcast_float_array(maxx_col),
-                    &upcast_float_array(maxy_col),
-                )
-            }
-            parquet::basic::Type::DOUBLE => {
-                let minx_col = struct_col
-                    .column(xmin_struct_idx)
-                    .as_primitive::<Float64Type>();
-                let miny_col = struct_col
-                    .column(ymin_struct_idx)
-                    .as_primitive::<Float64Type>();
-                let maxx_col = struct_col
-                    .column(xmax_struct_idx)
-                    .as_primitive::<Float64Type>();
-                let maxy_col = struct_col
-                    .column(ymax_struct_idx)
-                    .as_primitive::<Float64Type>();
-                (minx_col, miny_col, maxx_col, maxy_col)
-            }
-            _ => unreachable!(),
-        };
+        let xmin_col = bbox_child_f64(struct_col.column(xmin_struct_idx))?;
+        let ymin_col = bbox_child_f64(struct_col.column(ymin_struct_idx))?;
+        let xmax_col = bbox_child_f64(struct_col.column(xmax_struct_idx))?;
+        let ymax_col = bbox_child_f64(struct_col.column(ymax_struct_idx))?;
 
         // Construct the bounding box from user input
         let minx_scalar = Scalar::new(Float64Array::from(vec![bbox_query.min().x()]));
@@ -358,20 +356,37 @@ fn construct_bbox_columns_predicate(
 
         // Perform bbox comparison
         // TODO: do this in one pass instead of four?
-        let minx_cmp = gt_eq(&xmax_col, &minx_scalar).unwrap();
-        let miny_cmp = gt_eq(&ymax_col, &miny_scalar).unwrap();
-        let maxx_cmp = lt_eq(&xmin_col, &maxx_scalar).unwrap();
-        let maxy_cmp = lt_eq(&ymin_col, &maxy_scalar).unwrap();
+        let minx_cmp = gt_eq(&xmax_col, &minx_scalar)?;
+        let miny_cmp = gt_eq(&ymax_col, &miny_scalar)?;
+        let maxx_cmp = lt_eq(&xmin_col, &maxx_scalar)?;
+        let maxy_cmp = lt_eq(&ymin_col, &maxy_scalar)?;
 
         // AND together the results
-        let first = arrow_arith::boolean::and(&minx_cmp, &miny_cmp).unwrap();
-        let second = arrow_arith::boolean::and(&first, &maxx_cmp).unwrap();
-        let third = arrow_arith::boolean::and(&second, &maxy_cmp).unwrap();
+        let first = arrow_arith::boolean::and(&minx_cmp, &miny_cmp)?;
+        let second = arrow_arith::boolean::and(&first, &maxx_cmp)?;
+        let third = arrow_arith::boolean::and(&second, &maxy_cmp)?;
 
         Ok(third)
     });
 
     Ok(Box::new(predicate))
+}
+
+/// Read a bbox struct child as Float64, upcasting Float32.
+///
+/// The decoded array type can differ from the parquet physical type (e.g. through an embedded
+/// `ARROW:schema` hint), so this must not assume the construction-time check still holds.
+fn bbox_child_f64(array: &Arc<dyn Array>) -> Result<Float64Array, ArrowError> {
+    if let Some(float64) = array.as_primitive_opt::<Float64Type>() {
+        Ok(float64.clone())
+    } else if let Some(float32) = array.as_primitive_opt::<Float32Type>() {
+        Ok(upcast_float_array(float32))
+    } else {
+        Err(ArrowError::ComputeError(format!(
+            "Expected GeoParquet bbox covering field to decode as Float32 or Float64, got {:?}",
+            array.data_type()
+        )))
+    }
 }
 
 /// Check whether two paths are equal
@@ -399,14 +414,21 @@ fn parse_statistics_f64(column_meta: &ColumnChunkMetaData) -> GeoArrowResult<(f6
             "No statistics for column {}",
             column_meta.column_path()
         )))?;
+    // Statistics can carry a null count and no minimum or maximum value.
+    let missing_min_max = || {
+        GeoArrowError::GeoParquet(format!(
+            "Statistics for column {} have no min/max values",
+            column_meta.column_path()
+        ))
+    };
     match stats {
         Statistics::Double(typed_stats) => Ok((
-            *typed_stats.min_opt().unwrap(),
-            *typed_stats.max_opt().unwrap(),
+            *typed_stats.min_opt().ok_or_else(missing_min_max)?,
+            *typed_stats.max_opt().ok_or_else(missing_min_max)?,
         )),
         Statistics::Float(typed_stats) => Ok((
-            *typed_stats.min_opt().unwrap() as f64,
-            *typed_stats.max_opt().unwrap() as f64,
+            *typed_stats.min_opt().ok_or_else(missing_min_max)? as f64,
+            *typed_stats.max_opt().ok_or_else(missing_min_max)? as f64,
         )),
         st => Err(GeoArrowError::GeoParquet(format!(
             "Unexpected statistics type: {st:?}",
@@ -433,4 +455,58 @@ fn rect_intersects<T: CoordNum>(a: &impl RectTrait<T = T>, b: &impl RectTrait<T 
     }
 
     true
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::schema_descr;
+
+    #[test]
+    fn statistics_without_min_max_error() {
+        let descr = schema_descr("message schema { required double x; }");
+        let column_meta = ColumnChunkMetaData::builder(descr.column(0))
+            .set_statistics(Statistics::double(None, None, None, Some(4), false))
+            .build()
+            .unwrap();
+        let err = parse_statistics_f64(&column_meta).unwrap_err();
+        assert!(err.to_string().contains("min/max"));
+    }
+
+    /// Nonstandard covering shapes resolve for the statistics-only consumers but are rejected
+    /// by the row-filter path.
+    #[test]
+    fn covering_shapes_gate_the_row_filter_only() {
+        let query = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. });
+        let cases = [
+            (
+                "message schema { required double a; required double b; required double c; required double d; }",
+                serde_json::json!({"xmin": ["a"], "ymin": ["b"], "xmax": ["c"], "ymax": ["d"]}),
+                "same root column",
+            ),
+            (
+                "message schema { required group bbox { required double xmin; required double ymin; required double xmax; required double ymax; } }",
+                serde_json::json!({
+                    "xmin": ["bbox", "xmin"], "ymin": ["bbox", "ymin"],
+                    "xmax": ["bbox", "xmin"], "ymax": ["bbox", "ymax"]
+                }),
+                "distinct",
+            ),
+            (
+                "message schema { required group props { required group bbox { required double xmin; required double ymin; required double xmax; required double ymax; } } }",
+                serde_json::json!({
+                    "xmin": ["props", "bbox", "xmin"], "ymin": ["props", "bbox", "ymin"],
+                    "xmax": ["props", "bbox", "xmax"], "ymax": ["props", "bbox", "ymax"]
+                }),
+                "[column, field]",
+            ),
+        ];
+        for (message_type, covering, expected) in cases {
+            let descr = schema_descr(message_type);
+            let covering: GeoParquetBboxCovering = serde_json::from_value(covering).unwrap();
+            let stats = ParquetBboxStatistics::try_new(&descr, &covering).unwrap();
+            let err = bbox_arrow_predicate(&descr, stats, query).err().unwrap();
+            assert!(err.to_string().contains(expected), "{expected}");
+        }
+    }
 }

--- a/rust/geoparquet/src/reader/spatial_filter.rs
+++ b/rust/geoparquet/src/reader/spatial_filter.rs
@@ -183,6 +183,80 @@ pub(crate) fn bbox_row_groups(
     Ok(intersects_row_groups_idxs)
 }
 
+/// Find the leaf column index of a top-level primitive geometry column.
+///
+/// A GeoParquet 2.0 geometry column is a top-level BYTE_ARRAY leaf, so its schema path is the
+/// bare column name.
+pub(crate) fn geometry_leaf_index(
+    parquet_schema: &SchemaDescriptor,
+    column_name: &str,
+) -> GeoArrowResult<usize> {
+    parquet_schema
+        .columns()
+        .iter()
+        .position(|column| {
+            let parts = column.path().parts();
+            parts.len() == 1 && parts[0] == column_name
+        })
+        .ok_or_else(|| {
+            GeoArrowError::GeoParquet(format!("No top-level primitive column named {column_name}"))
+        })
+}
+
+/// Bbox of one row group from the geometry column's native geospatial statistics
+/// (Parquet GEOMETRY/GEOGRAPHY logical types).
+pub(crate) fn native_stats_bbox(
+    rg_meta: &RowGroupMetaData,
+    leaf_idx: usize,
+) -> GeoArrowResult<Rect> {
+    let column = rg_meta.column(leaf_idx);
+    let stats = column.geo_statistics().ok_or_else(|| {
+        GeoArrowError::GeoParquet(format!(
+            "No geospatial statistics for column {}",
+            column.column_path()
+        ))
+    })?;
+    let bbox = stats.bounding_box().ok_or_else(|| {
+        GeoArrowError::GeoParquet(format!(
+            "Geospatial statistics for column {} have no bounding box",
+            column.column_path()
+        ))
+    })?;
+    Ok(Rect::new(
+        coord! { x: bbox.get_xmin(), y: bbox.get_ymin() },
+        coord! { x: bbox.get_xmax(), y: bbox.get_ymax() },
+    ))
+}
+
+/// The bboxes of a sequence of row groups from native geospatial statistics.
+pub(crate) fn native_stats_bboxes(
+    row_groups: &[RowGroupMetaData],
+    leaf_idx: usize,
+    metadata: Arc<Metadata>,
+) -> GeoArrowResult<RectArray> {
+    let rect_type = BoxType::new(Dimension::XY, metadata);
+    let mut builder = RectBuilder::with_capacity(rect_type, row_groups.len());
+    for rg_meta in row_groups.iter() {
+        builder.push_rect(Some(&native_stats_bbox(rg_meta, leaf_idx)?));
+    }
+    Ok(builder.finish())
+}
+
+/// Row groups whose native geospatial statistics intersect the query bbox.
+pub(crate) fn native_bbox_row_groups(
+    row_groups: &[RowGroupMetaData],
+    leaf_idx: usize,
+    bbox_query: Rect,
+) -> GeoArrowResult<Vec<usize>> {
+    let mut intersects_row_groups_idxs = vec![];
+    for (row_group_idx, rg_meta) in row_groups.iter().enumerate() {
+        if rect_intersects(&native_stats_bbox(rg_meta, leaf_idx)?, &bbox_query) {
+            intersects_row_groups_idxs.push(row_group_idx);
+        }
+    }
+    Ok(intersects_row_groups_idxs)
+}
+
 pub(crate) fn bbox_arrow_predicate(
     parquet_schema: &SchemaDescriptor,
     bbox_cols: ParquetBboxStatistics,

--- a/rust/geoparquet/src/reader/spatial_filter.rs
+++ b/rust/geoparquet/src/reader/spatial_filter.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::{Float32Type, Float64Type};
-use arrow_array::{Array, Float32Array, Float64Array, Scalar};
+use arrow_array::{Array, BooleanArray, Float32Array, Float64Array, Scalar};
 use arrow_buffer::ScalarBuffer;
 use arrow_ord::cmp::{gt_eq, lt_eq};
 use arrow_schema::ArrowError;
@@ -204,6 +204,43 @@ fn upcast_float_array(array: &Float32Array) -> Float64Array {
     Float64Array::new(values, nulls)
 }
 
+/// The four query bounds as arrow scalars, built once per predicate instead of once per batch.
+struct BboxQueryScalars {
+    minx: Scalar<Float64Array>,
+    miny: Scalar<Float64Array>,
+    maxx: Scalar<Float64Array>,
+    maxy: Scalar<Float64Array>,
+}
+
+impl BboxQueryScalars {
+    fn new(bbox_query: &Rect) -> Self {
+        Self {
+            minx: Scalar::new(Float64Array::from(vec![bbox_query.min().x()])),
+            miny: Scalar::new(Float64Array::from(vec![bbox_query.min().y()])),
+            maxx: Scalar::new(Float64Array::from(vec![bbox_query.max().x()])),
+            maxy: Scalar::new(Float64Array::from(vec![bbox_query.max().y()])),
+        }
+    }
+
+    /// Mask of rows whose bounds intersect the query bounds.
+    // TODO: do this in one pass instead of four?
+    fn intersects_mask(
+        &self,
+        xmin_col: &Float64Array,
+        ymin_col: &Float64Array,
+        xmax_col: &Float64Array,
+        ymax_col: &Float64Array,
+    ) -> Result<BooleanArray, ArrowError> {
+        let minx_cmp = gt_eq(xmax_col, &self.minx)?;
+        let miny_cmp = gt_eq(ymax_col, &self.miny)?;
+        let maxx_cmp = lt_eq(xmin_col, &self.maxx)?;
+        let maxy_cmp = lt_eq(ymin_col, &self.maxy)?;
+        let first = arrow_arith::boolean::and(&minx_cmp, &miny_cmp)?;
+        let second = arrow_arith::boolean::and(&first, &maxx_cmp)?;
+        arrow_arith::boolean::and(&second, &maxy_cmp)
+    }
+}
+
 /// Construct an [ArrowPredicate] used for spatial filtering when the input is encoded as a native
 /// geometry.
 fn construct_native_predicate(
@@ -221,6 +258,7 @@ fn construct_native_predicate(
         ],
     );
 
+    let query_scalars = BboxQueryScalars::new(&bbox_query);
     let predicate = ArrowPredicateFn::new(mask, move |batch| {
         let array = batch.column(0);
         let field = batch.schema_ref().field(0);
@@ -233,25 +271,7 @@ fn construct_native_predicate(
         let xmax_col = Float64Array::new(rect_arr.upper().raw_buffers()[0].clone(), nulls.cloned());
         let ymax_col = Float64Array::new(rect_arr.upper().raw_buffers()[1].clone(), nulls.cloned());
 
-        // Construct the bounding box from user input
-        let minx_scalar = Scalar::new(Float64Array::from(vec![bbox_query.min().x()]));
-        let miny_scalar = Scalar::new(Float64Array::from(vec![bbox_query.min().y()]));
-        let maxx_scalar = Scalar::new(Float64Array::from(vec![bbox_query.max().x()]));
-        let maxy_scalar = Scalar::new(Float64Array::from(vec![bbox_query.max().y()]));
-
-        // Perform bbox comparison
-        // TODO: do this in one pass instead of four?
-        let minx_cmp = gt_eq(&xmax_col, &minx_scalar)?;
-        let miny_cmp = gt_eq(&ymax_col, &miny_scalar)?;
-        let maxx_cmp = lt_eq(&xmin_col, &maxx_scalar)?;
-        let maxy_cmp = lt_eq(&ymin_col, &maxy_scalar)?;
-
-        // AND together the results
-        let first = arrow_arith::boolean::and(&minx_cmp, &miny_cmp)?;
-        let second = arrow_arith::boolean::and(&first, &maxx_cmp)?;
-        let third = arrow_arith::boolean::and(&second, &maxy_cmp)?;
-
-        Ok(third)
+        query_scalars.intersects_mask(&xmin_col, &ymin_col, &xmax_col, &ymax_col)
     });
     Ok(Box::new(predicate))
 }
@@ -336,6 +356,7 @@ fn construct_bbox_columns_predicate(
         ymax_struct_idx,
     ] = leaf_columns.map(|column| leaf_columns.iter().filter(|&&other| other < column).count());
 
+    let query_scalars = BboxQueryScalars::new(&bbox_query);
     let predicate = ArrowPredicateFn::new(mask, move |batch| {
         let struct_col = batch.column(0).as_struct_opt().ok_or_else(|| {
             ArrowError::ComputeError(
@@ -348,25 +369,7 @@ fn construct_bbox_columns_predicate(
         let xmax_col = bbox_child_f64(struct_col.column(xmax_struct_idx))?;
         let ymax_col = bbox_child_f64(struct_col.column(ymax_struct_idx))?;
 
-        // Construct the bounding box from user input
-        let minx_scalar = Scalar::new(Float64Array::from(vec![bbox_query.min().x()]));
-        let miny_scalar = Scalar::new(Float64Array::from(vec![bbox_query.min().y()]));
-        let maxx_scalar = Scalar::new(Float64Array::from(vec![bbox_query.max().x()]));
-        let maxy_scalar = Scalar::new(Float64Array::from(vec![bbox_query.max().y()]));
-
-        // Perform bbox comparison
-        // TODO: do this in one pass instead of four?
-        let minx_cmp = gt_eq(&xmax_col, &minx_scalar)?;
-        let miny_cmp = gt_eq(&ymax_col, &miny_scalar)?;
-        let maxx_cmp = lt_eq(&xmin_col, &maxx_scalar)?;
-        let maxy_cmp = lt_eq(&ymin_col, &maxy_scalar)?;
-
-        // AND together the results
-        let first = arrow_arith::boolean::and(&minx_cmp, &miny_cmp)?;
-        let second = arrow_arith::boolean::and(&first, &maxx_cmp)?;
-        let third = arrow_arith::boolean::and(&second, &maxy_cmp)?;
-
-        Ok(third)
+        query_scalars.intersects_mask(&xmin_col, &ymin_col, &xmax_col, &ymax_col)
     });
 
     Ok(Box::new(predicate))

--- a/rust/geoparquet/src/test/mod.rs
+++ b/rust/geoparquet/src/test/mod.rs
@@ -30,13 +30,36 @@ pub(crate) fn schema_descr(message_type: &str) -> Arc<SchemaDescriptor> {
     Arc::new(SchemaDescriptor::new(schema))
 }
 
-/// Build [ArrowReaderMetadata] with the given footer row count and per-row-group row counts.
-pub(crate) fn arrow_meta(
-    message_type: &str,
+/// SchemaDescriptor with one top-level BYTE_ARRAY `geometry` column that carries the given
+/// logical type, next to a plain string column.
+pub(crate) fn geometry_schema_descr(
+    logical_type: parquet::basic::LogicalType,
+) -> Arc<SchemaDescriptor> {
+    use parquet::basic::{LogicalType, Type as PhysicalType};
+    use parquet::schema::types::Type;
+
+    let geometry = Type::primitive_type_builder("geometry", PhysicalType::BYTE_ARRAY)
+        .with_logical_type(Some(logical_type))
+        .build()
+        .unwrap();
+    let name = Type::primitive_type_builder("name", PhysicalType::BYTE_ARRAY)
+        .with_logical_type(Some(LogicalType::String))
+        .build()
+        .unwrap();
+    let root = Type::group_type_builder("schema")
+        .with_fields(vec![Arc::new(geometry), Arc::new(name)])
+        .build()
+        .unwrap();
+    Arc::new(SchemaDescriptor::new(Arc::new(root)))
+}
+
+/// Build [ArrowReaderMetadata] from a schema descriptor with the given footer row count and
+/// per-row-group row counts.
+pub(crate) fn arrow_meta_from_descr(
+    descr: Arc<SchemaDescriptor>,
     num_rows: i64,
     row_group_counts: &[i64],
 ) -> ArrowReaderMetadata {
-    let descr = schema_descr(message_type);
     let row_groups = row_group_counts
         .iter()
         .map(|count| {
@@ -53,4 +76,13 @@ pub(crate) fn arrow_meta(
     let file_meta = FileMetaData::new(1, num_rows, None, None, descr, None);
     let parquet_meta = ParquetMetaData::new(file_meta, row_groups);
     ArrowReaderMetadata::try_new(Arc::new(parquet_meta), Default::default()).unwrap()
+}
+
+/// Build [ArrowReaderMetadata] with the given footer row count and per-row-group row counts.
+pub(crate) fn arrow_meta(
+    message_type: &str,
+    num_rows: i64,
+    row_group_counts: &[i64],
+) -> ArrowReaderMetadata {
+    arrow_meta_from_descr(schema_descr(message_type), num_rows, row_group_counts)
 }

--- a/rust/geoparquet/src/test/mod.rs
+++ b/rust/geoparquet/src/test/mod.rs
@@ -15,3 +15,42 @@ pub(crate) fn geoarrow_data_example_files() -> PathBuf {
 pub(crate) fn geoarrow_data_example_crs_files() -> PathBuf {
     fixture_dir().join("geoarrow-data/example-crs/files")
 }
+
+use std::sync::Arc;
+
+use parquet::arrow::arrow_reader::ArrowReaderMetadata;
+use parquet::file::metadata::{
+    ColumnChunkMetaData, FileMetaData, ParquetMetaData, RowGroupMetaData,
+};
+use parquet::schema::parser::parse_message_type;
+use parquet::schema::types::SchemaDescriptor;
+
+pub(crate) fn schema_descr(message_type: &str) -> Arc<SchemaDescriptor> {
+    let schema = Arc::new(parse_message_type(message_type).unwrap());
+    Arc::new(SchemaDescriptor::new(schema))
+}
+
+/// Build [ArrowReaderMetadata] with the given footer row count and per-row-group row counts.
+pub(crate) fn arrow_meta(
+    message_type: &str,
+    num_rows: i64,
+    row_group_counts: &[i64],
+) -> ArrowReaderMetadata {
+    let descr = schema_descr(message_type);
+    let row_groups = row_group_counts
+        .iter()
+        .map(|count| {
+            let column = ColumnChunkMetaData::builder(descr.column(0))
+                .build()
+                .unwrap();
+            RowGroupMetaData::builder(descr.clone())
+                .set_num_rows(*count)
+                .set_column_metadata(vec![column])
+                .build()
+                .unwrap()
+        })
+        .collect();
+    let file_meta = FileMetaData::new(1, num_rows, None, None, descr, None);
+    let parquet_meta = ParquetMetaData::new(file_meta, row_groups);
+    ArrowReaderMetadata::try_new(Arc::new(parquet_meta), Default::default()).unwrap()
+}

--- a/rust/geoparquet/src/total_bounds.rs
+++ b/rust/geoparquet/src/total_bounds.rs
@@ -12,7 +12,7 @@ use geoarrow_array::array::RectArray;
 use geoarrow_array::builder::RectBuilder;
 use geoarrow_array::{GeoArrowArray, GeoArrowArrayAccessor, downcast_geoarrow_array};
 use geoarrow_schema::error::GeoArrowResult;
-use geoarrow_schema::{BoxType, Dimension, GeoArrowType};
+use geoarrow_schema::{BoxType, Dimension};
 
 #[derive(Debug, Clone, Copy)]
 pub struct BoundingRect {
@@ -295,26 +295,20 @@ pub(crate) fn bounding_rect(arr: &dyn GeoArrowArray) -> GeoArrowResult<RectArray
 
 /// The actual implementation of computing the bounding rect
 fn impl_array_accessor<'a>(arr: &'a impl GeoArrowArrayAccessor<'a>) -> GeoArrowResult<RectArray> {
-    match arr.data_type() {
-        // Note: the implementation in geodatafusion handles this
-        GeoArrowType::Rect(_) => unreachable!(),
-        _ => {
-            let mut builder = RectBuilder::with_capacity(
-                BoxType::new(Dimension::XY, arr.data_type().metadata().clone()),
-                arr.len(),
-            );
-            for item in arr.iter() {
-                if let Some(item) = item {
-                    let mut rect = BoundingRect::new();
-                    rect.add_geometry(&item?);
-                    builder.push_rect(Some(&rect));
-                } else {
-                    builder.push_null();
-                }
-            }
-            Ok(builder.finish())
+    let mut builder = RectBuilder::with_capacity(
+        BoxType::new(Dimension::XY, arr.data_type().metadata().clone()),
+        arr.len(),
+    );
+    for item in arr.iter() {
+        if let Some(item) = item {
+            let mut rect = BoundingRect::new();
+            rect.add_geometry(&item?);
+            builder.push_rect(Some(&rect));
+        } else {
+            builder.push_null();
         }
     }
+    Ok(builder.finish())
 }
 
 /// Get the total bounds (i.e. minx, miny, maxx, maxy) of the entire geoarrow array.

--- a/rust/geoparquet/src/writer/encode.rs
+++ b/rust/geoparquet/src/writer/encode.rs
@@ -6,6 +6,7 @@ use geoarrow_array::cast::{AsGeoArrowArray, to_wkb};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, GeoArrowType};
 use parquet::file::metadata::KeyValue;
+use parquet::schema::types::SchemaDescriptor;
 
 use crate::metadata::{GeoParquetColumnEncoding, GeoParquetMetadata};
 use crate::total_bounds::{BoundingRect, bounding_rect, total_bounds};
@@ -39,6 +40,19 @@ impl GeoParquetRecordBatchEncoder {
     /// [`Self::encode_record_batch`].
     pub fn target_schema(&self) -> SchemaRef {
         self.metadata_builder.output_schema.clone()
+    }
+
+    /// The Parquet schema override for GeoParquet 2.0 output, or `None` for 1.x output.
+    ///
+    /// For 2.0, geometry columns carry the GEOMETRY or GEOGRAPHY logical type, which the
+    /// upstream writer cannot derive from the Arrow schema. Pass the returned schema through
+    /// [`ArrowWriterOptions::with_parquet_schema`][parquet::arrow::arrow_writer::ArrowWriterOptions::with_parquet_schema];
+    /// the writer then also records native geospatial statistics.
+    ///
+    /// GeoParquet 2.0 is at release candidate 2.0.0-rc.1; 2.0 output can change until the
+    /// specification is final.
+    pub fn target_parquet_schema(&self) -> GeoArrowResult<Option<SchemaDescriptor>> {
+        self.metadata_builder.target_parquet_schema()
     }
 
     /// Encode a record batch into a GeoParquet-compatible format.

--- a/rust/geoparquet/src/writer/metadata.rs
+++ b/rust/geoparquet/src/writer/metadata.rs
@@ -14,8 +14,9 @@ use geoarrow_schema::{CoordType, Dimension, Edges, GeoArrowType, Metadata, WkbTy
 use serde_json::Value;
 
 use crate::metadata::{
-    GeoParquetBboxCovering, GeoParquetColumnEncoding, GeoParquetColumnMetadata, GeoParquetCovering,
-    GeoParquetGeometryType, GeoParquetGeometryTypeAndDimension, GeoParquetMetadata,
+    GeoParquetBbox, GeoParquetBboxCovering, GeoParquetColumnEncoding, GeoParquetColumnMetadata,
+    GeoParquetCovering, GeoParquetGeometryType, GeoParquetGeometryTypeAndDimension,
+    GeoParquetMetadata,
 };
 use crate::total_bounds::BoundingRect;
 use crate::writer::options::{GeoParquetWriterEncoding, GeoParquetWriterOptions};
@@ -233,16 +234,21 @@ impl ColumnInfo {
         });
         let bbox = if let Some(bbox) = self.bbox {
             if let (Some(minz), Some(maxz)) = (bbox.minz(), bbox.maxz()) {
-                Some(vec![
+                Some(GeoParquetBbox::Xyz([
                     bbox.minx(),
                     bbox.miny(),
                     minz,
                     bbox.maxx(),
                     bbox.maxy(),
                     maxz,
-                ])
+                ]))
             } else {
-                Some(vec![bbox.minx(), bbox.miny(), bbox.maxx(), bbox.maxy()])
+                Some(GeoParquetBbox::Xy([
+                    bbox.minx(),
+                    bbox.miny(),
+                    bbox.maxx(),
+                    bbox.maxy(),
+                ]))
             }
         } else {
             None

--- a/rust/geoparquet/src/writer/metadata.rs
+++ b/rust/geoparquet/src/writer/metadata.rs
@@ -11,18 +11,18 @@ use geoarrow_array::cast::AsGeoArrowArray;
 use geoarrow_schema::crs::{CrsTransform, DefaultCrsTransform};
 use geoarrow_schema::error::{GeoArrowError, GeoArrowResult};
 use geoarrow_schema::{CoordType, Dimension, Edges, GeoArrowType, Metadata, WkbType};
+use parquet::arrow::ArrowSchemaConverter;
+use parquet::basic::{EdgeInterpolationAlgorithm, LogicalType};
+use parquet::schema::types::{SchemaDescriptor, Type as ParquetType};
 use serde_json::Value;
 
 use crate::metadata::{
     GeoParquetBbox, GeoParquetBboxCovering, GeoParquetColumnEncoding, GeoParquetColumnMetadata,
     GeoParquetCovering, GeoParquetGeometryType, GeoParquetGeometryTypeAndDimension,
-    GeoParquetMetadata, GeoParquetVersion,
+    GeoParquetMetadata, GeoParquetVersion, INFERRED_PRIMARY_COLUMN_NAMES,
 };
 use crate::total_bounds::BoundingRect;
 use crate::writer::options::{GeoParquetWriterEncoding, GeoParquetWriterOptions};
-
-// https://github.com/geoarrow/geoarrow-rs/pull/1159#issuecomment-2904610370
-const INFERRED_PRIMARY_COLUMN_NAMES: [&str; 2] = ["geometry", "geography"];
 
 /// Information for one geometry column being written to Parquet
 pub(crate) struct ColumnInfo {
@@ -336,12 +336,6 @@ impl GeoParquetMetadataBuilder {
         schema: &Schema,
         options: &GeoParquetWriterOptions,
     ) -> GeoArrowResult<Self> {
-        if matches!(options.version, GeoParquetVersion::V2_0) {
-            return Err(GeoArrowError::GeoParquet(
-                "GeoParquet 2.0 output is not implemented yet".to_string(),
-            ));
-        }
-
         let mut columns = HashMap::new();
 
         for (col_idx, field) in schema.fields().iter().enumerate() {
@@ -471,6 +465,61 @@ impl GeoParquetMetadataBuilder {
         }
     }
 
+    /// The Parquet schema for 2.0 output: geometry columns carry the GEOMETRY or GEOGRAPHY
+    /// logical type. Returns `None` for 1.x output, where the derived schema is correct.
+    pub(crate) fn target_parquet_schema(&self) -> GeoArrowResult<Option<SchemaDescriptor>> {
+        if !matches!(self.version, GeoParquetVersion::V2_0) {
+            return Ok(None);
+        }
+        let converted = ArrowSchemaConverter::new()
+            .convert(&self.output_schema)
+            .map_err(|err| GeoArrowError::GeoParquet(err.to_string()))?;
+
+        let columns_by_name: HashMap<&str, &ColumnInfo> = self
+            .columns
+            .values()
+            .map(|info| (info.name.as_str(), info))
+            .collect();
+
+        let fields = converted
+            .root_schema()
+            .get_fields()
+            .iter()
+            .map(|field| {
+                let Some(info) = columns_by_name.get(field.name()) else {
+                    return Ok(field.clone());
+                };
+                let crs = info
+                    .crs
+                    .as_ref()
+                    .map(serde_json::to_string)
+                    .transpose()
+                    .map_err(|err| GeoArrowError::GeoParquet(err.to_string()))?;
+                // 2.0 geometry columns are WKB in a BYTE_ARRAY leaf; the version rules
+                // rejected native encodings before this point.
+                let logical_type = match info.edges {
+                    None => LogicalType::geometry(crs),
+                    Some(edges) => LogicalType::geography(crs, Some(parquet_edge_algorithm(edges))),
+                };
+                let rebuilt = ParquetType::primitive_type_builder(
+                    field.name(),
+                    parquet::basic::Type::BYTE_ARRAY,
+                )
+                .with_repetition(field.get_basic_info().repetition())
+                .with_logical_type(Some(logical_type))
+                .build()
+                .map_err(|err| GeoArrowError::GeoParquet(err.to_string()))?;
+                Ok(Arc::new(rebuilt))
+            })
+            .collect::<GeoArrowResult<Vec<_>>>()?;
+
+        let root = ParquetType::group_type_builder(converted.root_schema().name())
+            .with_fields(fields)
+            .build()
+            .map_err(|err| GeoArrowError::GeoParquet(err.to_string()))?;
+        Ok(Some(SchemaDescriptor::new(Arc::new(root))))
+    }
+
     /// Consume this builder, converting into [GeoParquetMetadata].
     pub(crate) fn finish(self) -> GeoParquetMetadata {
         let mut columns = HashMap::with_capacity(self.columns.len());
@@ -484,6 +533,16 @@ impl GeoParquetMetadataBuilder {
             primary_column: self.primary_column,
             columns,
         }
+    }
+}
+
+fn parquet_edge_algorithm(edges: Edges) -> EdgeInterpolationAlgorithm {
+    match edges {
+        Edges::Spherical => EdgeInterpolationAlgorithm::SPHERICAL,
+        Edges::Vincenty => EdgeInterpolationAlgorithm::VINCENTY,
+        Edges::Thomas => EdgeInterpolationAlgorithm::THOMAS,
+        Edges::Andoyer => EdgeInterpolationAlgorithm::ANDOYER,
+        Edges::Karney => EdgeInterpolationAlgorithm::KARNEY,
     }
 }
 
@@ -657,21 +716,23 @@ mod tests {
     }
 
     #[test]
-    fn v1_0_rejects_native_encoding() {
+    fn v1_0_and_v2_0_reject_native_encoding() {
         let field = PointType::new(Dimension::XY, Default::default()).to_field("geometry", false);
         let schema = Schema::new(vec![field]);
-        let options = GeoParquetWriterOptions {
-            version: GeoParquetVersion::V1_0,
-            default_column_properties: ColumnOptions {
-                encoding: Some(GeoParquetWriterEncoding::GeoArrow),
+        for version in [GeoParquetVersion::V1_0, GeoParquetVersion::V2_0] {
+            let options = GeoParquetWriterOptions {
+                version,
+                default_column_properties: ColumnOptions {
+                    encoding: Some(GeoParquetWriterEncoding::GeoArrow),
+                    ..Default::default()
+                },
                 ..Default::default()
-            },
-            ..Default::default()
-        };
-        let err = GeoParquetMetadataBuilder::try_new(&schema, &options)
-            .err()
-            .unwrap();
-        assert!(err.to_string().contains("Native encodings require"));
+            };
+            let err = GeoParquetMetadataBuilder::try_new(&schema, &options)
+                .err()
+                .unwrap();
+            assert!(err.to_string().contains("Native encodings require"));
+        }
     }
 
     #[test]
@@ -707,17 +768,31 @@ mod tests {
     }
 
     #[test]
-    fn v2_0_output_is_gated() {
-        let field = PointType::new(Dimension::XY, Default::default()).to_field("geometry", false);
+    fn v2_0_writes_wkb_with_geometry_logical_type() {
+        use arrow_schema::{DataType, Field};
+        use geoarrow_schema::WkbType;
+        use parquet::basic::LogicalType;
+
+        let field = Field::new("geometry", DataType::Binary, false)
+            .with_extension_type(WkbType::new(Default::default()));
         let schema = Schema::new(vec![field]);
         let options = GeoParquetWriterOptions {
             version: GeoParquetVersion::V2_0,
             ..Default::default()
         };
-        let err = GeoParquetMetadataBuilder::try_new(&schema, &options)
-            .err()
-            .unwrap();
-        assert!(err.to_string().contains("not implemented"));
+        let builder = GeoParquetMetadataBuilder::try_new(&schema, &options).unwrap();
+        let parquet_schema = builder.target_parquet_schema().unwrap().unwrap();
+        let leaf = &parquet_schema.columns()[0];
+        assert!(matches!(
+            leaf.self_type().get_basic_info().logical_type_ref(),
+            Some(LogicalType::Geometry(_))
+        ));
+        let metadata = builder.finish();
+        assert_eq!(metadata.version, "2.0.0");
+        assert!(matches!(
+            metadata.columns["geometry"].encoding,
+            crate::metadata::GeoParquetColumnEncoding::WKB
+        ));
     }
 
     #[test]

--- a/rust/geoparquet/src/writer/metadata.rs
+++ b/rust/geoparquet/src/writer/metadata.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use crate::metadata::{
     GeoParquetBbox, GeoParquetBboxCovering, GeoParquetColumnEncoding, GeoParquetColumnMetadata,
     GeoParquetCovering, GeoParquetGeometryType, GeoParquetGeometryTypeAndDimension,
-    GeoParquetMetadata,
+    GeoParquetMetadata, GeoParquetVersion,
 };
 use crate::total_bounds::BoundingRect;
 use crate::writer::options::{GeoParquetWriterEncoding, GeoParquetWriterOptions};
@@ -55,9 +55,13 @@ pub(crate) struct ColumnInfo {
     /// Whether or not to use large, i64 offsets when
     /// writing the column as WKB
     pub(crate) large_offsets: bool,
+
+    /// The target GeoParquet version, which constrains encodings and dimensions.
+    pub(crate) version: GeoParquetVersion,
 }
 
 impl ColumnInfo {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn try_new(
         name: String,
         writer_encoding: GeoParquetWriterEncoding,
@@ -66,9 +70,19 @@ impl ColumnInfo {
         crs_transform: Option<&dyn CrsTransform>,
         covering_name: Option<String>,
         large_offsets: bool,
+        version: GeoParquetVersion,
     ) -> GeoArrowResult<Self> {
         let encoding = GeoParquetColumnEncoding::try_new(writer_encoding, data_type)?;
+        if !version.supports_native_encoding() && !matches!(encoding, GeoParquetColumnEncoding::WKB)
+        {
+            return Err(GeoArrowError::GeoParquet(format!(
+                "Native encodings require GeoParquet 1.1, not {}",
+                version.as_str()
+            )));
+        }
+
         let geometry_types = get_geometry_types(data_type);
+        check_m_dimension(version, &geometry_types)?;
 
         let crs = if let Some(crs_transform) = crs_transform {
             crs_transform.extract_projjson(metadata.crs())?
@@ -87,6 +101,7 @@ impl ColumnInfo {
             covering_name,
             covering_field_idx: None,
             large_offsets,
+            version,
         })
     }
 
@@ -223,6 +238,10 @@ impl ColumnInfo {
             _ => {}
         };
 
+        // Columns without a statically-known dimension (WKB, Geometry) can surface M
+        // geometries only here, during encoding.
+        check_m_dimension(self.version, &self.geometry_types)?;
+
         Ok(())
     }
 
@@ -308,6 +327,7 @@ fn wkt_dim_to_geoarrow_dim(wkt_dim: wkt::types::Dimension) -> Dimension {
 pub(crate) struct GeoParquetMetadataBuilder {
     pub(crate) output_schema: SchemaRef,
     pub(crate) primary_column: String,
+    pub(crate) version: GeoParquetVersion,
     pub(crate) columns: HashMap<usize, ColumnInfo>,
 }
 
@@ -316,6 +336,12 @@ impl GeoParquetMetadataBuilder {
         schema: &Schema,
         options: &GeoParquetWriterOptions,
     ) -> GeoArrowResult<Self> {
+        if matches!(options.version, GeoParquetVersion::V2_0) {
+            return Err(GeoArrowError::GeoParquet(
+                "GeoParquet 2.0 output is not implemented yet".to_string(),
+            ));
+        }
+
         let mut columns = HashMap::new();
 
         for (col_idx, field) in schema.fields().iter().enumerate() {
@@ -343,6 +369,13 @@ impl GeoParquetMetadataBuilder {
                         |props| props.generate_covering,
                     )
                     .unwrap_or(false);
+
+                if generate_covering && !options.version.supports_covering() {
+                    return Err(GeoArrowError::GeoParquet(format!(
+                        "A bbox covering requires GeoParquet 1.1 or later, not {}",
+                        options.version.as_str()
+                    )));
+                }
 
                 let covering_name = if generate_covering {
                     let covering_name = options
@@ -376,6 +409,7 @@ impl GeoParquetMetadataBuilder {
                     options.crs_transform.as_deref(),
                     covering_name,
                     large_offsets,
+                    options.version,
                 )?;
 
                 columns.insert(col_idx, column_info);
@@ -421,6 +455,7 @@ impl GeoParquetMetadataBuilder {
         let output_schema = create_output_schema(schema, &mut columns);
         Ok(Self {
             primary_column,
+            version: options.version,
             columns,
             output_schema,
         })
@@ -445,11 +480,31 @@ impl GeoParquetMetadataBuilder {
         }
 
         GeoParquetMetadata {
-            version: "1.1.0".to_string(),
+            version: self.version.as_str().to_string(),
             primary_column: self.primary_column,
             columns,
         }
     }
+}
+
+/// Reject geometry types whose dimension carries M when the target version forbids it.
+fn check_m_dimension(
+    version: GeoParquetVersion,
+    geometry_types: &HashSet<GeoParquetGeometryTypeAndDimension>,
+) -> GeoArrowResult<()> {
+    if version.supports_m_dimension() {
+        return Ok(());
+    }
+    if let Some(geometry_type) = geometry_types
+        .iter()
+        .find(|gtd| matches!(gtd.dimension(), Dimension::XYM | Dimension::XYZM))
+    {
+        return Err(GeoArrowError::GeoParquet(format!(
+            "{geometry_type:?} requires GeoParquet 2.0, not {}",
+            version.as_str()
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn get_geometry_types(
@@ -577,7 +632,93 @@ mod tests {
     use geoarrow_schema::{Dimension, PointType};
 
     use super::GeoParquetMetadataBuilder;
-    use crate::writer::options::{ColumnOptions, GeoParquetWriterOptions};
+    use crate::metadata::GeoParquetVersion;
+    use crate::writer::options::{
+        ColumnOptions, GeoParquetWriterEncoding, GeoParquetWriterOptions,
+    };
+
+    #[test]
+    fn version_string_follows_writer_option() {
+        let field = PointType::new(Dimension::XY, Default::default()).to_field("geometry", false);
+        let schema = Schema::new(vec![field]);
+        for (version, expected) in [
+            (GeoParquetVersion::V1_0, "1.0.0"),
+            (GeoParquetVersion::V1_1, "1.1.0"),
+        ] {
+            let options = GeoParquetWriterOptions {
+                version,
+                ..Default::default()
+            };
+            let metadata = GeoParquetMetadataBuilder::try_new(&schema, &options)
+                .unwrap()
+                .finish();
+            assert_eq!(metadata.version, expected);
+        }
+    }
+
+    #[test]
+    fn v1_0_rejects_native_encoding() {
+        let field = PointType::new(Dimension::XY, Default::default()).to_field("geometry", false);
+        let schema = Schema::new(vec![field]);
+        let options = GeoParquetWriterOptions {
+            version: GeoParquetVersion::V1_0,
+            default_column_properties: ColumnOptions {
+                encoding: Some(GeoParquetWriterEncoding::GeoArrow),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let err = GeoParquetMetadataBuilder::try_new(&schema, &options)
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("Native encodings require"));
+    }
+
+    #[test]
+    fn v1_0_rejects_covering() {
+        let field = PointType::new(Dimension::XY, Default::default()).to_field("geometry", false);
+        let schema = Schema::new(vec![field]);
+        let options = GeoParquetWriterOptions {
+            version: GeoParquetVersion::V1_0,
+            default_column_properties: ColumnOptions {
+                generate_covering: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let err = GeoParquetMetadataBuilder::try_new(&schema, &options)
+            .err()
+            .unwrap();
+        assert!(
+            err.to_string()
+                .contains("covering requires GeoParquet 1.1 or later")
+        );
+    }
+
+    #[test]
+    fn v1_x_rejects_m_dimension_data() {
+        let field = PointType::new(Dimension::XYM, Default::default()).to_field("geometry", false);
+        let schema = Schema::new(vec![field]);
+        let options = GeoParquetWriterOptions::default();
+        let err = GeoParquetMetadataBuilder::try_new(&schema, &options)
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("GeoParquet 2.0"));
+    }
+
+    #[test]
+    fn v2_0_output_is_gated() {
+        let field = PointType::new(Dimension::XY, Default::default()).to_field("geometry", false);
+        let schema = Schema::new(vec![field]);
+        let options = GeoParquetWriterOptions {
+            version: GeoParquetVersion::V2_0,
+            ..Default::default()
+        };
+        let err = GeoParquetMetadataBuilder::try_new(&schema, &options)
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("not implemented"));
+    }
 
     #[test]
     fn primary_column_not_geometry() {

--- a/rust/geoparquet/src/writer/options.rs
+++ b/rust/geoparquet/src/writer/options.rs
@@ -109,8 +109,11 @@ impl GeoParquetWriterOptionsBuilder {
     /// Set the GeoParquet specification version to write. The default is
     /// [`GeoParquetVersion::V1_1`].
     ///
-    /// The version constrains the other options: native encodings and coverings require 1.1,
-    /// and M or ZM geometries 2.0.
+    /// The version constrains the other options: native encodings require 1.1, coverings 1.1
+    /// or later, and M or ZM geometries 2.0.
+    ///
+    /// GeoParquet 2.0 is at release candidate 2.0.0-rc.1; 2.0 output can change until the
+    /// specification is final.
     pub fn set_version(mut self, value: GeoParquetVersion) -> Self {
         self.version = value;
         self

--- a/rust/geoparquet/src/writer/options.rs
+++ b/rust/geoparquet/src/writer/options.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use geoarrow_schema::crs::CrsTransform;
 
+use crate::metadata::GeoParquetVersion;
+
 /// Allowed encodings when writing to GeoParquet
 #[derive(Copy, Clone, Default)]
 #[allow(clippy::upper_case_acronyms)]
@@ -50,6 +52,7 @@ impl ColumnOptions {
 pub struct GeoParquetWriterOptionsBuilder {
     /// Primary geometry column name.
     primary_column: Option<String>,
+    version: GeoParquetVersion,
     crs_transform: Option<Box<dyn CrsTransform>>,
     default_column_properties: ColumnOptions,
     column_properties: HashMap<String, ColumnOptions>,
@@ -103,6 +106,16 @@ impl GeoParquetWriterOptionsBuilder {
         self
     }
 
+    /// Set the GeoParquet specification version to write. The default is
+    /// [`GeoParquetVersion::V1_1`].
+    ///
+    /// The version constrains the other options: native encodings and coverings require 1.1,
+    /// and M or ZM geometries 2.0.
+    pub fn set_version(mut self, value: GeoParquetVersion) -> Self {
+        self.version = value;
+        self
+    }
+
     /// Set the default encoding for all geometry columns.
     pub fn set_encoding(mut self, value: GeoParquetWriterEncoding) -> Self {
         self.default_column_properties.set_encoding(value);
@@ -125,6 +138,7 @@ impl GeoParquetWriterOptionsBuilder {
     pub fn build(self) -> GeoParquetWriterOptions {
         GeoParquetWriterOptions {
             primary_column: self.primary_column,
+            version: self.version,
             crs_transform: self.crs_transform,
             default_column_properties: self.default_column_properties,
             column_properties: self.column_properties,
@@ -136,6 +150,7 @@ impl GeoParquetWriterOptionsBuilder {
 #[derive(Default)]
 pub struct GeoParquetWriterOptions {
     pub(crate) primary_column: Option<String>,
+    pub(crate) version: GeoParquetVersion,
     pub(crate) crs_transform: Option<Box<dyn CrsTransform>>,
     pub(crate) default_column_properties: ColumnOptions,
     pub(crate) column_properties: HashMap<String, ColumnOptions>,


### PR DESCRIPTION
In preparation for updating js bindings, here's a PR to work on cleaning up geoparquet read and write I've been working on the last few weeks. It's a big one, but each commit is still self-contained. Independent of #1462, #1466, and #1467.

(Heavily Claude assisted, but I have reviewed each commit on my own, though I also note my continued inexperience with Rust.)

The PR started as adding error handling to avoid crashing the wasm crate with invalid files. From there, many of the todos in the existing code ended up being resolved by the latest 2.0.0-rc.1 spec, so this also includes initial handling of 1.0.0, 1.1.0, and 2.0.0-rc.1.

It does include two breaking changes:
- num_rows returns a Result instead of a bare usize (it used to unwrap the row count, and now errors if the footer's value doesn't fit)
- the metadata bbox is a typed enum instead of a bare Vec<f64>

Things still to figure out:
- When to default to outputting 2.0 (likely once it finalizes?)
- Preferred merge behavior for mixed 1.1.0/2.0 datasets -- right now they merge without comparing version strings
- An eventual decision on https://github.com/opengeospatial/geoparquet/issues/297 -- this currently allows it manually for 2.0
